### PR TITLE
Fix parameter count comparisons

### DIFF
--- a/Documentation/install/install_local.sh
+++ b/Documentation/install/install_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ ${#@} < 2 ]; then
+if [[ ${#@} < 2 ]]; then
     echo "Usage: $0 namespace chart"
     echo "* namespace: namespace to install into"
     echo "* chart: directory of chart to install"

--- a/deploy/tectonic-alm-operator/package-release.sh
+++ b/deploy/tectonic-alm-operator/package-release.sh
@@ -2,7 +2,7 @@
 
 # requires helm to be installed
 
-if [ ${#@} < 4 ]; then
+if [[ ${#@} < 3 ]]; then
     echo "Usage: $0 version alm-sha catalog-sha"
     echo "* semver: semver-formatted version for this package"
     echo "* chart: the directory to output the chart"


### PR DESCRIPTION
The comparison needs to be wrapped in another set of `[]`:

```
./deploy/tectonic-alm-operator/package-release.sh: line 5: 4: No such file or directory
```