### PR TITLE
Rename and export FindReplacementCSVForName method

### DIFF
--- a/pkg/catalog/mem.go
+++ b/pkg/catalog/mem.go
@@ -216,8 +216,8 @@ func (m *InMem) FindCSVByName(name string) (*v1alpha1.ClusterServiceVersion, err
 	return &csv, nil
 }
 
-// findReplacementForName looks up any CSV in the catalog that replaces the given xservice
-func (m *InMem) findReplacementForName(name string) (*v1alpha1.ClusterServiceVersion, error) {
+// FindReplacementCSVForCSVName looks up any CSV in the catalog that replaces the given CSV, if any.
+func (m *InMem) FindReplacementCSVForName(name string) (*v1alpha1.ClusterServiceVersion, error) {
 	csvMetadata, ok := m.replaces[name]
 	if !ok {
 		return nil, fmt.Errorf("not found: ClusterServiceVersion that replaces %s", name)

--- a/pkg/catalog/mem_test.go
+++ b/pkg/catalog/mem_test.go
@@ -80,7 +80,7 @@ func TestFindClusterServiceVersionByNameAndVersion(t *testing.T) {
 	compareResources(t, &testCSVResource, foundCSV)
 }
 
-func TestFindReplacementByName(t *testing.T) {
+func TestFindReplacementCSVForName(t *testing.T) {
 	var (
 		testCSVName = "mockservice-operator.stable"
 
@@ -126,7 +126,7 @@ func TestFindReplacementByName(t *testing.T) {
 	catalog.AddOrReplaceService(testCSVResourceLatest)
 	catalog.AddOrReplaceService(otherTestCSVResource)
 
-	foundCSV, err := catalog.findReplacementForName(testReplacesName)
+	foundCSV, err := catalog.FindReplacementCSVForName(testReplacesName)
 	assert.NoError(t, err)
 	assert.Equal(t, testCSVName, foundCSV.GetName())
 	assert.Equal(t, testCSVLatestVersion, foundCSV.Spec.Version.String(),

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -7,11 +7,13 @@ import (
 )
 
 // Catalog Source
-//    - Map name to AppTypeClusterServiceVersion
+//    - Map name to ClusterServiceVersion
 //    - Map CRD to CRD definition
-//    - Map CRD to AppTypeClusterServiceVersion that manages it
+//    - Map CRD to ClusterServiceVersion that manages it
 
 type Source interface {
+	FindReplacementCSVForName(name string) (*v1alpha1.ClusterServiceVersion, error)
+
 	FindCSVByName(name string) (*v1alpha1.ClusterServiceVersion, error)
 	ListServices() ([]v1alpha1.ClusterServiceVersion, error)
 


### PR DESCRIPTION
Will be used to determine whether a CSV should be replaced