### PR TITLE
[WIP] Resource Ownership Chain Represented and Validated in CSV

### DIFF
--- a/Documentation/design/schema_test.go
+++ b/Documentation/design/schema_test.go
@@ -215,6 +215,7 @@ func ValidateKind(t *testing.T, kind string, fileBytes []byte) error {
 
 	switch kind {
 	case "ClusterServiceVersion":
+		// TODO(alecmerdler): Validate `spec.customresourcedefinitions.resources` ownership chain
 		csv := v1alpha1.ClusterServiceVersion{}
 		err = json.Unmarshal(exampleFileBytesJson, &csv)
 		require.NoError(t, err)


### PR DESCRIPTION
### Description

In order to correctly trace the `ownerReferences` chain, the order of `resources` matters (`ownerReferences` to the CR are only written to the top level object) and all levels need to be present.

Example: `VaultService` -> `Deployment` (has refs to `VaultService`) -> `ReplicaSet` -> `Pod`

Addresses https://jira.coreos.com/browse/ALM-563