### PR TITLE
Adjust CSV status descriptors for Vault to reflect new status block

### DIFF
--- a/catalog_resources/vaultoperator.clusterserviceversion.yaml
+++ b/catalog_resources/vaultoperator.clusterserviceversion.yaml
@@ -110,47 +110,22 @@ spec:
       displayName: Vault Service
       description: A running Vault instance, backed by an Etcd Cluster
       statusDescriptors:
-        - path: name
-          displayName: ServiceName
-          description: The service name for the running vault cluster.
+        - description: The status of each of the node Pods for the Vault cluster.
+          displayName: Node Status
+          path: nodes
           x-descriptors:
-          - urn:alm:descriptor:io.vaultproject:api.v1
+            - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+        - description: The service at which the running Vault cluster can be accessed.
+          displayName: Service
+          path: serviceName
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Service'
+        - description: The port at which the Vault cluster is running under the service.
+          displayName: Client Port
+          path: clientPort
     required:
     - name: etcdclusters.etcd.database.coreos.com
       version: v1beta2
       kind: EtcdCluster
       displayName: etcd Cluster
       description: Represents a cluster of etcd nodes.
-      statusDescriptors:
-        - path: importantMetrics
-          displayName: Important Metrics
-          description: Important prometheus metrics for the etcd cluster.
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:metrics
-          value:
-            queries:
-            - query: has_leader
-              name: Has Active Leader
-              type: Gauge
-              subtype: boolean
-            - query: leader_changes_seen_total
-              name: Leader Changes
-              type: Counter
-        - path: prometheus
-          displayName: Prometheus Endpoint
-          description: Endpoint of the prometheus instance for the etcd cluster.
-          x-descriptors:
-          - urn:alm:descriptor:io.prometheus:prometheus.v1
-          - urn:alm:descriptor:org.w3:link
-        - path: dashboard
-          displayName: Dashboard
-          description: URL of a Grafana dashboard for the etcd cluster.
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:important.link
-          - urn:alm:descriptor:org.w3:link
-        - path: serviceName
-          displayName: Service Name
-          description: The service name for the running etcd cluster.
-          x-descriptors:
-          - urn:alm:descriptor:com.coreos.etcd:api.v3.grpc
-          - urn:alm:descriptor:com.coreos.etcd:api.v2.rest


### PR DESCRIPTION
Example status block:

```
status:
    clientPort: 8200
    initialized: true
    nodes:
      active: example-vault-1395307387-682n0
      available:
      - example-vault-1395307387-682n0
      - example-vault-1395307387-w7smw
      sealed: null
      standby:
      - example-vault-1395307387-w7smw
      updated:
      - example-vault-1395307387-682n0
      - example-vault-1395307387-w7smw
    serviceName: example-vault
```