### PR TITLE
fix(servicebroker): add main_test.go to servicebroker cmd

### DIFF
--- a/cmd/servicebroker/main_test.go
+++ b/cmd/servicebroker/main_test.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"testing"
+)
+
+// Test started when the test binary is started. Only calls main.
+func TestServiceBrokerMain(t *testing.T) {
+	main()
+}


### PR DESCRIPTION
this will get build by our coverage-enabled builds for testing.

Previously this wasn't building servicebroker with coverage (`make build-coverage`) because coverage builds use `go test` which omits packages with no test files. This is the pattern we use for the other commands that let us collect coverage from e2e tests.