### PR TITLE
Example Custom Resources as Annotations

### DIFF
--- a/catalog_resources/etcdoperator.v0.9.0.clusterserviceversion.yaml
+++ b/catalog_resources/etcdoperator.v0.9.0.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
+    alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1alpha1","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3}}]'
 spec:
   displayName: etcd
   description: |

--- a/catalog_resources/prometheusoperator.0.15.0.clusterserviceversion.yaml
+++ b/catalog_resources/prometheusoperator.0.15.0.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
 spec:
   replaces: prometheusoperator.0.14.0
   displayName: Prometheus

--- a/catalog_resources/vaultoperator.0.1.9.clusterserviceversion.yaml
+++ b/catalog_resources/vaultoperator.0.1.9.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: placeholder
   annotations:
     tectonic-visibility: ocs
+    alm-examples: '[{"apiVersion":"vault.security.coreos.com/v1alpha1","kind":"VaultService","metadata":{"name":"example"},"spec":{"nodes":2,"version":"0.9.1-0"}}]'
   labels:
     alm-catalog: tectonic-ocs
 spec:

--- a/deploy/chart/templates/08-tectonicocs.configmap.yaml
+++ b/deploy/chart/templates/08-tectonicocs.configmap.yaml
@@ -759,6 +759,7 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1alpha1","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3}}]'
       spec:
         displayName: etcd
         description: |
@@ -1271,6 +1272,7 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
       spec:
         replaces: prometheusoperator.0.14.0
         displayName: Prometheus
@@ -1530,6 +1532,7 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"vault.security.coreos.com/v1alpha1","kind":"VaultService","metadata":{"name":"example"},"spec":{"nodes":2,"version":"0.9.1-0"}}]'
         labels:
           alm-catalog: tectonic-ocs
       spec:

--- a/deploy/tectonic-alm-operator/manifests/0.3.0/08-tectonicocs.configmap.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.3.0/08-tectonicocs.configmap.yaml
@@ -761,6 +761,7 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1alpha1","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3}}]'
       spec:
         displayName: etcd
         description: |
@@ -1273,6 +1274,7 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
       spec:
         replaces: prometheusoperator.0.14.0
         displayName: Prometheus
@@ -1532,6 +1534,7 @@ data:
         namespace: placeholder
         annotations:
           tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"vault.security.coreos.com/v1alpha1","kind":"VaultService","metadata":{"name":"example"},"spec":{"nodes":2,"version":"0.9.1-0"}}]'
         labels:
           alm-catalog: tectonic-ocs
       spec:


### PR DESCRIPTION
### Description
Stores the example custom resource instances for a given `ClusterServiceVersion` as a JSON annotation. This enables all types of clients (GUI, `kubectl`) to view examples, as well as the added benefit of versioning the examples to match their `ClusterServiceVersion`.

Resolves https://jira.coreos.com/browse/ALM-397