### PR TITLE
Example YAMLs

### DIFF
--- a/alm-manifests/apptype.crd.yaml
+++ b/alm-manifests/apptype.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata: 
+  name: apptypes.app.coreos.com
+spec: 
+  group: app.coreos.com
+  version: v1
+  scope: Namespaced
+  names: 
+    plural: apptypes
+    singular: apptype
+    kind: AppType
+    shortNames: 
+    - at
+ 

--- a/alm-manifests/my-console.tectonic-console.yaml
+++ b/alm-manifests/my-console.tectonic-console.yaml
@@ -1,0 +1,2 @@
+apiVersion: tectonic-console.coreos.com/v1
+kind: TectonicConsole

--- a/alm-manifests/mysql.apptype.yaml
+++ b/alm-manifests/mysql.apptype.yaml
@@ -1,0 +1,28 @@
+apiVersion: app.coreos.com/v1
+kind: AppType
+metadata: 
+  name: mysql
+  type: com.tectonic.storage
+spec:
+  operator: 
+    image: quay.io/coreos/mysql-operator:stable
+  descriptions: 
+    short: Managed MySQL database
+    long: Provides a managed MySQL database including support for automatic high availability, continuous backups and restoration, dashboards and management tooling.
+  resources:
+  - metadata:
+      name: mysqls.mysql.coreos.com
+    spec:
+      group: mysql.coreos.com
+      version: v1
+      scope: Namespaced
+      names: 
+        plural: mysqls
+        singular: mysql
+        kind: MySQL
+    schema: TODO
+    outputs:
+    - name: service-name
+      type: string
+      description: The service name at which to connect to the newly formed MySQL
+

--- a/alm-manifests/mysql.crd.yaml
+++ b/alm-manifests/mysql.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.mysql.coreos.com
+spec: 
+  group: mysql.coreos.com
+  version: v1
+  validation: 
+    openAPISpecV3: TODO
+  scope: Namespaced
+  names:
+    plural: mysqls
+    singular: mysql
+    kind: MySQL
+outputs: 
+- name: service-name
+  type: string
+  description: The service name at which to connect to the newly formed MySQL
+

--- a/alm-manifests/nginx.apptype.yaml
+++ b/alm-manifests/nginx.apptype.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.coreos.com/v1
+kind: AppType 
+metadata:
+  name: nginx
+spec:
+  operator: 
+    image: quay.io/coreos/stateless-app-operator:stable
+

--- a/alm-manifests/nginx.crd.yaml
+++ b/alm-manifests/nginx.crd.yaml
@@ -1,0 +1,17 @@
+# FIXME: Should be created by the ALM Operator
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata: 
+  name: nginxes.nginx.coreos.com
+spec: 
+  group: nginx.coreos.com
+  version: v1
+  validation:
+    openAPISpecV3: TODO
+  scope: Namespaced
+  names:
+    plural: nginxes
+    singular: nginx
+    kind: Nginx
+    shortNames:
+    - ng

--- a/alm-manifests/nginx.operator.yaml
+++ b/alm-manifests/nginx.operator.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.coreos.com/v1
+kind: Operator
+metadata: 
+  name: NginxOperator
+  namespace: alm
+spec: 
+  containers: 
+  - name: nginx-operator
+    image: quay.io/coreos/stateless-app-operator:stable
+ 

--- a/alm-manifests/operator.crd.yaml
+++ b/alm-manifests/operator.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata: 
+  name: operators.app.coreos.com
+spec: 
+  group: app.coreos.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: operators
+    singular: operator
+    kind: Operator
+    shortNames:
+    - op
+

--- a/alm-manifests/prod-db.mysql.yaml
+++ b/alm-manifests/prod-db.mysql.yaml
@@ -1,0 +1,8 @@
+apiVersion: mysql.coreos.com/v1
+kind: MySQL
+metadata: 
+  name: prod-db
+spec:
+  size: 3
+  version: 5.7.0
+

--- a/alm-manifests/staging-db.mysql.yaml
+++ b/alm-manifests/staging-db.mysql.yaml
@@ -1,0 +1,8 @@
+apiVersion: mysql.coreos.com/v1
+kind: MySQL
+metadata: 
+  name: staging-db
+spec: 
+  size: 3
+  version: 5.7.0
+


### PR DESCRIPTION
Implementations of the concepts in the current proposal. Includes `AppType`, `Operator` and app CRDs. 

Create CRD in running cluster:
`kubectl create -f <file>`