### PR TITLE
Reduce CSV update frequency ALM-458

### DIFF
--- a/pkg/operators/alm/operator.go
+++ b/pkg/operators/alm/operator.go
@@ -314,7 +314,9 @@ func (a *ALMOperator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, i
 	installed, strategyErr := installer.CheckInstalled(strategy)
 	if installed {
 		// if there's no error, we're successfully running
-		csv.SetPhase(v1alpha1.CSVPhaseSucceeded, v1alpha1.CSVReasonInstallSuccessful, "install strategy completed with no errors")
+		if csv.Status.Phase != v1alpha1.CSVPhaseSucceeded {
+			csv.SetPhase(v1alpha1.CSVPhaseSucceeded, v1alpha1.CSVReasonInstallSuccessful, "install strategy completed with no errors")
+		}
 		return nil
 	}
 

--- a/pkg/operators/alm/operator_test.go
+++ b/pkg/operators/alm/operator_test.go
@@ -951,8 +951,9 @@ func TestCSVStateTransitionsFromSucceeded(t *testing.T) {
 					},
 				}),
 				&v1alpha1.ClusterServiceVersionStatus{
-					Phase:  v1alpha1.CSVPhaseSucceeded,
-					Reason: v1alpha1.CSVReasonInstallSuccessful,
+					Phase:   v1alpha1.CSVPhaseSucceeded,
+					Message: "install strategy completed with no errors",
+					Reason:  v1alpha1.CSVReasonInstallSuccessful,
 				}),
 			out: withStatus(withSpec(testCSV(""),
 				&v1alpha1.ClusterServiceVersionSpec{


### PR DESCRIPTION
We were updating even when the status remained the same. For our cluster this looks like it's only getting updated once every few minutes, but on the testui cluster it was happening ~30s. Let's take alm out of the equation by not updating the timestamp if nothing has changed.