### PR TITLE
tectonic-alm-operator: bump operator SHAs

### DIFF
--- a/deploy/tectonic-alm-operator/manifests/0.2.0/09-alm-operator.deployment.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.2.0/09-alm-operator.deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: alm-operator
           command:
           - /bin/alm
-          image: quay.io/coreos/alm@sha256:39f528957d69a5449e4f83126785de73db0452f4da16007531b1867b93c6238b
+          image: quay.io/coreos/alm@sha256:511df7158ca0137c0c3e277f967785caae8223cf3eaf08d5886962861b16b0d8
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/deploy/tectonic-alm-operator/manifests/0.2.0/10-catalog-operator.deployment.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.2.0/10-catalog-operator.deployment.yaml
@@ -25,7 +25,7 @@ spec:
           - /bin/catalog
           - '-namespace'
           - tectonic-system
-          image: quay.io/coreos/catalog@sha256:f86666b37c2611e5b2b4f79bbee5b37f976f4e1e9a45f0c2e29f0b2b6efc7021
+          image: quay.io/coreos/catalog@sha256:d49bca61e937772803eef6b7e4713d70c2df4799a2c41101fb4e1ec4480889f3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
This includes our fix to copy secrets without runtime information.