### PR TITLE
pkg/catalog/directory_loader.go: skip hidden nodes

### DIFF
--- a/pkg/catalog/directory_loader.go
+++ b/pkg/catalog/directory_loader.go
@@ -35,6 +35,14 @@ func (d *DirectoryCatalogResourceLoader) LoadCRDsWalkFunc(path string, f os.File
 
 	if f.IsDir() {
 		log.Debugf("Load CRD     -- ISDIR %s", path)
+		if strings.HasPrefix(f.Name(), ".") {
+			log.Debugf("Load CRD     -- SKIPHIDDEN %s", path)
+			return filepath.SkipDir
+		}
+		return nil
+	}
+	if strings.HasPrefix(f.Name(), ".") {
+		log.Debugf("Load CRD     -- SKIPHIDDEN %s", path)
 		return nil
 	}
 	if strings.HasSuffix(path, ".crd.yaml") {
@@ -53,7 +61,15 @@ func (d *DirectoryCatalogResourceLoader) LoadCSVsWalkFunc(path string, f os.File
 	log.Debugf("Load CSV     -- BEGIN %s", path)
 
 	if f.IsDir() {
+		if strings.HasPrefix(f.Name(), ".") {
+			log.Debugf("Load CSV     -- SKIPHIDDEN %s", path)
+			return filepath.SkipDir
+		}
 		log.Debugf("Load CSV     -- ISDIR %s", path)
+		return nil
+	}
+	if strings.HasPrefix(f.Name(), ".") {
+		log.Debugf("Load CSV     -- SKIPHIDDEN %s", path)
 		return nil
 	}
 	if strings.HasSuffix(path, ".clusterserviceversion.yaml") {

--- a/pkg/catalog/directory_loader_test.go
+++ b/pkg/catalog/directory_loader_test.go
@@ -1,6 +1,11 @@
 package catalog
 
 import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,5 +13,41 @@ import (
 
 func TestDirectoryLoader(t *testing.T) {
 	_, err := NewInMemoryFromDirectory("../../catalog_resources")
+	require.NoError(t, err)
+}
+
+func TestDirectoryLoaderHiddenDirs(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	err = os.Mkdir(path.Join(tmpdir, ".hidden_dir"), 0755)
+	require.NoError(t, err)
+
+	dirinfo, err := os.Open("../../catalog_resources")
+	require.NoError(t, err)
+	defer dirinfo.Close()
+
+	dirnames, err := dirinfo.Readdirnames(0)
+	require.NoError(t, err)
+
+	for _, filename := range dirnames {
+		oldfile, err := os.Open(path.Join("../../catalog_resources", filename))
+		require.NoError(t, err)
+		defer oldfile.Close()
+
+		newfile, err := os.Create(path.Join(tmpdir, filename))
+		require.NoError(t, err)
+		defer newfile.Close()
+
+		_, err = io.Copy(newfile, oldfile)
+		require.NoError(t, err)
+
+		if strings.HasSuffix(filename, ".clusterserviceversion.yaml") {
+			err = os.Symlink(path.Join(tmpdir, filename), path.Join(tmpdir, ".hidden_dir", filename))
+			require.NoError(t, err)
+		}
+	}
+	_, err = NewInMemoryFromDirectory(tmpdir)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Chargeback isn't yet ready for being included by default in catalog, so we wanted to provide users with a couple `kubectl` commands to:
- install a configmap holding chargeback's CSVs and CRDs
- patch the catalog deployment to add a volume mount holding these files at `/var/catalog_resources/chargeback`

When I attempted to do this, catalog gave me this error:
```
Error loading in memory catalog from /var/catalog_resources: error loading CSVs from directory /var/catalog_resources: unable to set CSV found in catalog: cannot add CSV chargeback-alm-install.v0.4.5 safely: [CRD reportprometheusqueries.chargeback.coreos.com already managed by chargeback-alm-install.v0.4.5 CRD reportdatastores.chargeback.coreos.com already managed by chargeback-alm-install.v0.4.5 CRD reportgenerationqueries.chargeback.coreos.com already managed by chargeback-alm-install.v0.4.5 CRD reports.chargeback.coreos.com already managed by chargeback-alm-install.v0.4.5]
```

Upon some investigation, the issue is due to Kubernetes creating both the file and a symlink to the file in `/var/catalog_resources/chargeback`:

```
/var/catalog_resources/chargeback # ls -lah
total 48
drwxrwxrwx    3 root     root        4.0K Nov 15 23:21 .
drwxr-xr-x    1 root     root        4.0K Nov 15 23:22 ..
drwxr-xr-x    2 root     root        4.0K Nov 15 23:21 ..119811_15_11_23_21_53.210651805
lrwxrwxrwx    1 root     root          33 Nov 15 23:21 ..data -> ..119811_15_11_23_21_53.210651805
lrwxrwxrwx    1 root     root          44 Nov 15 23:21 chargeback.clusterserviceversion.yaml -> ..data/chargeback.clusterserviceversion.yaml
lrwxrwxrwx    1 root     root          32 Nov 15 23:21 report-datastore.crd.yaml -> ..data/report-datastore.crd.yaml
lrwxrwxrwx    1 root     root          39 Nov 15 23:21 report-generation-query.crd.yaml -> ..data/report-generation-query.crd.yaml
lrwxrwxrwx    1 root     root          39 Nov 15 23:21 report-prometheus-query.crd.yaml -> ..data/report-prometheus-query.crd.yaml
lrwxrwxrwx    1 root     root          22 Nov 15 23:21 report.crd.yaml -> ..data/report.crd.yaml
```

During the CSV loading pass catalog would:
- walk `/var/catalog_resources`
- find `chargeback/..119811_15_11_23_21_53.210651805/chargeback.clusterserviceversion.yaml` and load it successfully
- find `chargeback/chargeback.clusterserviceversion.yaml` and fail to validate it because the CRDs are already owned by `chargeback/..119811_15_11_23_21_53.210651805/chargeback.clusterserviceversion.yaml`

Since this feels like something I should be able to do with Kubernetes, I think the correct solution here is to ignore hidden files/directories during the walk.