### PR TITLE
deploy/TAO: use stable release of x-operator

### DIFF
--- a/deploy/tectonic-alm-operator/Dockerfile
+++ b/deploy/tectonic-alm-operator/Dockerfile
@@ -1,4 +1,3 @@
-# Update to quay.io address when new release made
-FROM quay.io/coreos/tectonic-x-operator:54972b1e
-LABEL maintainer="CoreOS Apps Team <team-apps@coreos.com>"
+FROM quay.io/coreos/tectonic-x-operator:lithium
+LABEL maintainer="CoreOS Apps Team <team-apps-members@coreos.com>"
 COPY manifests /manifests

--- a/deploy/tectonic-alm-operator/examples/appversion.yaml
+++ b/deploy/tectonic-alm-operator/examples/appversion.yaml
@@ -8,4 +8,4 @@ metadata:
   annotations:
     tectonic-operators.coreos.com/upgrade-behaviour: "CreateOrUpgrade"
 spec:
-  desiredVersion: 0.2.0
+  desiredVersion: 0.2.1

--- a/deploy/tectonic-alm-operator/examples/operator.yaml
+++ b/deploy/tectonic-alm-operator/examples/operator.yaml
@@ -22,10 +22,10 @@ spec:
         - name: coreos-pull-secret
       containers:
       - name: tectonic-alm-operator
-        image: quay.io/coreos/tectonic-alm-operator:latest
+        image: quay.io/coreos/tectonic-alm-operator:v0.2.1-lithium
         imagePullPolicy: Always
-        command:
-        - /tectonic-x-operator
+        args:
+        - --manifest-dir=/manifests
         - --operator-name=tectonic-alm-operator
         - --appversion-name=tectonic-alm-operator
         - --v=2


### PR DESCRIPTION
This should also allow tectonic-alm-operator to run when SELinux is
enabled.