### PR TITLE
feat(ci): release tagging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,6 +240,7 @@ stages:
 - test_teardown
 - integration
 - docker_release
+- tag_release
 - deploy_staging
 - teardown
 stop-preview:
@@ -267,6 +268,32 @@ stop-preview:
     GIT_STRATEGY: none
     K8S_NAMESPACE: ci-alm-${CI_COMMIT_REF_SLUG}
   when: manual
+tag-release:
+  before_script:
+  - docker login -u $DOCKER_USER -p $DOCKER_PASS quay.io
+  - mkdir -p $PWD/bin
+  image: docker:git
+  only:
+  - tags
+  script:
+  - docker pull quay.io/coreos/alm-ci:${CI_COMMIT_REF_SLUG}-pre
+  - docker tag quay.io/coreos/alm-ci:${CI_COMMIT_REF_SLUG}-pre quay.io/coreos/olm:${CI_COMMIT_TAG}
+  - docker push quay.io/coreos/olm:${CI_COMMIT_TAG}
+  - docker pull quay.io/coreos/catalog-ci:${CI_COMMIT_REF_SLUG}-pre
+  - docker tag quay.io/coreos/catalog-ci:${CI_COMMIT_REF_SLUG}-pre quay.io/coreos/catalog:${CI_COMMIT_TAG}
+  - docker push quay.io/coreos/catalog:${CI_COMMIT_TAG}
+  - docker pull quay.io/coreos/alm-service-broker-ci:${CI_COMMIT_REF_SLUG}-pre
+  - docker tag quay.io/coreos/alm-service-broker-ci:${CI_COMMIT_REF_SLUG}-pre quay.io/coreos/alm-service-broker:${CI_COMMIT_TAG}
+  - docker push quay.io/coreos/alm-service-broker:${CI_COMMIT_TAG}
+  - docker pull quay.io/coreos/alm-e2e:latest
+  - docker tag quay.io/coreos/alm-e2e:latest quay.io/coreos/alm-e2e:${CI_COMMIT_TAG}
+  - docker push quay.io/coreos/alm-e2e:${CI_COMMIT_TAG}
+  stage: tag_release
+  tags:
+  - kubernetes
+  variables:
+    DOCKER_DRIVER: overlay2
+    DOCKER_HOST: tcp://docker-host.gitlab.svc.cluster.local:2375
 unit-tests:
   before_script:
   - mkdir -p $GOPATH/src/github.com/operator-framework/operator-lifecycle-manager

--- a/.gitlab-ci/vars.libsonnet
+++ b/.gitlab-ci/vars.libsonnet
@@ -44,6 +44,30 @@ local utils = import "utils.libsonnet";
             },
         },
 
+        // tagRelease is a copy of the quayci image to the 'prod' repository for tags
+        tagRelease: {
+            alm: {
+                repo: "quay.io/coreos/olm",
+                tag: "${CI_COMMIT_TAG}",
+                name: utils.containerName(self.repo, self.tag),
+            },
+            catalog: {
+                repo: "quay.io/coreos/catalog",
+                tag: "${CI_COMMIT_TAG}",
+                name: utils.containerName(self.repo, self.tag),
+            },
+            servicebroker: {
+                repo: "quay.io/coreos/alm-service-broker",
+                tag: "${CI_COMMIT_TAG}",
+                name: utils.containerName(self.repo, self.tag),
+            },
+            e2e: {
+                repo: "quay.io/coreos/alm-e2e",
+                tag: "${CI_COMMIT_TAG}",
+                name: utils.containerName(self.repo, self.tag),
+            },
+        },
+
         ci: {
             alm: {
                 repo: "quay.io/coreos/alm-ci",

--- a/README.md
+++ b/README.md
@@ -104,3 +104,12 @@ spec:
 ```
 
 This will keep the etcd `ClusterServiceVersion` up to date as new versions become available in the catalog.
+
+# Contributing
+
+## Making a Release
+
+1. Tag release in github with a semver tag (e.g. `0.4.0`)
+2. Wait for containers to build
+3. Run `make ver=x.x.x release` locally and verify commit shas
+4. Make a PR containing the new release artifacts.


### PR DESCRIPTION
Builds release containers when tagged with a version

`make release` now pulls the image shas from the tagged containers on quay.