### PR TITLE
Update EtcdCluster CRD Description

### DIFF
--- a/catalog_resources/etcdoperator.clusterserviceversion.yaml
+++ b/catalog_resources/etcdoperator.clusterserviceversion.yaml
@@ -158,7 +158,7 @@ spec:
             - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
         - description: The service at which the running etcd cluster can be accessed.
           displayName: Service
-          path: service
+          path: serviceName
           x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:Service'
         - description: The current size of the etcd cluster.


### PR DESCRIPTION
### Description

Updates the `path` for the `EtcdCluster` service status descriptor (https://github.com/coreos/etcd-operator/blob/master/pkg/apis/etcd/v1beta2/status.go#L55).