### PR TITLE
SpecDescriptors 

### DIFF
--- a/Documentation/design/resources/clusterserviceversion.crd.yaml
+++ b/Documentation/design/resources/clusterserviceversion.crd.yaml
@@ -206,6 +206,33 @@ spec:
                         value:
                           type: object
                           description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+                  specDescriptor:
+                    type: array
+                    items:
+                      type: object
+                      description: A spec for a field in the spec block of the CRD
+                      required:
+                        - path
+                        - displayName
+                        - description
+                      properties:
+                        path:
+                          type: string
+                          description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                        displayName:
+                          type: string
+                          description: A human-readable name for the spec entry.
+                        description:
+                          type: string
+                          description: A description of the spec entry.
+                        x-descriptors:
+                          type: array
+                          description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                          items:
+                            type: string
+                        value:
+                          type: object
+                          description: If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR.
             required:
               type: array
               description: What resources this operator is responsible for managing. No two running operators should manage the same resource.

--- a/catalog_resources/etcdoperator.clusterserviceversion.yaml
+++ b/catalog_resources/etcdoperator.clusterserviceversion.yaml
@@ -107,6 +107,12 @@ spec:
       kind: EtcdCluster
       displayName: etcd Cluster
       description: Represents a cluster of etcd nodes.
+      specDescriptors:
+        - description: The desired number of member Pods for the etcd cluster.
+          displayName: Size
+          path: size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:podCount'
       statusDescriptors:
         - description: The status of each of the member Pods for the etcd cluster.
           displayName: Member Status

--- a/catalog_resources/prometheusoperator.clusterserviceversion.yaml
+++ b/catalog_resources/prometheusoperator.clusterserviceversion.yaml
@@ -128,6 +128,12 @@ spec:
       kind: Prometheus
       displayName: Prometheus
       description: A running Prometheus instance
+      specDescriptors: 
+      - description: Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors: 
+          - 'urn:alm:descriptor:com.tectonic.ui:podCount'
       statusDescriptors:
         - path: status.prometheusSelector
           displayName: Prometheus Service Selector
@@ -154,9 +160,15 @@ spec:
       version: v1
       kind: ServiceMonitor
       displayName: Service Monitor
-      description: Configures prometheus to monitr a particular k8s service
+      description: Configures prometheus to monitor a particular k8s service
     - name: alertmanagers.monitoring.coreos.com
       version: v1
       kind: Alertmanager
       displayName: Alert Manager
       description: Configures an Alert Manager for the namespace
+      specDescriptors: 
+      - description: Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors: 
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'

--- a/catalog_resources/vaultoperator.clusterserviceversion.yaml
+++ b/catalog_resources/vaultoperator.clusterserviceversion.yaml
@@ -109,6 +109,12 @@ spec:
       kind: VaultService
       displayName: Vault Service
       description: A running Vault instance, backed by an Etcd Cluster
+      specDescriptors: 
+        - description: The desired number of Pods for the cluster
+          displayName: Size
+          path: nodes
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:podCount'
       statusDescriptors:
         - description: The status of each of the node Pods for the Vault cluster.
           displayName: Node Status

--- a/pkg/apis/clusterserviceversion/v1alpha1/types.go
+++ b/pkg/apis/clusterserviceversion/v1alpha1/types.go
@@ -35,6 +35,15 @@ type StatusDescriptor struct {
 	Value        json.RawMessage `json:"value,omitempty"`
 }
 
+// SpecDescriptor describes a field in a spec block of a CRD so that ALM can consume it
+type SpecDescriptor struct {
+	Path         string          `json:"path"`
+	DisplayName  string          `json:"displayName,omitempty"`
+	Description  string          `json:"description,omitempty"`
+	XDescriptors []string        `json:"x-descriptors,omitempty"`
+	Value        json.RawMessage `json:"value,omitempty"`
+}
+
 // CRDDescription provides details to ALM about the CRDs
 type CRDDescription struct {
 	Name              string             `json:"name"`
@@ -43,6 +52,7 @@ type CRDDescription struct {
 	DisplayName       string             `json:"displayName,omitempty"`
 	Description       string             `json:"description,omitempty"`
 	StatusDescriptors []StatusDescriptor `json:"statusDescriptors,omitempty"`
+	SpecDescriptors   []SpecDescriptor   `json:"specDescriptors,omitempty"`
 }
 
 // CustomResourceDefinitions declares all of the CRDs managed or required by


### PR DESCRIPTION
### Description

Adds `specDescriptors` block to the custom resource descriptions for a `ClusterServiceVersion`. Schema is identical to `statusDescriptors`, but defines _inputs_ to the custom resource in a way that the Console UI can consume.

Addresses https://jira.prod.coreos.systems/browse/ALM-222