### PR TITLE
AppType discovery and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ The aim of this project is to serve the following purposes:
 
 ## Usage
 
-**Asumption**: The ALM operator is already installed in the cluster, which defines an AppType CRD and an InstallStrategy CRD
+**Asumption**: The ALM operator is already installed in the cluster, which defines an AppType CRD and an OperatorVersion CRD
 
 ```sh
 kubectl get crd
-NAME                            KIND
-app.stable.coreos.com           CustomResourceDefinition.v1beta1.apiextensions.k8s.io
-opinstaller.stable.coreos.com   CustomResourceDefinition.v1beta1.apiextensions.k8s.io
+NAME                                 KIND
+apptypes.stable.coreos.com           CustomResourceDefinition.v1beta1.apiextensions.k8s.io
+operatorversions.stable.coreos.com   CustomResourceDefinition.v1beta1.apiextensions.k8s.io
 ```
 
 ### Create an instance of an app type
@@ -40,26 +40,26 @@ metadata:
 ### Create an InstallStrategy
 
 ```sh
-kubectl create -f etcd-op-installstrategy.yaml
+kubectl create -f etcd-op.yaml
 ```
 
 ```yaml
-apiVersion: opinstaller.coreos.com/v1beta1
-kind: InstallStrategy 
+apiVersion: operator.coreos.com/v1beta1
+kind: OperatorVersion 
 metadata:
   ownerReference: etcd.com.tectonic.storage
-  version: 1
-  selfRef: install.1.etcd.com.tectonic.storage
+  version: aef4455
+  selfRef: operatorversion.aef4455.etcd.com.tectonic.storage
 spec:
   # an install strategy for the operator.
   strategy: 
     type: helm
     helmChart: quay.io/coreos/etcd-operator
     sha256: aef4455
-    values:
-      replicas: 2
+    valuesConfigMap: etcd-operator-values
   resources:
-    - etcds.1.etcd.coreos.com
+    - name: etcds.1.etcd.coreos.com
+      sha256: ffaaee1234
 ```
 
 ### Create the CRDs managed by the operator
@@ -149,25 +149,28 @@ spec:
   size: 3
   version: 3.2.2
   autoMinorVersionUpgrade: True
+  # these are added by the etcd operator
   outputs:
     service-name: etcd-purple-ant.service
 ```
 
-## Adding a new InstallStrategy and Resource
+## Adding a new OperatorVersion and  
 
 ```yaml
 apiVersion: opinstaller.coreos.com/v1beta1
-kind: InstallStrategy 
+kind: OperatorVersion 
 metadata:
-  version: 2
+  version: dbc1122
   # ...
 spec:
   strategy: 
     # ...
-    sha256: aef4455
+    sha256: dbc1122
   resources:
-    - etcds.1.etcd.coreos.com
-    - etcds.2.etcd.coreos.com
+    - name: etcds.1.etcd.coreos.com
+      sha256: ffaaee1234
+    - name: etcds.2.etcd.coreos.com
+      sha256: abababab
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
# Changes

 - Operator field should be repeatable, changed to sha256 ref
 - AppType is now an entity that is referenced by other objects.
 - OperatorVersions reference AppType (`ownerReference`)
 - Operator managed resources now directly reference the the AppType and the OperatorVersion
 - Description added of ALM's reconciliation loops and how that affects discovery and updates.

# Notes

The Readme describes this flow:

 1. install `AppType`
 1. install `OperatorVersion`
 1. install `<>Operator` 
 1. install `App CRD`
 1. install `App CR`

But with the reconciliation loops another option is: 

 1. install `App CRD`
 1. discover latest `OperatorVersion` that supports `App CRD` in catalog
 1. install discovered `OperatorVersion`
 1. install required `AppType` (referenced explicitly in `OperatorVersion`)
 1. install discovered `<>Operator` (defined in `OperatorVersion`)
 1. install `App CR`

This makes dependencies interesting: package authors have the option of spitting out the `App CRD` and/or `App CR` they depend on and letting ALM do the resolution, or explicitly defining the other `AppTypes` it requires upfront.


# Questions

  1. Should ALM be modeled in itself? (i.e. should there be an AppType AppType that specifies the ALM operator install strategy)
      1. Pros: update ALM with same mechanism as everything else
      1. Cons: bootstrapping (but could be sidestepped by including in tectonic installer)
  1. Do we actually just want to have `ARD`s (`ALM Resource Definitions`) instead of CRDs? An `ARD` being a `CRD` that is accepted and managed by the ALM Apiserver. This would allow us to do synchronous `ARD`->`AppType` resolution at `kubectl create` instead of writing a success/fail status back async.
  1. What standards do we place on CRDs managed by operators?
      1. Have an outputs field? A standard format for output in status field?
      1. Require `ownerReference` to ...?
      1. Require `migrateFrom` as a migration standard?