### PR TITLE
Add concept of packages to catalog, for tracking of services at a grouped level

### DIFF
--- a/catalog_resources/etcd.package.yaml
+++ b/catalog_resources/etcd.package.yaml
@@ -1,0 +1,5 @@
+#! package-manifest: ../../catalog_resources/etcdoperator.clusterserviceversion.yaml
+packageName: etcd
+channels:
+- name: alpha
+  currentCSV: etcdoperator.v0.7.2

--- a/catalog_resources/prometheus.package.yaml
+++ b/catalog_resources/prometheus.package.yaml
@@ -1,0 +1,5 @@
+#! package-manifest: ../../catalog_resources/prometheusoperator.clusterserviceversion.yaml
+packageName: prometheus
+channels:
+- name: alpha
+  currentCSV: prometheusoperator.0.15.0

--- a/catalog_resources/vault.package.yaml
+++ b/catalog_resources/vault.package.yaml
@@ -1,0 +1,5 @@
+#! package-manifest: ../../catalog_resources/vaultoperator.clusterserviceversion.yaml
+packageName: vault
+channels:
+- name: alpha
+  currentCSV: vault-operator.0.1.6

--- a/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
@@ -820,3 +820,16 @@ data:
                 path: reason
                 x-descriptors:
                   - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+  packages: |-
+    - packageName: etcd
+      channels:
+      - name: alpha
+        currentCSV: etcdoperator.v0.7.2
+    - packageName: prometheus
+      channels:
+      - name: alpha
+        currentCSV: prometheusoperator.0.15.0
+    - packageName: vault
+      channels:
+      - name: alpha
+        currentCSV: vault-operator.0.1.6

--- a/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
@@ -820,3 +820,16 @@ data:
                 path: reason
                 x-descriptors:
                   - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+  packages: |-
+    - packageName: etcd
+      channels:
+      - name: alpha
+        currentCSV: etcdoperator.v0.7.2
+    - packageName: prometheus
+      channels:
+      - name: alpha
+        currentCSV: prometheusoperator.0.15.0
+    - packageName: vault
+      channels:
+      - name: alpha
+        currentCSV: vault-operator.0.1.6

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -12,6 +12,11 @@ import (
 //    - Map CRD to ClusterServiceVersion that manages it
 
 type Source interface {
+	FindCSVForPackageNameUnderChannel(packageName string, channelName string) (*v1alpha1.ClusterServiceVersion, error)
+	FindReplacementCSVForPackageNameUnderChannel(packageName string, channelName string, csvName string) (*v1alpha1.ClusterServiceVersion, error)
+
+	// Deprecated: Switch to FindReplacementCSVForPackageNameUnderChannel when the caller has package and channel
+	// information.
 	FindReplacementCSVForName(name string) (*v1alpha1.ClusterServiceVersion, error)
 
 	FindCSVByName(name string) (*v1alpha1.ClusterServiceVersion, error)
@@ -26,4 +31,25 @@ type Source interface {
 type CSVMetadata struct {
 	Name    string
 	Version string
+}
+
+// PackageManifest holds information about a package, which is a reference to one (or more)
+// channels under a single package.
+type PackageManifest struct {
+	// PackageName is the name of the overall package, ala `etcd`.
+	PackageName string `json:"packageName"`
+
+	// Channels are the declared channels for the package, ala `stable` or `alpha`.
+	Channels []PackageChannel `json:"channels"`
+}
+
+// PackageChannel defines a single channel under a package, pointing to a version of that
+// package.
+type PackageChannel struct {
+	// Name is the name of the channel, e.g. `alpha` or `stable`
+	Name string `json:"name"`
+
+	// CurrentCSVName defines a reference to the CSV holding the version of this package currently
+	// for the channel.
+	CurrentCSVName string `json:"currentCSV"`
 }

--- a/scripts/build_catalog_configmap.sh
+++ b/scripts/build_catalog_configmap.sh
@@ -34,3 +34,14 @@ do
   tail -n +4 $csv | sed 's/^/      /' >> $OUTFILE
   sed -E -i.bak 's/[[:space:]]*$//' $OUTFILE # trim trailing whitespace
 done
+
+printf '  packages: |-\n' >> $OUTFILE
+
+for csv in catalog_resources/*.package.yaml
+do
+  printf "    - " >> $OUTFILE
+  head -n 2 $csv | tail -n 1 >> $OUTFILE
+  # need -i.bak for mac/linux cross-compat
+  tail -n +3 $csv | sed 's/^/      /' >> $OUTFILE
+  sed -E -i.bak 's/[[:space:]]*$//' $OUTFILE # trim trailing whitespace
+done


### PR DESCRIPTION
Adds support in the catalog for packages, defined in manifests in the catalog, which map a "package" via a channel to a CSV. Will be used for easy upgrading in subscriptions.