### PR TITLE
Label OCS ClusterServiceVersion Templates

### DIFF
--- a/catalog_resources/etcdoperator.clusterserviceversion.yaml
+++ b/catalog_resources/etcdoperator.clusterserviceversion.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
+  labels: 
+    alm-catalog: tectonic-ocs
 spec:
   displayName: etcd
   description: |

--- a/catalog_resources/prometheusoperator.clusterserviceversion.yaml
+++ b/catalog_resources/prometheusoperator.clusterserviceversion.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
+  labels: 
+    alm-catalog: tectonic-ocs
 spec:
   displayName: Prometheus
   description: |

--- a/catalog_resources/vaultoperator.clusterserviceversion.yaml
+++ b/catalog_resources/vaultoperator.clusterserviceversion.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
+  labels:
+    alm-catalog: tectonic-ocs
 spec:
   displayName: Vault
   description: |

--- a/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
@@ -153,6 +153,8 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+        labels:
+          alm-catalog: tectonic-ocs
       spec:
         displayName: etcd
         description: |
@@ -335,6 +337,8 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+        labels:
+          alm-catalog: tectonic-ocs
       spec:
         displayName: Prometheus
         description: |
@@ -589,6 +593,8 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+        labels:
+          alm-catalog: tectonic-ocs
       spec:
         displayName: Vault
         description: |

--- a/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
@@ -153,6 +153,8 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+        labels:
+          alm-catalog: tectonic-ocs
       spec:
         displayName: etcd
         description: |
@@ -335,6 +337,8 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+        labels:
+          alm-catalog: tectonic-ocs
       spec:
         displayName: Prometheus
         description: |
@@ -589,6 +593,8 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+        labels:
+          alm-catalog: tectonic-ocs
       spec:
         displayName: Vault
         description: |


### PR DESCRIPTION
### Description

Adds a `alm-catalog: tectonic-ocs` label to each OCS template to enable server-side filtering for the UI. 

Addresses https://jira.coreos.com/browse/ALM-395