### PR TITLE
Fix CRD Resources 

### DIFF
--- a/catalog_resources/prometheusoperator.clusterserviceversion.yaml
+++ b/catalog_resources/prometheusoperator.clusterserviceversion.yaml
@@ -162,10 +162,10 @@ spec:
       displayName: Prometheus
       description: A running Prometheus instance
       resources:
-        - kind: Pod
-          version: v1
         - kind: StatefulSet
           version: v1beta2
+        - kind: Pod
+          version: v1
       specDescriptors: 
       - description: Desired number of Pods for the cluster
         displayName: Size
@@ -231,10 +231,10 @@ spec:
       displayName: Alert Manager
       description: Configures an Alert Manager for the namespace
       resources:
-        - kind: Pod
-          version: v1
         - kind: StatefulSet
           version: v1beta2
+        - kind: Pod
+          version: v1
       specDescriptors: 
       - description: Desired number of Pods for the cluster
         displayName: Size

--- a/catalog_resources/vaultoperator.clusterserviceversion.yaml
+++ b/catalog_resources/vaultoperator.clusterserviceversion.yaml
@@ -132,10 +132,12 @@ spec:
           version: v1
         - kind: Secret
           version: v1
-        - kind: Pod
-          version: v1
+        - kind: Deployment
+          version: v1beta2
         - kind: ReplicaSet
           version: v1beta2
+        - kind: Pod
+          version: v1
       specDescriptors:
         - description: The desired number of Pods for the cluster
           displayName: Size


### PR DESCRIPTION
### Description

Needed to get "Resources" list view to show all `Pods` using `ownerReferences` more than 2 levels deep.