### PR TITLE
Add Missing "provider" Field to ClusterServiceVersion

### DIFF
--- a/apis/clusterserviceversion/v1alpha1/types.go
+++ b/apis/clusterserviceversion/v1alpha1/types.go
@@ -62,6 +62,7 @@ type ClusterServiceVersionSpec struct {
 	Description               string                    `json:"description"`
 	Keywords                  []string                  `json:"keywords"`
 	Maintainers               []Maintainer              `json:"maintainers"`
+	Provider									AppLink										`json:"provider"`
 	Links                     []AppLink                 `json:"links"`
 	Icon                      []Icon                    `json:"icon"`
 


### PR DESCRIPTION
This field is present in the `/samples` directory, and important for the UI.