### PR TITLE
Cut 0.5.0

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,3 +10,7 @@ WORKDIR /go/src/github.com/operator-framework/operator-lifecycle-manager
 COPY . .
 
 RUN make build
+
+RUN cp ./bin/alm /bin/alm
+RUN cp ./bin/catalog /bin/catalog
+EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -191,5 +191,35 @@ ansible-release: $(YQ)
 	# link newest release into playbook
 	ln -sfF ../../../../deploy/aos-olm/$(ver) deploy/aos-olm/playbook/private/roles/olm
 
-# make ver=0.3.0 release
-release: tectonic-release upstream-release ansible-release
+OLM_REF:=$(shell docker inspect --format='{{index .RepoDigests 0}}' quay.io/coreos/olm:$(ver))
+CATALOG_REF:=$(shell docker inspect --format='{{index .RepoDigests 0}}' quay.io/coreos/catalog:$(ver))
+
+# must have already tagged a version release in github so that the docker images are available
+release:
+ifndef ver
+	$(error ver is undefined)
+endif
+	docker pull quay.io/coreos/olm:$(ver)
+	docker pull quay.io/coreos/catalog:$(ver)
+	yaml w -i deploy/upstream/values.yaml alm.image.ref $(OLM_REF)
+	yaml w -i deploy/upstream/values.yaml catalog.image.ref $(CATALOG_REF)
+	yaml w -i deploy/tectonic-alm-operator/values.yaml alm.image.ref $(OLM_REF)
+	yaml w -i deploy/tectonic-alm-operator/values.yaml catalog.image.ref $(CATALOG_REF)
+	$(MAKE) tectonic-release upstream-release
+
+OLM_REF_RH:=$(shell docker inspect --format='{{index .RepoDigests 0}}' quay.io/coreos/olm:$(ver)-rhel)
+CATALOG_REF_RH:=$(shell docker inspect --format='{{index .RepoDigests 0}}' quay.io/coreos/catalog:$(ver)-rhel)
+
+# this will build locally on rhel
+release-rh:
+ifndef ver
+	$(error ver is undefined)
+endif
+	docker build -f Dockerfile.rhel7 -t quay.io/coreos/olm:$(ver)-rhel -t quay.io/coreos/catalog:$(ver)-rhel .
+	docker push quay.io/coreos/olm:$(ver)-rhel
+	docker push quay.io/coreos/catalog:$(ver)-rhel
+	yaml w -i deploy/aos-olm/values.yaml alm.image.ref $(OLM_REF_RH)
+	yaml w -i deploy/aos-olm/values.yaml catalog.image.ref $(CATALOG_REF_RH)
+	$(MAKE) ansible-release
+
+release-all: release release-rh

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,8 @@ endif
 	yaml w -i deploy/tectonic-alm-operator/values.yaml catalog.image.ref $(CATALOG_REF)
 	$(MAKE) tectonic-release upstream-release
 
-OLM_REF_RH:=$(shell docker inspect --format='{{index .RepoDigests 0}}' quay.io/coreos/olm:$(ver)-rhel)
+# These are built from the same image, and repodigests are ordered alphabetically, so olm is ref 1 and catalog ref 2
+OLM_REF_RH:=$(shell docker inspect --format='{{index .RepoDigests 1}}' quay.io/coreos/olm:$(ver)-rhel)
 CATALOG_REF_RH:=$(shell docker inspect --format='{{index .RepoDigests 0}}' quay.io/coreos/catalog:$(ver)-rhel)
 
 # this will build locally on rhel
@@ -215,9 +216,9 @@ release-rh:
 ifndef ver
 	$(error ver is undefined)
 endif
-	docker build -f Dockerfile.rhel7 -t quay.io/coreos/olm:$(ver)-rhel -t quay.io/coreos/catalog:$(ver)-rhel .
-	docker push quay.io/coreos/olm:$(ver)-rhel
-	docker push quay.io/coreos/catalog:$(ver)-rhel
+	./scripts/pull_or_build_rh.sh $(ver)
+	echo $(OLM_REF_RH)
+	docker inspect --format='{{index .RepoDigests 0}}' quay.io/coreos/olm:$(ver)-rhel
 	yaml w -i deploy/aos-olm/values.yaml alm.image.ref $(OLM_REF_RH)
 	yaml w -i deploy/aos-olm/values.yaml catalog.image.ref $(CATALOG_REF_RH)
 	$(MAKE) ansible-release

--- a/deploy/aos-olm/0.5.0/defaults/main.yaml
+++ b/deploy/aos-olm/0.5.0/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+operator_lifecycle_manager_remove: false
+operator_lifecycle_manager_install: true

--- a/deploy/aos-olm/0.5.0/files/01-alm-operator.serviceaccount.yaml
+++ b/deploy/aos-olm/0.5.0/files/01-alm-operator.serviceaccount.yaml
@@ -1,0 +1,11 @@
+##---
+# Source: olm/templates/01-alm-operator.serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: alm-operator-serviceaccount
+  namespace: operator-lifecycle-manager
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+imagePullSecrets:
+- name: coreos-pull-secret

--- a/deploy/aos-olm/0.5.0/files/02-alm-operator.rolebinding.yaml
+++ b/deploy/aos-olm/0.5.0/files/02-alm-operator.rolebinding.yaml
@@ -1,0 +1,16 @@
+##---
+# Source: olm/templates/02-alm-operator.rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alm-operator-binding
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: alm-operator-serviceaccount
+  namespace: operator-lifecycle-manager

--- a/deploy/aos-olm/0.5.0/files/03-clusterserviceversion.crd.yaml
+++ b/deploy/aos-olm/0.5.0/files/03-clusterserviceversion.crd.yaml
@@ -1,0 +1,413 @@
+##---
+# Source: olm/templates/03-clusterserviceversion.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterserviceversion-v1s.app.coreos.com
+  annotations:
+    displayName: Operator Version
+    description: Represents an Operator that should be running on the cluster, including requirements and install strategy.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  names:
+    plural: clusterserviceversion-v1s
+    singular: clusterserviceversion-v1
+    kind: ClusterServiceVersion-v1
+    listKind: ClusterServiceVersionList-v1
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a single version of the operator software
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a ClusterServiceVersion
+          required:
+          - displayName
+          - install
+          properties:
+            displayName:
+              type: string
+              description: Human readable name of the application that will be displayed in the ALM UI
+
+            description:
+              type: string
+              description: Human readable description of what the application does
+
+            keywords:
+              type: array
+              description: List of keywords which will be used to discover and categorize app types
+              items:
+                type: string
+
+            maintainers:
+              type: array
+              description: Those responsible for the creation of this specific app type
+              items:
+                type: object
+                description: Information for a single maintainer
+                required:
+                - name
+                - email
+                properties:
+                  name:
+                    type: string
+                    description: Maintainer's name
+                  email:
+                    type: string
+                    description: Maintainer's email address
+                    format: email
+                optionalProperties:
+                  type: string
+                  description: "Any additional key-value metadata you wish to expose about the maintainer, e.g. github: <username>"
+
+            links:
+              type: array
+              description: Interesting links to find more information about the project, such as marketing page, documentation, or github page
+              items:
+                type: object
+                description: A single link to describe one aspect of the project
+                required:
+                - name
+                - url
+                properties:
+                  name:
+                    type: string
+                    description: Name of the link type, e.g. homepage or github url
+                  url:
+                    type: string
+                    description: URL to which the link should point
+                    format: uri
+
+            icon:
+              type: array
+              description: Icon which should be rendered with the application information
+              required:
+              - base64data
+              - mediatype
+              properties:
+                base64data:
+                  type: string
+                  description: Base64 binary representation of the icon image
+                  pattern: ^(?:[A-Za-z0-9+/]{4}){0,16250}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                mediatype:
+                  type: string
+                  description: Mediatype for the binary data specified in the base64data property
+                  enum:
+                  - image/gif
+                  - image/jpeg
+                  - image/png
+                  - image/svg+xml
+            version:
+              type: string
+              description: Version string, recommended that users use semantic versioning
+              pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+            replaces:
+              type: string
+              description: Name of the ClusterServiceVersion custom resource that this version replaces
+
+            maturity:
+              type: string
+              description: What level of maturity the software has achieved at this version
+              enum:
+              - planning
+              - pre-alpha
+              - alpha
+              - beta
+              - stable
+              - mature
+              - inactive
+              - deprecated
+            labels:
+              type: object
+              description: Labels that will be applied to associated resources created by the operator.
+            selector:
+              type: object
+              description: Label selector to find resources associated with or managed by the operator
+              properties:
+                matchLabels:
+                  type: object
+                  description: Label key:value pairs to match directly
+                matchExpressions:
+                  type: array
+                  descriptions: A set of expressions to match against the resource.
+                  items:
+                    allOf:
+                      - type: object
+                        required:
+                        - key
+                        - operator
+                        - values
+                        properties:
+                          key:
+                            type: string
+                            description: the key to match
+                          operator:
+                            type: string
+                            description: the operator for the expression
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                          values:
+                            type: array
+                            description: set of values for the expression
+            customresourcedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the CRD
+                          required:
+                            - kind
+                            - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a CRD, the fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+
+
+            install:
+              type: object
+              description: Information required to install this specific version of the operator software
+              oneOf:
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['image']
+                  spec:
+                    type: object
+                    required:
+                    - image
+                    properties:
+                      image:
+                        type: string
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['deployment']
+                  spec:
+                    type: object
+                    required:
+                    - deployments
+                    properties:
+                      deployments:
+                        type: array
+                        description: List of deployments to create
+                        items:
+                          type: object
+                          description: A name and deployment to create in the cluster
+                          required:
+                            - name
+                            - spec
+                          properties:
+                            name:
+                              type: string
+                              description: the consistent name of the deployment
+                            spec:
+                              type: object
+                              description: The deployment spec to create in the cluster
+                      permissions:
+                        type: array
+                        description: Permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                            - serviceAccountName
+                            - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                        - "*"
+                                        - get
+                                        - list
+                                        - watch
+                                        - create
+                                        - update
+                                        - patch
+                                        - delete
+                                        - deletecollection

--- a/deploy/aos-olm/0.5.0/files/05-catalogsource.crd.yaml
+++ b/deploy/aos-olm/0.5.0/files/05-catalogsource.crd.yaml
@@ -1,0 +1,54 @@
+##---
+# Source: olm/templates/05-catalogsource.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogsource-v1s.app.coreos.com
+  annotations:
+    displayName: CatalogSource
+    description: A source configured to find packages and updates.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: catalogsource-v1s
+    singular: catalogsource-v1
+    kind: CatalogSource-v1
+    listKind: CatalogSourceList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a subscription to a source and channel
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a subscription
+          required:
+          - sourceType
+          - name
+          properties:
+            sourceType:
+              type: string
+              description: The type of the source. Currently the only supported type is "internal".
+              enum:
+              - internal
+
+            configMap:
+              type: string
+              string: The name of a ConfigMap that holds the entries for an in-memory catalog.
+
+            name:
+              type: string
+              description: Name of this catalog source
+
+            secrets:
+              type: array
+              description: A set of secrets that can be used to access the contents of the catalog. It is best to keep this list small, since each will need to be tried for every catalog entry.
+              items:
+                type: string
+                description: A name of a secret in the namespace where the CatalogSource is defined.

--- a/deploy/aos-olm/0.5.0/files/06-installplan.crd.yaml
+++ b/deploy/aos-olm/0.5.0/files/06-installplan.crd.yaml
@@ -1,0 +1,60 @@
+##---
+# Source: olm/templates/06-installplan.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installplan-v1s.app.coreos.com
+  annotations:
+    displayName: Install Plan
+    description: Represents a plan to install and resolve dependencies for Cluster Services
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: installplan-v1s
+    singular: installplan-v1
+    kind: InstallPlan-v1
+    listKind: InstallPlanList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Document which defines the desire and current state of an installation of a Cluster Service
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for an InstallPlan
+          required:
+          - clusterServiceVersionNames
+          - approval
+          properties:
+            clusterServiceVersionNames:
+              type: array
+              description: A list of the names of the Cluster Services
+              items:
+                type: string
+            approval:
+              type: string
+              enum:
+              - Automatic
+              - Manual
+              - Update-Only # Will only apply an update if it updates existing packages only and doesn't add any new ones
+            approved:
+              type: boolean
+      anyOf:
+        - properties:
+          approval: 
+            enum: 
+              - Manual
+          required:
+            - approved
+        - properties:
+          approval:
+            enum:
+              - Automatic
+              - Update-Only
+          required: []

--- a/deploy/aos-olm/0.5.0/files/07-subscription.crd.yaml
+++ b/deploy/aos-olm/0.5.0/files/07-subscription.crd.yaml
@@ -1,0 +1,49 @@
+##---
+# Source: olm/templates/07-subscription.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscription-v1s.app.coreos.com
+  annotations:
+    displayName: Subscription
+    description: Subcribes service catalog to a source and channel to recieve updates for packages.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: subscription-v1s
+    singular: subscription-v1
+    kind: Subscription-v1
+    listKind: SubscriptionList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a subscription to a source and channel
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a Subscription
+          required:
+          - source
+          - name
+          properties:
+            source:
+              type: string
+              description: Name of a CatalogSource that defines where and how to find the channel
+
+            name:
+              type: string
+              description: Name of the package that defines the application
+
+            channel:
+              type: string
+              description: Name of the channel to track
+            
+            startingCSV:
+              type: string
+              description: Name of the AppType that this subscription tracks

--- a/deploy/aos-olm/0.5.0/files/08-tectonicocs.configmap.yaml
+++ b/deploy/aos-olm/0.5.0/files/08-tectonicocs.configmap.yaml
@@ -1,0 +1,1810 @@
+##---
+# Source: olm/templates/08-tectonicocs.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tectonic-ocs
+  namespace: operator-lifecycle-manager
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: alertmanagers.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: alertmanagers
+          singular: alertmanager
+          kind: Alertmanager
+          listKind: AlertmanagerList
+          shortNames:
+            - alertman
+            - alrtman
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdbackups.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdBackup
+          listKind: EtcdBackupList
+          plural: etcdbackups
+          singular: etcdbackup
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdclusters.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        validation:
+          openAPIv3:
+            type: object
+            description: Represents a single instance of etcd
+            additionalProperties: false
+            required:
+            - version
+            properties:
+              version:
+                type: string
+                description: Version string
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+                x-descriptors:
+                - urn:alm:descriptor:versioning:semver
+              size:
+                type: number
+                description: The size of the etcd cluster
+                min: 1
+                max: 9
+                x-descriptors:
+                - urn:alm:descriptor:pod:count
+                - urn:alm:descriptor:number:integer
+              template:
+                type: object
+                description: Template for fields of subresources
+                labels:
+                  type: object
+                  description: Labels to apply to associated resources
+        names:
+          plural: etcdclusters
+          singular: etcdcluster
+          kind: EtcdCluster
+          listKind: EtcdClusterList
+          shortNames:
+            - etcdclus
+            - etcd
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdrestores.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdRestore
+          listKind: EtcdRestoreList
+          plural: etcdrestores
+          singular: etcdrestore
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prometheuses.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: prometheuses
+          singular: prometheus
+          kind: Prometheus
+          listKind: PrometheusList
+          shortNames:
+            - prom
+            - prm
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: servicemonitors.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: servicemonitors
+          singular: servicemonitor
+          kind: ServiceMonitor
+          listKind: ServiceMonitorList
+          shortNames:
+            - servicemon
+            - svcmon
+            - svcmonitor
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: vaultservices.vault.security.coreos.com
+      spec:
+        group: vault.security.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        validation:
+          openAPIv3:
+            type: object
+            description: Represents a single instance of Vault
+            additionalProperties: false
+            required:
+            - version
+            properties:
+              version:
+                type: string
+                description: Version string
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+                x-descriptors:
+                - urn:alm:descriptor:versioning:semver
+              nodes:
+                type: number
+                description: The number of nodes in the Vault cluster
+                min: 1
+                max: 9
+                x-descriptors:
+                - urn:alm:descriptor:pod:count
+                - urn:alm:descriptor:number:integer
+              template:
+                type: object
+                description: Template for fields of subresources
+                labels:
+                  type: object
+                  description: Labels to apply to associated resources
+        names:
+          plural: vaultservices
+          singular: vaultservice
+          kind: VaultService
+          listKind: VaultServiceList
+          shortNames:
+            - vault
+            - vaultserv
+            - vaultsrv
+      
+  clusterServiceVersions: |-
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.6.1
+        namespace: placeholder
+        annotations:		
+          tectonic-visibility: ocs		
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+          **High availability**
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+          **Automated updates**
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+          **Backups included**
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.6.1
+        maturity: alpha
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-status-descriptors: etcdoperator.v0.6.1
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: service
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.9.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.0
+        maturity: alpha
+        replaces: etcdoperator.v0.6.1
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.9.2
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.2
+        maturity: alpha
+        replaces: etcdoperator.v0.9.0
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: prometheusoperator.0.14.0
+        namespace: placeholder
+      spec:
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ## Supported Features
+      
+          **High availability**
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+          **Updates via automated operations**
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+          **Handles the dynamic nature of containers**
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.14.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.14.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.14.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Define resources requests and limits for single Pods
+              displayName: Resource Request
+              path: resources.requests
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: prometheusoperator.0.15.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+      spec:
+        replaces: prometheusoperator.0.14.0
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+      
+      
+          **Updates via automated operations**
+      
+      
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+      
+      
+          **Handles the dynamic nature of containers**
+      
+      
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.15.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.15.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: vault-operator.0.1.9
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"vault.security.coreos.com/v1alpha1","kind":"VaultService","metadata":{"name":"example"},"spec":{"nodes":2,"version":"0.9.1-0"}}]'
+        labels:
+          alm-catalog: tectonic-ocs
+      spec:
+        displayName: Vault
+        description: |
+          An encrypted, multi-tentant secure secret store. Vault handles the lifecycle of your secrets: leasing, key revocation, key rolling, and auditing.
+      
+          _The Vault Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Unsealing and using Vault
+      
+          Once a Vault instance is running, it must be initalized and "unsealed". Afterwards, your software can use the automatically created Kubernetes Service and Secret to communicate with it.
+      
+          [Read the complete guide to using the Vault Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/vault-ocs.html)
+      
+          ### Supported Features
+      
+          **Secure by Default**
+      
+      
+          Hands-free automated creation of TLS certificates between all components ensure all best practices are followed for secret security. Further, the API makes unseal operations easy.
+      
+      
+          **Highly available**
+      
+      
+          Multiple instances of Vault are clustered together via an etcd backend and secured.
+      
+      
+          **Safe Upgrades**
+      
+      
+          Rolling out a new Vault version is as easy as updating the Vault Cluster definition. Everything is automatically handled using Vault best practices while pausing for unseal tokens.
+      
+        keywords: ['vault', 'secret', 'encryption']
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+        provider:
+          name: CoreOS, Inc
+        links:
+        - name: Vault Project
+          url: https://www.vaultproject.io/
+        labels:
+          alm-status-descriptors: vault-operator.0.1.9
+          alm-owner-vault: vault-operator
+          operated-by: vault-operator
+        selector:
+          matchLabels:
+            alm-owner-vault: vault-operator
+            operated-by: vault-operator
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAAA7CAYAAADLjIzcAAAACXBIWXMAAAsTAAALEwEAmpwYAAAMLGlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjarVd3VFP51t23JKGEmoCAlNARBAHpSO+CgHQYW0gChBJCCip2x0EFxy4WrOjYcNSxADIWRB3rIPbuAx1URsbBgg2V9wcBZ+Z93x9vrfdb6+budbLPPvuce9dd6wA6HnyptJDUBYokCllSVCgvIzOLx2oHCxxogYQ7XyCXhiQmxgHAwP0vhwDe3gQBANec+VJpIf67oycUyQUAkQggWygXFAHEIYA2EUhlCoDRCsB6skKqABhvAHBlGZlZAFMNADe3H5sC4Gb3Y1cAXFlKUhjADAfU2Hy+LBfQTgTAKxXkKgBtKQBXiVAsAbQ3AwgU5PGFgHYbgOFFRcVCQIcNwCH7Lzq5f9PMHtTk83MHcX8vAAC1cLFcWsifiv/1KSpUDtSwAsDOk0UnAeACxM6C4tgkAGyAOCrJjk8AoA8Q58RCQIXv5imjU1X8LoE8LAuAIUBCyA+PBWAKkIbKgtQQFXbny4B+PhkvVsSkqHC2rDhJpU+WSgrj41Q6C/JEMQN4o0gekTzAyRFHxgDQBchDZXkp6f0+ydOl4rR4ANoA2SovSI5V5T4sywuLH+DIlEmpAGwA8k2OLDKpn0MZFckH+qJcBPyIZABGABWsyEuJ7s+lMkTyjLgBD0JReES/B0ookqSqvFEKqSI0SZVbLi1MVPGpjaLCqKT+OVP75aXJA7lXFbIU1cypR/n80Yn9/qm3UkViSr83mkYcwhAOHpTgIRvFyIe4pau+CzzVP5HgQ4ZciOCsigxkpIMPGSTgIxll+AMSiCAfzAsFHzKIUAoJPg9G+3+dkQM+ZCiFCHIU4AlkKKJN6EDan46jA+lgOpB2p31o34E8ns5AVWYEM5wZzYxkDhv0IUAxClEMGcT/RywWhRBBCRlEkAz08FWP8YRxhfGIcYPRxriDNPwGGcQDrIniubJ/OOdhDNqgVE1FhGxI0DnAoe1od9qTDqUD6EDaFzzakDaBM+1B+9AhdBDtT3vSvn9zqBz09nWW/6wnguRv/aji2o7anioX2YNPJmyQ9U+VsL/MSIhixP6TSS2gDlJnqZPUeeooVQ8edYJqoC5Rx6j6v7wJv0GG3MFqSRBBggIUQjzAca117XT99B/V+SoHMoggBxSiKQoACCuWTpWJc/MUvBCptFDEi5EIXIbz3F3dvIGMzCxe/+fjtSEIAIThha+xkibAtwIgcr/G+NbAkScA5+3XmPUrgL0UONYqUMpK+2M0ADCgAR1wYQxzWMMBznCHF/wRjAiMRgJSkIkJECAPRZBhMqZjDspRiaVYhXXYhK3YiR9xAPU4ipP4BRfRihu4hzZ04Dm68Ra9BEGwCC2CQxgTFoQt4US4Ez5EIBFBxBFJRCYxicglJISSmE58S1QSy4l1xBZiF/ETcYQ4SZwnrhB3iHaik3hFfCQpkk1ySTPSjhxB+pAhZCyZQo4nc8kSsoycRy4m15A15B6yjjxJXiRvkG3kc7KHAqVJGVKWlDPlQ4VRCVQWlUPJqJlUBVVF1VB7qUbqLHWNaqO6qA80k+bQPNqZ9qej6VRaQJfQM+lF9Dp6J11Hn6av0e10N/2FocUwZTgx/BgxjAxGLmMyo5xRxdjOOMw4w7jB6GC8ZTKZhkx7pjczmpnJzGdOYy5ibmDuYzYxrzAfM3tYLJYxy4kVwEpg8VkKVjlrLWsP6wTrKquD9V5NU81CzV0tUi1LTaI2V61KbbfacbWrak/VetV11W3V/dQT1IXqU9WXqG9Tb1S/rN6h3quhp2GvEaCRopGvMUdjjcZejTMa9zVea2pqWmn6ao7VFGvO1lyjuV/znGa75ge2PtuRHcYex1ayF7N3sJvYd9ivtbS07LSCtbK0FFqLtXZpndJ6qPVem6Ptoh2jLdSepV2tXad9VfuFjrqOrU6IzgSdMp0qnYM6l3W6dNV17XTDdPm6M3WrdY/o3tLt0ePouekl6BXpLdLbrXde75k+S99OP0JfqD9Pf6v+Kf3HHIpjzQnjCDjfcrZxznA6uEyuPTeGm8+t5P7IbeF2G+gbeBikGUwxqDY4ZtBmSBnaGcYYFhouMTxgeNPw4xCzISFDREMWDtk75OqQd0ZDjYKNREYVRvuMbhh9NOYZRxgXGC8zrjd+YEKbOJqMNZlsstHkjEnXUO5Q/6GCoRVDDwy9a0qaOpommU4z3Wp6ybTHzNwsykxqttbslFmXuaF5sHm++Urz4+adFhyLQAuxxUqLExa/8wx4IbxC3hreaV63palltKXScotli2Wvlb1VqtVcq31WD6w1rH2sc6xXWjdbd9tY2IyxmW5Ta3PXVt3WxzbPdrXtWdt3dvZ26Xbz7ertntkb2cfYl9nX2t930HIIcihxqHG4Pow5zGdYwbANw1odSUdPxzzHasfLTqSTl5PYaYPTleGM4b7DJcNrht9yZjuHOJc61zq3uxi6xLnMdal3eTHCZkTWiGUjzo744urpWui6zfWem77baLe5bo1ur9wd3QXu1e7XR2qNjBw5a2TDyJceTh4ij40etz05nmM853s2e3728vaSee316vS28Z7kvd77lg/XJ9Fnkc85X4ZvqO8s36O+H/y8/BR+B/z+9Hf2L/Df7f9slP0o0ahtox4HWAXwA7YEtAXyAicFbg5sC7IM4gfVBD0Ktg4WBm8PfhoyLCQ/ZE/Ii1DXUFno4dB3YX5hM8KawqnwqPCK8JYI/YjUiHURDyOtInMjayO7ozyjpkU1RTOiY6OXRd+KMYsRxOyK6R7tPXrG6NOx7Njk2HWxj+Ic42RxjWPIMaPHrBhzP942XhJfn4CEmIQVCQ8S7RNLEn8eyxybOLZ67JMkt6TpSWeTOckTk3cnv00JTVmSci/VIVWZ2pymkzYubVfau/Tw9OXpbRkjMmZkXMw0yRRnNmSxstKytmf1fBPxzapvOsZ5jisfd3O8/fgp489PMJlQOOHYRJ2J/IkHJzEmpU/aPekTP4Ffw+/Jjslen90tCBOsFjwXBgtXCjtFAaLloqc5ATnLc57lBuSuyO3MC8qryusSh4nXiV/mR+dvyn9XkFCwo6CvML1wX5Fa0aSiIxJ9SYHkdLF58ZTiK1Inabm0rcSvZFVJtyxWtl1OyMfLGxRchVRxSemg/E7ZXhpYWl36fnLa5INT9KZIplya6jh14dSnZZFlP0yjpwmmNU+3nD5nevuMkBlbZhIzs2c2z7KeNW9Wx+yo2TvnaMwpmPPrXNe5y+e++Tb928Z5ZvNmz3v8XdR3teXa5bLyW/P9529aQC8QL2hZOHLh2oVfKoQVFypdK6sqPy0SLLrwvdv3a77vW5yzuGWJ15KNS5lLJUtvLgtatnO53vKy5Y9XjFlRt5K3smLlm1UTV52v8qjatFpjtXJ125q4NQ1rbdYuXftpXd66G9Wh1fvWm65fuP7dBuGGqxuDN+7dZLapctPHzeLNt7dEbamrsaup2srcWrr1yba0bWd/8Plh13aT7ZXbP++Q7GjbmbTz9C7vXbt2m+5eUkvWKms794zb0/pj+I8Ne533btlnuK9yP/Yr9//+06Sfbh6IPdB80Ofg3kO2h9Yf5hyuqCPqptZ11+fVtzVkNlw5MvpIc6N/4+GfXX7ecdTyaPUxg2NLjmscn3e870TZiZ4maVPXydyTj5snNt87lXHq+umxp1vOxJ4590vkL6fOhpw9cS7g3NHzfuePXPC5UH/R62LdJc9Lh3/1/PVwi1dL3WXvyw2tvq2NV0ZdOX416OrJa+HXfrkec/3ijfgbV26m3rx9a9ytttvC28/uFN55ebf0bu+92fcZ9yse6D6oemj6sOZfw/61r82r7Vh7ePulR8mP7j0WPH7+m/y3Tx3znmg9qXpq8XTXM/dnRzsjO1t//+b3jufS571d5X/o/bH+hcOLQ38G/3mpO6O746XsZd+rRa+NX+944/GmuSex5+Hbore97yreG7/f+cHnw9mP6R+f9k7+xPq05vOwz41fYr/c7yvq65PyZXwAAAWAzMkBXu0AtDIBTiugod2/f6n2RuLrBvn/4f4dDQDgBewIBlJnA3FNwMYmwHY2wG4CEgGkBIMcOXLwUh15zkj3fi22DGC87+t7bQawGoHPsr6+3g19fZ+3AdQdoKmkf+8DAKYusJkHAL9az/+P/evfXvpsNqq3M8UAADowaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzExMSA3OS4xNTgzMjUsIDIwMTUvMDkvMTAtMDE6MTA6MjAgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgICAgICAgICAgeG1sbnM6cGhvdG9zaG9wPSJodHRwOi8vbnMuYWRvYmUuY29tL3Bob3Rvc2hvcC8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6Q3JlYXRlRGF0ZT4yMDE3LTA5LTA2VDE1OjMxOjU2LTA0OjAwPC94bXA6Q3JlYXRlRGF0ZT4KICAgICAgICAgPHhtcDpNZXRhZGF0YURhdGU+MjAxNy0wOS0wNlQxNTozMTo1Ni0wNDowMDwveG1wOk1ldGFkYXRhRGF0ZT4KICAgICAgICAgPHhtcDpNb2RpZnlEYXRlPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3htcDpNb2RpZnlEYXRlPgogICAgICAgICA8eG1wTU06SW5zdGFuY2VJRD54bXAuaWlkOjFlMjY4MTE5LWU2NmYtNGJjNC1hZTI0LThiMTViNTg3MzE2MjwveG1wTU06SW5zdGFuY2VJRD4KICAgICAgICAgPHhtcE1NOkRvY3VtZW50SUQ+YWRvYmU6ZG9jaWQ6cGhvdG9zaG9wOjczODM4YzJiLWQzYzgtMTE3YS1iNTYyLTllNjU3MTBkNzc5YzwveG1wTU06RG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD54bXAuZGlkOjQ1MjdmNDhmLTc2MGMtNGRhYi04NTJkLTNkNGZiOTA4ZmEzNjwveG1wTU06T3JpZ2luYWxEb2N1bWVudElEPgogICAgICAgICA8eG1wTU06SGlzdG9yeT4KICAgICAgICAgICAgPHJkZjpTZXE+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPmNyZWF0ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDo0NTI3ZjQ4Zi03NjBjLTRkYWItODUyZC0zZDRmYjkwOGZhMzY8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDphY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDoxZTI2ODExOS1lNjZmLTRiYzQtYWUyNC04YjE1YjU4NzMxNjI8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICAgICA8c3RFdnQ6Y2hhbmdlZD4vPC9zdEV2dDpjaGFuZ2VkPgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgPC9yZGY6U2VxPgogICAgICAgICA8L3htcE1NOkhpc3Rvcnk+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzpmb3JtYXQ+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZGU+CiAgICAgICAgIDxwaG90b3Nob3A6SUNDUHJvZmlsZT5EaXNwbGF5PC9waG90b3Nob3A6SUNDUHJvZmlsZT4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+NzIwMDAwLzEwMDAwPC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj43MjAwMDAvMTAwMDA8L3RpZmY6WVJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+NjU1MzU8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjY0PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjU5PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz6RZ44uAAAAIGNIUk0AAG11AABzoAAA/N0AAINkAABw6AAA7GgAADA+AAAQkOTsmeoAAAreSURBVHja7Jt5VFN3Fse/7yUkgQSyQBAiJWwTglKZqKBVFgURsVFgpAO2TRUonU7n0MWpVqnL6a7jtAdoz+lAsS61damHTnXascLUojMHLVUcpaesjUAVlFUWY7b35g+KhUBCEhJ71Pmd8/sDeO/edz+/e+/v3t97EDRN434eJO7zcd8DYJr+Ijc396kbN26EMxgM7b1kKE3TBEmSRHJy8m6VSlVrFkBLS4u2vLw8715cbS6X+/WcOXN6LYbAM888szckJOSre814giC0y5YtW93c3HzFIgA+n48nnnhi/b0GICIi4j2ZTHZdp9NZToJarRYpKSmXIiIiyu6ZRMdk9sfHx7/OZrMhEoksAxCJRBCLxdi0adOLDAaDuhcAxMbGFoSHh/exWCwIhULLAJhMJrq6uhAVFaWWyWQf3O3Gs9nsrrS0tB1MJhN8Ph8CgcDyNlhSUgKCIMBmszFz5sxX6urqsmmadrlbASiVyu0KheJma2vruNWf0AM0Gg2GhobQ19cHuVzePmvWrPfvVuN5PF772rVrCwBAIBDcnhY9YPr06SOFAzgcDhISEl6tra3NMRqN3LsNQE5Oztbly5cb6+vrxyU/swBM3UShUHRHR0cXVVZWbrqbjOdwOPXu7u6lhw8fRnd3NwiCuP23sLCwX+oD026wtLR0dPkIDw8PdHV1ua9bt+6yTqcT3S0AYmJifi+VSj9ta2sDkzl2nSsqKsx7AJ/PHycsMjJyQKlU7iwrK3trSp1XkBxU+xVAMzDK5cRAb+fYqi0wGLS62W49AoHgYlRU1KcajQZyudy2bnB0shAIBLeBZGdnv+3m5tZh93ak+gNEF/8L/jdnQU7zGTY0Mg4M1fMgl6QNX8TiwHX7R3D/5wWwcvMBEHbpSkxMzPf19YWHhwdEItG4aRFAQEDAmBkYGAihUIiHH35Yn5ubu81eAK6bXwfJZYEdFQaX5BXDyhXRIIwGEDMjAZIE6RcIVvrjII08sLNeBNhsm/X4+vp+m5iY+AVBEBCJRBAKheOmxSRYVVU1USuJhoYGeHt7l7DZ7Be1Wu1vbH0wTdE7YBa9CUN9O/TffD0s9/tqYE4s6LoLAEWBuqKG7ou/w0WZCt2uEkCvsxlARkbGBh8fH9A0PSbxmW2STJNgSkrKhBcaDAb4+fmhsbEx8+TJkwfs6sgkwaCvmsQ2wQHoW2PdMlAOSl1ns/zg4OCvS0tLE/r6+mAwGMxel56ebt4DgoKCLDUVWLBgwcELFy683NvbG26T8dOmw/VPT8PY8CO0e4drK8Zv54Hz5JPQHfsS+q8+G77O1x+02AdEXyfo3m5b2l0899xzGyQSCSiKsmr1JwRgWimZhoK3tzeSkpJePnjw4Oc2VWV7joCzbD5oAFRrM/QnT4Bb/AVc5nrCJe1J9C8IBtWiBql8HOCLgMAwGD8tASijVfIDAgIOL1my5JxWq4W7u7v9R2KWAIxASEpKOlpZWflde3v7XKs16XQgAIwOONqgBU0CtB6A8WdDKSNAkqAp2xpRmUy2tbi4GHq9HtQk90ZGRtpWB5gCkEgkyMjI2FhQUFBh7QMO5mSAynsBhvom6E+eAAAMZS8Fe7UK+q+Og/qpBQBg/Gw34O0H/NRk9eqHhIR8FBoaWt/a2mqT+0+YBMvKJj8HGWkts7KyKtVqdaz1h3KewJBJXIv9gc7WURmQAWZEJAw1Z6yNfX1WVlaoj4+PemBgwCrjCwsLzdcBE+2bppPH40EikSAvL2+DtbYzlq+G66H/gF30GQjPacN1T95r4H15EZw3dgNMFxBcLtzLqyE8XwW39z8BSOakchUKxW6FQqFmMpm3C7fJpk3NkLlhNBqhVCrPFhUVlV2+fPl3k3pNfCoIigIjfC6I4DDQ3dfgEp8C9PWCEZ0McHggJF5gxyuGmxnVatx8/ilAO2i+jCXJmytXrnyFw+HAw8PDJtc3C2Dfvn1WbztsNhthYWFbrQFgOFIC4tk3QJ2rBP39d8PnjwffB3vNs9Af+wQY6gOlHoRm31FwViyFZmeBReMBIC4u7m/z58+/euXKFasXbtIcsGrVKqtupGkaJEnC398fR48ePdDc3Jw5qTLPaaD7ugHjqCLF3RMYGJsXiIBQ0JfrJ8tDN4qLi4P8/f17enp6bFr9Rx55xLwHSKVSmwi6u7tj0aJFW5qbm9MnkjcGWve1MT+zkpRwfeGPuHX4OLQfvvvLdZMY//NRV+HChQt7WlpaJt25HFoHTBQKc+fObTp//vy+mpqabOu7I3dw9xyDiw/ATFoOQ/VpGC9dsG4z4XLb8/PzdwiFQhiNRrti32EAaJqGm5sbUlNTt9XU1DwKgGNdFtWD+rEZ8AkGdY0GPTRotc7w8PC3BgcHb549e9ZizW9ujD4RmjKAES+Ijo7+KTY29oNTp05Z915RdwsDmQnQr82G9vi/QP3YZJ3juLq2hYeHF+/atQs6nc6u1U9LSzMPwNzh4WRe4Orqiuzs7FdOnz6dTdO0VQeoVFsLbr5m2xHDwoULX5NKpbrOzs4pub5ZAA888IB92wlBYNWqVd3l5eXvfPzxx1uccc7H5/MbExISSimKgqenp0NkjgPQ1NRklyCapjE4OAi5XP4mg8F42mg0ih0NQKlUbgsMDKTb29sdsvoTAtizZ4/dwiiKgpeX161Zs2Ztr6mpeduRxnt7e19KS0s7oNfr7QpTqwGIxVNbOBaLhXnz5r1XV1e3TqPRTHfUg6pUqvygoCC0trbCzc3NeQC8vLymJJCmaYjFYl1MTMzrJ06ccMhrteDg4G8fe+yxf+h0OrtLXqsBOEIBg8HA0qVLS86cObO+v78/aKrycnJy/qxQKNDQ0ACSJJ0LYCpl5eghkUiolStXbtu/f/9HU4z9E0NDQ//euXMnNBqNQ55t69atzvWAkVBIT0/ff/z48Y1dXV0z7ZUTExOT39PTg4sXL457xeUUD7CnEjQHQCqVIicnJ3/Hjh2f2xn7n0dGRp7r7u6e9BWXwwD4+fk5TDiHw0FWVtbRvXv3nu7o6Iix9f4VK1Zs5PP5U254bAJw6NAhhwknSRIcDgcymezljo6OU7bcGxERcSAuLq6uo6PD4ZnfIoDq6mqHCacoCkwmE2FhYafr6upOXr9+fbG1t6pUqk1cLhc8Hs9pqz8hgJCQEIcqoGkaAoEAsbGxLx05cuRbKxueDxMTE1va2toclpPu+DZo2ig99NBD1efOnftSrVYvn6SSHNq8eXO+p6cndDqdw/f9O7YLmIYCn89HSkrKSwUFBRYBhIaGFnh5eXU2NjZCr9fD2WMcAA8PD6coMhqNWLRoUW1FRcWR2tra9AkfhsnsnzFjxl8KCwth+kmrI0diYuKdDYGRXMDj8bBmzZoN69evnxDA7NmzdwYGBvZ3dHQ4pej51UJgZOj1eiQnJ6vLysr2VFVVrTWpGToXL178VxaLBbFY7NTMbxGAr6+v05TRNA0vLy9s2bJlY0pKSqZer799gBofH/9maGjorfb2dnA4HNypMQ7AwMCAUxWq1Wr4+/tfk8vlhZcuXXoJALhcbltqauq7JElCKBTesdWfEMDo7wSdNVgsFh588MHtP/zwQ57BYHBLT09/dcaMGcbW1law7fgwyqEAnO1+Ix8vyWSyvqCgoEMtLS2PqlSqUoqinFry/urboCkErVaL2bNnv5OZmXlMKpXi6tWr4HLv/OfIxP//cfI+H/8bANeS5YFpLrRuAAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: vault-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - vault.security.coreos.com
+                resources:
+                - vaultservices
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+            deployments:
+            - name: vault-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: vault-operator
+                template:
+                  metadata:
+                    labels:
+                      name: vault-operator
+                  spec:
+                    serviceAccountName: vault-operator
+                    containers:
+                    - name: vault-operator
+                      image: quay.io/coreos/vault-operator@sha256:945a0a6d88cf6fa2bce9a83019a2a64f74d89fc8281301a4259f3302eabc79e6
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        version: 0.1.9
+        replaces: vault-operator.0.1.5
+        maturity: alpha
+        customresourcedefinitions:
+          owned:
+          - name: vaultservices.vault.security.coreos.com
+            version: v1alpha1
+            kind: VaultService
+            displayName: Vault Service
+            description: A running Vault instance, backed by an Etcd Cluster
+            resources:
+              - name: etcdclusters.etcd.database.coreos.com
+                version: v1beta2
+                kind: EtcdCluster
+              - kind: Service
+                version: v1
+              - kind: ConfigMap
+                version: v1
+              - kind: Secret
+                version: v1
+              - kind: Deployment
+                version: v1beta2
+              - kind: ReplicaSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of Pods for the cluster
+                displayName: Size
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The service at which the running Vault cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The port at which the Vault cluster is running under the service.
+                displayName: Client Port
+                path: clientPort
+          required:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents a backup for an etcd cluster
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents one try of restoring etcd cluster from previous backup
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        namespace: placeholder
+        name: vault-operator.0.1.5
+        annotations:
+          tectonic-visibility: ocs
+      spec:
+        displayName: Vault
+        description: |
+          An encrypted, multi-tentant secure secret store. Vault handles the lifecycle of your secrets: leasing, key revocation, key rolling, and auditing.
+      
+          _The Vault Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Unsealing and using Vault
+      
+          Once a Vault instance is running, it must be initalized and "unsealed". Afterwards, your software can use the automatically created Kubernetes Service and Secret to communicate with it.
+      
+          [Read the complete guide to using the Vault Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/vault-ocs.html)
+      
+          ### Supported Features
+      
+          **Secure by Default**
+          Hands-free automated creation of TLS certificates between all components ensure all best practices are followed for secret security. Further, the API makes unseal operations easy.
+          **Highly available**
+          Multiple instances of Vault are clustered together via an etcd backend and secured.
+          **Safe Upgrades**
+          Rolling out a new Vault version is as easy as updating the Vault Cluster definition. Everything is automatically handled using Vault best practices while pausing for unseal tokens.
+      
+        keywords: ['vault', 'secret', 'encryption']
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+        provider:
+          name: CoreOS, Inc
+        links:
+        - name: Vault Project
+          url: https://www.vaultproject.io/
+        labels:
+          alm-status-descriptors: vault-operator.0.1.5
+          alm-owner-vault: vault-operator
+          operated-by: vault-operator
+        selector:
+          matchLabels:
+            alm-owner-vault: vault-operator
+            operated-by: vault-operator
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAAA7CAYAAADLjIzcAAAACXBIWXMAAAsTAAALEwEAmpwYAAAMLGlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjarVd3VFP51t23JKGEmoCAlNARBAHpSO+CgHQYW0gChBJCCip2x0EFxy4WrOjYcNSxADIWRB3rIPbuAx1URsbBgg2V9wcBZ+Z93x9vrfdb6+budbLPPvuce9dd6wA6HnyptJDUBYokCllSVCgvIzOLx2oHCxxogYQ7XyCXhiQmxgHAwP0vhwDe3gQBANec+VJpIf67oycUyQUAkQggWygXFAHEIYA2EUhlCoDRCsB6skKqABhvAHBlGZlZAFMNADe3H5sC4Gb3Y1cAXFlKUhjADAfU2Hy+LBfQTgTAKxXkKgBtKQBXiVAsAbQ3AwgU5PGFgHYbgOFFRcVCQIcNwCH7Lzq5f9PMHtTk83MHcX8vAAC1cLFcWsifiv/1KSpUDtSwAsDOk0UnAeACxM6C4tgkAGyAOCrJjk8AoA8Q58RCQIXv5imjU1X8LoE8LAuAIUBCyA+PBWAKkIbKgtQQFXbny4B+PhkvVsSkqHC2rDhJpU+WSgrj41Q6C/JEMQN4o0gekTzAyRFHxgDQBchDZXkp6f0+ydOl4rR4ANoA2SovSI5V5T4sywuLH+DIlEmpAGwA8k2OLDKpn0MZFckH+qJcBPyIZABGABWsyEuJ7s+lMkTyjLgBD0JReES/B0ookqSqvFEKqSI0SZVbLi1MVPGpjaLCqKT+OVP75aXJA7lXFbIU1cypR/n80Yn9/qm3UkViSr83mkYcwhAOHpTgIRvFyIe4pau+CzzVP5HgQ4ZciOCsigxkpIMPGSTgIxll+AMSiCAfzAsFHzKIUAoJPg9G+3+dkQM+ZCiFCHIU4AlkKKJN6EDan46jA+lgOpB2p31o34E8ns5AVWYEM5wZzYxkDhv0IUAxClEMGcT/RywWhRBBCRlEkAz08FWP8YRxhfGIcYPRxriDNPwGGcQDrIniubJ/OOdhDNqgVE1FhGxI0DnAoe1od9qTDqUD6EDaFzzakDaBM+1B+9AhdBDtT3vSvn9zqBz09nWW/6wnguRv/aji2o7anioX2YNPJmyQ9U+VsL/MSIhixP6TSS2gDlJnqZPUeeooVQ8edYJqoC5Rx6j6v7wJv0GG3MFqSRBBggIUQjzAca117XT99B/V+SoHMoggBxSiKQoACCuWTpWJc/MUvBCptFDEi5EIXIbz3F3dvIGMzCxe/+fjtSEIAIThha+xkibAtwIgcr/G+NbAkScA5+3XmPUrgL0UONYqUMpK+2M0ADCgAR1wYQxzWMMBznCHF/wRjAiMRgJSkIkJECAPRZBhMqZjDspRiaVYhXXYhK3YiR9xAPU4ipP4BRfRihu4hzZ04Dm68Ra9BEGwCC2CQxgTFoQt4US4Ez5EIBFBxBFJRCYxicglJISSmE58S1QSy4l1xBZiF/ETcYQ4SZwnrhB3iHaik3hFfCQpkk1ySTPSjhxB+pAhZCyZQo4nc8kSsoycRy4m15A15B6yjjxJXiRvkG3kc7KHAqVJGVKWlDPlQ4VRCVQWlUPJqJlUBVVF1VB7qUbqLHWNaqO6qA80k+bQPNqZ9qej6VRaQJfQM+lF9Dp6J11Hn6av0e10N/2FocUwZTgx/BgxjAxGLmMyo5xRxdjOOMw4w7jB6GC8ZTKZhkx7pjczmpnJzGdOYy5ibmDuYzYxrzAfM3tYLJYxy4kVwEpg8VkKVjlrLWsP6wTrKquD9V5NU81CzV0tUi1LTaI2V61KbbfacbWrak/VetV11W3V/dQT1IXqU9WXqG9Tb1S/rN6h3quhp2GvEaCRopGvMUdjjcZejTMa9zVea2pqWmn6ao7VFGvO1lyjuV/znGa75ge2PtuRHcYex1ayF7N3sJvYd9ivtbS07LSCtbK0FFqLtXZpndJ6qPVem6Ptoh2jLdSepV2tXad9VfuFjrqOrU6IzgSdMp0qnYM6l3W6dNV17XTDdPm6M3WrdY/o3tLt0ePouekl6BXpLdLbrXde75k+S99OP0JfqD9Pf6v+Kf3HHIpjzQnjCDjfcrZxznA6uEyuPTeGm8+t5P7IbeF2G+gbeBikGUwxqDY4ZtBmSBnaGcYYFhouMTxgeNPw4xCzISFDREMWDtk75OqQd0ZDjYKNREYVRvuMbhh9NOYZRxgXGC8zrjd+YEKbOJqMNZlsstHkjEnXUO5Q/6GCoRVDDwy9a0qaOpommU4z3Wp6ybTHzNwsykxqttbslFmXuaF5sHm++Urz4+adFhyLQAuxxUqLExa/8wx4IbxC3hreaV63palltKXScotli2Wvlb1VqtVcq31WD6w1rH2sc6xXWjdbd9tY2IyxmW5Ta3PXVt3WxzbPdrXtWdt3dvZ26Xbz7ertntkb2cfYl9nX2t930HIIcihxqHG4Pow5zGdYwbANw1odSUdPxzzHasfLTqSTl5PYaYPTleGM4b7DJcNrht9yZjuHOJc61zq3uxi6xLnMdal3eTHCZkTWiGUjzo744urpWui6zfWem77baLe5bo1ur9wd3QXu1e7XR2qNjBw5a2TDyJceTh4ij40etz05nmM853s2e3728vaSee316vS28Z7kvd77lg/XJ9Fnkc85X4ZvqO8s36O+H/y8/BR+B/z+9Hf2L/Df7f9slP0o0ahtox4HWAXwA7YEtAXyAicFbg5sC7IM4gfVBD0Ktg4WBm8PfhoyLCQ/ZE/Ii1DXUFno4dB3YX5hM8KawqnwqPCK8JYI/YjUiHURDyOtInMjayO7ozyjpkU1RTOiY6OXRd+KMYsRxOyK6R7tPXrG6NOx7Njk2HWxj+Ic42RxjWPIMaPHrBhzP942XhJfn4CEmIQVCQ8S7RNLEn8eyxybOLZ67JMkt6TpSWeTOckTk3cnv00JTVmSci/VIVWZ2pymkzYubVfau/Tw9OXpbRkjMmZkXMw0yRRnNmSxstKytmf1fBPxzapvOsZ5jisfd3O8/fgp489PMJlQOOHYRJ2J/IkHJzEmpU/aPekTP4Ffw+/Jjslen90tCBOsFjwXBgtXCjtFAaLloqc5ATnLc57lBuSuyO3MC8qryusSh4nXiV/mR+dvyn9XkFCwo6CvML1wX5Fa0aSiIxJ9SYHkdLF58ZTiK1Inabm0rcSvZFVJtyxWtl1OyMfLGxRchVRxSemg/E7ZXhpYWl36fnLa5INT9KZIplya6jh14dSnZZFlP0yjpwmmNU+3nD5nevuMkBlbZhIzs2c2z7KeNW9Wx+yo2TvnaMwpmPPrXNe5y+e++Tb928Z5ZvNmz3v8XdR3teXa5bLyW/P9529aQC8QL2hZOHLh2oVfKoQVFypdK6sqPy0SLLrwvdv3a77vW5yzuGWJ15KNS5lLJUtvLgtatnO53vKy5Y9XjFlRt5K3smLlm1UTV52v8qjatFpjtXJ125q4NQ1rbdYuXftpXd66G9Wh1fvWm65fuP7dBuGGqxuDN+7dZLapctPHzeLNt7dEbamrsaup2srcWrr1yba0bWd/8Plh13aT7ZXbP++Q7GjbmbTz9C7vXbt2m+5eUkvWKms794zb0/pj+I8Ne533btlnuK9yP/Yr9//+06Sfbh6IPdB80Ofg3kO2h9Yf5hyuqCPqptZ11+fVtzVkNlw5MvpIc6N/4+GfXX7ecdTyaPUxg2NLjmscn3e870TZiZ4maVPXydyTj5snNt87lXHq+umxp1vOxJ4590vkL6fOhpw9cS7g3NHzfuePXPC5UH/R62LdJc9Lh3/1/PVwi1dL3WXvyw2tvq2NV0ZdOX416OrJa+HXfrkec/3ijfgbV26m3rx9a9ytttvC28/uFN55ebf0bu+92fcZ9yse6D6oemj6sOZfw/61r82r7Vh7ePulR8mP7j0WPH7+m/y3Tx3znmg9qXpq8XTXM/dnRzsjO1t//+b3jufS571d5X/o/bH+hcOLQ38G/3mpO6O746XsZd+rRa+NX+944/GmuSex5+Hbore97yreG7/f+cHnw9mP6R+f9k7+xPq05vOwz41fYr/c7yvq65PyZXwAAAWAzMkBXu0AtDIBTiugod2/f6n2RuLrBvn/4f4dDQDgBewIBlJnA3FNwMYmwHY2wG4CEgGkBIMcOXLwUh15zkj3fi22DGC87+t7bQawGoHPsr6+3g19fZ+3AdQdoKmkf+8DAKYusJkHAL9az/+P/evfXvpsNqq3M8UAADowaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzExMSA3OS4xNTgzMjUsIDIwMTUvMDkvMTAtMDE6MTA6MjAgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgICAgICAgICAgeG1sbnM6cGhvdG9zaG9wPSJodHRwOi8vbnMuYWRvYmUuY29tL3Bob3Rvc2hvcC8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6Q3JlYXRlRGF0ZT4yMDE3LTA5LTA2VDE1OjMxOjU2LTA0OjAwPC94bXA6Q3JlYXRlRGF0ZT4KICAgICAgICAgPHhtcDpNZXRhZGF0YURhdGU+MjAxNy0wOS0wNlQxNTozMTo1Ni0wNDowMDwveG1wOk1ldGFkYXRhRGF0ZT4KICAgICAgICAgPHhtcDpNb2RpZnlEYXRlPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3htcDpNb2RpZnlEYXRlPgogICAgICAgICA8eG1wTU06SW5zdGFuY2VJRD54bXAuaWlkOjFlMjY4MTE5LWU2NmYtNGJjNC1hZTI0LThiMTViNTg3MzE2MjwveG1wTU06SW5zdGFuY2VJRD4KICAgICAgICAgPHhtcE1NOkRvY3VtZW50SUQ+YWRvYmU6ZG9jaWQ6cGhvdG9zaG9wOjczODM4YzJiLWQzYzgtMTE3YS1iNTYyLTllNjU3MTBkNzc5YzwveG1wTU06RG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD54bXAuZGlkOjQ1MjdmNDhmLTc2MGMtNGRhYi04NTJkLTNkNGZiOTA4ZmEzNjwveG1wTU06T3JpZ2luYWxEb2N1bWVudElEPgogICAgICAgICA8eG1wTU06SGlzdG9yeT4KICAgICAgICAgICAgPHJkZjpTZXE+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPmNyZWF0ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDo0NTI3ZjQ4Zi03NjBjLTRkYWItODUyZC0zZDRmYjkwOGZhMzY8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDphY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDoxZTI2ODExOS1lNjZmLTRiYzQtYWUyNC04YjE1YjU4NzMxNjI8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICAgICA8c3RFdnQ6Y2hhbmdlZD4vPC9zdEV2dDpjaGFuZ2VkPgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgPC9yZGY6U2VxPgogICAgICAgICA8L3htcE1NOkhpc3Rvcnk+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzpmb3JtYXQ+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZGU+CiAgICAgICAgIDxwaG90b3Nob3A6SUNDUHJvZmlsZT5EaXNwbGF5PC9waG90b3Nob3A6SUNDUHJvZmlsZT4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+NzIwMDAwLzEwMDAwPC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj43MjAwMDAvMTAwMDA8L3RpZmY6WVJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+NjU1MzU8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjY0PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjU5PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz6RZ44uAAAAIGNIUk0AAG11AABzoAAA/N0AAINkAABw6AAA7GgAADA+AAAQkOTsmeoAAAreSURBVHja7Jt5VFN3Fse/7yUkgQSyQBAiJWwTglKZqKBVFgURsVFgpAO2TRUonU7n0MWpVqnL6a7jtAdoz+lAsS61damHTnXascLUojMHLVUcpaesjUAVlFUWY7b35g+KhUBCEhJ71Pmd8/sDeO/edz+/e+/v3t97EDRN434eJO7zcd8DYJr+Ijc396kbN26EMxgM7b1kKE3TBEmSRHJy8m6VSlVrFkBLS4u2vLw8715cbS6X+/WcOXN6LYbAM888szckJOSre814giC0y5YtW93c3HzFIgA+n48nnnhi/b0GICIi4j2ZTHZdp9NZToJarRYpKSmXIiIiyu6ZRMdk9sfHx7/OZrMhEoksAxCJRBCLxdi0adOLDAaDuhcAxMbGFoSHh/exWCwIhULLAJhMJrq6uhAVFaWWyWQf3O3Gs9nsrrS0tB1MJhN8Ph8CgcDyNlhSUgKCIMBmszFz5sxX6urqsmmadrlbASiVyu0KheJma2vruNWf0AM0Gg2GhobQ19cHuVzePmvWrPfvVuN5PF772rVrCwBAIBDcnhY9YPr06SOFAzgcDhISEl6tra3NMRqN3LsNQE5Oztbly5cb6+vrxyU/swBM3UShUHRHR0cXVVZWbrqbjOdwOPXu7u6lhw8fRnd3NwiCuP23sLCwX+oD026wtLR0dPkIDw8PdHV1ua9bt+6yTqcT3S0AYmJifi+VSj9ta2sDkzl2nSsqKsx7AJ/PHycsMjJyQKlU7iwrK3trSp1XkBxU+xVAMzDK5cRAb+fYqi0wGLS62W49AoHgYlRU1KcajQZyudy2bnB0shAIBLeBZGdnv+3m5tZh93ak+gNEF/8L/jdnQU7zGTY0Mg4M1fMgl6QNX8TiwHX7R3D/5wWwcvMBEHbpSkxMzPf19YWHhwdEItG4aRFAQEDAmBkYGAihUIiHH35Yn5ubu81eAK6bXwfJZYEdFQaX5BXDyhXRIIwGEDMjAZIE6RcIVvrjII08sLNeBNhsm/X4+vp+m5iY+AVBEBCJRBAKheOmxSRYVVU1USuJhoYGeHt7l7DZ7Be1Wu1vbH0wTdE7YBa9CUN9O/TffD0s9/tqYE4s6LoLAEWBuqKG7ou/w0WZCt2uEkCvsxlARkbGBh8fH9A0PSbxmW2STJNgSkrKhBcaDAb4+fmhsbEx8+TJkwfs6sgkwaCvmsQ2wQHoW2PdMlAOSl1ns/zg4OCvS0tLE/r6+mAwGMxel56ebt4DgoKCLDUVWLBgwcELFy683NvbG26T8dOmw/VPT8PY8CO0e4drK8Zv54Hz5JPQHfsS+q8+G77O1x+02AdEXyfo3m5b2l0899xzGyQSCSiKsmr1JwRgWimZhoK3tzeSkpJePnjw4Oc2VWV7joCzbD5oAFRrM/QnT4Bb/AVc5nrCJe1J9C8IBtWiBql8HOCLgMAwGD8tASijVfIDAgIOL1my5JxWq4W7u7v9R2KWAIxASEpKOlpZWflde3v7XKs16XQgAIwOONqgBU0CtB6A8WdDKSNAkqAp2xpRmUy2tbi4GHq9HtQk90ZGRtpWB5gCkEgkyMjI2FhQUFBh7QMO5mSAynsBhvom6E+eAAAMZS8Fe7UK+q+Og/qpBQBg/Gw34O0H/NRk9eqHhIR8FBoaWt/a2mqT+0+YBMvKJj8HGWkts7KyKtVqdaz1h3KewJBJXIv9gc7WURmQAWZEJAw1Z6yNfX1WVlaoj4+PemBgwCrjCwsLzdcBE+2bppPH40EikSAvL2+DtbYzlq+G66H/gF30GQjPacN1T95r4H15EZw3dgNMFxBcLtzLqyE8XwW39z8BSOakchUKxW6FQqFmMpm3C7fJpk3NkLlhNBqhVCrPFhUVlV2+fPl3k3pNfCoIigIjfC6I4DDQ3dfgEp8C9PWCEZ0McHggJF5gxyuGmxnVatx8/ilAO2i+jCXJmytXrnyFw+HAw8PDJtc3C2Dfvn1WbztsNhthYWFbrQFgOFIC4tk3QJ2rBP39d8PnjwffB3vNs9Af+wQY6gOlHoRm31FwViyFZmeBReMBIC4u7m/z58+/euXKFasXbtIcsGrVKqtupGkaJEnC398fR48ePdDc3Jw5qTLPaaD7ugHjqCLF3RMYGJsXiIBQ0JfrJ8tDN4qLi4P8/f17enp6bFr9Rx55xLwHSKVSmwi6u7tj0aJFW5qbm9MnkjcGWve1MT+zkpRwfeGPuHX4OLQfvvvLdZMY//NRV+HChQt7WlpaJt25HFoHTBQKc+fObTp//vy+mpqabOu7I3dw9xyDiw/ATFoOQ/VpGC9dsG4z4XLb8/PzdwiFQhiNRrti32EAaJqGm5sbUlNTt9XU1DwKgGNdFtWD+rEZ8AkGdY0GPTRotc7w8PC3BgcHb549e9ZizW9ujD4RmjKAES+Ijo7+KTY29oNTp05Z915RdwsDmQnQr82G9vi/QP3YZJ3juLq2hYeHF+/atQs6nc6u1U9LSzMPwNzh4WRe4Orqiuzs7FdOnz6dTdO0VQeoVFsLbr5m2xHDwoULX5NKpbrOzs4pub5ZAA888IB92wlBYNWqVd3l5eXvfPzxx1uccc7H5/MbExISSimKgqenp0NkjgPQ1NRklyCapjE4OAi5XP4mg8F42mg0ih0NQKlUbgsMDKTb29sdsvoTAtizZ4/dwiiKgpeX161Zs2Ztr6mpeduRxnt7e19KS0s7oNfr7QpTqwGIxVNbOBaLhXnz5r1XV1e3TqPRTHfUg6pUqvygoCC0trbCzc3NeQC8vLymJJCmaYjFYl1MTMzrJ06ccMhrteDg4G8fe+yxf+h0OrtLXqsBOEIBg8HA0qVLS86cObO+v78/aKrycnJy/qxQKNDQ0ACSJJ0LYCpl5eghkUiolStXbtu/f/9HU4z9E0NDQ//euXMnNBqNQ55t69atzvWAkVBIT0/ff/z48Y1dXV0z7ZUTExOT39PTg4sXL457xeUUD7CnEjQHQCqVIicnJ3/Hjh2f2xn7n0dGRp7r7u6e9BWXwwD4+fk5TDiHw0FWVtbRvXv3nu7o6Iix9f4VK1Zs5PP5U254bAJw6NAhhwknSRIcDgcymezljo6OU7bcGxERcSAuLq6uo6PD4ZnfIoDq6mqHCacoCkwmE2FhYafr6upOXr9+fbG1t6pUqk1cLhc8Hs9pqz8hgJCQEIcqoGkaAoEAsbGxLx05cuRbKxueDxMTE1va2toclpPu+DZo2ig99NBD1efOnftSrVYvn6SSHNq8eXO+p6cndDqdw/f9O7YLmIYCn89HSkrKSwUFBRYBhIaGFnh5eXU2NjZCr9fD2WMcAA8PD6coMhqNWLRoUW1FRcWR2tra9AkfhsnsnzFjxl8KCwth+kmrI0diYuKdDYGRXMDj8bBmzZoN69evnxDA7NmzdwYGBvZ3dHQ4pej51UJgZOj1eiQnJ6vLysr2VFVVrTWpGToXL178VxaLBbFY7NTMbxGAr6+v05TRNA0vLy9s2bJlY0pKSqZer799gBofH/9maGjorfb2dnA4HNypMQ7AwMCAUxWq1Wr4+/tfk8vlhZcuXXoJALhcbltqauq7JElCKBTesdWfEMDo7wSdNVgsFh588MHtP/zwQ57BYHBLT09/dcaMGcbW1law7fgwyqEAnO1+Ix8vyWSyvqCgoEMtLS2PqlSqUoqinFry/urboCkErVaL2bNnv5OZmXlMKpXi6tWr4HLv/OfIxP//cfI+H/8bANeS5YFpLrRuAAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: vault-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - vault.security.coreos.com
+                resources:
+                - vaultservices
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+            deployments:
+            - name: vault-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: vault-operator
+                template:
+                  metadata:
+                    labels:
+                      name: vault-operator
+                  spec:
+                    serviceAccountName: vault-operator
+                    containers:
+                    - name: vault-operator
+                      image: quay.io/coreos/vault-operator@sha256:74036811bc5d6cc1a136d8cc6d5577db67f29ba95eba02fbf0c3a8d2357dc8fe
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        version: 0.1.5
+        maturity: alpha
+        customresourcedefinitions:
+          owned:
+          - name: vaultservices.vault.security.coreos.com
+            version: v1alpha1
+            kind: VaultService
+            displayName: Vault Service
+            description: A running Vault instance, backed by an Etcd Cluster
+            resources:
+              - name: etcdclusters.etcd.database.coreos.com
+                version: v1beta2
+                kind: EtcdCluster
+              - kind: Service
+                version: v1
+              - kind: ConfigMap
+                version: v1
+              - kind: Secret
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of Pods for the cluster
+                displayName: Size
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The status of each of the node Pods for the Vault cluster.
+                displayName: Node Status
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running Vault cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The port at which the Vault cluster is running under the service.
+                displayName: Client Port
+                path: clientPort
+          required:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/etcdoperator.v0.9.2.clusterserviceversion.yaml
+      packageName: etcd
+      channels:
+      - name: alpha
+        currentCSV: etcdoperator.v0.9.2
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/prometheusoperator.0.15.0.clusterserviceversion.yaml
+      packageName: prometheus
+      channels:
+      - name: alpha
+        currentCSV: prometheusoperator.0.15.0
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/vaultoperator.0.1.9.clusterserviceversion.yaml
+      packageName: vault
+      channels:
+      - name: alpha
+        currentCSV: vault-operator.0.1.9
+      
+

--- a/deploy/aos-olm/0.5.0/files/10-tectonicocs.catalogsource.yaml
+++ b/deploy/aos-olm/0.5.0/files/10-tectonicocs.catalogsource.yaml
@@ -1,0 +1,19 @@
+##---
+# Source: olm/templates/10-tectonicocs.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: app.coreos.com/v1alpha1
+kind: CatalogSource-v1
+metadata:
+  name: tectonic-ocs
+  namespace: operator-lifecycle-manager
+  annotations:
+    tectonic-operators.coreos.com/upgrade-strategy: 'DeleteAndRecreate'
+spec:
+  name: tectonic-ocs
+  sourceType: internal
+  configMap: tectonic-ocs
+  displayName: Tectonic Open Cloud Services
+  publisher: CoreOS, Inc.
+

--- a/deploy/aos-olm/0.5.0/files/12-alm-operator.deployment.yaml
+++ b/deploy/aos-olm/0.5.0/files/12-alm-operator.deployment.yaml
@@ -1,0 +1,48 @@
+##---
+# Source: olm/templates/12-alm-operator.deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: alm-operator
+  namespace: operator-lifecycle-manager
+  labels:
+    app: alm-operator
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alm-operator
+  template:
+    metadata:
+      labels:
+        app: alm-operator
+    spec:
+      serviceAccountName: alm-operator-serviceaccount
+      containers:
+        - name: alm-operator
+          command:
+          - /bin/alm
+          image: quay.io/coreos/olm@sha256:d19b64d801a08fd4838ed4bd9752712688ac9f2a26fab89bcb4f28b1bbdcab16
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: alm-operator
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/deploy/aos-olm/0.5.0/files/13-catalog-operator.deployment.yaml
+++ b/deploy/aos-olm/0.5.0/files/13-catalog-operator.deployment.yaml
@@ -1,0 +1,44 @@
+##---
+# Source: olm/templates/13-catalog-operator.deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  namespace: operator-lifecycle-manager
+  labels:
+    app: catalog-operator
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      labels:
+        app: catalog-operator
+    spec:
+      serviceAccountName: alm-operator-serviceaccount
+      containers:
+        - name: catalog-operator
+          command:
+          - /bin/catalog
+          - '-namespace'
+          - operator-lifecycle-manager
+          - '-debug'
+          image: quay.io/coreos/catalog@sha256:299a9cd6b34c9ccb601d6fffa8b6a633658165510940ed8c5481ce6acdad46b1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/deploy/aos-olm/0.5.0/files/18-upstreamcomponents.configmap.yaml
+++ b/deploy/aos-olm/0.5.0/files/18-upstreamcomponents.configmap.yaml
@@ -1,0 +1,462 @@
+##---
+# Source: olm/templates/18-upstreamcomponents.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: upstream-components
+  namespace: operator-lifecycle-manager
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: meterings.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/description: An instance of Chargeback
+          catalog.app.coreos.com/displayName: Chargeback
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: meterings
+          singular: metering
+          kind: Metering
+          listKind: MeteringList
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prestotables.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Presto Table"
+          catalog.app.coreos.com/description: "A table within PrestoDB"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: prestotables
+          singular: prestotable
+          kind: PrestoTable
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reports.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Report"
+          catalog.app.coreos.com/description: "A chargeback report for a specific time interval"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reports
+          kind: Report
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportdatasources.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback data source"
+          catalog.app.coreos.com/description: "A resource describing a source of data for usage by Report Generation Queries"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportdatasources
+          singular: reportdatasource
+          kind: ReportDataSource
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportgenerationqueries.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback generation query"
+          catalog.app.coreos.com/description: "A SQL query used by Chargeback to generate reports"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportgenerationqueries
+          singular: reportgenerationquery
+          kind: ReportGenerationQuery
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportprometheusqueries.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback prometheus query"
+          catalog.app.coreos.com/description: "A Prometheus query by Chargeback to do metering"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportprometheusqueries
+          singular: reportprometheusquery
+          kind: ReportPrometheusQuery
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: scheduledreports.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Scheduled Report"
+          catalog.app.coreos.com/description: "A chargeback report that runs on a scheduled interval"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: scheduledreports
+          kind: ScheduledReport
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: storagelocations.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback storage location"
+          catalog.app.coreos.com/description: "Represents a configurable storage location for Chargeback to store metering and report data"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: storagelocations
+          kind: StorageLocation
+      
+  clusterServiceVersions: |-
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: metering-helm-operator.v0.6.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: tectonic-feature
+        labels:
+          alm-catalog: tectonic-feature
+          operator-metering: "true"
+      spec:
+        displayName: Metering
+        description: Metering can generate reports based on historical usage data from a cluster, providing accountability for how resources have been used.
+        keywords: [metering metrics reporting coreos]
+        version: 0.6.0
+        maturity: alpha
+        maintainers:
+          - email: support@coreos.com
+            name: CoreOS, Inc
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-metering: metering-helm-operator
+          alm-status-descriptors: metering-helm-operator.v0.6.0
+        selector:
+          matchLabels:
+            alm-owner-metering: metering-helm-operator
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+              - rules:
+                - apiGroups:
+                  - chargeback.coreos.com
+                  resources:
+                  - '*'
+                  verbs:
+                  - '*'
+                - apiGroups:
+                  - ""
+                  resources:
+                  - pods
+                  - pods/attach
+                  - pods/exec
+                  - pods/portforward
+                  - pods/proxy
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - configmaps
+                  - endpoints
+                  - persistentvolumeclaims
+                  - replicationcontrollers
+                  - replicationcontrollers/scale
+                  - secrets
+                  - serviceaccounts
+                  - services
+                  - services/proxy
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - bindings
+                  - events
+                  - limitranges
+                  - namespaces/status
+                  - pods/log
+                  - pods/status
+                  - replicationcontrollers/status
+                  - resourcequotas
+                  - resourcequotas/status
+                  verbs:
+                  - get
+                  - list
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - events
+                  verbs:
+                  - create
+                  - update
+                  - patch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - namespaces
+                  verbs:
+                  - get
+                  - list
+                  - watch
+                - apiGroups:
+                  - apps
+                  resources:
+                  - deployments
+                  - deployments/rollback
+                  - deployments/scale
+                  - statefulsets
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - batch
+                  resources:
+                  - cronjobs
+                  - jobs
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - extensions
+                  resources:
+                  - daemonsets
+                  - deployments
+                  - deployments/rollback
+                  - deployments/scale
+                  - replicasets
+                  - replicasets/scale
+                  - replicationcontrollers/scale
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - rbac.authorization.k8s.io
+                  resources:
+                  - rolebindings
+                  - roles
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                serviceAccountName: metering-helm-operator
+            deployments:
+              - name: metering-helm-operator
+                spec:
+                  replicas: 1
+                  selector:
+                    matchLabels:
+                      app: metering-helm-operator
+                  strategy:
+                    type: Recreate
+                  template:
+                    metadata:
+                      labels:
+                        app: metering-helm-operator
+                    spec:
+                      containers:
+                      - args:
+                        - run-operator.sh
+                        env:
+                        - name: HELM_RELEASE_CRD_NAME
+                          value: Metering
+                        - name: HELM_RELEASE_CRD_API_GROUP
+                          value: chargeback.coreos.com
+                        - name: HELM_CHART_PATH
+                          value: /operator-metering-0.1.0.tgz
+                        - name: MY_POD_NAME
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.name
+                        - name: MY_POD_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: HELM_HOST
+                          value: 127.0.0.1:44134
+                        - name: HELM_WAIT
+                          value: "false"
+                        - name: HELM_RECONCILE_INTERVAL_SECONDS
+                          value: "30"
+                        - name: RELEASE_HISTORY_LIMIT
+                          value: "3"
+                        image: quay.io/coreos/chargeback-helm-operator:0.6.0
+                        imagePullPolicy: Always
+                        name: metering-helm-operator
+                        resources:
+                          limits:
+                            cpu: 50m
+                            memory: 25Mi
+                          requests:
+                            cpu: 50m
+                            memory: 25Mi
+                      - args:
+                        - /tiller
+                        env:
+                        - name: TILLER_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: TILLER_HISTORY_MAX
+                          value: "3"
+                        image: quay.io/coreos/chargeback-helm-operator:0.6.0
+                        imagePullPolicy: Always
+                        livenessProbe:
+                          failureThreshold: 3
+                          httpGet:
+                            path: /liveness
+                            port: 44135
+                            scheme: HTTP
+                          initialDelaySeconds: 1
+                          periodSeconds: 10
+                          successThreshold: 1
+                          timeoutSeconds: 1
+                        name: tiller
+                        readinessProbe:
+                          failureThreshold: 3
+                          httpGet:
+                            path: /readiness
+                            port: 44135
+                            scheme: HTTP
+                          initialDelaySeconds: 1
+                          periodSeconds: 10
+                          successThreshold: 1
+                          timeoutSeconds: 1
+                        resources:
+                          limits:
+                            cpu: 50m
+                            memory: 100Mi
+                          requests:
+                            cpu: 50m
+                            memory: 50Mi
+                      imagePullSecrets: []
+                      restartPolicy: Always
+                      securityContext:
+                        runAsNonRoot: true
+                      serviceAccount: metering-helm-operator
+                      terminationGracePeriodSeconds: 30
+        customresourcedefinitions:
+          owned:
+          - description: An instance of Metering
+            displayName: Metering
+            kind: Metering
+            name: meterings.chargeback.coreos.com
+            version: v1alpha1
+          - description: A table within PrestoDB
+            displayName: Chargeback Presto Table
+            kind: PrestoTable
+            name: prestotables.chargeback.coreos.com
+            version: v1alpha1
+          - description: A resource describing a source of data for usage by Report Generation
+              Queries
+            displayName: Chargeback data source
+            kind: ReportDataSource
+            name: reportdatasources.chargeback.coreos.com
+            version: v1alpha1
+          - description: A SQL query used by Chargeback to generate reports
+            displayName: Chargeback generation query
+            kind: ReportGenerationQuery
+            name: reportgenerationqueries.chargeback.coreos.com
+            version: v1alpha1
+          - description: A Prometheus query by Chargeback to do metering
+            displayName: Chargeback prometheus query
+            kind: ReportPrometheusQuery
+            name: reportprometheusqueries.chargeback.coreos.com
+            version: v1alpha1
+          - description: A chargeback report for a specific time interval
+            displayName: Chargeback Report
+            kind: Report
+            name: reports.chargeback.coreos.com
+            version: v1alpha1
+          - description: A chargeback report that runs on a scheduled interval
+            displayName: Chargeback Scheduled Report
+            kind: ScheduledReport
+            name: scheduledreports.chargeback.coreos.com
+            version: v1alpha1
+          - description: Represents a configurable storage location for Chargeback to store
+              metering and report data
+            displayName: Chargeback storage location
+            kind: StorageLocation
+            name: storagelocations.chargeback.coreos.com
+            version: v1alpha1
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/upstream/metering.0.6.0.clusterserviceversion.yaml
+      packageName: metering
+      channels:
+      - currentCSV: metering-helm-operator.v0.6.0
+        name: alpha
+      
+

--- a/deploy/aos-olm/0.5.0/files/19-upstreamcomponents.catalogsource.yaml
+++ b/deploy/aos-olm/0.5.0/files/19-upstreamcomponents.catalogsource.yaml
@@ -1,0 +1,19 @@
+##---
+# Source: olm/templates/19-upstreamcomponents.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: app.coreos.com/v1alpha1
+kind: CatalogSource-v1
+metadata:
+  name: upstream-components
+  namespace: operator-lifecycle-manager
+  annotations:
+    tectonic-operators.coreos.com/upgrade-strategy: 'DeleteAndRecreate'
+spec:
+  name: upstream-components
+  sourceType: internal
+  configMap: upstream-components
+  displayName: OLM Upstream Components
+  publisher: CoreOS, Inc.
+

--- a/deploy/aos-olm/0.5.0/meta/main.yaml
+++ b/deploy/aos-olm/0.5.0/meta/main.yaml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Evan Cordell
+  description: Operator Lifecycle Manager
+  company: Red Hat, Inc.
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.1
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - cloud
+dependencies:
+- role: lib_utils
+- role: lib_openshift

--- a/deploy/aos-olm/0.5.0/tasks/install.yaml
+++ b/deploy/aos-olm/0.5.0/tasks/install.yaml
@@ -1,0 +1,126 @@
+---
+
+- name: create operator-lifecycle-manager project
+  oc_project:
+    name: operator-lifecycle-manager
+    state: present
+    node_selector:
+      - ""
+
+- name: Make temp directory for manifests
+  command: mktemp -d /tmp/olm-ansible-XXXXXX
+  register: mktemp
+  changed_when: False
+
+- name: Copy manifests to temp directory
+  copy:
+    src: "{{ item }}"
+    dest: "{{ mktemp.stdout }}"
+  with_fileglob: files/*.yaml
+- name: Apply alm-operator-serviceaccount ServiceAccount manifest
+  oc_obj:
+    state: present
+    kind: ServiceAccount
+    name: alm-operator-serviceaccount
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/01-alm-operator.serviceaccount.yaml"
+
+- name: Apply alm-operator-binding ClusterRoleBinding manifest
+  oc_obj:
+    state: present
+    kind: ClusterRoleBinding
+    name: alm-operator-binding
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/02-alm-operator.rolebinding.yaml"
+
+- name: Apply clusterserviceversion-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: present
+    kind: CustomResourceDefinition
+    name: clusterserviceversion-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/03-clusterserviceversion.crd.yaml"
+
+- name: Apply catalogsource-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: present
+    kind: CustomResourceDefinition
+    name: catalogsource-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/05-catalogsource.crd.yaml"
+
+- name: Apply installplan-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: present
+    kind: CustomResourceDefinition
+    name: installplan-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/06-installplan.crd.yaml"
+
+- name: Apply subscription-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: present
+    kind: CustomResourceDefinition
+    name: subscription-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/07-subscription.crd.yaml"
+
+- name: Apply tectonic-ocs ConfigMap manifest
+  oc_obj:
+    state: present
+    kind: ConfigMap
+    name: tectonic-ocs
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/08-tectonicocs.configmap.yaml"
+
+- name: Apply tectonic-ocs CatalogSource-v1 manifest
+  oc_obj:
+    state: present
+    kind: CatalogSource-v1
+    name: tectonic-ocs
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/10-tectonicocs.catalogsource.yaml"
+
+- name: Apply alm-operator Deployment manifest
+  oc_obj:
+    state: present
+    kind: Deployment
+    name: alm-operator
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/12-alm-operator.deployment.yaml"
+
+- name: Apply catalog-operator Deployment manifest
+  oc_obj:
+    state: present
+    kind: Deployment
+    name: catalog-operator
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/13-catalog-operator.deployment.yaml"
+
+- name: Apply upstream-components ConfigMap manifest
+  oc_obj:
+    state: present
+    kind: ConfigMap
+    name: upstream-components
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/18-upstreamcomponents.configmap.yaml"
+
+- name: Apply upstream-components CatalogSource-v1 manifest
+  oc_obj:
+    state: present
+    kind: CatalogSource-v1
+    name: upstream-components
+    namespace: operator-lifecycle-manager
+    files:
+      - "{{ mktemp.stdout }}/19-upstreamcomponents.catalogsource.yaml"

--- a/deploy/aos-olm/0.5.0/tasks/main.yaml
+++ b/deploy/aos-olm/0.5.0/tasks/main.yaml
@@ -1,0 +1,8 @@
+---
+# do any asserts here
+
+- include_tasks: install.yaml
+  when: operator_lifecycle_manager_install | bool
+
+- include_tasks: remove.yaml
+  when: operator_lifecycle_manager_remove | bool

--- a/deploy/aos-olm/0.5.0/tasks/remove.yaml
+++ b/deploy/aos-olm/0.5.0/tasks/remove.yaml
@@ -1,0 +1,8 @@
+---
+
+- import_tasks: remove_components.yaml
+
+- name: remove openshift-ansible-service-broker project
+  oc_project:
+    name: openshift-ansible-service-broker
+    state: absent

--- a/deploy/aos-olm/0.5.0/tasks/remove_components.yaml
+++ b/deploy/aos-olm/0.5.0/tasks/remove_components.yaml
@@ -1,0 +1,84 @@
+---
+- name: Remove alm-operator-serviceaccount ServiceAccount manifest
+  oc_obj:
+    state: absent
+    kind: ServiceAccount
+    name: alm-operator-serviceaccount
+    namespace: operator-lifecycle-manager
+
+- name: Remove alm-operator-binding ClusterRoleBinding manifest
+  oc_obj:
+    state: absent
+    kind: ClusterRoleBinding
+    name: alm-operator-binding
+    namespace: operator-lifecycle-manager
+
+- name: Remove clusterserviceversion-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: absent
+    kind: CustomResourceDefinition
+    name: clusterserviceversion-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+
+- name: Remove catalogsource-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: absent
+    kind: CustomResourceDefinition
+    name: catalogsource-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+
+- name: Remove installplan-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: absent
+    kind: CustomResourceDefinition
+    name: installplan-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+
+- name: Remove subscription-v1s.app.coreos.com CustomResourceDefinition manifest
+  oc_obj:
+    state: absent
+    kind: CustomResourceDefinition
+    name: subscription-v1s.app.coreos.com
+    namespace: operator-lifecycle-manager
+
+- name: Remove tectonic-ocs ConfigMap manifest
+  oc_obj:
+    state: absent
+    kind: ConfigMap
+    name: tectonic-ocs
+    namespace: operator-lifecycle-manager
+
+- name: Remove tectonic-ocs CatalogSource-v1 manifest
+  oc_obj:
+    state: absent
+    kind: CatalogSource-v1
+    name: tectonic-ocs
+    namespace: operator-lifecycle-manager
+
+- name: Remove alm-operator Deployment manifest
+  oc_obj:
+    state: absent
+    kind: Deployment
+    name: alm-operator
+    namespace: operator-lifecycle-manager
+
+- name: Remove catalog-operator Deployment manifest
+  oc_obj:
+    state: absent
+    kind: Deployment
+    name: catalog-operator
+    namespace: operator-lifecycle-manager
+
+- name: Remove upstream-components ConfigMap manifest
+  oc_obj:
+    state: absent
+    kind: ConfigMap
+    name: upstream-components
+    namespace: operator-lifecycle-manager
+
+- name: Remove upstream-components CatalogSource-v1 manifest
+  oc_obj:
+    state: absent
+    kind: CatalogSource-v1
+    name: upstream-components
+    namespace: operator-lifecycle-manager

--- a/deploy/aos-olm/playbook/private/roles/olm
+++ b/deploy/aos-olm/playbook/private/roles/olm
@@ -1,1 +1,1 @@
-../../../../deploy/aos-olm/0.4.1
+../../../../deploy/aos-olm/0.5.0

--- a/deploy/aos-olm/values.yaml
+++ b/deploy/aos-olm/values.yaml
@@ -4,19 +4,17 @@ catalog_namespace: operator-lifecycle-manager
 alm:
   replicaCount: 1
   image:
-    ref: quay.io/coreos/olm@sha256:351f0c4973a88a4ea606721555829776429b0ecb53d5a2bfee6bce459d109e5b
+    ref: quay.io/coreos/olm@sha256:d19b64d801a08fd4838ed4bd9752712688ac9f2a26fab89bcb4f28b1bbdcab16
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
-
 catalog:
   replicaCount: 1
   image:
-    ref: quay.io/coreos/catalog@sha256:54571e25474a9a063a144922e7321203e5aa5e63d03f748682d559341359a916
+    ref: quay.io/coreos/catalog@sha256:299a9cd6b34c9ccb601d6fffa8b6a633658165510940ed8c5481ce6acdad46b1
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
-
 catalog_sources:
- - tectonic-ocs
- - upstream-components
+- tectonic-ocs
+- upstream-components

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/01-alm-operator.serviceaccount.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/01-alm-operator.serviceaccount.yaml
@@ -1,0 +1,11 @@
+##---
+# Source: olm/templates/01-alm-operator.serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: alm-operator-serviceaccount
+  namespace: tectonic-system
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+imagePullSecrets:
+- name: coreos-pull-secret

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/02-alm-operator.rolebinding.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/02-alm-operator.rolebinding.yaml
@@ -1,0 +1,16 @@
+##---
+# Source: olm/templates/02-alm-operator.rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alm-operator-binding
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: alm-operator-serviceaccount
+  namespace: tectonic-system

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/03-clusterserviceversion.crd.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/03-clusterserviceversion.crd.yaml
@@ -1,0 +1,413 @@
+##---
+# Source: olm/templates/03-clusterserviceversion.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterserviceversion-v1s.app.coreos.com
+  annotations:
+    displayName: Operator Version
+    description: Represents an Operator that should be running on the cluster, including requirements and install strategy.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  names:
+    plural: clusterserviceversion-v1s
+    singular: clusterserviceversion-v1
+    kind: ClusterServiceVersion-v1
+    listKind: ClusterServiceVersionList-v1
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a single version of the operator software
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a ClusterServiceVersion
+          required:
+          - displayName
+          - install
+          properties:
+            displayName:
+              type: string
+              description: Human readable name of the application that will be displayed in the ALM UI
+
+            description:
+              type: string
+              description: Human readable description of what the application does
+
+            keywords:
+              type: array
+              description: List of keywords which will be used to discover and categorize app types
+              items:
+                type: string
+
+            maintainers:
+              type: array
+              description: Those responsible for the creation of this specific app type
+              items:
+                type: object
+                description: Information for a single maintainer
+                required:
+                - name
+                - email
+                properties:
+                  name:
+                    type: string
+                    description: Maintainer's name
+                  email:
+                    type: string
+                    description: Maintainer's email address
+                    format: email
+                optionalProperties:
+                  type: string
+                  description: "Any additional key-value metadata you wish to expose about the maintainer, e.g. github: <username>"
+
+            links:
+              type: array
+              description: Interesting links to find more information about the project, such as marketing page, documentation, or github page
+              items:
+                type: object
+                description: A single link to describe one aspect of the project
+                required:
+                - name
+                - url
+                properties:
+                  name:
+                    type: string
+                    description: Name of the link type, e.g. homepage or github url
+                  url:
+                    type: string
+                    description: URL to which the link should point
+                    format: uri
+
+            icon:
+              type: array
+              description: Icon which should be rendered with the application information
+              required:
+              - base64data
+              - mediatype
+              properties:
+                base64data:
+                  type: string
+                  description: Base64 binary representation of the icon image
+                  pattern: ^(?:[A-Za-z0-9+/]{4}){0,16250}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                mediatype:
+                  type: string
+                  description: Mediatype for the binary data specified in the base64data property
+                  enum:
+                  - image/gif
+                  - image/jpeg
+                  - image/png
+                  - image/svg+xml
+            version:
+              type: string
+              description: Version string, recommended that users use semantic versioning
+              pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+            replaces:
+              type: string
+              description: Name of the ClusterServiceVersion custom resource that this version replaces
+
+            maturity:
+              type: string
+              description: What level of maturity the software has achieved at this version
+              enum:
+              - planning
+              - pre-alpha
+              - alpha
+              - beta
+              - stable
+              - mature
+              - inactive
+              - deprecated
+            labels:
+              type: object
+              description: Labels that will be applied to associated resources created by the operator.
+            selector:
+              type: object
+              description: Label selector to find resources associated with or managed by the operator
+              properties:
+                matchLabels:
+                  type: object
+                  description: Label key:value pairs to match directly
+                matchExpressions:
+                  type: array
+                  descriptions: A set of expressions to match against the resource.
+                  items:
+                    allOf:
+                      - type: object
+                        required:
+                        - key
+                        - operator
+                        - values
+                        properties:
+                          key:
+                            type: string
+                            description: the key to match
+                          operator:
+                            type: string
+                            description: the operator for the expression
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                          values:
+                            type: array
+                            description: set of values for the expression
+            customresourcedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the CRD
+                          required:
+                            - kind
+                            - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a CRD, the fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+
+
+            install:
+              type: object
+              description: Information required to install this specific version of the operator software
+              oneOf:
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['image']
+                  spec:
+                    type: object
+                    required:
+                    - image
+                    properties:
+                      image:
+                        type: string
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['deployment']
+                  spec:
+                    type: object
+                    required:
+                    - deployments
+                    properties:
+                      deployments:
+                        type: array
+                        description: List of deployments to create
+                        items:
+                          type: object
+                          description: A name and deployment to create in the cluster
+                          required:
+                            - name
+                            - spec
+                          properties:
+                            name:
+                              type: string
+                              description: the consistent name of the deployment
+                            spec:
+                              type: object
+                              description: The deployment spec to create in the cluster
+                      permissions:
+                        type: array
+                        description: Permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                            - serviceAccountName
+                            - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                        - "*"
+                                        - get
+                                        - list
+                                        - watch
+                                        - create
+                                        - update
+                                        - patch
+                                        - delete
+                                        - deletecollection

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/05-catalogsource.crd.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/05-catalogsource.crd.yaml
@@ -1,0 +1,54 @@
+##---
+# Source: olm/templates/05-catalogsource.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogsource-v1s.app.coreos.com
+  annotations:
+    displayName: CatalogSource
+    description: A source configured to find packages and updates.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: catalogsource-v1s
+    singular: catalogsource-v1
+    kind: CatalogSource-v1
+    listKind: CatalogSourceList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a subscription to a source and channel
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a subscription
+          required:
+          - sourceType
+          - name
+          properties:
+            sourceType:
+              type: string
+              description: The type of the source. Currently the only supported type is "internal".
+              enum:
+              - internal
+
+            configMap:
+              type: string
+              string: The name of a ConfigMap that holds the entries for an in-memory catalog.
+
+            name:
+              type: string
+              description: Name of this catalog source
+
+            secrets:
+              type: array
+              description: A set of secrets that can be used to access the contents of the catalog. It is best to keep this list small, since each will need to be tried for every catalog entry.
+              items:
+                type: string
+                description: A name of a secret in the namespace where the CatalogSource is defined.

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/06-installplan.crd.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/06-installplan.crd.yaml
@@ -1,0 +1,60 @@
+##---
+# Source: olm/templates/06-installplan.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installplan-v1s.app.coreos.com
+  annotations:
+    displayName: Install Plan
+    description: Represents a plan to install and resolve dependencies for Cluster Services
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: installplan-v1s
+    singular: installplan-v1
+    kind: InstallPlan-v1
+    listKind: InstallPlanList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Document which defines the desire and current state of an installation of a Cluster Service
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for an InstallPlan
+          required:
+          - clusterServiceVersionNames
+          - approval
+          properties:
+            clusterServiceVersionNames:
+              type: array
+              description: A list of the names of the Cluster Services
+              items:
+                type: string
+            approval:
+              type: string
+              enum:
+              - Automatic
+              - Manual
+              - Update-Only # Will only apply an update if it updates existing packages only and doesn't add any new ones
+            approved:
+              type: boolean
+      anyOf:
+        - properties:
+          approval: 
+            enum: 
+              - Manual
+          required:
+            - approved
+        - properties:
+          approval:
+            enum:
+              - Automatic
+              - Update-Only
+          required: []

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/07-subscription.crd.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/07-subscription.crd.yaml
@@ -1,0 +1,49 @@
+##---
+# Source: olm/templates/07-subscription.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscription-v1s.app.coreos.com
+  annotations:
+    displayName: Subscription
+    description: Subcribes service catalog to a source and channel to recieve updates for packages.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: subscription-v1s
+    singular: subscription-v1
+    kind: Subscription-v1
+    listKind: SubscriptionList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a subscription to a source and channel
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a Subscription
+          required:
+          - source
+          - name
+          properties:
+            source:
+              type: string
+              description: Name of a CatalogSource that defines where and how to find the channel
+
+            name:
+              type: string
+              description: Name of the package that defines the application
+
+            channel:
+              type: string
+              description: Name of the channel to track
+            
+            startingCSV:
+              type: string
+              description: Name of the AppType that this subscription tracks

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/08-tectonicocs.configmap.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/08-tectonicocs.configmap.yaml
@@ -1,0 +1,1810 @@
+##---
+# Source: olm/templates/08-tectonicocs.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tectonic-ocs
+  namespace: tectonic-system
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: alertmanagers.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: alertmanagers
+          singular: alertmanager
+          kind: Alertmanager
+          listKind: AlertmanagerList
+          shortNames:
+            - alertman
+            - alrtman
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdbackups.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdBackup
+          listKind: EtcdBackupList
+          plural: etcdbackups
+          singular: etcdbackup
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdclusters.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        validation:
+          openAPIv3:
+            type: object
+            description: Represents a single instance of etcd
+            additionalProperties: false
+            required:
+            - version
+            properties:
+              version:
+                type: string
+                description: Version string
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+                x-descriptors:
+                - urn:alm:descriptor:versioning:semver
+              size:
+                type: number
+                description: The size of the etcd cluster
+                min: 1
+                max: 9
+                x-descriptors:
+                - urn:alm:descriptor:pod:count
+                - urn:alm:descriptor:number:integer
+              template:
+                type: object
+                description: Template for fields of subresources
+                labels:
+                  type: object
+                  description: Labels to apply to associated resources
+        names:
+          plural: etcdclusters
+          singular: etcdcluster
+          kind: EtcdCluster
+          listKind: EtcdClusterList
+          shortNames:
+            - etcdclus
+            - etcd
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdrestores.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdRestore
+          listKind: EtcdRestoreList
+          plural: etcdrestores
+          singular: etcdrestore
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prometheuses.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: prometheuses
+          singular: prometheus
+          kind: Prometheus
+          listKind: PrometheusList
+          shortNames:
+            - prom
+            - prm
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: servicemonitors.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: servicemonitors
+          singular: servicemonitor
+          kind: ServiceMonitor
+          listKind: ServiceMonitorList
+          shortNames:
+            - servicemon
+            - svcmon
+            - svcmonitor
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: vaultservices.vault.security.coreos.com
+      spec:
+        group: vault.security.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        validation:
+          openAPIv3:
+            type: object
+            description: Represents a single instance of Vault
+            additionalProperties: false
+            required:
+            - version
+            properties:
+              version:
+                type: string
+                description: Version string
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+                x-descriptors:
+                - urn:alm:descriptor:versioning:semver
+              nodes:
+                type: number
+                description: The number of nodes in the Vault cluster
+                min: 1
+                max: 9
+                x-descriptors:
+                - urn:alm:descriptor:pod:count
+                - urn:alm:descriptor:number:integer
+              template:
+                type: object
+                description: Template for fields of subresources
+                labels:
+                  type: object
+                  description: Labels to apply to associated resources
+        names:
+          plural: vaultservices
+          singular: vaultservice
+          kind: VaultService
+          listKind: VaultServiceList
+          shortNames:
+            - vault
+            - vaultserv
+            - vaultsrv
+      
+  clusterServiceVersions: |-
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.6.1
+        namespace: placeholder
+        annotations:		
+          tectonic-visibility: ocs		
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+          **High availability**
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+          **Automated updates**
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+          **Backups included**
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.6.1
+        maturity: alpha
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-status-descriptors: etcdoperator.v0.6.1
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: service
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.9.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.0
+        maturity: alpha
+        replaces: etcdoperator.v0.6.1
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.9.2
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.2
+        maturity: alpha
+        replaces: etcdoperator.v0.9.0
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: prometheusoperator.0.14.0
+        namespace: placeholder
+      spec:
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ## Supported Features
+      
+          **High availability**
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+          **Updates via automated operations**
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+          **Handles the dynamic nature of containers**
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.14.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.14.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.14.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Define resources requests and limits for single Pods
+              displayName: Resource Request
+              path: resources.requests
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: prometheusoperator.0.15.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+      spec:
+        replaces: prometheusoperator.0.14.0
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+      
+      
+          **Updates via automated operations**
+      
+      
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+      
+      
+          **Handles the dynamic nature of containers**
+      
+      
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.15.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.15.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: vault-operator.0.1.9
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"vault.security.coreos.com/v1alpha1","kind":"VaultService","metadata":{"name":"example"},"spec":{"nodes":2,"version":"0.9.1-0"}}]'
+        labels:
+          alm-catalog: tectonic-ocs
+      spec:
+        displayName: Vault
+        description: |
+          An encrypted, multi-tentant secure secret store. Vault handles the lifecycle of your secrets: leasing, key revocation, key rolling, and auditing.
+      
+          _The Vault Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Unsealing and using Vault
+      
+          Once a Vault instance is running, it must be initalized and "unsealed". Afterwards, your software can use the automatically created Kubernetes Service and Secret to communicate with it.
+      
+          [Read the complete guide to using the Vault Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/vault-ocs.html)
+      
+          ### Supported Features
+      
+          **Secure by Default**
+      
+      
+          Hands-free automated creation of TLS certificates between all components ensure all best practices are followed for secret security. Further, the API makes unseal operations easy.
+      
+      
+          **Highly available**
+      
+      
+          Multiple instances of Vault are clustered together via an etcd backend and secured.
+      
+      
+          **Safe Upgrades**
+      
+      
+          Rolling out a new Vault version is as easy as updating the Vault Cluster definition. Everything is automatically handled using Vault best practices while pausing for unseal tokens.
+      
+        keywords: ['vault', 'secret', 'encryption']
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+        provider:
+          name: CoreOS, Inc
+        links:
+        - name: Vault Project
+          url: https://www.vaultproject.io/
+        labels:
+          alm-status-descriptors: vault-operator.0.1.9
+          alm-owner-vault: vault-operator
+          operated-by: vault-operator
+        selector:
+          matchLabels:
+            alm-owner-vault: vault-operator
+            operated-by: vault-operator
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAAA7CAYAAADLjIzcAAAACXBIWXMAAAsTAAALEwEAmpwYAAAMLGlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjarVd3VFP51t23JKGEmoCAlNARBAHpSO+CgHQYW0gChBJCCip2x0EFxy4WrOjYcNSxADIWRB3rIPbuAx1URsbBgg2V9wcBZ+Z93x9vrfdb6+budbLPPvuce9dd6wA6HnyptJDUBYokCllSVCgvIzOLx2oHCxxogYQ7XyCXhiQmxgHAwP0vhwDe3gQBANec+VJpIf67oycUyQUAkQggWygXFAHEIYA2EUhlCoDRCsB6skKqABhvAHBlGZlZAFMNADe3H5sC4Gb3Y1cAXFlKUhjADAfU2Hy+LBfQTgTAKxXkKgBtKQBXiVAsAbQ3AwgU5PGFgHYbgOFFRcVCQIcNwCH7Lzq5f9PMHtTk83MHcX8vAAC1cLFcWsifiv/1KSpUDtSwAsDOk0UnAeACxM6C4tgkAGyAOCrJjk8AoA8Q58RCQIXv5imjU1X8LoE8LAuAIUBCyA+PBWAKkIbKgtQQFXbny4B+PhkvVsSkqHC2rDhJpU+WSgrj41Q6C/JEMQN4o0gekTzAyRFHxgDQBchDZXkp6f0+ydOl4rR4ANoA2SovSI5V5T4sywuLH+DIlEmpAGwA8k2OLDKpn0MZFckH+qJcBPyIZABGABWsyEuJ7s+lMkTyjLgBD0JReES/B0ookqSqvFEKqSI0SZVbLi1MVPGpjaLCqKT+OVP75aXJA7lXFbIU1cypR/n80Yn9/qm3UkViSr83mkYcwhAOHpTgIRvFyIe4pau+CzzVP5HgQ4ZciOCsigxkpIMPGSTgIxll+AMSiCAfzAsFHzKIUAoJPg9G+3+dkQM+ZCiFCHIU4AlkKKJN6EDan46jA+lgOpB2p31o34E8ns5AVWYEM5wZzYxkDhv0IUAxClEMGcT/RywWhRBBCRlEkAz08FWP8YRxhfGIcYPRxriDNPwGGcQDrIniubJ/OOdhDNqgVE1FhGxI0DnAoe1od9qTDqUD6EDaFzzakDaBM+1B+9AhdBDtT3vSvn9zqBz09nWW/6wnguRv/aji2o7anioX2YNPJmyQ9U+VsL/MSIhixP6TSS2gDlJnqZPUeeooVQ8edYJqoC5Rx6j6v7wJv0GG3MFqSRBBggIUQjzAca117XT99B/V+SoHMoggBxSiKQoACCuWTpWJc/MUvBCptFDEi5EIXIbz3F3dvIGMzCxe/+fjtSEIAIThha+xkibAtwIgcr/G+NbAkScA5+3XmPUrgL0UONYqUMpK+2M0ADCgAR1wYQxzWMMBznCHF/wRjAiMRgJSkIkJECAPRZBhMqZjDspRiaVYhXXYhK3YiR9xAPU4ipP4BRfRihu4hzZ04Dm68Ra9BEGwCC2CQxgTFoQt4US4Ez5EIBFBxBFJRCYxicglJISSmE58S1QSy4l1xBZiF/ETcYQ4SZwnrhB3iHaik3hFfCQpkk1ySTPSjhxB+pAhZCyZQo4nc8kSsoycRy4m15A15B6yjjxJXiRvkG3kc7KHAqVJGVKWlDPlQ4VRCVQWlUPJqJlUBVVF1VB7qUbqLHWNaqO6qA80k+bQPNqZ9qej6VRaQJfQM+lF9Dp6J11Hn6av0e10N/2FocUwZTgx/BgxjAxGLmMyo5xRxdjOOMw4w7jB6GC8ZTKZhkx7pjczmpnJzGdOYy5ibmDuYzYxrzAfM3tYLJYxy4kVwEpg8VkKVjlrLWsP6wTrKquD9V5NU81CzV0tUi1LTaI2V61KbbfacbWrak/VetV11W3V/dQT1IXqU9WXqG9Tb1S/rN6h3quhp2GvEaCRopGvMUdjjcZejTMa9zVea2pqWmn6ao7VFGvO1lyjuV/znGa75ge2PtuRHcYex1ayF7N3sJvYd9ivtbS07LSCtbK0FFqLtXZpndJ6qPVem6Ptoh2jLdSepV2tXad9VfuFjrqOrU6IzgSdMp0qnYM6l3W6dNV17XTDdPm6M3WrdY/o3tLt0ePouekl6BXpLdLbrXde75k+S99OP0JfqD9Pf6v+Kf3HHIpjzQnjCDjfcrZxznA6uEyuPTeGm8+t5P7IbeF2G+gbeBikGUwxqDY4ZtBmSBnaGcYYFhouMTxgeNPw4xCzISFDREMWDtk75OqQd0ZDjYKNREYVRvuMbhh9NOYZRxgXGC8zrjd+YEKbOJqMNZlsstHkjEnXUO5Q/6GCoRVDDwy9a0qaOpommU4z3Wp6ybTHzNwsykxqttbslFmXuaF5sHm++Urz4+adFhyLQAuxxUqLExa/8wx4IbxC3hreaV63palltKXScotli2Wvlb1VqtVcq31WD6w1rH2sc6xXWjdbd9tY2IyxmW5Ta3PXVt3WxzbPdrXtWdt3dvZ26Xbz7ertntkb2cfYl9nX2t930HIIcihxqHG4Pow5zGdYwbANw1odSUdPxzzHasfLTqSTl5PYaYPTleGM4b7DJcNrht9yZjuHOJc61zq3uxi6xLnMdal3eTHCZkTWiGUjzo744urpWui6zfWem77baLe5bo1ur9wd3QXu1e7XR2qNjBw5a2TDyJceTh4ij40etz05nmM853s2e3728vaSee316vS28Z7kvd77lg/XJ9Fnkc85X4ZvqO8s36O+H/y8/BR+B/z+9Hf2L/Df7f9slP0o0ahtox4HWAXwA7YEtAXyAicFbg5sC7IM4gfVBD0Ktg4WBm8PfhoyLCQ/ZE/Ii1DXUFno4dB3YX5hM8KawqnwqPCK8JYI/YjUiHURDyOtInMjayO7ozyjpkU1RTOiY6OXRd+KMYsRxOyK6R7tPXrG6NOx7Njk2HWxj+Ic42RxjWPIMaPHrBhzP942XhJfn4CEmIQVCQ8S7RNLEn8eyxybOLZ67JMkt6TpSWeTOckTk3cnv00JTVmSci/VIVWZ2pymkzYubVfau/Tw9OXpbRkjMmZkXMw0yRRnNmSxstKytmf1fBPxzapvOsZ5jisfd3O8/fgp489PMJlQOOHYRJ2J/IkHJzEmpU/aPekTP4Ffw+/Jjslen90tCBOsFjwXBgtXCjtFAaLloqc5ATnLc57lBuSuyO3MC8qryusSh4nXiV/mR+dvyn9XkFCwo6CvML1wX5Fa0aSiIxJ9SYHkdLF58ZTiK1Inabm0rcSvZFVJtyxWtl1OyMfLGxRchVRxSemg/E7ZXhpYWl36fnLa5INT9KZIplya6jh14dSnZZFlP0yjpwmmNU+3nD5nevuMkBlbZhIzs2c2z7KeNW9Wx+yo2TvnaMwpmPPrXNe5y+e++Tb928Z5ZvNmz3v8XdR3teXa5bLyW/P9529aQC8QL2hZOHLh2oVfKoQVFypdK6sqPy0SLLrwvdv3a77vW5yzuGWJ15KNS5lLJUtvLgtatnO53vKy5Y9XjFlRt5K3smLlm1UTV52v8qjatFpjtXJ125q4NQ1rbdYuXftpXd66G9Wh1fvWm65fuP7dBuGGqxuDN+7dZLapctPHzeLNt7dEbamrsaup2srcWrr1yba0bWd/8Plh13aT7ZXbP++Q7GjbmbTz9C7vXbt2m+5eUkvWKms794zb0/pj+I8Ne533btlnuK9yP/Yr9//+06Sfbh6IPdB80Ofg3kO2h9Yf5hyuqCPqptZ11+fVtzVkNlw5MvpIc6N/4+GfXX7ecdTyaPUxg2NLjmscn3e870TZiZ4maVPXydyTj5snNt87lXHq+umxp1vOxJ4590vkL6fOhpw9cS7g3NHzfuePXPC5UH/R62LdJc9Lh3/1/PVwi1dL3WXvyw2tvq2NV0ZdOX416OrJa+HXfrkec/3ijfgbV26m3rx9a9ytttvC28/uFN55ebf0bu+92fcZ9yse6D6oemj6sOZfw/61r82r7Vh7ePulR8mP7j0WPH7+m/y3Tx3znmg9qXpq8XTXM/dnRzsjO1t//+b3jufS571d5X/o/bH+hcOLQ38G/3mpO6O746XsZd+rRa+NX+944/GmuSex5+Hbore97yreG7/f+cHnw9mP6R+f9k7+xPq05vOwz41fYr/c7yvq65PyZXwAAAWAzMkBXu0AtDIBTiugod2/f6n2RuLrBvn/4f4dDQDgBewIBlJnA3FNwMYmwHY2wG4CEgGkBIMcOXLwUh15zkj3fi22DGC87+t7bQawGoHPsr6+3g19fZ+3AdQdoKmkf+8DAKYusJkHAL9az/+P/evfXvpsNqq3M8UAADowaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzExMSA3OS4xNTgzMjUsIDIwMTUvMDkvMTAtMDE6MTA6MjAgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgICAgICAgICAgeG1sbnM6cGhvdG9zaG9wPSJodHRwOi8vbnMuYWRvYmUuY29tL3Bob3Rvc2hvcC8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6Q3JlYXRlRGF0ZT4yMDE3LTA5LTA2VDE1OjMxOjU2LTA0OjAwPC94bXA6Q3JlYXRlRGF0ZT4KICAgICAgICAgPHhtcDpNZXRhZGF0YURhdGU+MjAxNy0wOS0wNlQxNTozMTo1Ni0wNDowMDwveG1wOk1ldGFkYXRhRGF0ZT4KICAgICAgICAgPHhtcDpNb2RpZnlEYXRlPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3htcDpNb2RpZnlEYXRlPgogICAgICAgICA8eG1wTU06SW5zdGFuY2VJRD54bXAuaWlkOjFlMjY4MTE5LWU2NmYtNGJjNC1hZTI0LThiMTViNTg3MzE2MjwveG1wTU06SW5zdGFuY2VJRD4KICAgICAgICAgPHhtcE1NOkRvY3VtZW50SUQ+YWRvYmU6ZG9jaWQ6cGhvdG9zaG9wOjczODM4YzJiLWQzYzgtMTE3YS1iNTYyLTllNjU3MTBkNzc5YzwveG1wTU06RG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD54bXAuZGlkOjQ1MjdmNDhmLTc2MGMtNGRhYi04NTJkLTNkNGZiOTA4ZmEzNjwveG1wTU06T3JpZ2luYWxEb2N1bWVudElEPgogICAgICAgICA8eG1wTU06SGlzdG9yeT4KICAgICAgICAgICAgPHJkZjpTZXE+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPmNyZWF0ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDo0NTI3ZjQ4Zi03NjBjLTRkYWItODUyZC0zZDRmYjkwOGZhMzY8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDphY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDoxZTI2ODExOS1lNjZmLTRiYzQtYWUyNC04YjE1YjU4NzMxNjI8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICAgICA8c3RFdnQ6Y2hhbmdlZD4vPC9zdEV2dDpjaGFuZ2VkPgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgPC9yZGY6U2VxPgogICAgICAgICA8L3htcE1NOkhpc3Rvcnk+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzpmb3JtYXQ+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZGU+CiAgICAgICAgIDxwaG90b3Nob3A6SUNDUHJvZmlsZT5EaXNwbGF5PC9waG90b3Nob3A6SUNDUHJvZmlsZT4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+NzIwMDAwLzEwMDAwPC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj43MjAwMDAvMTAwMDA8L3RpZmY6WVJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+NjU1MzU8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjY0PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjU5PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz6RZ44uAAAAIGNIUk0AAG11AABzoAAA/N0AAINkAABw6AAA7GgAADA+AAAQkOTsmeoAAAreSURBVHja7Jt5VFN3Fse/7yUkgQSyQBAiJWwTglKZqKBVFgURsVFgpAO2TRUonU7n0MWpVqnL6a7jtAdoz+lAsS61damHTnXascLUojMHLVUcpaesjUAVlFUWY7b35g+KhUBCEhJ71Pmd8/sDeO/edz+/e+/v3t97EDRN434eJO7zcd8DYJr+Ijc396kbN26EMxgM7b1kKE3TBEmSRHJy8m6VSlVrFkBLS4u2vLw8715cbS6X+/WcOXN6LYbAM888szckJOSre814giC0y5YtW93c3HzFIgA+n48nnnhi/b0GICIi4j2ZTHZdp9NZToJarRYpKSmXIiIiyu6ZRMdk9sfHx7/OZrMhEoksAxCJRBCLxdi0adOLDAaDuhcAxMbGFoSHh/exWCwIhULLAJhMJrq6uhAVFaWWyWQf3O3Gs9nsrrS0tB1MJhN8Ph8CgcDyNlhSUgKCIMBmszFz5sxX6urqsmmadrlbASiVyu0KheJma2vruNWf0AM0Gg2GhobQ19cHuVzePmvWrPfvVuN5PF772rVrCwBAIBDcnhY9YPr06SOFAzgcDhISEl6tra3NMRqN3LsNQE5Oztbly5cb6+vrxyU/swBM3UShUHRHR0cXVVZWbrqbjOdwOPXu7u6lhw8fRnd3NwiCuP23sLCwX+oD026wtLR0dPkIDw8PdHV1ua9bt+6yTqcT3S0AYmJifi+VSj9ta2sDkzl2nSsqKsx7AJ/PHycsMjJyQKlU7iwrK3trSp1XkBxU+xVAMzDK5cRAb+fYqi0wGLS62W49AoHgYlRU1KcajQZyudy2bnB0shAIBLeBZGdnv+3m5tZh93ak+gNEF/8L/jdnQU7zGTY0Mg4M1fMgl6QNX8TiwHX7R3D/5wWwcvMBEHbpSkxMzPf19YWHhwdEItG4aRFAQEDAmBkYGAihUIiHH35Yn5ubu81eAK6bXwfJZYEdFQaX5BXDyhXRIIwGEDMjAZIE6RcIVvrjII08sLNeBNhsm/X4+vp+m5iY+AVBEBCJRBAKheOmxSRYVVU1USuJhoYGeHt7l7DZ7Be1Wu1vbH0wTdE7YBa9CUN9O/TffD0s9/tqYE4s6LoLAEWBuqKG7ou/w0WZCt2uEkCvsxlARkbGBh8fH9A0PSbxmW2STJNgSkrKhBcaDAb4+fmhsbEx8+TJkwfs6sgkwaCvmsQ2wQHoW2PdMlAOSl1ns/zg4OCvS0tLE/r6+mAwGMxel56ebt4DgoKCLDUVWLBgwcELFy683NvbG26T8dOmw/VPT8PY8CO0e4drK8Zv54Hz5JPQHfsS+q8+G77O1x+02AdEXyfo3m5b2l0899xzGyQSCSiKsmr1JwRgWimZhoK3tzeSkpJePnjw4Oc2VWV7joCzbD5oAFRrM/QnT4Bb/AVc5nrCJe1J9C8IBtWiBql8HOCLgMAwGD8tASijVfIDAgIOL1my5JxWq4W7u7v9R2KWAIxASEpKOlpZWflde3v7XKs16XQgAIwOONqgBU0CtB6A8WdDKSNAkqAp2xpRmUy2tbi4GHq9HtQk90ZGRtpWB5gCkEgkyMjI2FhQUFBh7QMO5mSAynsBhvom6E+eAAAMZS8Fe7UK+q+Og/qpBQBg/Gw34O0H/NRk9eqHhIR8FBoaWt/a2mqT+0+YBMvKJj8HGWkts7KyKtVqdaz1h3KewJBJXIv9gc7WURmQAWZEJAw1Z6yNfX1WVlaoj4+PemBgwCrjCwsLzdcBE+2bppPH40EikSAvL2+DtbYzlq+G66H/gF30GQjPacN1T95r4H15EZw3dgNMFxBcLtzLqyE8XwW39z8BSOakchUKxW6FQqFmMpm3C7fJpk3NkLlhNBqhVCrPFhUVlV2+fPl3k3pNfCoIigIjfC6I4DDQ3dfgEp8C9PWCEZ0McHggJF5gxyuGmxnVatx8/ilAO2i+jCXJmytXrnyFw+HAw8PDJtc3C2Dfvn1WbztsNhthYWFbrQFgOFIC4tk3QJ2rBP39d8PnjwffB3vNs9Af+wQY6gOlHoRm31FwViyFZmeBReMBIC4u7m/z58+/euXKFasXbtIcsGrVKqtupGkaJEnC398fR48ePdDc3Jw5qTLPaaD7ugHjqCLF3RMYGJsXiIBQ0JfrJ8tDN4qLi4P8/f17enp6bFr9Rx55xLwHSKVSmwi6u7tj0aJFW5qbm9MnkjcGWve1MT+zkpRwfeGPuHX4OLQfvvvLdZMY//NRV+HChQt7WlpaJt25HFoHTBQKc+fObTp//vy+mpqabOu7I3dw9xyDiw/ATFoOQ/VpGC9dsG4z4XLb8/PzdwiFQhiNRrti32EAaJqGm5sbUlNTt9XU1DwKgGNdFtWD+rEZ8AkGdY0GPTRotc7w8PC3BgcHb549e9ZizW9ujD4RmjKAES+Ijo7+KTY29oNTp05Z915RdwsDmQnQr82G9vi/QP3YZJ3juLq2hYeHF+/atQs6nc6u1U9LSzMPwNzh4WRe4Orqiuzs7FdOnz6dTdO0VQeoVFsLbr5m2xHDwoULX5NKpbrOzs4pub5ZAA888IB92wlBYNWqVd3l5eXvfPzxx1uccc7H5/MbExISSimKgqenp0NkjgPQ1NRklyCapjE4OAi5XP4mg8F42mg0ih0NQKlUbgsMDKTb29sdsvoTAtizZ4/dwiiKgpeX161Zs2Ztr6mpeduRxnt7e19KS0s7oNfr7QpTqwGIxVNbOBaLhXnz5r1XV1e3TqPRTHfUg6pUqvygoCC0trbCzc3NeQC8vLymJJCmaYjFYl1MTMzrJ06ccMhrteDg4G8fe+yxf+h0OrtLXqsBOEIBg8HA0qVLS86cObO+v78/aKrycnJy/qxQKNDQ0ACSJJ0LYCpl5eghkUiolStXbtu/f/9HU4z9E0NDQ//euXMnNBqNQ55t69atzvWAkVBIT0/ff/z48Y1dXV0z7ZUTExOT39PTg4sXL457xeUUD7CnEjQHQCqVIicnJ3/Hjh2f2xn7n0dGRp7r7u6e9BWXwwD4+fk5TDiHw0FWVtbRvXv3nu7o6Iix9f4VK1Zs5PP5U254bAJw6NAhhwknSRIcDgcymezljo6OU7bcGxERcSAuLq6uo6PD4ZnfIoDq6mqHCacoCkwmE2FhYafr6upOXr9+fbG1t6pUqk1cLhc8Hs9pqz8hgJCQEIcqoGkaAoEAsbGxLx05cuRbKxueDxMTE1va2toclpPu+DZo2ig99NBD1efOnftSrVYvn6SSHNq8eXO+p6cndDqdw/f9O7YLmIYCn89HSkrKSwUFBRYBhIaGFnh5eXU2NjZCr9fD2WMcAA8PD6coMhqNWLRoUW1FRcWR2tra9AkfhsnsnzFjxl8KCwth+kmrI0diYuKdDYGRXMDj8bBmzZoN69evnxDA7NmzdwYGBvZ3dHQ4pej51UJgZOj1eiQnJ6vLysr2VFVVrTWpGToXL178VxaLBbFY7NTMbxGAr6+v05TRNA0vLy9s2bJlY0pKSqZer799gBofH/9maGjorfb2dnA4HNypMQ7AwMCAUxWq1Wr4+/tfk8vlhZcuXXoJALhcbltqauq7JElCKBTesdWfEMDo7wSdNVgsFh588MHtP/zwQ57BYHBLT09/dcaMGcbW1law7fgwyqEAnO1+Ix8vyWSyvqCgoEMtLS2PqlSqUoqinFry/urboCkErVaL2bNnv5OZmXlMKpXi6tWr4HLv/OfIxP//cfI+H/8bANeS5YFpLrRuAAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: vault-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - vault.security.coreos.com
+                resources:
+                - vaultservices
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+            deployments:
+            - name: vault-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: vault-operator
+                template:
+                  metadata:
+                    labels:
+                      name: vault-operator
+                  spec:
+                    serviceAccountName: vault-operator
+                    containers:
+                    - name: vault-operator
+                      image: quay.io/coreos/vault-operator@sha256:945a0a6d88cf6fa2bce9a83019a2a64f74d89fc8281301a4259f3302eabc79e6
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        version: 0.1.9
+        replaces: vault-operator.0.1.5
+        maturity: alpha
+        customresourcedefinitions:
+          owned:
+          - name: vaultservices.vault.security.coreos.com
+            version: v1alpha1
+            kind: VaultService
+            displayName: Vault Service
+            description: A running Vault instance, backed by an Etcd Cluster
+            resources:
+              - name: etcdclusters.etcd.database.coreos.com
+                version: v1beta2
+                kind: EtcdCluster
+              - kind: Service
+                version: v1
+              - kind: ConfigMap
+                version: v1
+              - kind: Secret
+                version: v1
+              - kind: Deployment
+                version: v1beta2
+              - kind: ReplicaSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of Pods for the cluster
+                displayName: Size
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The service at which the running Vault cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The port at which the Vault cluster is running under the service.
+                displayName: Client Port
+                path: clientPort
+          required:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents a backup for an etcd cluster
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents one try of restoring etcd cluster from previous backup
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        namespace: placeholder
+        name: vault-operator.0.1.5
+        annotations:
+          tectonic-visibility: ocs
+      spec:
+        displayName: Vault
+        description: |
+          An encrypted, multi-tentant secure secret store. Vault handles the lifecycle of your secrets: leasing, key revocation, key rolling, and auditing.
+      
+          _The Vault Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Unsealing and using Vault
+      
+          Once a Vault instance is running, it must be initalized and "unsealed". Afterwards, your software can use the automatically created Kubernetes Service and Secret to communicate with it.
+      
+          [Read the complete guide to using the Vault Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/vault-ocs.html)
+      
+          ### Supported Features
+      
+          **Secure by Default**
+          Hands-free automated creation of TLS certificates between all components ensure all best practices are followed for secret security. Further, the API makes unseal operations easy.
+          **Highly available**
+          Multiple instances of Vault are clustered together via an etcd backend and secured.
+          **Safe Upgrades**
+          Rolling out a new Vault version is as easy as updating the Vault Cluster definition. Everything is automatically handled using Vault best practices while pausing for unseal tokens.
+      
+        keywords: ['vault', 'secret', 'encryption']
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+        provider:
+          name: CoreOS, Inc
+        links:
+        - name: Vault Project
+          url: https://www.vaultproject.io/
+        labels:
+          alm-status-descriptors: vault-operator.0.1.5
+          alm-owner-vault: vault-operator
+          operated-by: vault-operator
+        selector:
+          matchLabels:
+            alm-owner-vault: vault-operator
+            operated-by: vault-operator
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAAA7CAYAAADLjIzcAAAACXBIWXMAAAsTAAALEwEAmpwYAAAMLGlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjarVd3VFP51t23JKGEmoCAlNARBAHpSO+CgHQYW0gChBJCCip2x0EFxy4WrOjYcNSxADIWRB3rIPbuAx1URsbBgg2V9wcBZ+Z93x9vrfdb6+budbLPPvuce9dd6wA6HnyptJDUBYokCllSVCgvIzOLx2oHCxxogYQ7XyCXhiQmxgHAwP0vhwDe3gQBANec+VJpIf67oycUyQUAkQggWygXFAHEIYA2EUhlCoDRCsB6skKqABhvAHBlGZlZAFMNADe3H5sC4Gb3Y1cAXFlKUhjADAfU2Hy+LBfQTgTAKxXkKgBtKQBXiVAsAbQ3AwgU5PGFgHYbgOFFRcVCQIcNwCH7Lzq5f9PMHtTk83MHcX8vAAC1cLFcWsifiv/1KSpUDtSwAsDOk0UnAeACxM6C4tgkAGyAOCrJjk8AoA8Q58RCQIXv5imjU1X8LoE8LAuAIUBCyA+PBWAKkIbKgtQQFXbny4B+PhkvVsSkqHC2rDhJpU+WSgrj41Q6C/JEMQN4o0gekTzAyRFHxgDQBchDZXkp6f0+ydOl4rR4ANoA2SovSI5V5T4sywuLH+DIlEmpAGwA8k2OLDKpn0MZFckH+qJcBPyIZABGABWsyEuJ7s+lMkTyjLgBD0JReES/B0ookqSqvFEKqSI0SZVbLi1MVPGpjaLCqKT+OVP75aXJA7lXFbIU1cypR/n80Yn9/qm3UkViSr83mkYcwhAOHpTgIRvFyIe4pau+CzzVP5HgQ4ZciOCsigxkpIMPGSTgIxll+AMSiCAfzAsFHzKIUAoJPg9G+3+dkQM+ZCiFCHIU4AlkKKJN6EDan46jA+lgOpB2p31o34E8ns5AVWYEM5wZzYxkDhv0IUAxClEMGcT/RywWhRBBCRlEkAz08FWP8YRxhfGIcYPRxriDNPwGGcQDrIniubJ/OOdhDNqgVE1FhGxI0DnAoe1od9qTDqUD6EDaFzzakDaBM+1B+9AhdBDtT3vSvn9zqBz09nWW/6wnguRv/aji2o7anioX2YNPJmyQ9U+VsL/MSIhixP6TSS2gDlJnqZPUeeooVQ8edYJqoC5Rx6j6v7wJv0GG3MFqSRBBggIUQjzAca117XT99B/V+SoHMoggBxSiKQoACCuWTpWJc/MUvBCptFDEi5EIXIbz3F3dvIGMzCxe/+fjtSEIAIThha+xkibAtwIgcr/G+NbAkScA5+3XmPUrgL0UONYqUMpK+2M0ADCgAR1wYQxzWMMBznCHF/wRjAiMRgJSkIkJECAPRZBhMqZjDspRiaVYhXXYhK3YiR9xAPU4ipP4BRfRihu4hzZ04Dm68Ra9BEGwCC2CQxgTFoQt4US4Ez5EIBFBxBFJRCYxicglJISSmE58S1QSy4l1xBZiF/ETcYQ4SZwnrhB3iHaik3hFfCQpkk1ySTPSjhxB+pAhZCyZQo4nc8kSsoycRy4m15A15B6yjjxJXiRvkG3kc7KHAqVJGVKWlDPlQ4VRCVQWlUPJqJlUBVVF1VB7qUbqLHWNaqO6qA80k+bQPNqZ9qej6VRaQJfQM+lF9Dp6J11Hn6av0e10N/2FocUwZTgx/BgxjAxGLmMyo5xRxdjOOMw4w7jB6GC8ZTKZhkx7pjczmpnJzGdOYy5ibmDuYzYxrzAfM3tYLJYxy4kVwEpg8VkKVjlrLWsP6wTrKquD9V5NU81CzV0tUi1LTaI2V61KbbfacbWrak/VetV11W3V/dQT1IXqU9WXqG9Tb1S/rN6h3quhp2GvEaCRopGvMUdjjcZejTMa9zVea2pqWmn6ao7VFGvO1lyjuV/znGa75ge2PtuRHcYex1ayF7N3sJvYd9ivtbS07LSCtbK0FFqLtXZpndJ6qPVem6Ptoh2jLdSepV2tXad9VfuFjrqOrU6IzgSdMp0qnYM6l3W6dNV17XTDdPm6M3WrdY/o3tLt0ePouekl6BXpLdLbrXde75k+S99OP0JfqD9Pf6v+Kf3HHIpjzQnjCDjfcrZxznA6uEyuPTeGm8+t5P7IbeF2G+gbeBikGUwxqDY4ZtBmSBnaGcYYFhouMTxgeNPw4xCzISFDREMWDtk75OqQd0ZDjYKNREYVRvuMbhh9NOYZRxgXGC8zrjd+YEKbOJqMNZlsstHkjEnXUO5Q/6GCoRVDDwy9a0qaOpommU4z3Wp6ybTHzNwsykxqttbslFmXuaF5sHm++Urz4+adFhyLQAuxxUqLExa/8wx4IbxC3hreaV63palltKXScotli2Wvlb1VqtVcq31WD6w1rH2sc6xXWjdbd9tY2IyxmW5Ta3PXVt3WxzbPdrXtWdt3dvZ26Xbz7ertntkb2cfYl9nX2t930HIIcihxqHG4Pow5zGdYwbANw1odSUdPxzzHasfLTqSTl5PYaYPTleGM4b7DJcNrht9yZjuHOJc61zq3uxi6xLnMdal3eTHCZkTWiGUjzo744urpWui6zfWem77baLe5bo1ur9wd3QXu1e7XR2qNjBw5a2TDyJceTh4ij40etz05nmM853s2e3728vaSee316vS28Z7kvd77lg/XJ9Fnkc85X4ZvqO8s36O+H/y8/BR+B/z+9Hf2L/Df7f9slP0o0ahtox4HWAXwA7YEtAXyAicFbg5sC7IM4gfVBD0Ktg4WBm8PfhoyLCQ/ZE/Ii1DXUFno4dB3YX5hM8KawqnwqPCK8JYI/YjUiHURDyOtInMjayO7ozyjpkU1RTOiY6OXRd+KMYsRxOyK6R7tPXrG6NOx7Njk2HWxj+Ic42RxjWPIMaPHrBhzP942XhJfn4CEmIQVCQ8S7RNLEn8eyxybOLZ67JMkt6TpSWeTOckTk3cnv00JTVmSci/VIVWZ2pymkzYubVfau/Tw9OXpbRkjMmZkXMw0yRRnNmSxstKytmf1fBPxzapvOsZ5jisfd3O8/fgp489PMJlQOOHYRJ2J/IkHJzEmpU/aPekTP4Ffw+/Jjslen90tCBOsFjwXBgtXCjtFAaLloqc5ATnLc57lBuSuyO3MC8qryusSh4nXiV/mR+dvyn9XkFCwo6CvML1wX5Fa0aSiIxJ9SYHkdLF58ZTiK1Inabm0rcSvZFVJtyxWtl1OyMfLGxRchVRxSemg/E7ZXhpYWl36fnLa5INT9KZIplya6jh14dSnZZFlP0yjpwmmNU+3nD5nevuMkBlbZhIzs2c2z7KeNW9Wx+yo2TvnaMwpmPPrXNe5y+e++Tb928Z5ZvNmz3v8XdR3teXa5bLyW/P9529aQC8QL2hZOHLh2oVfKoQVFypdK6sqPy0SLLrwvdv3a77vW5yzuGWJ15KNS5lLJUtvLgtatnO53vKy5Y9XjFlRt5K3smLlm1UTV52v8qjatFpjtXJ125q4NQ1rbdYuXftpXd66G9Wh1fvWm65fuP7dBuGGqxuDN+7dZLapctPHzeLNt7dEbamrsaup2srcWrr1yba0bWd/8Plh13aT7ZXbP++Q7GjbmbTz9C7vXbt2m+5eUkvWKms794zb0/pj+I8Ne533btlnuK9yP/Yr9//+06Sfbh6IPdB80Ofg3kO2h9Yf5hyuqCPqptZ11+fVtzVkNlw5MvpIc6N/4+GfXX7ecdTyaPUxg2NLjmscn3e870TZiZ4maVPXydyTj5snNt87lXHq+umxp1vOxJ4590vkL6fOhpw9cS7g3NHzfuePXPC5UH/R62LdJc9Lh3/1/PVwi1dL3WXvyw2tvq2NV0ZdOX416OrJa+HXfrkec/3ijfgbV26m3rx9a9ytttvC28/uFN55ebf0bu+92fcZ9yse6D6oemj6sOZfw/61r82r7Vh7ePulR8mP7j0WPH7+m/y3Tx3znmg9qXpq8XTXM/dnRzsjO1t//+b3jufS571d5X/o/bH+hcOLQ38G/3mpO6O746XsZd+rRa+NX+944/GmuSex5+Hbore97yreG7/f+cHnw9mP6R+f9k7+xPq05vOwz41fYr/c7yvq65PyZXwAAAWAzMkBXu0AtDIBTiugod2/f6n2RuLrBvn/4f4dDQDgBewIBlJnA3FNwMYmwHY2wG4CEgGkBIMcOXLwUh15zkj3fi22DGC87+t7bQawGoHPsr6+3g19fZ+3AdQdoKmkf+8DAKYusJkHAL9az/+P/evfXvpsNqq3M8UAADowaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzExMSA3OS4xNTgzMjUsIDIwMTUvMDkvMTAtMDE6MTA6MjAgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgICAgICAgICAgeG1sbnM6cGhvdG9zaG9wPSJodHRwOi8vbnMuYWRvYmUuY29tL3Bob3Rvc2hvcC8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6Q3JlYXRlRGF0ZT4yMDE3LTA5LTA2VDE1OjMxOjU2LTA0OjAwPC94bXA6Q3JlYXRlRGF0ZT4KICAgICAgICAgPHhtcDpNZXRhZGF0YURhdGU+MjAxNy0wOS0wNlQxNTozMTo1Ni0wNDowMDwveG1wOk1ldGFkYXRhRGF0ZT4KICAgICAgICAgPHhtcDpNb2RpZnlEYXRlPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3htcDpNb2RpZnlEYXRlPgogICAgICAgICA8eG1wTU06SW5zdGFuY2VJRD54bXAuaWlkOjFlMjY4MTE5LWU2NmYtNGJjNC1hZTI0LThiMTViNTg3MzE2MjwveG1wTU06SW5zdGFuY2VJRD4KICAgICAgICAgPHhtcE1NOkRvY3VtZW50SUQ+YWRvYmU6ZG9jaWQ6cGhvdG9zaG9wOjczODM4YzJiLWQzYzgtMTE3YS1iNTYyLTllNjU3MTBkNzc5YzwveG1wTU06RG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD54bXAuZGlkOjQ1MjdmNDhmLTc2MGMtNGRhYi04NTJkLTNkNGZiOTA4ZmEzNjwveG1wTU06T3JpZ2luYWxEb2N1bWVudElEPgogICAgICAgICA8eG1wTU06SGlzdG9yeT4KICAgICAgICAgICAgPHJkZjpTZXE+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPmNyZWF0ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDo0NTI3ZjQ4Zi03NjBjLTRkYWItODUyZC0zZDRmYjkwOGZhMzY8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDphY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDoxZTI2ODExOS1lNjZmLTRiYzQtYWUyNC04YjE1YjU4NzMxNjI8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICAgICA8c3RFdnQ6Y2hhbmdlZD4vPC9zdEV2dDpjaGFuZ2VkPgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgPC9yZGY6U2VxPgogICAgICAgICA8L3htcE1NOkhpc3Rvcnk+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzpmb3JtYXQ+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZGU+CiAgICAgICAgIDxwaG90b3Nob3A6SUNDUHJvZmlsZT5EaXNwbGF5PC9waG90b3Nob3A6SUNDUHJvZmlsZT4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+NzIwMDAwLzEwMDAwPC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj43MjAwMDAvMTAwMDA8L3RpZmY6WVJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+NjU1MzU8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjY0PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjU5PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz6RZ44uAAAAIGNIUk0AAG11AABzoAAA/N0AAINkAABw6AAA7GgAADA+AAAQkOTsmeoAAAreSURBVHja7Jt5VFN3Fse/7yUkgQSyQBAiJWwTglKZqKBVFgURsVFgpAO2TRUonU7n0MWpVqnL6a7jtAdoz+lAsS61damHTnXascLUojMHLVUcpaesjUAVlFUWY7b35g+KhUBCEhJ71Pmd8/sDeO/edz+/e+/v3t97EDRN434eJO7zcd8DYJr+Ijc396kbN26EMxgM7b1kKE3TBEmSRHJy8m6VSlVrFkBLS4u2vLw8715cbS6X+/WcOXN6LYbAM888szckJOSre814giC0y5YtW93c3HzFIgA+n48nnnhi/b0GICIi4j2ZTHZdp9NZToJarRYpKSmXIiIiyu6ZRMdk9sfHx7/OZrMhEoksAxCJRBCLxdi0adOLDAaDuhcAxMbGFoSHh/exWCwIhULLAJhMJrq6uhAVFaWWyWQf3O3Gs9nsrrS0tB1MJhN8Ph8CgcDyNlhSUgKCIMBmszFz5sxX6urqsmmadrlbASiVyu0KheJma2vruNWf0AM0Gg2GhobQ19cHuVzePmvWrPfvVuN5PF772rVrCwBAIBDcnhY9YPr06SOFAzgcDhISEl6tra3NMRqN3LsNQE5Oztbly5cb6+vrxyU/swBM3UShUHRHR0cXVVZWbrqbjOdwOPXu7u6lhw8fRnd3NwiCuP23sLCwX+oD026wtLR0dPkIDw8PdHV1ua9bt+6yTqcT3S0AYmJifi+VSj9ta2sDkzl2nSsqKsx7AJ/PHycsMjJyQKlU7iwrK3trSp1XkBxU+xVAMzDK5cRAb+fYqi0wGLS62W49AoHgYlRU1KcajQZyudy2bnB0shAIBLeBZGdnv+3m5tZh93ak+gNEF/8L/jdnQU7zGTY0Mg4M1fMgl6QNX8TiwHX7R3D/5wWwcvMBEHbpSkxMzPf19YWHhwdEItG4aRFAQEDAmBkYGAihUIiHH35Yn5ubu81eAK6bXwfJZYEdFQaX5BXDyhXRIIwGEDMjAZIE6RcIVvrjII08sLNeBNhsm/X4+vp+m5iY+AVBEBCJRBAKheOmxSRYVVU1USuJhoYGeHt7l7DZ7Be1Wu1vbH0wTdE7YBa9CUN9O/TffD0s9/tqYE4s6LoLAEWBuqKG7ou/w0WZCt2uEkCvsxlARkbGBh8fH9A0PSbxmW2STJNgSkrKhBcaDAb4+fmhsbEx8+TJkwfs6sgkwaCvmsQ2wQHoW2PdMlAOSl1ns/zg4OCvS0tLE/r6+mAwGMxel56ebt4DgoKCLDUVWLBgwcELFy683NvbG26T8dOmw/VPT8PY8CO0e4drK8Zv54Hz5JPQHfsS+q8+G77O1x+02AdEXyfo3m5b2l0899xzGyQSCSiKsmr1JwRgWimZhoK3tzeSkpJePnjw4Oc2VWV7joCzbD5oAFRrM/QnT4Bb/AVc5nrCJe1J9C8IBtWiBql8HOCLgMAwGD8tASijVfIDAgIOL1my5JxWq4W7u7v9R2KWAIxASEpKOlpZWflde3v7XKs16XQgAIwOONqgBU0CtB6A8WdDKSNAkqAp2xpRmUy2tbi4GHq9HtQk90ZGRtpWB5gCkEgkyMjI2FhQUFBh7QMO5mSAynsBhvom6E+eAAAMZS8Fe7UK+q+Og/qpBQBg/Gw34O0H/NRk9eqHhIR8FBoaWt/a2mqT+0+YBMvKJj8HGWkts7KyKtVqdaz1h3KewJBJXIv9gc7WURmQAWZEJAw1Z6yNfX1WVlaoj4+PemBgwCrjCwsLzdcBE+2bppPH40EikSAvL2+DtbYzlq+G66H/gF30GQjPacN1T95r4H15EZw3dgNMFxBcLtzLqyE8XwW39z8BSOakchUKxW6FQqFmMpm3C7fJpk3NkLlhNBqhVCrPFhUVlV2+fPl3k3pNfCoIigIjfC6I4DDQ3dfgEp8C9PWCEZ0McHggJF5gxyuGmxnVatx8/ilAO2i+jCXJmytXrnyFw+HAw8PDJtc3C2Dfvn1WbztsNhthYWFbrQFgOFIC4tk3QJ2rBP39d8PnjwffB3vNs9Af+wQY6gOlHoRm31FwViyFZmeBReMBIC4u7m/z58+/euXKFasXbtIcsGrVKqtupGkaJEnC398fR48ePdDc3Jw5qTLPaaD7ugHjqCLF3RMYGJsXiIBQ0JfrJ8tDN4qLi4P8/f17enp6bFr9Rx55xLwHSKVSmwi6u7tj0aJFW5qbm9MnkjcGWve1MT+zkpRwfeGPuHX4OLQfvvvLdZMY//NRV+HChQt7WlpaJt25HFoHTBQKc+fObTp//vy+mpqabOu7I3dw9xyDiw/ATFoOQ/VpGC9dsG4z4XLb8/PzdwiFQhiNRrti32EAaJqGm5sbUlNTt9XU1DwKgGNdFtWD+rEZ8AkGdY0GPTRotc7w8PC3BgcHb549e9ZizW9ujD4RmjKAES+Ijo7+KTY29oNTp05Z915RdwsDmQnQr82G9vi/QP3YZJ3juLq2hYeHF+/atQs6nc6u1U9LSzMPwNzh4WRe4Orqiuzs7FdOnz6dTdO0VQeoVFsLbr5m2xHDwoULX5NKpbrOzs4pub5ZAA888IB92wlBYNWqVd3l5eXvfPzxx1uccc7H5/MbExISSimKgqenp0NkjgPQ1NRklyCapjE4OAi5XP4mg8F42mg0ih0NQKlUbgsMDKTb29sdsvoTAtizZ4/dwiiKgpeX161Zs2Ztr6mpeduRxnt7e19KS0s7oNfr7QpTqwGIxVNbOBaLhXnz5r1XV1e3TqPRTHfUg6pUqvygoCC0trbCzc3NeQC8vLymJJCmaYjFYl1MTMzrJ06ccMhrteDg4G8fe+yxf+h0OrtLXqsBOEIBg8HA0qVLS86cObO+v78/aKrycnJy/qxQKNDQ0ACSJJ0LYCpl5eghkUiolStXbtu/f/9HU4z9E0NDQ//euXMnNBqNQ55t69atzvWAkVBIT0/ff/z48Y1dXV0z7ZUTExOT39PTg4sXL457xeUUD7CnEjQHQCqVIicnJ3/Hjh2f2xn7n0dGRp7r7u6e9BWXwwD4+fk5TDiHw0FWVtbRvXv3nu7o6Iix9f4VK1Zs5PP5U254bAJw6NAhhwknSRIcDgcymezljo6OU7bcGxERcSAuLq6uo6PD4ZnfIoDq6mqHCacoCkwmE2FhYafr6upOXr9+fbG1t6pUqk1cLhc8Hs9pqz8hgJCQEIcqoGkaAoEAsbGxLx05cuRbKxueDxMTE1va2toclpPu+DZo2ig99NBD1efOnftSrVYvn6SSHNq8eXO+p6cndDqdw/f9O7YLmIYCn89HSkrKSwUFBRYBhIaGFnh5eXU2NjZCr9fD2WMcAA8PD6coMhqNWLRoUW1FRcWR2tra9AkfhsnsnzFjxl8KCwth+kmrI0diYuKdDYGRXMDj8bBmzZoN69evnxDA7NmzdwYGBvZ3dHQ4pej51UJgZOj1eiQnJ6vLysr2VFVVrTWpGToXL178VxaLBbFY7NTMbxGAr6+v05TRNA0vLy9s2bJlY0pKSqZer799gBofH/9maGjorfb2dnA4HNypMQ7AwMCAUxWq1Wr4+/tfk8vlhZcuXXoJALhcbltqauq7JElCKBTesdWfEMDo7wSdNVgsFh588MHtP/zwQ57BYHBLT09/dcaMGcbW1law7fgwyqEAnO1+Ix8vyWSyvqCgoEMtLS2PqlSqUoqinFry/urboCkErVaL2bNnv5OZmXlMKpXi6tWr4HLv/OfIxP//cfI+H/8bANeS5YFpLrRuAAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: vault-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - vault.security.coreos.com
+                resources:
+                - vaultservices
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+            deployments:
+            - name: vault-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: vault-operator
+                template:
+                  metadata:
+                    labels:
+                      name: vault-operator
+                  spec:
+                    serviceAccountName: vault-operator
+                    containers:
+                    - name: vault-operator
+                      image: quay.io/coreos/vault-operator@sha256:74036811bc5d6cc1a136d8cc6d5577db67f29ba95eba02fbf0c3a8d2357dc8fe
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        version: 0.1.5
+        maturity: alpha
+        customresourcedefinitions:
+          owned:
+          - name: vaultservices.vault.security.coreos.com
+            version: v1alpha1
+            kind: VaultService
+            displayName: Vault Service
+            description: A running Vault instance, backed by an Etcd Cluster
+            resources:
+              - name: etcdclusters.etcd.database.coreos.com
+                version: v1beta2
+                kind: EtcdCluster
+              - kind: Service
+                version: v1
+              - kind: ConfigMap
+                version: v1
+              - kind: Secret
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of Pods for the cluster
+                displayName: Size
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The status of each of the node Pods for the Vault cluster.
+                displayName: Node Status
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running Vault cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The port at which the Vault cluster is running under the service.
+                displayName: Client Port
+                path: clientPort
+          required:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/etcdoperator.v0.9.2.clusterserviceversion.yaml
+      packageName: etcd
+      channels:
+      - name: alpha
+        currentCSV: etcdoperator.v0.9.2
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/prometheusoperator.0.15.0.clusterserviceversion.yaml
+      packageName: prometheus
+      channels:
+      - name: alpha
+        currentCSV: prometheusoperator.0.15.0
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/vaultoperator.0.1.9.clusterserviceversion.yaml
+      packageName: vault
+      channels:
+      - name: alpha
+        currentCSV: vault-operator.0.1.9
+      
+

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/09-tectoniccomponents.configmap.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/09-tectoniccomponents.configmap.yaml
@@ -1,0 +1,444 @@
+##---
+# Source: olm/templates/09-tectoniccomponents.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tectonic-components
+  namespace: tectonic-system
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: chargebacks.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/description: An instance of Chargeback
+          catalog.app.coreos.com/displayName: Chargeback
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: chargebacks
+          singular: chargeback
+          kind: Chargeback
+          listKind: ChargebackList
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prestotables.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Presto Table"
+          catalog.app.coreos.com/description: "A table within PrestoDB"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: prestotables
+          singular: prestotable
+          kind: PrestoTable
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reports.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Report"
+          catalog.app.coreos.com/description: "A chargeback report for a specific time interval"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reports
+          kind: Report
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportdatasources.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback data source"
+          catalog.app.coreos.com/description: "A resource describing a source of data for usage by Report Generation Queries"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportdatasources
+          singular: reportdatasource
+          kind: ReportDataSource
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportgenerationqueries.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback generation query"
+          catalog.app.coreos.com/description: "A SQL query used by Chargeback to generate reports"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportgenerationqueries
+          singular: reportgenerationquery
+          kind: ReportGenerationQuery
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportprometheusqueries.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback prometheus query"
+          catalog.app.coreos.com/description: "A Prometheus query by Chargeback to do metering"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportprometheusqueries
+          singular: reportprometheusquery
+          kind: ReportPrometheusQuery
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: scheduledreports.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Scheduled Report"
+          catalog.app.coreos.com/description: "A chargeback report that runs on a scheduled interval"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: scheduledreports
+          kind: ScheduledReport
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: storagelocations.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback storage location"
+          catalog.app.coreos.com/description: "Represents a configurable storage location for Chargeback to store metering and report data"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: storagelocations
+          kind: StorageLocation
+      
+  clusterServiceVersions: |-
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: chargeback-helm-operator.v0.5.1
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: tectonic-feature
+      spec:
+        displayName: Chargeback
+        description: Chargeback can generate reports based on historical usage data from a cluster, providing accountability for how resources have been used.
+        keywords: [chargeback metrics reporting coreos]
+        version: 0.5.1
+        maturity: alpha
+        maintainers:
+          - email: support@coreos.com
+            name: CoreOS, Inc
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-chargeback: chargeback-helm-operator
+          alm-status-descriptors: chargeback-helm-operator.v0.5.1
+        selector:
+          matchLabels:
+            alm-owner-chargeback: chargeback-helm-operator
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+              - rules:
+                - apiGroups:
+                  - chargeback.coreos.com
+                  resources:
+                  - '*'
+                  verbs:
+                  - '*'
+                - apiGroups:
+                  - ""
+                  resources:
+                  - pods
+                  - pods/attach
+                  - pods/exec
+                  - pods/portforward
+                  - pods/proxy
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - configmaps
+                  - endpoints
+                  - persistentvolumeclaims
+                  - replicationcontrollers
+                  - replicationcontrollers/scale
+                  - secrets
+                  - serviceaccounts
+                  - services
+                  - services/proxy
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - bindings
+                  - events
+                  - limitranges
+                  - namespaces/status
+                  - pods/log
+                  - pods/status
+                  - replicationcontrollers/status
+                  - resourcequotas
+                  - resourcequotas/status
+                  verbs:
+                  - get
+                  - list
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - namespaces
+                  verbs:
+                  - get
+                  - list
+                  - watch
+                - apiGroups:
+                  - apps
+                  resources:
+                  - deployments
+                  - deployments/rollback
+                  - deployments/scale
+                  - statefulsets
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - batch
+                  resources:
+                  - cronjobs
+                  - jobs
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - extensions
+                  resources:
+                  - daemonsets
+                  - deployments
+                  - deployments/rollback
+                  - deployments/scale
+                  - replicasets
+                  - replicasets/scale
+                  - replicationcontrollers/scale
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - rbac.authorization.k8s.io
+                  resources:
+                  - rolebindings
+                  - roles
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                serviceAccountName: chargeback-helm-operator
+            deployments:
+              - name: chargeback-helm-operator
+                spec:
+                  replicas: 1
+                  strategy:
+                    type: Recreate
+                  selector:
+                    matchLabels:
+                      app: chargeback-helm-operator
+                  template:
+                    metadata:
+                      labels:
+                        app: chargeback-helm-operator
+                    spec:
+                      containers:
+                      - env:
+                        - name: HELM_RELEASE_CRD_NAME
+                          value: Chargeback
+                        - name: HELM_RELEASE_CRD_API_GROUP
+                          value: chargeback.coreos.com
+                        - name: MY_POD_NAME
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.name
+                        - name: MY_POD_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: HELM_HOST
+                          value: 127.0.0.1:44134
+                        - name: SET_OWNER_REFERENCE_VALUE
+                          value: "true"
+                        - name: HELM_WAIT
+                          value: "false"
+                        - name: HELM_RECONCILE_INTERVAL_SECONDS
+                          value: "120"
+                        - name: RELEASE_HISTORY_LIMIT
+                          value: "3"
+                        image: quay.io/coreos/chargeback-helm-operator:0.5.1
+                        imagePullPolicy: Always
+                        name: chargeback-helm-operator
+                        resources:
+                          limits:
+                            cpu: 50m
+                            memory: 25Mi
+                          requests:
+                            cpu: 50m
+                            memory: 25Mi
+                      - env:
+                        - name: TILLER_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: TILLER_HISTORY_MAX
+                          value: "3"
+                        image: gcr.io/kubernetes-helm/tiller:v2.6.2
+                        imagePullPolicy: Always
+                        livenessProbe:
+                          failureThreshold: 3
+                          httpGet:
+                            path: /liveness
+                            port: 44135
+                            scheme: HTTP
+                          initialDelaySeconds: 1
+                          periodSeconds: 10
+                          successThreshold: 1
+                          timeoutSeconds: 1
+                        name: tiller
+                        readinessProbe:
+                          failureThreshold: 3
+                          httpGet:
+                            path: /readiness
+                            port: 44135
+                            scheme: HTTP
+                          initialDelaySeconds: 1
+                          periodSeconds: 10
+                          successThreshold: 1
+                          timeoutSeconds: 1
+                        resources:
+                          limits:
+                            cpu: 50m
+                            memory: 100Mi
+                          requests:
+                            cpu: 50m
+                            memory: 50Mi
+                      restartPolicy: Always
+                      serviceAccount: chargeback-helm-operator
+                      terminationGracePeriodSeconds: 30
+        customresourcedefinitions:
+          owned:
+          - description: An instance of Chargeback
+            displayName: Chargeback
+            kind: Chargeback
+            name: chargebacks.chargeback.coreos.com
+            version: v1alpha1
+          - description: A table within PrestoDB
+            displayName: Chargeback Presto Table
+            kind: PrestoTable
+            name: prestotables.chargeback.coreos.com
+            version: v1alpha1
+          - description: A chargeback report for a specific time interval
+            displayName: Chargeback Report
+            kind: Report
+            name: reports.chargeback.coreos.com
+            version: v1alpha1
+          - description: A resource describing a source of data for usage by Report Generation
+              Queries
+            displayName: Chargeback data source
+            kind: ReportDataSource
+            name: reportdatasources.chargeback.coreos.com
+            version: v1alpha1
+          - description: A SQL query used by Chargeback to generate reports
+            displayName: Chargeback generation query
+            kind: ReportGenerationQuery
+            name: reportgenerationqueries.chargeback.coreos.com
+            version: v1alpha1
+          - description: A Prometheus query by Chargeback to do metering
+            displayName: Chargeback prometheus query
+            kind: ReportPrometheusQuery
+            name: reportprometheusqueries.chargeback.coreos.com
+            version: v1alpha1
+          - description: A chargeback report that runs on a scheduled interval
+            displayName: Chargeback Scheduled Report
+            kind: ScheduledReport
+            name: scheduledreports.chargeback.coreos.com
+            version: v1alpha1
+          - description: Represents a configurable storage location for Chargeback to store
+              metering and report data
+            displayName: Chargeback storage location
+            kind: StorageLocation
+            name: storagelocations.chargeback.coreos.com
+            version: v1alpha1
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/components/chargeback.v0.5.1.clusterserviceversion.yaml
+      packageName: chargeback
+      channels:
+      - name: alpha
+        currentCSV: chargeback-helm-operator.v0.5.1
+      
+

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/10-tectonicocs.catalogsource.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/10-tectonicocs.catalogsource.yaml
@@ -1,0 +1,19 @@
+##---
+# Source: olm/templates/10-tectonicocs.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: app.coreos.com/v1alpha1
+kind: CatalogSource-v1
+metadata:
+  name: tectonic-ocs
+  namespace: tectonic-system
+  annotations:
+    tectonic-operators.coreos.com/upgrade-strategy: 'DeleteAndRecreate'
+spec:
+  name: tectonic-ocs
+  sourceType: internal
+  configMap: tectonic-ocs
+  displayName: Tectonic Open Cloud Services
+  publisher: CoreOS, Inc.
+

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/11-tectoniccomponents.catalogsource.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/11-tectoniccomponents.catalogsource.yaml
@@ -1,0 +1,19 @@
+##---
+# Source: olm/templates/11-tectoniccomponents.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: app.coreos.com/v1alpha1
+kind: CatalogSource-v1
+metadata:
+  name: tectonic-components
+  namespace: tectonic-system
+  annotations:
+    tectonic-operators.coreos.com/upgrade-strategy: 'DeleteAndRecreate'
+spec:
+  name: tectonic-components
+  sourceType: internal
+  configMap: tectonic-components
+  displayName: Tectonic Cluster Components
+  publisher: CoreOS, Inc.
+

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/12-alm-operator.deployment.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/12-alm-operator.deployment.yaml
@@ -1,0 +1,48 @@
+##---
+# Source: olm/templates/12-alm-operator.deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: alm-operator
+  namespace: tectonic-system
+  labels:
+    app: alm-operator
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alm-operator
+  template:
+    metadata:
+      labels:
+        app: alm-operator
+    spec:
+      serviceAccountName: alm-operator-serviceaccount
+      containers:
+        - name: alm-operator
+          command:
+          - /bin/alm
+          image: quay.io/coreos/olm@sha256:00b6b703d235b622d8e2e5424d0bfb4aa9e46ec10abd295def47e2c6ed7a18e8
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: alm-operator
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/deploy/tectonic-alm-operator/manifests/0.5.0/13-catalog-operator.deployment.yaml
+++ b/deploy/tectonic-alm-operator/manifests/0.5.0/13-catalog-operator.deployment.yaml
@@ -1,0 +1,44 @@
+##---
+# Source: olm/templates/13-catalog-operator.deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  namespace: tectonic-system
+  labels:
+    app: catalog-operator
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      labels:
+        app: catalog-operator
+    spec:
+      serviceAccountName: alm-operator-serviceaccount
+      containers:
+        - name: catalog-operator
+          command:
+          - /bin/catalog
+          - '-namespace'
+          - tectonic-system
+          - '-debug'
+          image: quay.io/coreos/catalog@sha256:08667c7c409c8ca044c05db9bf90a0aa9954ce511490e72df4a3493cebd58b8e
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/deploy/tectonic-alm-operator/values.yaml
+++ b/deploy/tectonic-alm-operator/values.yaml
@@ -4,19 +4,17 @@ catalog_namespace: tectonic-system
 alm:
   replicaCount: 1
   image:
-    ref: quay.io/coreos/olm@sha256:351f0c4973a88a4ea606721555829776429b0ecb53d5a2bfee6bce459d109e5b
+    ref: quay.io/coreos/olm@sha256:00b6b703d235b622d8e2e5424d0bfb4aa9e46ec10abd295def47e2c6ed7a18e8
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
-
 catalog:
   replicaCount: 1
   image:
-    ref: quay.io/coreos/catalog@sha256:54571e25474a9a063a144922e7321203e5aa5e63d03f748682d559341359a916
+    ref: quay.io/coreos/catalog@sha256:08667c7c409c8ca044c05db9bf90a0aa9954ce511490e72df4a3493cebd58b8e
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
-
 catalog_sources:
- - tectonic-ocs
- - tectonic-components
+- tectonic-ocs
+- tectonic-components

--- a/deploy/upstream/manifests/0.5.0/01-alm-operator.serviceaccount.yaml
+++ b/deploy/upstream/manifests/0.5.0/01-alm-operator.serviceaccount.yaml
@@ -1,0 +1,11 @@
+##---
+# Source: olm/templates/01-alm-operator.serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: alm-operator-serviceaccount
+  namespace: kube-system
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+imagePullSecrets:
+- name: coreos-pull-secret

--- a/deploy/upstream/manifests/0.5.0/02-alm-operator.rolebinding.yaml
+++ b/deploy/upstream/manifests/0.5.0/02-alm-operator.rolebinding.yaml
@@ -1,0 +1,16 @@
+##---
+# Source: olm/templates/02-alm-operator.rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alm-operator-binding
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: alm-operator-serviceaccount
+  namespace: kube-system

--- a/deploy/upstream/manifests/0.5.0/03-clusterserviceversion.crd.yaml
+++ b/deploy/upstream/manifests/0.5.0/03-clusterserviceversion.crd.yaml
@@ -1,0 +1,413 @@
+##---
+# Source: olm/templates/03-clusterserviceversion.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterserviceversion-v1s.app.coreos.com
+  annotations:
+    displayName: Operator Version
+    description: Represents an Operator that should be running on the cluster, including requirements and install strategy.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  names:
+    plural: clusterserviceversion-v1s
+    singular: clusterserviceversion-v1
+    kind: ClusterServiceVersion-v1
+    listKind: ClusterServiceVersionList-v1
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a single version of the operator software
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a ClusterServiceVersion
+          required:
+          - displayName
+          - install
+          properties:
+            displayName:
+              type: string
+              description: Human readable name of the application that will be displayed in the ALM UI
+
+            description:
+              type: string
+              description: Human readable description of what the application does
+
+            keywords:
+              type: array
+              description: List of keywords which will be used to discover and categorize app types
+              items:
+                type: string
+
+            maintainers:
+              type: array
+              description: Those responsible for the creation of this specific app type
+              items:
+                type: object
+                description: Information for a single maintainer
+                required:
+                - name
+                - email
+                properties:
+                  name:
+                    type: string
+                    description: Maintainer's name
+                  email:
+                    type: string
+                    description: Maintainer's email address
+                    format: email
+                optionalProperties:
+                  type: string
+                  description: "Any additional key-value metadata you wish to expose about the maintainer, e.g. github: <username>"
+
+            links:
+              type: array
+              description: Interesting links to find more information about the project, such as marketing page, documentation, or github page
+              items:
+                type: object
+                description: A single link to describe one aspect of the project
+                required:
+                - name
+                - url
+                properties:
+                  name:
+                    type: string
+                    description: Name of the link type, e.g. homepage or github url
+                  url:
+                    type: string
+                    description: URL to which the link should point
+                    format: uri
+
+            icon:
+              type: array
+              description: Icon which should be rendered with the application information
+              required:
+              - base64data
+              - mediatype
+              properties:
+                base64data:
+                  type: string
+                  description: Base64 binary representation of the icon image
+                  pattern: ^(?:[A-Za-z0-9+/]{4}){0,16250}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                mediatype:
+                  type: string
+                  description: Mediatype for the binary data specified in the base64data property
+                  enum:
+                  - image/gif
+                  - image/jpeg
+                  - image/png
+                  - image/svg+xml
+            version:
+              type: string
+              description: Version string, recommended that users use semantic versioning
+              pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+            replaces:
+              type: string
+              description: Name of the ClusterServiceVersion custom resource that this version replaces
+
+            maturity:
+              type: string
+              description: What level of maturity the software has achieved at this version
+              enum:
+              - planning
+              - pre-alpha
+              - alpha
+              - beta
+              - stable
+              - mature
+              - inactive
+              - deprecated
+            labels:
+              type: object
+              description: Labels that will be applied to associated resources created by the operator.
+            selector:
+              type: object
+              description: Label selector to find resources associated with or managed by the operator
+              properties:
+                matchLabels:
+                  type: object
+                  description: Label key:value pairs to match directly
+                matchExpressions:
+                  type: array
+                  descriptions: A set of expressions to match against the resource.
+                  items:
+                    allOf:
+                      - type: object
+                        required:
+                        - key
+                        - operator
+                        - values
+                        properties:
+                          key:
+                            type: string
+                            description: the key to match
+                          operator:
+                            type: string
+                            description: the operator for the expression
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                          values:
+                            type: array
+                            description: set of values for the expression
+            customresourcedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the CRD
+                          required:
+                            - kind
+                            - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a CRD, the fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+
+
+            install:
+              type: object
+              description: Information required to install this specific version of the operator software
+              oneOf:
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['image']
+                  spec:
+                    type: object
+                    required:
+                    - image
+                    properties:
+                      image:
+                        type: string
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['deployment']
+                  spec:
+                    type: object
+                    required:
+                    - deployments
+                    properties:
+                      deployments:
+                        type: array
+                        description: List of deployments to create
+                        items:
+                          type: object
+                          description: A name and deployment to create in the cluster
+                          required:
+                            - name
+                            - spec
+                          properties:
+                            name:
+                              type: string
+                              description: the consistent name of the deployment
+                            spec:
+                              type: object
+                              description: The deployment spec to create in the cluster
+                      permissions:
+                        type: array
+                        description: Permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                            - serviceAccountName
+                            - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                        - "*"
+                                        - get
+                                        - list
+                                        - watch
+                                        - create
+                                        - update
+                                        - patch
+                                        - delete
+                                        - deletecollection

--- a/deploy/upstream/manifests/0.5.0/05-catalogsource.crd.yaml
+++ b/deploy/upstream/manifests/0.5.0/05-catalogsource.crd.yaml
@@ -1,0 +1,54 @@
+##---
+# Source: olm/templates/05-catalogsource.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogsource-v1s.app.coreos.com
+  annotations:
+    displayName: CatalogSource
+    description: A source configured to find packages and updates.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: catalogsource-v1s
+    singular: catalogsource-v1
+    kind: CatalogSource-v1
+    listKind: CatalogSourceList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a subscription to a source and channel
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a subscription
+          required:
+          - sourceType
+          - name
+          properties:
+            sourceType:
+              type: string
+              description: The type of the source. Currently the only supported type is "internal".
+              enum:
+              - internal
+
+            configMap:
+              type: string
+              string: The name of a ConfigMap that holds the entries for an in-memory catalog.
+
+            name:
+              type: string
+              description: Name of this catalog source
+
+            secrets:
+              type: array
+              description: A set of secrets that can be used to access the contents of the catalog. It is best to keep this list small, since each will need to be tried for every catalog entry.
+              items:
+                type: string
+                description: A name of a secret in the namespace where the CatalogSource is defined.

--- a/deploy/upstream/manifests/0.5.0/06-installplan.crd.yaml
+++ b/deploy/upstream/manifests/0.5.0/06-installplan.crd.yaml
@@ -1,0 +1,60 @@
+##---
+# Source: olm/templates/06-installplan.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installplan-v1s.app.coreos.com
+  annotations:
+    displayName: Install Plan
+    description: Represents a plan to install and resolve dependencies for Cluster Services
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: installplan-v1s
+    singular: installplan-v1
+    kind: InstallPlan-v1
+    listKind: InstallPlanList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Document which defines the desire and current state of an installation of a Cluster Service
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for an InstallPlan
+          required:
+          - clusterServiceVersionNames
+          - approval
+          properties:
+            clusterServiceVersionNames:
+              type: array
+              description: A list of the names of the Cluster Services
+              items:
+                type: string
+            approval:
+              type: string
+              enum:
+              - Automatic
+              - Manual
+              - Update-Only # Will only apply an update if it updates existing packages only and doesn't add any new ones
+            approved:
+              type: boolean
+      anyOf:
+        - properties:
+          approval: 
+            enum: 
+              - Manual
+          required:
+            - approved
+        - properties:
+          approval:
+            enum:
+              - Automatic
+              - Update-Only
+          required: []

--- a/deploy/upstream/manifests/0.5.0/07-subscription.crd.yaml
+++ b/deploy/upstream/manifests/0.5.0/07-subscription.crd.yaml
@@ -1,0 +1,49 @@
+##---
+# Source: olm/templates/07-subscription.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscription-v1s.app.coreos.com
+  annotations:
+    displayName: Subscription
+    description: Subcribes service catalog to a source and channel to recieve updates for packages.
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  group: app.coreos.com
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: subscription-v1s
+    singular: subscription-v1
+    kind: Subscription-v1
+    listKind: SubscriptionList-v1
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Represents a subscription to a source and channel
+      required:
+      - spec
+      properties:
+        spec:
+          type: object
+          description: Spec for a Subscription
+          required:
+          - source
+          - name
+          properties:
+            source:
+              type: string
+              description: Name of a CatalogSource that defines where and how to find the channel
+
+            name:
+              type: string
+              description: Name of the package that defines the application
+
+            channel:
+              type: string
+              description: Name of the channel to track
+            
+            startingCSV:
+              type: string
+              description: Name of the AppType that this subscription tracks

--- a/deploy/upstream/manifests/0.5.0/08-tectonicocs.configmap.yaml
+++ b/deploy/upstream/manifests/0.5.0/08-tectonicocs.configmap.yaml
@@ -1,0 +1,1810 @@
+##---
+# Source: olm/templates/08-tectonicocs.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tectonic-ocs
+  namespace: kube-system
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: alertmanagers.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: alertmanagers
+          singular: alertmanager
+          kind: Alertmanager
+          listKind: AlertmanagerList
+          shortNames:
+            - alertman
+            - alrtman
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdbackups.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdBackup
+          listKind: EtcdBackupList
+          plural: etcdbackups
+          singular: etcdbackup
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdclusters.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        validation:
+          openAPIv3:
+            type: object
+            description: Represents a single instance of etcd
+            additionalProperties: false
+            required:
+            - version
+            properties:
+              version:
+                type: string
+                description: Version string
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+                x-descriptors:
+                - urn:alm:descriptor:versioning:semver
+              size:
+                type: number
+                description: The size of the etcd cluster
+                min: 1
+                max: 9
+                x-descriptors:
+                - urn:alm:descriptor:pod:count
+                - urn:alm:descriptor:number:integer
+              template:
+                type: object
+                description: Template for fields of subresources
+                labels:
+                  type: object
+                  description: Labels to apply to associated resources
+        names:
+          plural: etcdclusters
+          singular: etcdcluster
+          kind: EtcdCluster
+          listKind: EtcdClusterList
+          shortNames:
+            - etcdclus
+            - etcd
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdrestores.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdRestore
+          listKind: EtcdRestoreList
+          plural: etcdrestores
+          singular: etcdrestore
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prometheuses.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: prometheuses
+          singular: prometheus
+          kind: Prometheus
+          listKind: PrometheusList
+          shortNames:
+            - prom
+            - prm
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: servicemonitors.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        version: v1
+        scope: Namespaced
+        names:
+          plural: servicemonitors
+          singular: servicemonitor
+          kind: ServiceMonitor
+          listKind: ServiceMonitorList
+          shortNames:
+            - servicemon
+            - svcmon
+            - svcmonitor
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: vaultservices.vault.security.coreos.com
+      spec:
+        group: vault.security.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        validation:
+          openAPIv3:
+            type: object
+            description: Represents a single instance of Vault
+            additionalProperties: false
+            required:
+            - version
+            properties:
+              version:
+                type: string
+                description: Version string
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+                x-descriptors:
+                - urn:alm:descriptor:versioning:semver
+              nodes:
+                type: number
+                description: The number of nodes in the Vault cluster
+                min: 1
+                max: 9
+                x-descriptors:
+                - urn:alm:descriptor:pod:count
+                - urn:alm:descriptor:number:integer
+              template:
+                type: object
+                description: Template for fields of subresources
+                labels:
+                  type: object
+                  description: Labels to apply to associated resources
+        names:
+          plural: vaultservices
+          singular: vaultservice
+          kind: VaultService
+          listKind: VaultServiceList
+          shortNames:
+            - vault
+            - vaultserv
+            - vaultsrv
+      
+  clusterServiceVersions: |-
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.6.1
+        namespace: placeholder
+        annotations:		
+          tectonic-visibility: ocs		
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+          **High availability**
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+          **Automated updates**
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+          **Backups included**
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.6.1
+        maturity: alpha
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-status-descriptors: etcdoperator.v0.6.1
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: service
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.9.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.0
+        maturity: alpha
+        replaces: etcdoperator.v0.6.1
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: etcdoperator.v0.9.2
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.2
+        maturity: alpha
+        replaces: etcdoperator.v0.9.0
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: prometheusoperator.0.14.0
+        namespace: placeholder
+      spec:
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ## Supported Features
+      
+          **High availability**
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+          **Updates via automated operations**
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+          **Handles the dynamic nature of containers**
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.14.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.14.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.14.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Define resources requests and limits for single Pods
+              displayName: Resource Request
+              path: resources.requests
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: prometheusoperator.0.15.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+      spec:
+        replaces: prometheusoperator.0.14.0
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+      
+      
+          **Updates via automated operations**
+      
+      
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+      
+      
+          **Handles the dynamic nature of containers**
+      
+      
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.15.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.15.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: vault-operator.0.1.9
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"vault.security.coreos.com/v1alpha1","kind":"VaultService","metadata":{"name":"example"},"spec":{"nodes":2,"version":"0.9.1-0"}}]'
+        labels:
+          alm-catalog: tectonic-ocs
+      spec:
+        displayName: Vault
+        description: |
+          An encrypted, multi-tentant secure secret store. Vault handles the lifecycle of your secrets: leasing, key revocation, key rolling, and auditing.
+      
+          _The Vault Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Unsealing and using Vault
+      
+          Once a Vault instance is running, it must be initalized and "unsealed". Afterwards, your software can use the automatically created Kubernetes Service and Secret to communicate with it.
+      
+          [Read the complete guide to using the Vault Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/vault-ocs.html)
+      
+          ### Supported Features
+      
+          **Secure by Default**
+      
+      
+          Hands-free automated creation of TLS certificates between all components ensure all best practices are followed for secret security. Further, the API makes unseal operations easy.
+      
+      
+          **Highly available**
+      
+      
+          Multiple instances of Vault are clustered together via an etcd backend and secured.
+      
+      
+          **Safe Upgrades**
+      
+      
+          Rolling out a new Vault version is as easy as updating the Vault Cluster definition. Everything is automatically handled using Vault best practices while pausing for unseal tokens.
+      
+        keywords: ['vault', 'secret', 'encryption']
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+        provider:
+          name: CoreOS, Inc
+        links:
+        - name: Vault Project
+          url: https://www.vaultproject.io/
+        labels:
+          alm-status-descriptors: vault-operator.0.1.9
+          alm-owner-vault: vault-operator
+          operated-by: vault-operator
+        selector:
+          matchLabels:
+            alm-owner-vault: vault-operator
+            operated-by: vault-operator
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAAA7CAYAAADLjIzcAAAACXBIWXMAAAsTAAALEwEAmpwYAAAMLGlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjarVd3VFP51t23JKGEmoCAlNARBAHpSO+CgHQYW0gChBJCCip2x0EFxy4WrOjYcNSxADIWRB3rIPbuAx1URsbBgg2V9wcBZ+Z93x9vrfdb6+budbLPPvuce9dd6wA6HnyptJDUBYokCllSVCgvIzOLx2oHCxxogYQ7XyCXhiQmxgHAwP0vhwDe3gQBANec+VJpIf67oycUyQUAkQggWygXFAHEIYA2EUhlCoDRCsB6skKqABhvAHBlGZlZAFMNADe3H5sC4Gb3Y1cAXFlKUhjADAfU2Hy+LBfQTgTAKxXkKgBtKQBXiVAsAbQ3AwgU5PGFgHYbgOFFRcVCQIcNwCH7Lzq5f9PMHtTk83MHcX8vAAC1cLFcWsifiv/1KSpUDtSwAsDOk0UnAeACxM6C4tgkAGyAOCrJjk8AoA8Q58RCQIXv5imjU1X8LoE8LAuAIUBCyA+PBWAKkIbKgtQQFXbny4B+PhkvVsSkqHC2rDhJpU+WSgrj41Q6C/JEMQN4o0gekTzAyRFHxgDQBchDZXkp6f0+ydOl4rR4ANoA2SovSI5V5T4sywuLH+DIlEmpAGwA8k2OLDKpn0MZFckH+qJcBPyIZABGABWsyEuJ7s+lMkTyjLgBD0JReES/B0ookqSqvFEKqSI0SZVbLi1MVPGpjaLCqKT+OVP75aXJA7lXFbIU1cypR/n80Yn9/qm3UkViSr83mkYcwhAOHpTgIRvFyIe4pau+CzzVP5HgQ4ZciOCsigxkpIMPGSTgIxll+AMSiCAfzAsFHzKIUAoJPg9G+3+dkQM+ZCiFCHIU4AlkKKJN6EDan46jA+lgOpB2p31o34E8ns5AVWYEM5wZzYxkDhv0IUAxClEMGcT/RywWhRBBCRlEkAz08FWP8YRxhfGIcYPRxriDNPwGGcQDrIniubJ/OOdhDNqgVE1FhGxI0DnAoe1od9qTDqUD6EDaFzzakDaBM+1B+9AhdBDtT3vSvn9zqBz09nWW/6wnguRv/aji2o7anioX2YNPJmyQ9U+VsL/MSIhixP6TSS2gDlJnqZPUeeooVQ8edYJqoC5Rx6j6v7wJv0GG3MFqSRBBggIUQjzAca117XT99B/V+SoHMoggBxSiKQoACCuWTpWJc/MUvBCptFDEi5EIXIbz3F3dvIGMzCxe/+fjtSEIAIThha+xkibAtwIgcr/G+NbAkScA5+3XmPUrgL0UONYqUMpK+2M0ADCgAR1wYQxzWMMBznCHF/wRjAiMRgJSkIkJECAPRZBhMqZjDspRiaVYhXXYhK3YiR9xAPU4ipP4BRfRihu4hzZ04Dm68Ra9BEGwCC2CQxgTFoQt4US4Ez5EIBFBxBFJRCYxicglJISSmE58S1QSy4l1xBZiF/ETcYQ4SZwnrhB3iHaik3hFfCQpkk1ySTPSjhxB+pAhZCyZQo4nc8kSsoycRy4m15A15B6yjjxJXiRvkG3kc7KHAqVJGVKWlDPlQ4VRCVQWlUPJqJlUBVVF1VB7qUbqLHWNaqO6qA80k+bQPNqZ9qej6VRaQJfQM+lF9Dp6J11Hn6av0e10N/2FocUwZTgx/BgxjAxGLmMyo5xRxdjOOMw4w7jB6GC8ZTKZhkx7pjczmpnJzGdOYy5ibmDuYzYxrzAfM3tYLJYxy4kVwEpg8VkKVjlrLWsP6wTrKquD9V5NU81CzV0tUi1LTaI2V61KbbfacbWrak/VetV11W3V/dQT1IXqU9WXqG9Tb1S/rN6h3quhp2GvEaCRopGvMUdjjcZejTMa9zVea2pqWmn6ao7VFGvO1lyjuV/znGa75ge2PtuRHcYex1ayF7N3sJvYd9ivtbS07LSCtbK0FFqLtXZpndJ6qPVem6Ptoh2jLdSepV2tXad9VfuFjrqOrU6IzgSdMp0qnYM6l3W6dNV17XTDdPm6M3WrdY/o3tLt0ePouekl6BXpLdLbrXde75k+S99OP0JfqD9Pf6v+Kf3HHIpjzQnjCDjfcrZxznA6uEyuPTeGm8+t5P7IbeF2G+gbeBikGUwxqDY4ZtBmSBnaGcYYFhouMTxgeNPw4xCzISFDREMWDtk75OqQd0ZDjYKNREYVRvuMbhh9NOYZRxgXGC8zrjd+YEKbOJqMNZlsstHkjEnXUO5Q/6GCoRVDDwy9a0qaOpommU4z3Wp6ybTHzNwsykxqttbslFmXuaF5sHm++Urz4+adFhyLQAuxxUqLExa/8wx4IbxC3hreaV63palltKXScotli2Wvlb1VqtVcq31WD6w1rH2sc6xXWjdbd9tY2IyxmW5Ta3PXVt3WxzbPdrXtWdt3dvZ26Xbz7ertntkb2cfYl9nX2t930HIIcihxqHG4Pow5zGdYwbANw1odSUdPxzzHasfLTqSTl5PYaYPTleGM4b7DJcNrht9yZjuHOJc61zq3uxi6xLnMdal3eTHCZkTWiGUjzo744urpWui6zfWem77baLe5bo1ur9wd3QXu1e7XR2qNjBw5a2TDyJceTh4ij40etz05nmM853s2e3728vaSee316vS28Z7kvd77lg/XJ9Fnkc85X4ZvqO8s36O+H/y8/BR+B/z+9Hf2L/Df7f9slP0o0ahtox4HWAXwA7YEtAXyAicFbg5sC7IM4gfVBD0Ktg4WBm8PfhoyLCQ/ZE/Ii1DXUFno4dB3YX5hM8KawqnwqPCK8JYI/YjUiHURDyOtInMjayO7ozyjpkU1RTOiY6OXRd+KMYsRxOyK6R7tPXrG6NOx7Njk2HWxj+Ic42RxjWPIMaPHrBhzP942XhJfn4CEmIQVCQ8S7RNLEn8eyxybOLZ67JMkt6TpSWeTOckTk3cnv00JTVmSci/VIVWZ2pymkzYubVfau/Tw9OXpbRkjMmZkXMw0yRRnNmSxstKytmf1fBPxzapvOsZ5jisfd3O8/fgp489PMJlQOOHYRJ2J/IkHJzEmpU/aPekTP4Ffw+/Jjslen90tCBOsFjwXBgtXCjtFAaLloqc5ATnLc57lBuSuyO3MC8qryusSh4nXiV/mR+dvyn9XkFCwo6CvML1wX5Fa0aSiIxJ9SYHkdLF58ZTiK1Inabm0rcSvZFVJtyxWtl1OyMfLGxRchVRxSemg/E7ZXhpYWl36fnLa5INT9KZIplya6jh14dSnZZFlP0yjpwmmNU+3nD5nevuMkBlbZhIzs2c2z7KeNW9Wx+yo2TvnaMwpmPPrXNe5y+e++Tb928Z5ZvNmz3v8XdR3teXa5bLyW/P9529aQC8QL2hZOHLh2oVfKoQVFypdK6sqPy0SLLrwvdv3a77vW5yzuGWJ15KNS5lLJUtvLgtatnO53vKy5Y9XjFlRt5K3smLlm1UTV52v8qjatFpjtXJ125q4NQ1rbdYuXftpXd66G9Wh1fvWm65fuP7dBuGGqxuDN+7dZLapctPHzeLNt7dEbamrsaup2srcWrr1yba0bWd/8Plh13aT7ZXbP++Q7GjbmbTz9C7vXbt2m+5eUkvWKms794zb0/pj+I8Ne533btlnuK9yP/Yr9//+06Sfbh6IPdB80Ofg3kO2h9Yf5hyuqCPqptZ11+fVtzVkNlw5MvpIc6N/4+GfXX7ecdTyaPUxg2NLjmscn3e870TZiZ4maVPXydyTj5snNt87lXHq+umxp1vOxJ4590vkL6fOhpw9cS7g3NHzfuePXPC5UH/R62LdJc9Lh3/1/PVwi1dL3WXvyw2tvq2NV0ZdOX416OrJa+HXfrkec/3ijfgbV26m3rx9a9ytttvC28/uFN55ebf0bu+92fcZ9yse6D6oemj6sOZfw/61r82r7Vh7ePulR8mP7j0WPH7+m/y3Tx3znmg9qXpq8XTXM/dnRzsjO1t//+b3jufS571d5X/o/bH+hcOLQ38G/3mpO6O746XsZd+rRa+NX+944/GmuSex5+Hbore97yreG7/f+cHnw9mP6R+f9k7+xPq05vOwz41fYr/c7yvq65PyZXwAAAWAzMkBXu0AtDIBTiugod2/f6n2RuLrBvn/4f4dDQDgBewIBlJnA3FNwMYmwHY2wG4CEgGkBIMcOXLwUh15zkj3fi22DGC87+t7bQawGoHPsr6+3g19fZ+3AdQdoKmkf+8DAKYusJkHAL9az/+P/evfXvpsNqq3M8UAADowaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzExMSA3OS4xNTgzMjUsIDIwMTUvMDkvMTAtMDE6MTA6MjAgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgICAgICAgICAgeG1sbnM6cGhvdG9zaG9wPSJodHRwOi8vbnMuYWRvYmUuY29tL3Bob3Rvc2hvcC8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6Q3JlYXRlRGF0ZT4yMDE3LTA5LTA2VDE1OjMxOjU2LTA0OjAwPC94bXA6Q3JlYXRlRGF0ZT4KICAgICAgICAgPHhtcDpNZXRhZGF0YURhdGU+MjAxNy0wOS0wNlQxNTozMTo1Ni0wNDowMDwveG1wOk1ldGFkYXRhRGF0ZT4KICAgICAgICAgPHhtcDpNb2RpZnlEYXRlPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3htcDpNb2RpZnlEYXRlPgogICAgICAgICA8eG1wTU06SW5zdGFuY2VJRD54bXAuaWlkOjFlMjY4MTE5LWU2NmYtNGJjNC1hZTI0LThiMTViNTg3MzE2MjwveG1wTU06SW5zdGFuY2VJRD4KICAgICAgICAgPHhtcE1NOkRvY3VtZW50SUQ+YWRvYmU6ZG9jaWQ6cGhvdG9zaG9wOjczODM4YzJiLWQzYzgtMTE3YS1iNTYyLTllNjU3MTBkNzc5YzwveG1wTU06RG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD54bXAuZGlkOjQ1MjdmNDhmLTc2MGMtNGRhYi04NTJkLTNkNGZiOTA4ZmEzNjwveG1wTU06T3JpZ2luYWxEb2N1bWVudElEPgogICAgICAgICA8eG1wTU06SGlzdG9yeT4KICAgICAgICAgICAgPHJkZjpTZXE+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPmNyZWF0ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDo0NTI3ZjQ4Zi03NjBjLTRkYWItODUyZC0zZDRmYjkwOGZhMzY8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDphY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDoxZTI2ODExOS1lNjZmLTRiYzQtYWUyNC04YjE1YjU4NzMxNjI8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICAgICA8c3RFdnQ6Y2hhbmdlZD4vPC9zdEV2dDpjaGFuZ2VkPgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgPC9yZGY6U2VxPgogICAgICAgICA8L3htcE1NOkhpc3Rvcnk+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzpmb3JtYXQ+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZGU+CiAgICAgICAgIDxwaG90b3Nob3A6SUNDUHJvZmlsZT5EaXNwbGF5PC9waG90b3Nob3A6SUNDUHJvZmlsZT4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+NzIwMDAwLzEwMDAwPC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj43MjAwMDAvMTAwMDA8L3RpZmY6WVJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+NjU1MzU8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjY0PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjU5PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz6RZ44uAAAAIGNIUk0AAG11AABzoAAA/N0AAINkAABw6AAA7GgAADA+AAAQkOTsmeoAAAreSURBVHja7Jt5VFN3Fse/7yUkgQSyQBAiJWwTglKZqKBVFgURsVFgpAO2TRUonU7n0MWpVqnL6a7jtAdoz+lAsS61damHTnXascLUojMHLVUcpaesjUAVlFUWY7b35g+KhUBCEhJ71Pmd8/sDeO/edz+/e+/v3t97EDRN434eJO7zcd8DYJr+Ijc396kbN26EMxgM7b1kKE3TBEmSRHJy8m6VSlVrFkBLS4u2vLw8715cbS6X+/WcOXN6LYbAM888szckJOSre814giC0y5YtW93c3HzFIgA+n48nnnhi/b0GICIi4j2ZTHZdp9NZToJarRYpKSmXIiIiyu6ZRMdk9sfHx7/OZrMhEoksAxCJRBCLxdi0adOLDAaDuhcAxMbGFoSHh/exWCwIhULLAJhMJrq6uhAVFaWWyWQf3O3Gs9nsrrS0tB1MJhN8Ph8CgcDyNlhSUgKCIMBmszFz5sxX6urqsmmadrlbASiVyu0KheJma2vruNWf0AM0Gg2GhobQ19cHuVzePmvWrPfvVuN5PF772rVrCwBAIBDcnhY9YPr06SOFAzgcDhISEl6tra3NMRqN3LsNQE5Oztbly5cb6+vrxyU/swBM3UShUHRHR0cXVVZWbrqbjOdwOPXu7u6lhw8fRnd3NwiCuP23sLCwX+oD026wtLR0dPkIDw8PdHV1ua9bt+6yTqcT3S0AYmJifi+VSj9ta2sDkzl2nSsqKsx7AJ/PHycsMjJyQKlU7iwrK3trSp1XkBxU+xVAMzDK5cRAb+fYqi0wGLS62W49AoHgYlRU1KcajQZyudy2bnB0shAIBLeBZGdnv+3m5tZh93ak+gNEF/8L/jdnQU7zGTY0Mg4M1fMgl6QNX8TiwHX7R3D/5wWwcvMBEHbpSkxMzPf19YWHhwdEItG4aRFAQEDAmBkYGAihUIiHH35Yn5ubu81eAK6bXwfJZYEdFQaX5BXDyhXRIIwGEDMjAZIE6RcIVvrjII08sLNeBNhsm/X4+vp+m5iY+AVBEBCJRBAKheOmxSRYVVU1USuJhoYGeHt7l7DZ7Be1Wu1vbH0wTdE7YBa9CUN9O/TffD0s9/tqYE4s6LoLAEWBuqKG7ou/w0WZCt2uEkCvsxlARkbGBh8fH9A0PSbxmW2STJNgSkrKhBcaDAb4+fmhsbEx8+TJkwfs6sgkwaCvmsQ2wQHoW2PdMlAOSl1ns/zg4OCvS0tLE/r6+mAwGMxel56ebt4DgoKCLDUVWLBgwcELFy683NvbG26T8dOmw/VPT8PY8CO0e4drK8Zv54Hz5JPQHfsS+q8+G77O1x+02AdEXyfo3m5b2l0899xzGyQSCSiKsmr1JwRgWimZhoK3tzeSkpJePnjw4Oc2VWV7joCzbD5oAFRrM/QnT4Bb/AVc5nrCJe1J9C8IBtWiBql8HOCLgMAwGD8tASijVfIDAgIOL1my5JxWq4W7u7v9R2KWAIxASEpKOlpZWflde3v7XKs16XQgAIwOONqgBU0CtB6A8WdDKSNAkqAp2xpRmUy2tbi4GHq9HtQk90ZGRtpWB5gCkEgkyMjI2FhQUFBh7QMO5mSAynsBhvom6E+eAAAMZS8Fe7UK+q+Og/qpBQBg/Gw34O0H/NRk9eqHhIR8FBoaWt/a2mqT+0+YBMvKJj8HGWkts7KyKtVqdaz1h3KewJBJXIv9gc7WURmQAWZEJAw1Z6yNfX1WVlaoj4+PemBgwCrjCwsLzdcBE+2bppPH40EikSAvL2+DtbYzlq+G66H/gF30GQjPacN1T95r4H15EZw3dgNMFxBcLtzLqyE8XwW39z8BSOakchUKxW6FQqFmMpm3C7fJpk3NkLlhNBqhVCrPFhUVlV2+fPl3k3pNfCoIigIjfC6I4DDQ3dfgEp8C9PWCEZ0McHggJF5gxyuGmxnVatx8/ilAO2i+jCXJmytXrnyFw+HAw8PDJtc3C2Dfvn1WbztsNhthYWFbrQFgOFIC4tk3QJ2rBP39d8PnjwffB3vNs9Af+wQY6gOlHoRm31FwViyFZmeBReMBIC4u7m/z58+/euXKFasXbtIcsGrVKqtupGkaJEnC398fR48ePdDc3Jw5qTLPaaD7ugHjqCLF3RMYGJsXiIBQ0JfrJ8tDN4qLi4P8/f17enp6bFr9Rx55xLwHSKVSmwi6u7tj0aJFW5qbm9MnkjcGWve1MT+zkpRwfeGPuHX4OLQfvvvLdZMY//NRV+HChQt7WlpaJt25HFoHTBQKc+fObTp//vy+mpqabOu7I3dw9xyDiw/ATFoOQ/VpGC9dsG4z4XLb8/PzdwiFQhiNRrti32EAaJqGm5sbUlNTt9XU1DwKgGNdFtWD+rEZ8AkGdY0GPTRotc7w8PC3BgcHb549e9ZizW9ujD4RmjKAES+Ijo7+KTY29oNTp05Z915RdwsDmQnQr82G9vi/QP3YZJ3juLq2hYeHF+/atQs6nc6u1U9LSzMPwNzh4WRe4Orqiuzs7FdOnz6dTdO0VQeoVFsLbr5m2xHDwoULX5NKpbrOzs4pub5ZAA888IB92wlBYNWqVd3l5eXvfPzxx1uccc7H5/MbExISSimKgqenp0NkjgPQ1NRklyCapjE4OAi5XP4mg8F42mg0ih0NQKlUbgsMDKTb29sdsvoTAtizZ4/dwiiKgpeX161Zs2Ztr6mpeduRxnt7e19KS0s7oNfr7QpTqwGIxVNbOBaLhXnz5r1XV1e3TqPRTHfUg6pUqvygoCC0trbCzc3NeQC8vLymJJCmaYjFYl1MTMzrJ06ccMhrteDg4G8fe+yxf+h0OrtLXqsBOEIBg8HA0qVLS86cObO+v78/aKrycnJy/qxQKNDQ0ACSJJ0LYCpl5eghkUiolStXbtu/f/9HU4z9E0NDQ//euXMnNBqNQ55t69atzvWAkVBIT0/ff/z48Y1dXV0z7ZUTExOT39PTg4sXL457xeUUD7CnEjQHQCqVIicnJ3/Hjh2f2xn7n0dGRp7r7u6e9BWXwwD4+fk5TDiHw0FWVtbRvXv3nu7o6Iix9f4VK1Zs5PP5U254bAJw6NAhhwknSRIcDgcymezljo6OU7bcGxERcSAuLq6uo6PD4ZnfIoDq6mqHCacoCkwmE2FhYafr6upOXr9+fbG1t6pUqk1cLhc8Hs9pqz8hgJCQEIcqoGkaAoEAsbGxLx05cuRbKxueDxMTE1va2toclpPu+DZo2ig99NBD1efOnftSrVYvn6SSHNq8eXO+p6cndDqdw/f9O7YLmIYCn89HSkrKSwUFBRYBhIaGFnh5eXU2NjZCr9fD2WMcAA8PD6coMhqNWLRoUW1FRcWR2tra9AkfhsnsnzFjxl8KCwth+kmrI0diYuKdDYGRXMDj8bBmzZoN69evnxDA7NmzdwYGBvZ3dHQ4pej51UJgZOj1eiQnJ6vLysr2VFVVrTWpGToXL178VxaLBbFY7NTMbxGAr6+v05TRNA0vLy9s2bJlY0pKSqZer799gBofH/9maGjorfb2dnA4HNypMQ7AwMCAUxWq1Wr4+/tfk8vlhZcuXXoJALhcbltqauq7JElCKBTesdWfEMDo7wSdNVgsFh588MHtP/zwQ57BYHBLT09/dcaMGcbW1law7fgwyqEAnO1+Ix8vyWSyvqCgoEMtLS2PqlSqUoqinFry/urboCkErVaL2bNnv5OZmXlMKpXi6tWr4HLv/OfIxP//cfI+H/8bANeS5YFpLrRuAAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: vault-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - vault.security.coreos.com
+                resources:
+                - vaultservices
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+            deployments:
+            - name: vault-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: vault-operator
+                template:
+                  metadata:
+                    labels:
+                      name: vault-operator
+                  spec:
+                    serviceAccountName: vault-operator
+                    containers:
+                    - name: vault-operator
+                      image: quay.io/coreos/vault-operator@sha256:945a0a6d88cf6fa2bce9a83019a2a64f74d89fc8281301a4259f3302eabc79e6
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        version: 0.1.9
+        replaces: vault-operator.0.1.5
+        maturity: alpha
+        customresourcedefinitions:
+          owned:
+          - name: vaultservices.vault.security.coreos.com
+            version: v1alpha1
+            kind: VaultService
+            displayName: Vault Service
+            description: A running Vault instance, backed by an Etcd Cluster
+            resources:
+              - name: etcdclusters.etcd.database.coreos.com
+                version: v1beta2
+                kind: EtcdCluster
+              - kind: Service
+                version: v1
+              - kind: ConfigMap
+                version: v1
+              - kind: Secret
+                version: v1
+              - kind: Deployment
+                version: v1beta2
+              - kind: ReplicaSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of Pods for the cluster
+                displayName: Size
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The service at which the running Vault cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The port at which the Vault cluster is running under the service.
+                displayName: Client Port
+                path: clientPort
+          required:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents a backup for an etcd cluster
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents one try of restoring etcd cluster from previous backup
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        namespace: placeholder
+        name: vault-operator.0.1.5
+        annotations:
+          tectonic-visibility: ocs
+      spec:
+        displayName: Vault
+        description: |
+          An encrypted, multi-tentant secure secret store. Vault handles the lifecycle of your secrets: leasing, key revocation, key rolling, and auditing.
+      
+          _The Vault Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Unsealing and using Vault
+      
+          Once a Vault instance is running, it must be initalized and "unsealed". Afterwards, your software can use the automatically created Kubernetes Service and Secret to communicate with it.
+      
+          [Read the complete guide to using the Vault Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/vault-ocs.html)
+      
+          ### Supported Features
+      
+          **Secure by Default**
+          Hands-free automated creation of TLS certificates between all components ensure all best practices are followed for secret security. Further, the API makes unseal operations easy.
+          **Highly available**
+          Multiple instances of Vault are clustered together via an etcd backend and secured.
+          **Safe Upgrades**
+          Rolling out a new Vault version is as easy as updating the Vault Cluster definition. Everything is automatically handled using Vault best practices while pausing for unseal tokens.
+      
+        keywords: ['vault', 'secret', 'encryption']
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+        provider:
+          name: CoreOS, Inc
+        links:
+        - name: Vault Project
+          url: https://www.vaultproject.io/
+        labels:
+          alm-status-descriptors: vault-operator.0.1.5
+          alm-owner-vault: vault-operator
+          operated-by: vault-operator
+        selector:
+          matchLabels:
+            alm-owner-vault: vault-operator
+            operated-by: vault-operator
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAAA7CAYAAADLjIzcAAAACXBIWXMAAAsTAAALEwEAmpwYAAAMLGlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjarVd3VFP51t23JKGEmoCAlNARBAHpSO+CgHQYW0gChBJCCip2x0EFxy4WrOjYcNSxADIWRB3rIPbuAx1URsbBgg2V9wcBZ+Z93x9vrfdb6+budbLPPvuce9dd6wA6HnyptJDUBYokCllSVCgvIzOLx2oHCxxogYQ7XyCXhiQmxgHAwP0vhwDe3gQBANec+VJpIf67oycUyQUAkQggWygXFAHEIYA2EUhlCoDRCsB6skKqABhvAHBlGZlZAFMNADe3H5sC4Gb3Y1cAXFlKUhjADAfU2Hy+LBfQTgTAKxXkKgBtKQBXiVAsAbQ3AwgU5PGFgHYbgOFFRcVCQIcNwCH7Lzq5f9PMHtTk83MHcX8vAAC1cLFcWsifiv/1KSpUDtSwAsDOk0UnAeACxM6C4tgkAGyAOCrJjk8AoA8Q58RCQIXv5imjU1X8LoE8LAuAIUBCyA+PBWAKkIbKgtQQFXbny4B+PhkvVsSkqHC2rDhJpU+WSgrj41Q6C/JEMQN4o0gekTzAyRFHxgDQBchDZXkp6f0+ydOl4rR4ANoA2SovSI5V5T4sywuLH+DIlEmpAGwA8k2OLDKpn0MZFckH+qJcBPyIZABGABWsyEuJ7s+lMkTyjLgBD0JReES/B0ookqSqvFEKqSI0SZVbLi1MVPGpjaLCqKT+OVP75aXJA7lXFbIU1cypR/n80Yn9/qm3UkViSr83mkYcwhAOHpTgIRvFyIe4pau+CzzVP5HgQ4ZciOCsigxkpIMPGSTgIxll+AMSiCAfzAsFHzKIUAoJPg9G+3+dkQM+ZCiFCHIU4AlkKKJN6EDan46jA+lgOpB2p31o34E8ns5AVWYEM5wZzYxkDhv0IUAxClEMGcT/RywWhRBBCRlEkAz08FWP8YRxhfGIcYPRxriDNPwGGcQDrIniubJ/OOdhDNqgVE1FhGxI0DnAoe1od9qTDqUD6EDaFzzakDaBM+1B+9AhdBDtT3vSvn9zqBz09nWW/6wnguRv/aji2o7anioX2YNPJmyQ9U+VsL/MSIhixP6TSS2gDlJnqZPUeeooVQ8edYJqoC5Rx6j6v7wJv0GG3MFqSRBBggIUQjzAca117XT99B/V+SoHMoggBxSiKQoACCuWTpWJc/MUvBCptFDEi5EIXIbz3F3dvIGMzCxe/+fjtSEIAIThha+xkibAtwIgcr/G+NbAkScA5+3XmPUrgL0UONYqUMpK+2M0ADCgAR1wYQxzWMMBznCHF/wRjAiMRgJSkIkJECAPRZBhMqZjDspRiaVYhXXYhK3YiR9xAPU4ipP4BRfRihu4hzZ04Dm68Ra9BEGwCC2CQxgTFoQt4US4Ez5EIBFBxBFJRCYxicglJISSmE58S1QSy4l1xBZiF/ETcYQ4SZwnrhB3iHaik3hFfCQpkk1ySTPSjhxB+pAhZCyZQo4nc8kSsoycRy4m15A15B6yjjxJXiRvkG3kc7KHAqVJGVKWlDPlQ4VRCVQWlUPJqJlUBVVF1VB7qUbqLHWNaqO6qA80k+bQPNqZ9qej6VRaQJfQM+lF9Dp6J11Hn6av0e10N/2FocUwZTgx/BgxjAxGLmMyo5xRxdjOOMw4w7jB6GC8ZTKZhkx7pjczmpnJzGdOYy5ibmDuYzYxrzAfM3tYLJYxy4kVwEpg8VkKVjlrLWsP6wTrKquD9V5NU81CzV0tUi1LTaI2V61KbbfacbWrak/VetV11W3V/dQT1IXqU9WXqG9Tb1S/rN6h3quhp2GvEaCRopGvMUdjjcZejTMa9zVea2pqWmn6ao7VFGvO1lyjuV/znGa75ge2PtuRHcYex1ayF7N3sJvYd9ivtbS07LSCtbK0FFqLtXZpndJ6qPVem6Ptoh2jLdSepV2tXad9VfuFjrqOrU6IzgSdMp0qnYM6l3W6dNV17XTDdPm6M3WrdY/o3tLt0ePouekl6BXpLdLbrXde75k+S99OP0JfqD9Pf6v+Kf3HHIpjzQnjCDjfcrZxznA6uEyuPTeGm8+t5P7IbeF2G+gbeBikGUwxqDY4ZtBmSBnaGcYYFhouMTxgeNPw4xCzISFDREMWDtk75OqQd0ZDjYKNREYVRvuMbhh9NOYZRxgXGC8zrjd+YEKbOJqMNZlsstHkjEnXUO5Q/6GCoRVDDwy9a0qaOpommU4z3Wp6ybTHzNwsykxqttbslFmXuaF5sHm++Urz4+adFhyLQAuxxUqLExa/8wx4IbxC3hreaV63palltKXScotli2Wvlb1VqtVcq31WD6w1rH2sc6xXWjdbd9tY2IyxmW5Ta3PXVt3WxzbPdrXtWdt3dvZ26Xbz7ertntkb2cfYl9nX2t930HIIcihxqHG4Pow5zGdYwbANw1odSUdPxzzHasfLTqSTl5PYaYPTleGM4b7DJcNrht9yZjuHOJc61zq3uxi6xLnMdal3eTHCZkTWiGUjzo744urpWui6zfWem77baLe5bo1ur9wd3QXu1e7XR2qNjBw5a2TDyJceTh4ij40etz05nmM853s2e3728vaSee316vS28Z7kvd77lg/XJ9Fnkc85X4ZvqO8s36O+H/y8/BR+B/z+9Hf2L/Df7f9slP0o0ahtox4HWAXwA7YEtAXyAicFbg5sC7IM4gfVBD0Ktg4WBm8PfhoyLCQ/ZE/Ii1DXUFno4dB3YX5hM8KawqnwqPCK8JYI/YjUiHURDyOtInMjayO7ozyjpkU1RTOiY6OXRd+KMYsRxOyK6R7tPXrG6NOx7Njk2HWxj+Ic42RxjWPIMaPHrBhzP942XhJfn4CEmIQVCQ8S7RNLEn8eyxybOLZ67JMkt6TpSWeTOckTk3cnv00JTVmSci/VIVWZ2pymkzYubVfau/Tw9OXpbRkjMmZkXMw0yRRnNmSxstKytmf1fBPxzapvOsZ5jisfd3O8/fgp489PMJlQOOHYRJ2J/IkHJzEmpU/aPekTP4Ffw+/Jjslen90tCBOsFjwXBgtXCjtFAaLloqc5ATnLc57lBuSuyO3MC8qryusSh4nXiV/mR+dvyn9XkFCwo6CvML1wX5Fa0aSiIxJ9SYHkdLF58ZTiK1Inabm0rcSvZFVJtyxWtl1OyMfLGxRchVRxSemg/E7ZXhpYWl36fnLa5INT9KZIplya6jh14dSnZZFlP0yjpwmmNU+3nD5nevuMkBlbZhIzs2c2z7KeNW9Wx+yo2TvnaMwpmPPrXNe5y+e++Tb928Z5ZvNmz3v8XdR3teXa5bLyW/P9529aQC8QL2hZOHLh2oVfKoQVFypdK6sqPy0SLLrwvdv3a77vW5yzuGWJ15KNS5lLJUtvLgtatnO53vKy5Y9XjFlRt5K3smLlm1UTV52v8qjatFpjtXJ125q4NQ1rbdYuXftpXd66G9Wh1fvWm65fuP7dBuGGqxuDN+7dZLapctPHzeLNt7dEbamrsaup2srcWrr1yba0bWd/8Plh13aT7ZXbP++Q7GjbmbTz9C7vXbt2m+5eUkvWKms794zb0/pj+I8Ne533btlnuK9yP/Yr9//+06Sfbh6IPdB80Ofg3kO2h9Yf5hyuqCPqptZ11+fVtzVkNlw5MvpIc6N/4+GfXX7ecdTyaPUxg2NLjmscn3e870TZiZ4maVPXydyTj5snNt87lXHq+umxp1vOxJ4590vkL6fOhpw9cS7g3NHzfuePXPC5UH/R62LdJc9Lh3/1/PVwi1dL3WXvyw2tvq2NV0ZdOX416OrJa+HXfrkec/3ijfgbV26m3rx9a9ytttvC28/uFN55ebf0bu+92fcZ9yse6D6oemj6sOZfw/61r82r7Vh7ePulR8mP7j0WPH7+m/y3Tx3znmg9qXpq8XTXM/dnRzsjO1t//+b3jufS571d5X/o/bH+hcOLQ38G/3mpO6O746XsZd+rRa+NX+944/GmuSex5+Hbore97yreG7/f+cHnw9mP6R+f9k7+xPq05vOwz41fYr/c7yvq65PyZXwAAAWAzMkBXu0AtDIBTiugod2/f6n2RuLrBvn/4f4dDQDgBewIBlJnA3FNwMYmwHY2wG4CEgGkBIMcOXLwUh15zkj3fi22DGC87+t7bQawGoHPsr6+3g19fZ+3AdQdoKmkf+8DAKYusJkHAL9az/+P/evfXvpsNqq3M8UAADowaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzExMSA3OS4xNTgzMjUsIDIwMTUvMDkvMTAtMDE6MTA6MjAgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgICAgICAgICAgeG1sbnM6cGhvdG9zaG9wPSJodHRwOi8vbnMuYWRvYmUuY29tL3Bob3Rvc2hvcC8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6Q3JlYXRlRGF0ZT4yMDE3LTA5LTA2VDE1OjMxOjU2LTA0OjAwPC94bXA6Q3JlYXRlRGF0ZT4KICAgICAgICAgPHhtcDpNZXRhZGF0YURhdGU+MjAxNy0wOS0wNlQxNTozMTo1Ni0wNDowMDwveG1wOk1ldGFkYXRhRGF0ZT4KICAgICAgICAgPHhtcDpNb2RpZnlEYXRlPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3htcDpNb2RpZnlEYXRlPgogICAgICAgICA8eG1wTU06SW5zdGFuY2VJRD54bXAuaWlkOjFlMjY4MTE5LWU2NmYtNGJjNC1hZTI0LThiMTViNTg3MzE2MjwveG1wTU06SW5zdGFuY2VJRD4KICAgICAgICAgPHhtcE1NOkRvY3VtZW50SUQ+YWRvYmU6ZG9jaWQ6cGhvdG9zaG9wOjczODM4YzJiLWQzYzgtMTE3YS1iNTYyLTllNjU3MTBkNzc5YzwveG1wTU06RG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD54bXAuZGlkOjQ1MjdmNDhmLTc2MGMtNGRhYi04NTJkLTNkNGZiOTA4ZmEzNjwveG1wTU06T3JpZ2luYWxEb2N1bWVudElEPgogICAgICAgICA8eG1wTU06SGlzdG9yeT4KICAgICAgICAgICAgPHJkZjpTZXE+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPmNyZWF0ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDo0NTI3ZjQ4Zi03NjBjLTRkYWItODUyZC0zZDRmYjkwOGZhMzY8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDphY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDoxZTI2ODExOS1lNjZmLTRiYzQtYWUyNC04YjE1YjU4NzMxNjI8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTctMDktMDZUMTU6MzE6NTYtMDQ6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICAgICA8c3RFdnQ6Y2hhbmdlZD4vPC9zdEV2dDpjaGFuZ2VkPgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgPC9yZGY6U2VxPgogICAgICAgICA8L3htcE1NOkhpc3Rvcnk+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzpmb3JtYXQ+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZGU+CiAgICAgICAgIDxwaG90b3Nob3A6SUNDUHJvZmlsZT5EaXNwbGF5PC9waG90b3Nob3A6SUNDUHJvZmlsZT4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+NzIwMDAwLzEwMDAwPC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj43MjAwMDAvMTAwMDA8L3RpZmY6WVJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+NjU1MzU8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjY0PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjU5PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz6RZ44uAAAAIGNIUk0AAG11AABzoAAA/N0AAINkAABw6AAA7GgAADA+AAAQkOTsmeoAAAreSURBVHja7Jt5VFN3Fse/7yUkgQSyQBAiJWwTglKZqKBVFgURsVFgpAO2TRUonU7n0MWpVqnL6a7jtAdoz+lAsS61damHTnXascLUojMHLVUcpaesjUAVlFUWY7b35g+KhUBCEhJ71Pmd8/sDeO/edz+/e+/v3t97EDRN434eJO7zcd8DYJr+Ijc396kbN26EMxgM7b1kKE3TBEmSRHJy8m6VSlVrFkBLS4u2vLw8715cbS6X+/WcOXN6LYbAM888szckJOSre814giC0y5YtW93c3HzFIgA+n48nnnhi/b0GICIi4j2ZTHZdp9NZToJarRYpKSmXIiIiyu6ZRMdk9sfHx7/OZrMhEoksAxCJRBCLxdi0adOLDAaDuhcAxMbGFoSHh/exWCwIhULLAJhMJrq6uhAVFaWWyWQf3O3Gs9nsrrS0tB1MJhN8Ph8CgcDyNlhSUgKCIMBmszFz5sxX6urqsmmadrlbASiVyu0KheJma2vruNWf0AM0Gg2GhobQ19cHuVzePmvWrPfvVuN5PF772rVrCwBAIBDcnhY9YPr06SOFAzgcDhISEl6tra3NMRqN3LsNQE5Oztbly5cb6+vrxyU/swBM3UShUHRHR0cXVVZWbrqbjOdwOPXu7u6lhw8fRnd3NwiCuP23sLCwX+oD026wtLR0dPkIDw8PdHV1ua9bt+6yTqcT3S0AYmJifi+VSj9ta2sDkzl2nSsqKsx7AJ/PHycsMjJyQKlU7iwrK3trSp1XkBxU+xVAMzDK5cRAb+fYqi0wGLS62W49AoHgYlRU1KcajQZyudy2bnB0shAIBLeBZGdnv+3m5tZh93ak+gNEF/8L/jdnQU7zGTY0Mg4M1fMgl6QNX8TiwHX7R3D/5wWwcvMBEHbpSkxMzPf19YWHhwdEItG4aRFAQEDAmBkYGAihUIiHH35Yn5ubu81eAK6bXwfJZYEdFQaX5BXDyhXRIIwGEDMjAZIE6RcIVvrjII08sLNeBNhsm/X4+vp+m5iY+AVBEBCJRBAKheOmxSRYVVU1USuJhoYGeHt7l7DZ7Be1Wu1vbH0wTdE7YBa9CUN9O/TffD0s9/tqYE4s6LoLAEWBuqKG7ou/w0WZCt2uEkCvsxlARkbGBh8fH9A0PSbxmW2STJNgSkrKhBcaDAb4+fmhsbEx8+TJkwfs6sgkwaCvmsQ2wQHoW2PdMlAOSl1ns/zg4OCvS0tLE/r6+mAwGMxel56ebt4DgoKCLDUVWLBgwcELFy683NvbG26T8dOmw/VPT8PY8CO0e4drK8Zv54Hz5JPQHfsS+q8+G77O1x+02AdEXyfo3m5b2l0899xzGyQSCSiKsmr1JwRgWimZhoK3tzeSkpJePnjw4Oc2VWV7joCzbD5oAFRrM/QnT4Bb/AVc5nrCJe1J9C8IBtWiBql8HOCLgMAwGD8tASijVfIDAgIOL1my5JxWq4W7u7v9R2KWAIxASEpKOlpZWflde3v7XKs16XQgAIwOONqgBU0CtB6A8WdDKSNAkqAp2xpRmUy2tbi4GHq9HtQk90ZGRtpWB5gCkEgkyMjI2FhQUFBh7QMO5mSAynsBhvom6E+eAAAMZS8Fe7UK+q+Og/qpBQBg/Gw34O0H/NRk9eqHhIR8FBoaWt/a2mqT+0+YBMvKJj8HGWkts7KyKtVqdaz1h3KewJBJXIv9gc7WURmQAWZEJAw1Z6yNfX1WVlaoj4+PemBgwCrjCwsLzdcBE+2bppPH40EikSAvL2+DtbYzlq+G66H/gF30GQjPacN1T95r4H15EZw3dgNMFxBcLtzLqyE8XwW39z8BSOakchUKxW6FQqFmMpm3C7fJpk3NkLlhNBqhVCrPFhUVlV2+fPl3k3pNfCoIigIjfC6I4DDQ3dfgEp8C9PWCEZ0McHggJF5gxyuGmxnVatx8/ilAO2i+jCXJmytXrnyFw+HAw8PDJtc3C2Dfvn1WbztsNhthYWFbrQFgOFIC4tk3QJ2rBP39d8PnjwffB3vNs9Af+wQY6gOlHoRm31FwViyFZmeBReMBIC4u7m/z58+/euXKFasXbtIcsGrVKqtupGkaJEnC398fR48ePdDc3Jw5qTLPaaD7ugHjqCLF3RMYGJsXiIBQ0JfrJ8tDN4qLi4P8/f17enp6bFr9Rx55xLwHSKVSmwi6u7tj0aJFW5qbm9MnkjcGWve1MT+zkpRwfeGPuHX4OLQfvvvLdZMY//NRV+HChQt7WlpaJt25HFoHTBQKc+fObTp//vy+mpqabOu7I3dw9xyDiw/ATFoOQ/VpGC9dsG4z4XLb8/PzdwiFQhiNRrti32EAaJqGm5sbUlNTt9XU1DwKgGNdFtWD+rEZ8AkGdY0GPTRotc7w8PC3BgcHb549e9ZizW9ujD4RmjKAES+Ijo7+KTY29oNTp05Z915RdwsDmQnQr82G9vi/QP3YZJ3juLq2hYeHF+/atQs6nc6u1U9LSzMPwNzh4WRe4Orqiuzs7FdOnz6dTdO0VQeoVFsLbr5m2xHDwoULX5NKpbrOzs4pub5ZAA888IB92wlBYNWqVd3l5eXvfPzxx1uccc7H5/MbExISSimKgqenp0NkjgPQ1NRklyCapjE4OAi5XP4mg8F42mg0ih0NQKlUbgsMDKTb29sdsvoTAtizZ4/dwiiKgpeX161Zs2Ztr6mpeduRxnt7e19KS0s7oNfr7QpTqwGIxVNbOBaLhXnz5r1XV1e3TqPRTHfUg6pUqvygoCC0trbCzc3NeQC8vLymJJCmaYjFYl1MTMzrJ06ccMhrteDg4G8fe+yxf+h0OrtLXqsBOEIBg8HA0qVLS86cObO+v78/aKrycnJy/qxQKNDQ0ACSJJ0LYCpl5eghkUiolStXbtu/f/9HU4z9E0NDQ//euXMnNBqNQ55t69atzvWAkVBIT0/ff/z48Y1dXV0z7ZUTExOT39PTg4sXL457xeUUD7CnEjQHQCqVIicnJ3/Hjh2f2xn7n0dGRp7r7u6e9BWXwwD4+fk5TDiHw0FWVtbRvXv3nu7o6Iix9f4VK1Zs5PP5U254bAJw6NAhhwknSRIcDgcymezljo6OU7bcGxERcSAuLq6uo6PD4ZnfIoDq6mqHCacoCkwmE2FhYafr6upOXr9+fbG1t6pUqk1cLhc8Hs9pqz8hgJCQEIcqoGkaAoEAsbGxLx05cuRbKxueDxMTE1va2toclpPu+DZo2ig99NBD1efOnftSrVYvn6SSHNq8eXO+p6cndDqdw/f9O7YLmIYCn89HSkrKSwUFBRYBhIaGFnh5eXU2NjZCr9fD2WMcAA8PD6coMhqNWLRoUW1FRcWR2tra9AkfhsnsnzFjxl8KCwth+kmrI0diYuKdDYGRXMDj8bBmzZoN69evnxDA7NmzdwYGBvZ3dHQ4pej51UJgZOj1eiQnJ6vLysr2VFVVrTWpGToXL178VxaLBbFY7NTMbxGAr6+v05TRNA0vLy9s2bJlY0pKSqZer799gBofH/9maGjorfb2dnA4HNypMQ7AwMCAUxWq1Wr4+/tfk8vlhZcuXXoJALhcbltqauq7JElCKBTesdWfEMDo7wSdNVgsFh588MHtP/zwQ57BYHBLT09/dcaMGcbW1law7fgwyqEAnO1+Ix8vyWSyvqCgoEMtLS2PqlSqUoqinFry/urboCkErVaL2bNnv5OZmXlMKpXi6tWr4HLv/OfIxP//cfI+H/8bANeS5YFpLrRuAAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: vault-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - vault.security.coreos.com
+                resources:
+                - vaultservices
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+            deployments:
+            - name: vault-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: vault-operator
+                template:
+                  metadata:
+                    labels:
+                      name: vault-operator
+                  spec:
+                    serviceAccountName: vault-operator
+                    containers:
+                    - name: vault-operator
+                      image: quay.io/coreos/vault-operator@sha256:74036811bc5d6cc1a136d8cc6d5577db67f29ba95eba02fbf0c3a8d2357dc8fe
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        version: 0.1.5
+        maturity: alpha
+        customresourcedefinitions:
+          owned:
+          - name: vaultservices.vault.security.coreos.com
+            version: v1alpha1
+            kind: VaultService
+            displayName: Vault Service
+            description: A running Vault instance, backed by an Etcd Cluster
+            resources:
+              - name: etcdclusters.etcd.database.coreos.com
+                version: v1beta2
+                kind: EtcdCluster
+              - kind: Service
+                version: v1
+              - kind: ConfigMap
+                version: v1
+              - kind: Secret
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of Pods for the cluster
+                displayName: Size
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The status of each of the node Pods for the Vault cluster.
+                displayName: Node Status
+                path: nodes
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running Vault cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The port at which the Vault cluster is running under the service.
+                displayName: Client Port
+                path: clientPort
+          required:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/etcdoperator.v0.9.2.clusterserviceversion.yaml
+      packageName: etcd
+      channels:
+      - name: alpha
+        currentCSV: etcdoperator.v0.9.2
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/prometheusoperator.0.15.0.clusterserviceversion.yaml
+      packageName: prometheus
+      channels:
+      - name: alpha
+        currentCSV: prometheusoperator.0.15.0
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/vaultoperator.0.1.9.clusterserviceversion.yaml
+      packageName: vault
+      channels:
+      - name: alpha
+        currentCSV: vault-operator.0.1.9
+      
+

--- a/deploy/upstream/manifests/0.5.0/09-tectoniccomponents.configmap.yaml
+++ b/deploy/upstream/manifests/0.5.0/09-tectoniccomponents.configmap.yaml
@@ -1,0 +1,444 @@
+##---
+# Source: olm/templates/09-tectoniccomponents.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tectonic-components
+  namespace: kube-system
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: chargebacks.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/description: An instance of Chargeback
+          catalog.app.coreos.com/displayName: Chargeback
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: chargebacks
+          singular: chargeback
+          kind: Chargeback
+          listKind: ChargebackList
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prestotables.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Presto Table"
+          catalog.app.coreos.com/description: "A table within PrestoDB"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: prestotables
+          singular: prestotable
+          kind: PrestoTable
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reports.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Report"
+          catalog.app.coreos.com/description: "A chargeback report for a specific time interval"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reports
+          kind: Report
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportdatasources.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback data source"
+          catalog.app.coreos.com/description: "A resource describing a source of data for usage by Report Generation Queries"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportdatasources
+          singular: reportdatasource
+          kind: ReportDataSource
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportgenerationqueries.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback generation query"
+          catalog.app.coreos.com/description: "A SQL query used by Chargeback to generate reports"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportgenerationqueries
+          singular: reportgenerationquery
+          kind: ReportGenerationQuery
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportprometheusqueries.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback prometheus query"
+          catalog.app.coreos.com/description: "A Prometheus query by Chargeback to do metering"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportprometheusqueries
+          singular: reportprometheusquery
+          kind: ReportPrometheusQuery
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: scheduledreports.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Scheduled Report"
+          catalog.app.coreos.com/description: "A chargeback report that runs on a scheduled interval"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: scheduledreports
+          kind: ScheduledReport
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: storagelocations.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback storage location"
+          catalog.app.coreos.com/description: "Represents a configurable storage location for Chargeback to store metering and report data"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: storagelocations
+          kind: StorageLocation
+      
+  clusterServiceVersions: |-
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: chargeback-helm-operator.v0.5.1
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: tectonic-feature
+      spec:
+        displayName: Chargeback
+        description: Chargeback can generate reports based on historical usage data from a cluster, providing accountability for how resources have been used.
+        keywords: [chargeback metrics reporting coreos]
+        version: 0.5.1
+        maturity: alpha
+        maintainers:
+          - email: support@coreos.com
+            name: CoreOS, Inc
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-chargeback: chargeback-helm-operator
+          alm-status-descriptors: chargeback-helm-operator.v0.5.1
+        selector:
+          matchLabels:
+            alm-owner-chargeback: chargeback-helm-operator
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+              - rules:
+                - apiGroups:
+                  - chargeback.coreos.com
+                  resources:
+                  - '*'
+                  verbs:
+                  - '*'
+                - apiGroups:
+                  - ""
+                  resources:
+                  - pods
+                  - pods/attach
+                  - pods/exec
+                  - pods/portforward
+                  - pods/proxy
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - configmaps
+                  - endpoints
+                  - persistentvolumeclaims
+                  - replicationcontrollers
+                  - replicationcontrollers/scale
+                  - secrets
+                  - serviceaccounts
+                  - services
+                  - services/proxy
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - bindings
+                  - events
+                  - limitranges
+                  - namespaces/status
+                  - pods/log
+                  - pods/status
+                  - replicationcontrollers/status
+                  - resourcequotas
+                  - resourcequotas/status
+                  verbs:
+                  - get
+                  - list
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - namespaces
+                  verbs:
+                  - get
+                  - list
+                  - watch
+                - apiGroups:
+                  - apps
+                  resources:
+                  - deployments
+                  - deployments/rollback
+                  - deployments/scale
+                  - statefulsets
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - batch
+                  resources:
+                  - cronjobs
+                  - jobs
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - extensions
+                  resources:
+                  - daemonsets
+                  - deployments
+                  - deployments/rollback
+                  - deployments/scale
+                  - replicasets
+                  - replicasets/scale
+                  - replicationcontrollers/scale
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - rbac.authorization.k8s.io
+                  resources:
+                  - rolebindings
+                  - roles
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                serviceAccountName: chargeback-helm-operator
+            deployments:
+              - name: chargeback-helm-operator
+                spec:
+                  replicas: 1
+                  strategy:
+                    type: Recreate
+                  selector:
+                    matchLabels:
+                      app: chargeback-helm-operator
+                  template:
+                    metadata:
+                      labels:
+                        app: chargeback-helm-operator
+                    spec:
+                      containers:
+                      - env:
+                        - name: HELM_RELEASE_CRD_NAME
+                          value: Chargeback
+                        - name: HELM_RELEASE_CRD_API_GROUP
+                          value: chargeback.coreos.com
+                        - name: MY_POD_NAME
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.name
+                        - name: MY_POD_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: HELM_HOST
+                          value: 127.0.0.1:44134
+                        - name: SET_OWNER_REFERENCE_VALUE
+                          value: "true"
+                        - name: HELM_WAIT
+                          value: "false"
+                        - name: HELM_RECONCILE_INTERVAL_SECONDS
+                          value: "120"
+                        - name: RELEASE_HISTORY_LIMIT
+                          value: "3"
+                        image: quay.io/coreos/chargeback-helm-operator:0.5.1
+                        imagePullPolicy: Always
+                        name: chargeback-helm-operator
+                        resources:
+                          limits:
+                            cpu: 50m
+                            memory: 25Mi
+                          requests:
+                            cpu: 50m
+                            memory: 25Mi
+                      - env:
+                        - name: TILLER_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: TILLER_HISTORY_MAX
+                          value: "3"
+                        image: gcr.io/kubernetes-helm/tiller:v2.6.2
+                        imagePullPolicy: Always
+                        livenessProbe:
+                          failureThreshold: 3
+                          httpGet:
+                            path: /liveness
+                            port: 44135
+                            scheme: HTTP
+                          initialDelaySeconds: 1
+                          periodSeconds: 10
+                          successThreshold: 1
+                          timeoutSeconds: 1
+                        name: tiller
+                        readinessProbe:
+                          failureThreshold: 3
+                          httpGet:
+                            path: /readiness
+                            port: 44135
+                            scheme: HTTP
+                          initialDelaySeconds: 1
+                          periodSeconds: 10
+                          successThreshold: 1
+                          timeoutSeconds: 1
+                        resources:
+                          limits:
+                            cpu: 50m
+                            memory: 100Mi
+                          requests:
+                            cpu: 50m
+                            memory: 50Mi
+                      restartPolicy: Always
+                      serviceAccount: chargeback-helm-operator
+                      terminationGracePeriodSeconds: 30
+        customresourcedefinitions:
+          owned:
+          - description: An instance of Chargeback
+            displayName: Chargeback
+            kind: Chargeback
+            name: chargebacks.chargeback.coreos.com
+            version: v1alpha1
+          - description: A table within PrestoDB
+            displayName: Chargeback Presto Table
+            kind: PrestoTable
+            name: prestotables.chargeback.coreos.com
+            version: v1alpha1
+          - description: A chargeback report for a specific time interval
+            displayName: Chargeback Report
+            kind: Report
+            name: reports.chargeback.coreos.com
+            version: v1alpha1
+          - description: A resource describing a source of data for usage by Report Generation
+              Queries
+            displayName: Chargeback data source
+            kind: ReportDataSource
+            name: reportdatasources.chargeback.coreos.com
+            version: v1alpha1
+          - description: A SQL query used by Chargeback to generate reports
+            displayName: Chargeback generation query
+            kind: ReportGenerationQuery
+            name: reportgenerationqueries.chargeback.coreos.com
+            version: v1alpha1
+          - description: A Prometheus query by Chargeback to do metering
+            displayName: Chargeback prometheus query
+            kind: ReportPrometheusQuery
+            name: reportprometheusqueries.chargeback.coreos.com
+            version: v1alpha1
+          - description: A chargeback report that runs on a scheduled interval
+            displayName: Chargeback Scheduled Report
+            kind: ScheduledReport
+            name: scheduledreports.chargeback.coreos.com
+            version: v1alpha1
+          - description: Represents a configurable storage location for Chargeback to store
+              metering and report data
+            displayName: Chargeback storage location
+            kind: StorageLocation
+            name: storagelocations.chargeback.coreos.com
+            version: v1alpha1
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/components/chargeback.v0.5.1.clusterserviceversion.yaml
+      packageName: chargeback
+      channels:
+      - name: alpha
+        currentCSV: chargeback-helm-operator.v0.5.1
+      
+

--- a/deploy/upstream/manifests/0.5.0/10-tectonicocs.catalogsource.yaml
+++ b/deploy/upstream/manifests/0.5.0/10-tectonicocs.catalogsource.yaml
@@ -1,0 +1,19 @@
+##---
+# Source: olm/templates/10-tectonicocs.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: app.coreos.com/v1alpha1
+kind: CatalogSource-v1
+metadata:
+  name: tectonic-ocs
+  namespace: kube-system
+  annotations:
+    tectonic-operators.coreos.com/upgrade-strategy: 'DeleteAndRecreate'
+spec:
+  name: tectonic-ocs
+  sourceType: internal
+  configMap: tectonic-ocs
+  displayName: Tectonic Open Cloud Services
+  publisher: CoreOS, Inc.
+

--- a/deploy/upstream/manifests/0.5.0/11-tectoniccomponents.catalogsource.yaml
+++ b/deploy/upstream/manifests/0.5.0/11-tectoniccomponents.catalogsource.yaml
@@ -1,0 +1,19 @@
+##---
+# Source: olm/templates/11-tectoniccomponents.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: app.coreos.com/v1alpha1
+kind: CatalogSource-v1
+metadata:
+  name: tectonic-components
+  namespace: kube-system
+  annotations:
+    tectonic-operators.coreos.com/upgrade-strategy: 'DeleteAndRecreate'
+spec:
+  name: tectonic-components
+  sourceType: internal
+  configMap: tectonic-components
+  displayName: Tectonic Cluster Components
+  publisher: CoreOS, Inc.
+

--- a/deploy/upstream/manifests/0.5.0/12-alm-operator.deployment.yaml
+++ b/deploy/upstream/manifests/0.5.0/12-alm-operator.deployment.yaml
@@ -1,0 +1,48 @@
+##---
+# Source: olm/templates/12-alm-operator.deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: alm-operator
+  namespace: kube-system
+  labels:
+    app: alm-operator
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alm-operator
+  template:
+    metadata:
+      labels:
+        app: alm-operator
+    spec:
+      serviceAccountName: alm-operator-serviceaccount
+      containers:
+        - name: alm-operator
+          command:
+          - /bin/alm
+          image: quay.io/coreos/olm@sha256:00b6b703d235b622d8e2e5424d0bfb4aa9e46ec10abd295def47e2c6ed7a18e8
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: alm-operator
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/deploy/upstream/manifests/0.5.0/13-catalog-operator.deployment.yaml
+++ b/deploy/upstream/manifests/0.5.0/13-catalog-operator.deployment.yaml
@@ -1,0 +1,44 @@
+##---
+# Source: olm/templates/13-catalog-operator.deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  namespace: kube-system
+  labels:
+    app: catalog-operator
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      labels:
+        app: catalog-operator
+    spec:
+      serviceAccountName: alm-operator-serviceaccount
+      containers:
+        - name: catalog-operator
+          command:
+          - /bin/catalog
+          - '-namespace'
+          - kube-system
+          - '-debug'
+          image: quay.io/coreos/catalog@sha256:08667c7c409c8ca044c05db9bf90a0aa9954ce511490e72df4a3493cebd58b8e
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/deploy/upstream/manifests/0.5.0/18-upstreamcomponents.configmap.yaml
+++ b/deploy/upstream/manifests/0.5.0/18-upstreamcomponents.configmap.yaml
@@ -1,0 +1,462 @@
+##---
+# Source: olm/templates/18-upstreamcomponents.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: upstream-components
+  namespace: kube-system
+  labels:
+    tectonic-operators.coreos.com/managed-by: tectonic-x-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: meterings.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/description: An instance of Chargeback
+          catalog.app.coreos.com/displayName: Chargeback
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: meterings
+          singular: metering
+          kind: Metering
+          listKind: MeteringList
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prestotables.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Presto Table"
+          catalog.app.coreos.com/description: "A table within PrestoDB"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: prestotables
+          singular: prestotable
+          kind: PrestoTable
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reports.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Report"
+          catalog.app.coreos.com/description: "A chargeback report for a specific time interval"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reports
+          kind: Report
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportdatasources.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback data source"
+          catalog.app.coreos.com/description: "A resource describing a source of data for usage by Report Generation Queries"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportdatasources
+          singular: reportdatasource
+          kind: ReportDataSource
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportgenerationqueries.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback generation query"
+          catalog.app.coreos.com/description: "A SQL query used by Chargeback to generate reports"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportgenerationqueries
+          singular: reportgenerationquery
+          kind: ReportGenerationQuery
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: reportprometheusqueries.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback prometheus query"
+          catalog.app.coreos.com/description: "A Prometheus query by Chargeback to do metering"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: reportprometheusqueries
+          singular: reportprometheusquery
+          kind: ReportPrometheusQuery
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: scheduledreports.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback Scheduled Report"
+          catalog.app.coreos.com/description: "A chargeback report that runs on a scheduled interval"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: scheduledreports
+          kind: ScheduledReport
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: storagelocations.chargeback.coreos.com
+        annotations:
+          catalog.app.coreos.com/displayName: "Chargeback storage location"
+          catalog.app.coreos.com/description: "Represents a configurable storage location for Chargeback to store metering and report data"
+      spec:
+        group: chargeback.coreos.com
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          plural: storagelocations
+          kind: StorageLocation
+      
+  clusterServiceVersions: |-
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: metering-helm-operator.v0.6.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: tectonic-feature
+        labels:
+          alm-catalog: tectonic-feature
+          operator-metering: "true"
+      spec:
+        displayName: Metering
+        description: Metering can generate reports based on historical usage data from a cluster, providing accountability for how resources have been used.
+        keywords: [metering metrics reporting coreos]
+        version: 0.6.0
+        maturity: alpha
+        maintainers:
+          - email: support@coreos.com
+            name: CoreOS, Inc
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-metering: metering-helm-operator
+          alm-status-descriptors: metering-helm-operator.v0.6.0
+        selector:
+          matchLabels:
+            alm-owner-metering: metering-helm-operator
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+              - rules:
+                - apiGroups:
+                  - chargeback.coreos.com
+                  resources:
+                  - '*'
+                  verbs:
+                  - '*'
+                - apiGroups:
+                  - ""
+                  resources:
+                  - pods
+                  - pods/attach
+                  - pods/exec
+                  - pods/portforward
+                  - pods/proxy
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - configmaps
+                  - endpoints
+                  - persistentvolumeclaims
+                  - replicationcontrollers
+                  - replicationcontrollers/scale
+                  - secrets
+                  - serviceaccounts
+                  - services
+                  - services/proxy
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - bindings
+                  - events
+                  - limitranges
+                  - namespaces/status
+                  - pods/log
+                  - pods/status
+                  - replicationcontrollers/status
+                  - resourcequotas
+                  - resourcequotas/status
+                  verbs:
+                  - get
+                  - list
+                  - watch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - events
+                  verbs:
+                  - create
+                  - update
+                  - patch
+                - apiGroups:
+                  - ""
+                  resources:
+                  - namespaces
+                  verbs:
+                  - get
+                  - list
+                  - watch
+                - apiGroups:
+                  - apps
+                  resources:
+                  - deployments
+                  - deployments/rollback
+                  - deployments/scale
+                  - statefulsets
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - batch
+                  resources:
+                  - cronjobs
+                  - jobs
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - extensions
+                  resources:
+                  - daemonsets
+                  - deployments
+                  - deployments/rollback
+                  - deployments/scale
+                  - replicasets
+                  - replicasets/scale
+                  - replicationcontrollers/scale
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                - apiGroups:
+                  - rbac.authorization.k8s.io
+                  resources:
+                  - rolebindings
+                  - roles
+                  verbs:
+                  - create
+                  - delete
+                  - deletecollection
+                  - get
+                  - list
+                  - patch
+                  - update
+                  - watch
+                serviceAccountName: metering-helm-operator
+            deployments:
+              - name: metering-helm-operator
+                spec:
+                  replicas: 1
+                  selector:
+                    matchLabels:
+                      app: metering-helm-operator
+                  strategy:
+                    type: Recreate
+                  template:
+                    metadata:
+                      labels:
+                        app: metering-helm-operator
+                    spec:
+                      containers:
+                      - args:
+                        - run-operator.sh
+                        env:
+                        - name: HELM_RELEASE_CRD_NAME
+                          value: Metering
+                        - name: HELM_RELEASE_CRD_API_GROUP
+                          value: chargeback.coreos.com
+                        - name: HELM_CHART_PATH
+                          value: /operator-metering-0.1.0.tgz
+                        - name: MY_POD_NAME
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.name
+                        - name: MY_POD_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: HELM_HOST
+                          value: 127.0.0.1:44134
+                        - name: HELM_WAIT
+                          value: "false"
+                        - name: HELM_RECONCILE_INTERVAL_SECONDS
+                          value: "30"
+                        - name: RELEASE_HISTORY_LIMIT
+                          value: "3"
+                        image: quay.io/coreos/chargeback-helm-operator:0.6.0
+                        imagePullPolicy: Always
+                        name: metering-helm-operator
+                        resources:
+                          limits:
+                            cpu: 50m
+                            memory: 25Mi
+                          requests:
+                            cpu: 50m
+                            memory: 25Mi
+                      - args:
+                        - /tiller
+                        env:
+                        - name: TILLER_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: TILLER_HISTORY_MAX
+                          value: "3"
+                        image: quay.io/coreos/chargeback-helm-operator:0.6.0
+                        imagePullPolicy: Always
+                        livenessProbe:
+                          failureThreshold: 3
+                          httpGet:
+                            path: /liveness
+                            port: 44135
+                            scheme: HTTP
+                          initialDelaySeconds: 1
+                          periodSeconds: 10
+                          successThreshold: 1
+                          timeoutSeconds: 1
+                        name: tiller
+                        readinessProbe:
+                          failureThreshold: 3
+                          httpGet:
+                            path: /readiness
+                            port: 44135
+                            scheme: HTTP
+                          initialDelaySeconds: 1
+                          periodSeconds: 10
+                          successThreshold: 1
+                          timeoutSeconds: 1
+                        resources:
+                          limits:
+                            cpu: 50m
+                            memory: 100Mi
+                          requests:
+                            cpu: 50m
+                            memory: 50Mi
+                      imagePullSecrets: []
+                      restartPolicy: Always
+                      securityContext:
+                        runAsNonRoot: true
+                      serviceAccount: metering-helm-operator
+                      terminationGracePeriodSeconds: 30
+        customresourcedefinitions:
+          owned:
+          - description: An instance of Metering
+            displayName: Metering
+            kind: Metering
+            name: meterings.chargeback.coreos.com
+            version: v1alpha1
+          - description: A table within PrestoDB
+            displayName: Chargeback Presto Table
+            kind: PrestoTable
+            name: prestotables.chargeback.coreos.com
+            version: v1alpha1
+          - description: A resource describing a source of data for usage by Report Generation
+              Queries
+            displayName: Chargeback data source
+            kind: ReportDataSource
+            name: reportdatasources.chargeback.coreos.com
+            version: v1alpha1
+          - description: A SQL query used by Chargeback to generate reports
+            displayName: Chargeback generation query
+            kind: ReportGenerationQuery
+            name: reportgenerationqueries.chargeback.coreos.com
+            version: v1alpha1
+          - description: A Prometheus query by Chargeback to do metering
+            displayName: Chargeback prometheus query
+            kind: ReportPrometheusQuery
+            name: reportprometheusqueries.chargeback.coreos.com
+            version: v1alpha1
+          - description: A chargeback report for a specific time interval
+            displayName: Chargeback Report
+            kind: Report
+            name: reports.chargeback.coreos.com
+            version: v1alpha1
+          - description: A chargeback report that runs on a scheduled interval
+            displayName: Chargeback Scheduled Report
+            kind: ScheduledReport
+            name: scheduledreports.chargeback.coreos.com
+            version: v1alpha1
+          - description: Represents a configurable storage location for Chargeback to store
+              metering and report data
+            displayName: Chargeback storage location
+            kind: StorageLocation
+            name: storagelocations.chargeback.coreos.com
+            version: v1alpha1
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/upstream/metering.0.6.0.clusterserviceversion.yaml
+      packageName: metering
+      channels:
+      - currentCSV: metering-helm-operator.v0.6.0
+        name: alpha
+      
+

--- a/deploy/upstream/manifests/0.5.0/19-upstreamcomponents.catalogsource.yaml
+++ b/deploy/upstream/manifests/0.5.0/19-upstreamcomponents.catalogsource.yaml
@@ -1,0 +1,19 @@
+##---
+# Source: olm/templates/19-upstreamcomponents.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: app.coreos.com/v1alpha1
+kind: CatalogSource-v1
+metadata:
+  name: upstream-components
+  namespace: kube-system
+  annotations:
+    tectonic-operators.coreos.com/upgrade-strategy: 'DeleteAndRecreate'
+spec:
+  name: upstream-components
+  sourceType: internal
+  configMap: upstream-components
+  displayName: OLM Upstream Components
+  publisher: CoreOS, Inc.
+

--- a/deploy/upstream/values.yaml
+++ b/deploy/upstream/values.yaml
@@ -4,20 +4,18 @@ catalog_namespace: kube-system
 alm:
   replicaCount: 1
   image:
-    ref: quay.io/coreos/olm@sha256:351f0c4973a88a4ea606721555829776429b0ecb53d5a2bfee6bce459d109e5b
+    ref: quay.io/coreos/olm@sha256:00b6b703d235b622d8e2e5424d0bfb4aa9e46ec10abd295def47e2c6ed7a18e8
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
-
 catalog:
   replicaCount: 1
   image:
-    ref: quay.io/coreos/catalog@sha256:54571e25474a9a063a144922e7321203e5aa5e63d03f748682d559341359a916
+    ref: quay.io/coreos/catalog@sha256:08667c7c409c8ca044c05db9bf90a0aa9954ce511490e72df4a3493cebd58b8e
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
-
 catalog_sources:
- - tectonic-ocs
- - tectonic-components
- - upstream-components
+- tectonic-ocs
+- tectonic-components
+- upstream-components

--- a/scripts/pull_or_build_rh.sh
+++ b/scripts/pull_or_build_rh.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if ! docker pull "quay.io/coreos/olm:$1-rhel" || ! docker pull "quay.io/coreos/catalog:$1-rhel"; then
+  docker build -f Dockerfile.rhel7 -t "quay.io/coreos/olm:$1-rhel" -t "quay.io/coreos/catalog:$1-rhel" .
+  docker push "quay.io/coreos/olm:$1-rhel"
+  docker push "quay.io/coreos/catalog:$1-rhel"
+fi


### PR DESCRIPTION
- Prevent a CSV from installing if there is another CSV in the namespace that owns the same CRD, but isn't being replaced.
- Add checks for runaway control loops in e2e tests
- Removed tectonic-operators dependency
- Added CSV validation tool
- Manual Approval implemented for subscriptions and installplans
- Fixes memory leak in catalog
- Ansible install uses CentOS images
