### PR TITLE
Ensure Subscriptions Labeled with Package Metadata

### DIFF
--- a/pkg/operators/catalog/subscriptions.go
+++ b/pkg/operators/catalog/subscriptions.go
@@ -15,10 +15,26 @@ var (
 	ErrNilSubscription = errors.New("invalid Subscription object: <nil>")
 )
 
+const (
+	PackageLabel = "alm-package"
+	CatalogLabel = "alm-catalog"
+	ChannelLabel = "alm-channel"
+)
+
 func (o *Operator) syncSubscription(sub *v1alpha1.Subscription) error {
 	if sub == nil || sub.Spec == nil {
 		return ErrNilSubscription
 	}
+
+	labels := sub.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[PackageLabel] = sub.Spec.Package
+	labels[CatalogLabel] = sub.Spec.CatalogSource
+	labels[ChannelLabel] = sub.Spec.Channel
+	sub.SetLabels(labels)
+
 	// only sync if catalog has been updated since last sync time
 	if o.sourcesLastUpdate.Before(&sub.Status.LastUpdated) {
 		log.Infof("skipping sync: no new updates to catalog since last sync at %s",

--- a/pkg/operators/catalog/subscriptions_test.go
+++ b/pkg/operators/catalog/subscriptions_test.go
@@ -696,7 +696,9 @@ func TestSyncSubscription(t *testing.T) {
 				defer func() {
 					require.Equal(t, 1, subscriptionClientFake.UpdateSubscriptionCallCount())
 					sub := subscriptionClientFake.UpdateSubscriptionArgsForCall(0)
-					require.Equal(t, tt.expected.subscription, sub)
+					require.Equal(t, map[string]string{PackageLabel: "rainbows", CatalogLabel: "flying-unicorns", ChannelLabel: "magical"}, sub.GetLabels())
+					require.Equal(t, tt.expected.subscription.Spec, sub.Spec)
+					require.Equal(t, tt.expected.subscription.Status, sub.Status)
 				}()
 				subscriptionClientFake.UpdateSubscriptionReturns(nil, tt.initial.updateSubscriptionError)
 			}


### PR DESCRIPTION
### Description
The Catalog Operator ensures that created `Subscription-v1s` are labeled with the following: 
```
"alm-package": spec.name,
"alm-catalog": spec.source,
"alm-channel": spec.channel
```
This enables server-side filtering and better UX for `kubectl` and UI.

Addresses https://jira.coreos.com/browse/ALM-452