### PR TITLE
Tests for Runaway Control Loops

### DIFF
--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -292,6 +292,10 @@ func TestCreateNewSubscription(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, subscription)
 
+	// Fetch subscription again to check for unnecessary control loops
+	sameSubscription, err := fetchSubscription(t, c, testSubscriptionName)
+	compareResources(t, subscription, sameSubscription)
+
 	// Deleting subscription / installplan doesn't clean up the CSV
 	cleanupCustomResource(t, c, csvv1alpha1.GroupVersion,
 		csvv1alpha1.ClusterServiceVersionKind, csv.GetName())()
@@ -343,4 +347,8 @@ func TestCreateNewSubscriptionManualApproval(t *testing.T) {
 
 	require.Equal(t, v1alpha1.ApprovalManual, installPlan.Spec.Approval)
 	require.Equal(t, v1alpha1.InstallPlanPhaseRequiresApproval, installPlan.Status.Phase)
+
+	// Fetch subscription again to check for unnecessary control loops
+	sameSubscription, err := fetchSubscription(t, c, "manual-subscription")
+	compareResources(t, subscription, sameSubscription)
 }

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
 
@@ -144,5 +146,13 @@ func cleanupCustomResource(t *testing.T, c operatorclient.ClientInterface, group
 	return func() {
 		t.Logf("deleting %s %s", kind, name)
 		require.NoError(t, c.DeleteCustomResource(apis.GroupName, group, testNamespace, kind, name))
+	}
+}
+
+// compareResources compares resource equality then prints a diff for easier debugging
+func compareResources(t *testing.T, expected, actual interface{}) {
+	if eq := equality.Semantic.DeepEqual(expected, actual); !eq {
+		t.Fatalf("Resource does not match expected value: %s",
+			diff.ObjectDiff(expected, actual))
 	}
 }


### PR DESCRIPTION
### Description

Adds checks in the e2e tests to ensure that the Operators are not rapidly processing OLM custom resources. 

Addresses https://jira.coreos.com/browse/ALM-581