### PR TITLE
Add CatalogSource Namespace to Subscription Objects

### DIFF
--- a/pkg/api/apis/subscription/v1alpha1/types.go
+++ b/pkg/api/apis/subscription/v1alpha1/types.go
@@ -26,11 +26,12 @@ const (
 
 // SubscriptionSpec defines an Application that can be installed
 type SubscriptionSpec struct {
-	CatalogSource       string            `json:"source"`
-	Package             string            `json:"name"`
-	Channel             string            `json:"channel,omitempty"`
-	StartingCSV         string            `json:"startingCSV,omitempty"`
-	InstallPlanApproval v1alpha1.Approval `json:"installPlanApproval,omitempty"`
+	CatalogSource          string            `json:"source"`
+	CatalogSourceNamespace string            `json:"sourceNamespace"`
+	Package                string            `json:"name"`
+	Channel                string            `json:"channel,omitempty"`
+	StartingCSV            string            `json:"startingCSV,omitempty"`
+	InstallPlanApproval    v1alpha1.Approval `json:"installPlanApproval,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/operators/catalog/subscriptions.go
+++ b/pkg/controller/operators/catalog/subscriptions.go
@@ -40,9 +40,13 @@ func (o *Operator) syncSubscription(sub *v1alpha1.Subscription) (*v1alpha1.Subsc
 	o.sourcesLock.Lock()
 	defer o.sourcesLock.Unlock()
 
-	catalog, ok := o.sources[sub.Spec.CatalogSource]
+	catalogNamespace := sub.Spec.CatalogSourceNamespace
+	if catalogNamespace == "" {
+		catalogNamespace = o.namespace
+	}
+	catalog, ok := o.sources[sourceKey{name: sub.Spec.CatalogSource, namespace: catalogNamespace}]
 	if !ok {
-		return sub, fmt.Errorf("unknown catalog source %s", sub.Spec.CatalogSource)
+		return sub, fmt.Errorf("unknown catalog source %s in namespace %s", sub.Spec.CatalogSource, catalogNamespace)
 	}
 
 	// Find latest CSV if no CSVs are installed already

--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -112,7 +112,7 @@ func TestSyncSubscription(t *testing.T) {
 					CatalogSource: "flying-unicorns",
 				},
 			}},
-			expected: expected{err: "unknown catalog source flying-unicorns"},
+			expected: expected{err: "unknown catalog source flying-unicorns in namespace ns"},
 		},
 		{
 			name:    "no updates",
@@ -934,8 +934,8 @@ func TestSyncSubscription(t *testing.T) {
 			op := &Operator{
 				client:    clientFake,
 				namespace: "ns",
-				sources: map[string]registry.Source{
-					tt.initial.catalogName: catalogFake,
+				sources: map[sourceKey]registry.Source{
+					sourceKey{name: tt.initial.catalogName, namespace: "ns"}: catalogFake,
 				},
 				sourcesLastUpdate: tt.initial.sourcesLastUpdate,
 			}


### PR DESCRIPTION
### Description

Makes it possible to find the contents of a `CatalogSource-v1` without needing permission to fetch in _all namespaces_. 

Fixes https://jira.coreos.com/browse/ALM-639