### PR TITLE
[e2e] Add a test for InstallPlans with manual approval

### DIFF
--- a/e2e/alm_e2e_test.go
+++ b/e2e/alm_e2e_test.go
@@ -87,3 +87,74 @@ func TestCreateInstallPlan(t *testing.T) {
 
 	//TODO: poll for creation of other resources
 }
+
+// This test is skipped until manual approval is implemented
+func TestCreateInstallPlanManualApproval(t *testing.T) {
+	c := newKubeClient(t)
+
+	vaultInstallPlan := installplanv1alpha1.InstallPlan{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       installplanv1alpha1.InstallPlanKind,
+			APIVersion: installplanv1alpha1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "install-vaultmanual",
+			Namespace: testNamespace,
+		},
+		Spec: installplanv1alpha1.InstallPlanSpec{
+			ClusterServiceVersionNames: []string{"vault-operator.0.1.5"},
+			Approval:                   installplanv1alpha1.ApprovalManual,
+		},
+	}
+
+	// Create a new installplan for vault with manual approval
+	unstructuredConverter := conversion.NewConverter(true)
+	vaultUnst, err := unstructuredConverter.ToUnstructured(&vaultInstallPlan)
+	require.NoError(t, err)
+	err = c.CreateCustomResource(&unstructured.Unstructured{Object: vaultUnst})
+	require.NoError(t, err)
+
+	// Get InstallPlan and verify status
+	fetchedInstallPlan := &installplanv1alpha1.InstallPlan{}
+	wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		fetchedInstallPlanUnst, err := c.GetCustomResource(apis.GroupName, installplanv1alpha1.GroupVersion, testNamespace, installplanv1alpha1.InstallPlanKind, vaultInstallPlan.GetName())
+		if err != nil {
+			return false, err
+		}
+		err = unstructuredConverter.FromUnstructured(fetchedInstallPlanUnst.Object, fetchedInstallPlan)
+		require.NoError(t, err)
+		if fetchedInstallPlan.Status.Phase != installplanv1alpha1.InstallPlanPhaseComplete {
+			t.Log("waiting for installplan phase to complete")
+			return false, nil
+		}
+		return true, nil
+	})
+	require.Equal(t, installplanv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
+
+	vaultResourcesPresent := 0
+
+	// Step through the InstallPlan and check if resources have been created
+	for _, step := range fetchedInstallPlan.Status.Plan {
+		t.Logf("Verifiying that %s %s is not present", step.Resource.Kind, step.Resource.Name)
+		if step.Resource.Kind == "CustomResourceDefinition" {
+				_, err := c.GetCustomResourceDefinition(step.Resource.Name)
+
+				require.NoError(t, err)
+				vaultResourcesPresent++
+			} else if step.Resource.Kind == "ClusterServiceVersion-v1" {
+				_, err := c.GetCustomResource(apis.GroupName, installplanv1alpha1.GroupVersion, testNamespace, step.Resource.Kind, step.Resource.Name)
+
+				require.NoError(t, err)
+				vaultResourcesPresent++
+			} else if step.Resource.Kind == "Secret" {
+				_, err := c.KubernetesInterface().CoreV1().Secrets(testNamespace).Get(step.Resource.Name, metav1.GetOptions{})
+
+				require.NoError(t, err)
+			}
+		}
+
+	// Result: Ensure that the InstallPlan actually creates no vault resources
+	t.Skip()
+	t.Logf("%d Vault Resources present", vaultResourcesPresent)
+	require.Zero(t, vaultResourcesPresent)
+}

--- a/e2e/run_e2e_local.sh
+++ b/e2e/run_e2e_local.sh
@@ -35,4 +35,4 @@ trap cleanupAndExit SIGINT SIGTERM EXIT
 
 ./Documentation/install/install_local.sh ${namespace} e2e/resources
 
-KUBECONFIG=~/.kube/config NAMESPACE=${namespace} go test -v ./e2e/...
+KUBECONFIG=~/.kube/config NAMESPACE=${namespace} go test -v ./e2e/... ${1/[[:alnum:]-]*/-run ${1}}


### PR DESCRIPTION
Test: As an infra owner, creating an installplan with “approval: manual”
should have a resolved status block but should not create any
other resources.

**This test is commented out as it will fail until manual approval
is actually implemented in ALM.**