### PR TITLE
Clarify Status Condition when Catalog Source Not Found

### DIFF
--- a/e2e/alm_e2e_test.go
+++ b/e2e/alm_e2e_test.go
@@ -148,7 +148,7 @@ func TestCreateInstallPlanManualApproval(t *testing.T) {
 	require.Zero(t, vaultResourcesPresent)
 }
 
-// This captures the current state of ALM where Failed InstallPlans aren't implemented and should be removed in the future
+// This captures the current state of OLM where Failed InstallPlans aren't implemented and should be removed in the future
 func TestCreateInstallPlanFromInvalidClusterServiceVersionNameExistingBehavior(t *testing.T) {
 	c := newKubeClient(t)
 
@@ -179,10 +179,9 @@ func TestCreateInstallPlanFromInvalidClusterServiceVersionNameExistingBehavior(t
 	})
 
 	// InstallPlans don't have a failed status, they end up in a Planning state with a "false" resolved state
-	require.Equal(t, fetchedInstallPlan.Status.Conditions[0].Type, installplanv1alpha1.InstallPlanResolved)
-	require.Equal(t, fetchedInstallPlan.Status.Conditions[0].Status, corev1.ConditionFalse)
-	require.Equal(t, fetchedInstallPlan.Status.Conditions[0].Reason, installplanv1alpha1.InstallPlanReasonDependencyConflict)
-
+	require.Equal(t, installplanv1alpha1.InstallPlanResolved, fetchedInstallPlan.Status.Conditions[0].Type)
+	require.Equal(t, corev1.ConditionFalse, fetchedInstallPlan.Status.Conditions[0].Status)
+	require.Equal(t, installplanv1alpha1.InstallPlanReasonInstallCheckFailed, fetchedInstallPlan.Status.Conditions[0].Reason)
 }
 
 // As an infra owner, creating an installplan with a clusterServiceVersionName that does not exist in the catalog should result in a “Failed” status
@@ -213,5 +212,5 @@ func TestCreateInstallPlanFromInvalidClusterServiceVersionName(t *testing.T) {
 	fetchedInstallPlan, err := fetchInstallPlan(t, c, installPlan.GetName(), installPlanFailedChecker)
 	require.NoError(t, err)
 
-	require.Equal(t, fetchedInstallPlan.Status.Phase, installplanv1alpha1.InstallPlanPhaseFailed)
+	require.Equal(t, installplanv1alpha1.InstallPlanPhaseFailed, fetchedInstallPlan.Status.Phase)
 }

--- a/pkg/api/apis/installplan/v1alpha1/types.go
+++ b/pkg/api/apis/installplan/v1alpha1/types.go
@@ -63,9 +63,9 @@ type InstallPlanConditionReason string
 
 const (
 	InstallPlanReasonPlanUnknown        InstallPlanConditionReason = "PlanUnknown"
+	InstallPlanReasonInstallCheckFailed InstallPlanConditionReason = "InstallCheckFailed"
 	InstallPlanReasonDependencyConflict InstallPlanConditionReason = "DependenciesConflict"
 	InstallPlanReasonComponentFailed    InstallPlanConditionReason = "InstallComponentFailed"
-	InstallPlanReasonInstallCheckFailed InstallPlanConditionReason = "InstallCheckFailed"
 )
 
 // StepStatus is the current status of a particular resource an in
@@ -98,7 +98,7 @@ type InstallPlanStatus struct {
 // an InstallPlan.
 type InstallPlanCondition struct {
 	Type               InstallPlanConditionType   `json:"type,omitempty"`
-	Status             corev1.ConditionStatus     `json:"status,omitempty"` // True False or Unknown
+	Status             corev1.ConditionStatus     `json:"status,omitempty"` // True, False, or Unknown
 	LastUpdateTime     metav1.Time                `json:"lastUpdateTime,omitempty"`
 	LastTransitionTime metav1.Time                `json:"lastTransitionTime,omitempty"`
 	Reason             InstallPlanConditionReason `json:"reason,omitempty"`

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -213,7 +213,7 @@ func transitionInstallPlanState(transitioner installPlanTransitioner, plan *v1al
 		log.Debug("plan phase Planning, attempting to resolve")
 		if err := transitioner.ResolvePlan(plan); err != nil {
 			plan.Status.SetCondition(v1alpha1.ConditionFailed(v1alpha1.InstallPlanResolved,
-				v1alpha1.InstallPlanReasonDependencyConflict, err))
+				v1alpha1.InstallPlanReasonInstallCheckFailed, err))
 			plan.Status.Phase = v1alpha1.InstallPlanPhaseFailed
 			return err
 		}

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -41,7 +41,7 @@ func TestTransitionInstallPlan(t *testing.T) {
 		unresolved = &v1alpha1.InstallPlanCondition{
 			Type:    v1alpha1.InstallPlanResolved,
 			Status:  corev1.ConditionFalse,
-			Reason:  v1alpha1.InstallPlanReasonDependencyConflict,
+			Reason:  v1alpha1.InstallPlanReasonInstallCheckFailed,
 			Message: errMsg,
 		}
 		installed = &v1alpha1.InstallPlanCondition{


### PR DESCRIPTION
### Description

Use `InstallCheckFailed` instead of `DependenciesConflict`.

Addresses https://jira.coreos.com/browse/ALM-572