### PR TITLE
fix(package-release): use gnu compatible cp options

### DIFF
--- a/deploy/tectonic-alm-operator/package-release.sh
+++ b/deploy/tectonic-alm-operator/package-release.sh
@@ -15,10 +15,10 @@ chartdir=$2
 values=$3
 
 charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`
-mkdir ${charttmpdir}/chart
+
 charttmpdir=${charttmpdir}/chart
 
-cp -R deploy/chart/kube-1.8/ ${charttmpdir}/
+cp -R deploy/chart/kube-1.8/ ${charttmpdir}
 echo "version: $1" >> ${charttmpdir}/Chart.yaml
 
 mkdir ${chartdir}


### PR DESCRIPTION
Ensure directories are copied correctly using MacOS's default `cp` or the `cp` packaged with GNU tools. The GNU version treats the second argument as the target directory if it is an existing directory, rather than as a normal file. This causes the source directory to be nested in, rather than renamed as, the destination directory. When the destination directory doesn't exist, the behaviors between versions are identical.