### PR TITLE
operators/catalog: only add catalogsources once

### DIFF
--- a/pkg/apis/installplan/v1alpha1/types.go
+++ b/pkg/apis/installplan/v1alpha1/types.go
@@ -214,6 +214,18 @@ type InstallPlan struct {
 	Status InstallPlanStatus `json:"status"`
 }
 
+// EnsureCatalogSource ensures that a CatalogSource is present in the Status
+// block of an InstallPlan.
+func (p *InstallPlan) EnsureCatalogSource(catalogSourceName string) {
+	for _, source := range p.Status.CatalogSources {
+		if source == catalogSourceName {
+			return
+		}
+	}
+
+	p.Status.CatalogSources = append(p.Status.CatalogSources, catalogSourceName)
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type InstallPlanList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/operators/catalog/operator.go
+++ b/pkg/operators/catalog/operator.go
@@ -253,7 +253,7 @@ func (o *Operator) ResolvePlan(plan *v1alpha1.InstallPlan) error {
 
 	for sourceName, source := range o.sources {
 		log.Debugf("resolving against source %v", sourceName)
-		plan.Status.CatalogSources = append(plan.Status.CatalogSources, sourceName)
+		plan.EnsureCatalogSource(sourceName)
 		err := resolveInstallPlan(source, plan)
 		if err != nil {
 			return err


### PR DESCRIPTION
This fixes the scenario where an InstallPlan crash loops and continues
to append the same CatalogSource to the Status field.