### PR TITLE
Add install strategies

### DIFF
--- a/Documentation/design/resources/almoperator.operatorversion.yaml
+++ b/Documentation/design/resources/almoperator.operatorversion.yaml
@@ -52,5 +52,15 @@ spec:
       resources: ["configmaps"]
       resourceNames: ["cluster-features"]
       verbs: ["get"]
-  installStrategy:
-    todo: EvB
+  install:
+    strategy: deployment
+    deployments:
+      - replicas: 1
+        template:
+          metadata:
+            labels:
+              name: alm-operator
+          spec:
+            containers:
+            - name: alm-operator
+              image: quay.io/coreos/alm-operator:v0.0.1

--- a/Documentation/design/resources/operatorversion.crd.yaml
+++ b/Documentation/design/resources/operatorversion.crd.yaml
@@ -18,7 +18,7 @@ spec:
       - maturity
       - requirements
       - selector
-      - installStrategy
+      - install
       properties:
         version:
           type: string
@@ -174,12 +174,38 @@ spec:
                                 - create
                                 - update
                                 - patch
-                                - delete   
-        installStrategy:
-          # TODO EvB
-          type: object
-          description: Information required to install this specific version of the operato software
+                                - delete  
+                                type: object
 
+        install:
+          type: object
+          description: Information required to install this specific version of the operator software
+          oneOf:
+          - type: object
+            required:
+            - strategy
+            - image
+            properties:
+              strategy: 
+                type: string
+                enum: ['image']
+              image:
+                type: string
+          - type: object
+            required:
+            - strategy
+            - deployments
+            properties:
+              strategy:
+                type: string
+                enum: ['deployment']
+              deployments: 
+                type: array
+                description: List of deployments to create
+                items:
+                - type: object
+                  description: A deployment to create in the cluster 
+        
   names: 
     plural: operatorversion-v1s
     singular: operatorversion-v1

--- a/Documentation/design/resources/samples/etcd/etcdoperator.operatorversion.yaml
+++ b/Documentation/design/resources/samples/etcd/etcdoperator.operatorversion.yaml
@@ -7,9 +7,18 @@ metadata:
   labels:
     alm-owner-etcd: etcd.apptypev1s.app.coreos.com.v1alpha1 
 spec:
-  installStrategy:
-    type: image
-    image: quay.io/coreos/etcd-operator:v0.5.1
+  install:
+    strategy: deployment
+    deployments:
+      - replicas: 1
+        template:
+          metadata:
+            labels:
+              name: etcd-operator
+          spec:
+            containers:
+            - name: etcd-operator
+              image: quay.io/coreos/etcd-operator:v0.5.1
   version: 0.5.1
   replaces: etcdoperator.v0.5.0
   maturity: beta

--- a/Documentation/design/resources/samples/etcd/resolved/etcdoperator.operatorversion.yaml
+++ b/Documentation/design/resources/samples/etcd/resolved/etcdoperator.operatorversion.yaml
@@ -13,9 +13,18 @@ metadata:
     name: etcd
     uid: cccccccc-bbbb-cccc-dddd-eeeeeeeeeeee
 spec:
-  installStrategy:
-    type: image
-    image: quay.io/coreos/etcd-operator:v0.5.1
+  install:
+    strategy: deployment
+    deployments:
+      - replicas: 1
+        template:
+          metadata:
+            labels:
+              name: etcd-operator
+          spec:
+            containers:
+            - name: etcd-operator
+              image: quay.io/coreos/etcd-operator:v0.5.1
   version: 0.5.1
   replaces: etcdoperator.v0.5.0  
   maturity: beta

--- a/Documentation/design/resources/samples/vault/vaultoperator.operatorversion.yaml
+++ b/Documentation/design/resources/samples/vault/vaultoperator.operatorversion.yaml
@@ -6,9 +6,18 @@ metadata:
   labels:
     alm-owner-vault: vault.apptypev1s.app.coreos.com.v1alpha1 
 spec:
-  installStrategy:
-    type: image
-    image: quay.io/coreos/vault-operator:0.0.2
+  install:
+    strategy: deployment
+    deployments:
+      - replicas: 1
+        template:
+          metadata:
+            labels:
+              name: vault-operator
+          spec:
+            containers:
+            - name: vault-operator
+              image: quay.io/coreos/vault-operator:0.0.2
   version: 0.0.2
   maturity: beta
   replaces: vaultoperator.0.0.1


### PR DESCRIPTION
This was easier than trying to rebase and fix. This adds a schema for install strategies.

Punting on validating the deployments for now, ideally we'll be able to reference the schema in the currently running cluster.