### PR TITLE
Fix invalid `minishift start` option in build_local_shift.sh

### DIFF
--- a/scripts/build_local_shift.sh
+++ b/scripts/build_local_shift.sh
@@ -4,7 +4,7 @@
 # This is used to start and build services for running e2e tests
 
 set -e
-MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --service-catalog \
+MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --extra-clusterup-flags "--service-catalog" \
     || { echo 'Cannot start shift.'; exit 1; }
 
 eval $(minishift docker-env) \


### PR DESCRIPTION
This is necessary for using OLM with recent versions of Minishift, as the `minishift start` command fails with an invalid option for `--service-catalog`.