### PR TITLE
Resource Requirements Spec Descriptor for etcd OCS

### DIFF
--- a/catalog_resources/etcdoperator.clusterserviceversion.yaml
+++ b/catalog_resources/etcdoperator.clusterserviceversion.yaml
@@ -154,6 +154,11 @@ spec:
           path: size
           x-descriptors:
             - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+        - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+          displayName: Resource Requirements
+          path: pod.resources
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
       statusDescriptors:
         - description: The status of each of the member Pods for the etcd cluster.
           displayName: Member Status

--- a/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
@@ -300,6 +300,11 @@ data:
                 path: size
                 x-descriptors:
                   - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
             statusDescriptors:
               - description: The status of each of the member Pods for the etcd cluster.
                 displayName: Member Status

--- a/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
@@ -300,6 +300,11 @@ data:
                 path: size
                 x-descriptors:
                   - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
             statusDescriptors:
               - description: The status of each of the member Pods for the etcd cluster.
                 displayName: Member Status


### PR DESCRIPTION
### Description

Adds `ResourceRequirement` spec descriptor for etcd OCS.

### Screenshots

![screenshot_20180112_163632](https://user-images.githubusercontent.com/11700385/34896244-0ebbc352-f7b7-11e7-9dab-686597248d17.png)
