### PR TITLE
test validate service broker api version function

### DIFF
--- a/pkg/server/servicebroker/apiserver.go
+++ b/pkg/server/servicebroker/apiserver.go
@@ -71,7 +71,7 @@ func NewALMBroker(kubeconfigPath string, options Options) (*ALMBroker, error) {
 var _ broker.Interface = &ALMBroker{}
 
 func (a *ALMBroker) ValidateBrokerAPIVersion(version string) error {
-	ok, supported := supportedOSBVersions[version]
+	supported, ok := supportedOSBVersions[version]
 	log.Debugf("Component=ServiceBroker Endpoint=ValidateBrokerAPIVersion Version=%s Supported=%s",
 		version, ok)
 	if !ok {

--- a/pkg/server/servicebroker/apiserver_test.go
+++ b/pkg/server/servicebroker/apiserver_test.go
@@ -1,0 +1,35 @@
+package servicebroker
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+)
+
+const (
+	testNamespace = "testns"
+)
+
+func mockALMBroker(ctrl *gomock.Controller) *ALMBroker {
+	return &ALMBroker{
+		client:    fake.NewSimpleClientset(),
+		namespace: testNamespace,
+	}
+}
+
+func TestValidateBrokerAPIVersion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	// test bad version
+	brokerMock := mockALMBroker(ctrl)
+	err := brokerMock.ValidateBrokerAPIVersion("oops")
+	require.EqualError(t, err, "unknown OpenServiceBroker API Version: oops")
+
+	// supported version
+	require.NoError(t, brokerMock.ValidateBrokerAPIVersion("2.11"))
+	require.NoError(t, brokerMock.ValidateBrokerAPIVersion("2.12"))
+	require.NoError(t, brokerMock.ValidateBrokerAPIVersion("2.13"))
+}

--- a/pkg/server/servicebroker/apiserver_test.go
+++ b/pkg/server/servicebroker/apiserver_test.go
@@ -3,28 +3,12 @@ package servicebroker
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 )
-
-const (
-	testNamespace = "testns"
-)
-
-func mockALMBroker(ctrl *gomock.Controller) *ALMBroker {
-	return &ALMBroker{
-		client:    fake.NewSimpleClientset(),
-		namespace: testNamespace,
-	}
-}
 
 func TestValidateBrokerAPIVersion(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	// test bad version
-	brokerMock := mockALMBroker(ctrl)
+	brokerMock := &ALMBroker{}
 	err := brokerMock.ValidateBrokerAPIVersion("oops")
 	require.EqualError(t, err, "unknown OpenServiceBroker API Version: oops")
 


### PR DESCRIPTION
Add test of the implementation to validate supported versions of the Open Service Broker as per the service broker interface. All current versions (2.11, 2.12, and 2.13) are supported. 