### PR TITLE
Strip Markdown Descriptions from OSB

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -370,6 +370,12 @@
   version = "v1.2.1"
 
 [[projects]]
+  name = "github.com/writeas/go-strip-markdown"
+  packages = ["."]
+  revision = "135c36d3fc27c66a8cfe556f1d6d33d3e84d5213"
+  version = "v2.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
@@ -742,6 +748,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4acbcba008ef413801c043c4da0d4c3afd4e44649f6effcb2a280dcbf6e1b764"
+  inputs-digest = "670fb2eee0078b14ff3a6ae5e0ca1bae59eb2bfdb887e7482b7b6a4ce99dfb49"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,3 +57,7 @@
 [[constraint]]
   name = "k8s.io/client-go"
   version = "kubernetes-1.9.3"
+
+[[constraint]]
+  name = "github.com/writeas/go-strip-markdown"
+  version = "2.0.0"

--- a/pkg/server/servicebroker/apiserver.go
+++ b/pkg/server/servicebroker/apiserver.go
@@ -11,6 +11,7 @@ import (
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	"github.com/pmorie/osb-broker-lib/pkg/broker"
 	log "github.com/sirupsen/logrus"
+	stripmd "github.com/writeas/go-strip-markdown"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,7 +116,7 @@ func (a *ALMBroker) GetCatalog(b *broker.RequestContext) (*osb.CatalogResponse, 
 	// convert ClusterServiceVersions into OpenServiceBroker API `Service` object
 	services := make([]osb.Service, len(csvs))
 	for i, csv := range csvs {
-		s, err := csvToService(csv)
+		s, err := csvToService(csv, stripmd.Strip)
 		if err != nil {
 			log.Errorf("Component=ServiceBroker Endpoint=GetCatalog Error=%s", err)
 			return nil, err
@@ -253,9 +254,9 @@ func (a *ALMBroker) Provision(request *osb.ProvisionRequest, c *broker.RequestCo
 	}
 	opkey := osb.OperationKey(obj.GetSelfLink())
 	response := &osb.ProvisionResponse{
-			Async:        true,
-			OperationKey: &opkey,
-			DashboardURL: a.dashboardURL, // TODO make specific to created resource
+		Async:        true,
+		OperationKey: &opkey,
+		DashboardURL: a.dashboardURL, // TODO make specific to created resource
 	}
 	logStep(request.PlanID, fmt.Sprintf("EndRequest link=%s opKey=%+v &opKey=%+v Response=%+v", obj.GetSelfLink(), opkey, response.OperationKey, response))
 	return response, nil

--- a/pkg/server/servicebroker/types.go
+++ b/pkg/server/servicebroker/types.go
@@ -9,6 +9,7 @@ import (
 
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	//log "github.com/sirupsen/logrus"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,7 +67,7 @@ func planName(service string, plan csvv1alpha1.CRDDescription) string {
 	return strings.ToLower(invalidServiceNameChars.ReplaceAllString(service+"-"+plan.Kind, "-"))
 }
 
-func csvToService(csv csvv1alpha1.ClusterServiceVersion) (osb.Service, error) {
+func csvToService(csv csvv1alpha1.ClusterServiceVersion, parseDesc ParseDescription) (osb.Service, error) {
 	// validate CSV can be converted into a valid OpenServiceBroker ServiceInstance
 	name := csv.GetName()
 	if ok := validServiceName.MatchString(name); !ok {
@@ -76,9 +77,9 @@ func csvToService(csv csvv1alpha1.ClusterServiceVersion) (osb.Service, error) {
 	for i, crdDef := range csv.Spec.CustomResourceDefinitions.Owned {
 		plans[i] = crdToServicePlan(name, crdDef)
 	}
-	description := csv.Spec.Description
+	description := parseDesc(csv.Spec.Description)
 	if description == "" {
-		description = fmt.Sprintf("OpenCloudService for %s", name) // TODO better default msg
+		description = fmt.Sprintf("Cloud Service for %s", name)
 	}
 
 	service := osb.Service{

--- a/pkg/server/servicebroker/types_test.go
+++ b/pkg/server/servicebroker/types_test.go
@@ -1,0 +1,33 @@
+package servicebroker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	csvv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/clusterserviceversion/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func mockCSV() csvv1alpha1.ClusterServiceVersion {
+	return csvv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-service.v1.0.0",
+		},
+		Spec: csvv1alpha1.ClusterServiceVersionSpec{
+			Description: "A cool description of this service",
+		},
+	}
+}
+
+func TestCSVToServiceParsesDescription(t *testing.T) {
+	var parseDesc = func(desc string) string {
+		require.Equal(t, mockCSV().Spec.Description, desc)
+
+		return ""
+	}
+
+	_, err := csvToService(mockCSV(), parseDesc)
+
+	require.NoError(t, err)
+}

--- a/pkg/server/servicebroker/util.go
+++ b/pkg/server/servicebroker/util.go
@@ -1,0 +1,4 @@
+package servicebroker
+
+// ParseDescription accepts a description string and returns a parsed output
+type ParseDescription func(desc string) string


### PR DESCRIPTION
### Description

Uses https://github.com/writeas/go-strip-markdown to strip Markdown text when building an OSB Service from a `ClusterServiceVersion`.

Addresses https://jira.coreos.com/browse/ALM-567