### PR TITLE
Spec/Status Descriptors for Vault's EtcdCluster

### DIFF
--- a/catalog_resources/vaultoperator.clusterserviceversion.yaml
+++ b/catalog_resources/vaultoperator.clusterserviceversion.yaml
@@ -178,3 +178,49 @@ spec:
       kind: EtcdCluster
       displayName: etcd Cluster
       description: Represents a cluster of etcd nodes.
+      resources:
+        - kind: Service
+          version: v1
+        - kind: Pod
+          version: v1
+      specDescriptors:
+        - description: The desired number of member Pods for the etcd cluster.
+          displayName: Size
+          path: size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+        - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+          displayName: Resource Requirements
+          path: pod.resources
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      statusDescriptors:
+        - description: The status of each of the member Pods for the etcd cluster.
+          displayName: Member Status
+          path: members
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+        - description: The service at which the running etcd cluster can be accessed.
+          displayName: Service
+          path: serviceName
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Service'
+        - description: The current size of the etcd cluster.
+          displayName: Cluster Size
+          path: size
+        - description: The current version of the etcd cluster.
+          displayName: Current Version
+          path: currentVersion
+        - description: The target version of the etcd cluster, after upgrading.
+          displayName: Target Version
+          path: targetVersion
+        - description: The current status of the etcd cluster.
+          displayName: Status
+          path: phase
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase'
+        - description: Explanation for the current status of the cluster.
+          displayName: Status Details
+          path: reason
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase:reason'

--- a/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.7/templates/tectonicocs.configmap.yaml
@@ -774,3 +774,49 @@ data:
             kind: EtcdCluster
             displayName: etcd Cluster
             description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: The target version of the etcd cluster, after upgrading.
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'

--- a/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
+++ b/deploy/chart/kube-1.8/templates/08-tectonicocs.configmap.yaml
@@ -774,3 +774,49 @@ data:
             kind: EtcdCluster
             displayName: etcd Cluster
             description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: The target version of the etcd cluster, after upgrading.
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'


### PR DESCRIPTION
### Description

Poor UI as a result of missing spec/status descriptors, as well as no `ownerRef`'ed resources.

### Screenshots 

**Before (detail):**
![screenshot_20180113_172510](https://user-images.githubusercontent.com/11700385/34910638-a450b500-f887-11e7-8e2a-1d72d1af7d9f.png)

**After (detail):**
![screenshot_20180113_172955](https://user-images.githubusercontent.com/11700385/34910641-a8b84428-f887-11e7-94a3-056ffa900ed8.png)

**After (resource list):**
![screenshot_20180113_173319](https://user-images.githubusercontent.com/11700385/34910655-dfe47b88-f887-11e7-85bf-98699c584ccd.png)

Addresses https://jira.coreos.com/browse/ALM-412
