### PR TITLE
Update VaultService Status Descriptor for clientPort

### DIFF
--- a/catalog_resources/vaultoperator.clusterserviceversion.yaml
+++ b/catalog_resources/vaultoperator.clusterserviceversion.yaml
@@ -168,6 +168,8 @@ spec:
         - description: The port at which the Vault cluster is running under the service.
           displayName: Client Port
           path: clientPort
+          x-descriptors: 
+            - 'urn:alm:descriptor:text'
     required:
     - name: etcdclusters.etcd.database.coreos.com
       version: v1beta2

--- a/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
@@ -746,6 +746,8 @@ data:
               - description: The port at which the Vault cluster is running under the service.
                 displayName: Client Port
                 path: clientPort
+                x-descriptors:
+                  - 'urn:alm:descriptor:text'
           required:
           - name: etcdclusters.etcd.database.coreos.com
             version: v1beta2

--- a/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
@@ -746,6 +746,8 @@ data:
               - description: The port at which the Vault cluster is running under the service.
                 displayName: Client Port
                 path: clientPort
+                x-descriptors:
+                  - 'urn:alm:descriptor:text'
           required:
           - name: etcdclusters.etcd.database.coreos.com
             version: v1beta2


### PR DESCRIPTION
### Description

Tectonic Console UI needs at least one `x-descriptor` to display a status descriptor.

### Screenshots

![screenshot_20180105_161704](https://user-images.githubusercontent.com/11700385/34628851-be542fe0-f21a-11e7-94f7-6c1efe3fb4fd.png)
