### PR TITLE
Make CatalogSource Namespace Required Field on Subscription

### DIFF
--- a/deploy/chart/templates/07-subscription.crd.yaml
+++ b/deploy/chart/templates/07-subscription.crd.yaml
@@ -29,10 +29,15 @@ spec:
           required:
           - source
           - name
+          - sourceNamespace
           properties:
             source:
               type: string
               description: Name of a CatalogSource that defines where and how to find the channel
+
+            sourceNamespace:
+              type: string
+              description: The Kubernetes namespace where the CatalogSource used is located
 
             name:
               type: string


### PR DESCRIPTION
### Description

It was added to the Go types, but not the CRD manifest itself.

Addresses https://jira.coreos.com/browse/ALM-644