### PR TITLE
Prevent ownership conflicts for CRDs

### DIFF
--- a/pkg/api/apis/clusterserviceversion/v1alpha1/types.go
+++ b/pkg/api/apis/clusterserviceversion/v1alpha1/types.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"sort"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis"
 	"github.com/coreos/go-semver/semver"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -153,6 +153,7 @@ const (
 	CSVReasonRequirementsUnknown ConditionReason = "RequirementsUnknown"
 	CSVReasonRequirementsNotMet  ConditionReason = "RequirementsNotMet"
 	CSVReasonRequirementsMet     ConditionReason = "AllRequirementsMet"
+	CSVReasonOwnerConflict       ConditionReason = "OwnerConflict"
 	CSVReasonComponentFailed     ConditionReason = "InstallComponentFailed"
 	CSVReasonInvalidStrategy     ConditionReason = "InvalidInstallStrategy"
 	CSVReasonWaiting             ConditionReason = "InstallWaiting"


### PR DESCRIPTION
Prevent a CSV from installing if there is another CSV in the namespace that owns the same CRD, but isn't being replaced.

https://jira.coreos.com/browse/ALM-608