### PR TITLE
Deploy to OpenShift Cluster

### DIFF
--- a/.gitlab-ci.jsonnet
+++ b/.gitlab-ci.jsonnet
@@ -154,7 +154,7 @@ local jobs = {
         local _vars = self.localvars,
         localvars+:: {
             image: images.release,
-            domain: "teamui18.console.team.coreos.systems",
+            domain: "teamui.console.team.coreos.systems",
             namespace: "tectonic-system",
             channel: "staging",
             helm_opts: ["--force"],
@@ -169,6 +169,29 @@ local jobs = {
         ],
         environment+: {
             name: "teamui",
+        },
+        only: ['master'],
+    },
+
+    "deploy-openshift": baseJob.Deploy {
+        local _vars = self.localvars,
+        localvars+:: {
+            image: images.release,
+            domain: "console.apps.ui-preserve.origin-gce.dev.openshift.com",
+            namespace: "openshift",
+            channel: "staging",
+            helm_opts: ["--force"],
+            kubeconfig: "$OPENSHIFT_KUBECONFIG",
+            params+:: {
+                watchedNamespaces: "",
+            },
+        },
+        stage: stages.deploy_staging,
+        script+: [
+            "curl -X POST --data-urlencode \"payload={\\\"text\\\": \\\"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${OPENSHIFT_HOST}/k8s/ns/tectonic-system/deployments/alm-operator\\\"}\" ${TEAMUI_SLACK_URL}",
+        ],
+        environment+: {
+            name: "openshift",
         },
         only: ['master'],
     },

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,37 @@ container-release:
   variables:
     DOCKER_DRIVER: overlay2
     DOCKER_HOST: tcp://docker-host.gitlab.svc.cluster.local:2375
+deploy-openshift:
+  before_script:
+  - 'echo "version: 1.0.0-${CI_COMMIT_REF_SLUG}-pre" >> deploy/chart/Chart.yaml'
+  - 'echo "{\"alm.image.ref\": \"quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8}\", \"catalog.image.ref\": \"quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8}\", \"catalog_namespace\": \"tectonic-system\",
+    \"namespace\": \"openshift\", \"watchedNamespaces\": \"\"}" > params.json'
+  - cat params.json
+  environment:
+    name: openshift
+    url: https://console.apps.ui-preserve.origin-gce.dev.openshift.com
+  image: quay.io/coreos/alm-ci-build:latest
+  only:
+  - master
+  script:
+  - echo $OPENSHIFT_KUBECONFIG | base64 -d > kubeconfig
+  - export KUBECONFIG=./kubeconfig
+  - kubectl create ns openshift || true
+  - kubectl create secret docker-registry coreos-pull-secret --docker-server quay.io --docker-username $DOCKER_USER --docker-password $DOCKER_PASS --docker-email ignored@example.com --namespace=openshift
+    || true
+  - charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`;mkdir -p ${charttmpdir};pushd deploy/chart/templates;filenames=$(ls *.yaml);popd;for f in ${filenames};do helm template --set namespace=openshift
+    deploy/chart -x templates/${f} --set alm.image.ref=quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog.image.ref=quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog_namespace=tectonic-system
+    --set namespace=openshift --set watchedNamespaces= > ${charttmpdir}/${f};done;kubectl apply -f ${charttmpdir}
+  - kubectl rollout status -w deployment/alm-operator --namespace=openshift
+  - kubectl rollout status -w deployment/catalog-operator --namespace=openshift
+  - 'curl -X POST --data-urlencode "payload={\"text\": \"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${OPENSHIFT_HOST}/k8s/ns/tectonic-system/deployments/alm-operator\"}"
+    ${TEAMUI_SLACK_URL}'
+  stage: deploy_staging
+  tags:
+  - kubernetes
+  variables:
+    ALM_DOMAIN: console.apps.ui-preserve.origin-gce.dev.openshift.com
+    K8S_NAMESPACE: openshift
 deploy-preview:
   before_script:
   - 'echo "version: 1.0.0-${CI_COMMIT_REF_SLUG}-pre" >> deploy/chart/Chart.yaml'
@@ -139,7 +170,7 @@ deploy-teamui:
   - cat params.json
   environment:
     name: teamui
-    url: https://teamui18.console.team.coreos.systems
+    url: https://teamui.console.team.coreos.systems
   image: quay.io/coreos/alm-ci-build:latest
   only:
   - master
@@ -160,7 +191,7 @@ deploy-teamui:
   tags:
   - kubernetes
   variables:
-    ALM_DOMAIN: teamui18.console.team.coreos.systems
+    ALM_DOMAIN: teamui.console.team.coreos.systems
     K8S_NAMESPACE: tectonic-system
 e2e-setup:
   before_script:


### PR DESCRIPTION
### Description

Uses the persistent cluster at https://console.apps.ui-preserve.origin-gce.dev.openshift.com for continuous deployment of `master`.

**NOTE:** Currently `OPENSHIFT_KUBECONFIG` is using credentials generated using my token, which might expire...