### PR TITLE
Fix memory usage in catalog operator

### DIFF
--- a/pkg/controller/registry/mem.go
+++ b/pkg/controller/registry/mem.go
@@ -51,11 +51,12 @@ func NewInMemoryFromDirectory(directory string) (*InMem, error) {
 
 func NewInMemoryFromConfigMap(cmClient client.ConfigMapClient, namespace, cmName string) (*InMem, error) {
 	log.Infof("loading ui catalog entries from a configmap: %s", cmName)
-	loader := ConfigMapCatalogResourceLoader{NewInMem(), namespace, cmClient}
-	if err := loader.LoadCatalogResources(cmName); err != nil {
+	loader := ConfigMapCatalogResourceLoader{namespace, cmClient}
+	catalog := NewInMem()
+	if err := loader.LoadCatalogResources(catalog, cmName); err != nil {
 		return nil, err
 	}
-	return loader.Catalog, nil
+	return catalog, nil
 }
 
 // NewInMem returns a ptr to a new InMem instance

--- a/pkg/server/servicebroker/apiserver.go
+++ b/pkg/server/servicebroker/apiserver.go
@@ -97,15 +97,16 @@ func (c *inClusterCatalog) Load(namespace string) (registry.Source, error) {
 	}
 
 	// load service definitions from configmaps into temp in memory service registry
-	loader := registry.ConfigMapCatalogResourceLoader{registry.NewInMem(), namespace, c.opClient}
+	catalog := registry.NewInMem()
+	loader := registry.ConfigMapCatalogResourceLoader{namespace, c.opClient}
 	for _, cs := range csList.Items {
 		loader.Namespace = cs.GetNamespace()
-		if err := loader.LoadCatalogResources(cs.Spec.ConfigMap); err != nil {
+		if err := loader.LoadCatalogResources(catalog, cs.Spec.ConfigMap); err != nil {
 			log.Errorf("Component=ServiceBroker Endpoint=GetCatalog Error=%s", err)
 			return nil, err
 		}
 	}
-	return loader.Catalog, nil
+	return catalog, nil
 }
 
 func (a *ALMBroker) ValidateBrokerAPIVersion(version string) error {

--- a/pkg/server/servicebroker/apiserver_test.go
+++ b/pkg/server/servicebroker/apiserver_test.go
@@ -27,18 +27,18 @@ type mockCatalogLoader struct {
 
 func (m *mockCatalogLoader) Load(namespace string) (registry.Source, error) {
 	loader := registry.ConfigMapCatalogResourceLoader{
-		Catalog:   registry.NewInMem(),
 		Namespace: namespace,
 	}
+	catalog := registry.NewInMem()
 	for _, cm := range m.configMaps {
 		if namespace != "" && cm.GetNamespace() != namespace {
 			continue
 		}
-		if err := loader.LoadCatalogResourcesFromConfigMap(&cm); err != nil {
+		if err := loader.LoadCatalogResourcesFromConfigMap(catalog, &cm); err != nil {
 			return nil, err
 		}
 	}
-	return loader.Catalog, nil
+	return catalog, nil
 }
 
 func mockALMBroker(ctrl *gomock.Controller, namespace string, configMaps []v1.ConfigMap, objects []runtime.Object) *ALMBroker {

--- a/test/schema/catalog_versions_test.go
+++ b/test/schema/catalog_versions_test.go
@@ -41,9 +41,7 @@ type LoadedCatalog struct {
 
 // loadCatalogFromFile loads an in memory catalog from a file path. Only used for testing.
 func loadCatalogFromFile(path string) (*LoadedCatalog, error) {
-	loader := registry.ConfigMapCatalogResourceLoader{
-		Catalog: registry.NewInMem(),
-	}
+	loader := registry.ConfigMapCatalogResourceLoader{}
 	currentBytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -57,12 +55,13 @@ func loadCatalogFromFile(path string) (*LoadedCatalog, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = loader.LoadCatalogResourcesFromConfigMap(&currentConfigMap)
+	catalog := registry.NewInMem()
+	err = loader.LoadCatalogResourcesFromConfigMap(catalog, &currentConfigMap)
 	if err != nil {
 		return nil, err
 	}
 	return &LoadedCatalog{
-		Registry: loader.Catalog,
+		Registry: catalog,
 		Name:     currentConfigMap.Name,
 	}, nil
 }


### PR DESCRIPTION
Also scopes the catalog operator to only watch the "catalogNamespace" for catalog sources (it was watching all before).

Mem usage before:
<img width="1316" alt="screen shot 2018-05-31 at 9 26 34 am" src="https://user-images.githubusercontent.com/58055/40795954-8fd45d14-64d1-11e8-85a5-0622d590d994.png">

Mem usage after:
<img width="1335" alt="screen shot 2018-05-31 at 6 12 54 pm" src="https://user-images.githubusercontent.com/58055/40846169-d38a8f28-6586-11e8-9d97-08e383e96e54.png">