### PR TITLE
fix(operators/catalog): don't update catalogsource status when processed

### DIFF
--- a/pkg/operators/catalog/operator.go
+++ b/pkg/operators/catalog/operator.go
@@ -222,11 +222,6 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 	defer o.sourcesLock.Unlock()
 	o.sources[catsrc.Spec.Name] = src
 	o.sourcesLastUpdate = timeNow()
-	catsrc.Status = catsrcv1alpha1.CatalogSourceStatus{
-		LastSync: o.sourcesLastUpdate,
-		// TODO store ConfigMapResource reference info in status
-	}
-	_, err = o.catsrcClient.UpdateCS(catsrc)
 	return err
 }
 


### PR DESCRIPTION
Removing this for now since it causes a very fast loop in the catalog, and we're not using it anywhere at the moment.