### PR TITLE
Fix Subscriptions being Updated Without Changes

### DIFF
--- a/pkg/controller/operators/catalog/subscriptions.go
+++ b/pkg/controller/operators/catalog/subscriptions.go
@@ -33,7 +33,7 @@ func (o *Operator) syncSubscription(sub *v1alpha1.Subscription) (*v1alpha1.Subsc
 	if o.sourcesLastUpdate.Before(&sub.Status.LastUpdated) && sub.Status.State == v1alpha1.SubscriptionStateAtLatest {
 		log.Infof("skipping sync: no new updates to catalog since last sync at %s",
 			sub.Status.LastUpdated.String())
-		return sub, nil
+		return nil, nil
 	}
 
 	o.sourcesLock.Lock()


### PR DESCRIPTION
### Description

We need to return `nil` in order to prevent the `metadata.resourceVersion` from being updated even if there are no changes made to the resource.

Addresses https://jira.coreos.com/browse/ALM-601