### PR TITLE
Deploy CI to `operator-lifecycle-manager` Namespace

### DIFF
--- a/.gitlab-ci.jsonnet
+++ b/.gitlab-ci.jsonnet
@@ -155,7 +155,7 @@ local jobs = {
         localvars+:: {
             image: images.release,
             domain: "teamui.console.team.coreos.systems",
-            namespace: "tectonic-system",
+            namespace: "operator-lifecycle-manager",
             channel: "staging",
             helm_opts: ["--force"],
             kubeconfig: "$TEAMUI_KUBECONFIG",
@@ -165,7 +165,7 @@ local jobs = {
         },
         stage: stages.deploy_staging,
         script+: [
-            "curl -X POST --data-urlencode \"payload={\\\"text\\\": \\\"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${TEAMUI_HOST}/k8s/ns/tectonic-system/deployments/alm-operator\\\"}\" ${TEAMUI_SLACK_URL}",
+            "curl -X POST --data-urlencode \"payload={\\\"text\\\": \\\"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${TEAMUI_HOST}/k8s/ns/operator-lifecycle-manager/deployments/alm-operator\\\"}\" ${TEAMUI_SLACK_URL}",
         ],
         environment+: {
             name: "teamui",
@@ -178,8 +178,8 @@ local jobs = {
         localvars+:: {
             image: images.release,
             domain: "console.apps.ui-preserve.origin-gce.dev.openshift.com",
-            namespace: "openshift",
-            catalog_namespace: "openshift",
+            namespace: "operator-lifecycle-manager",
+            catalog_namespace: "operator-lifecycle-manager",
             channel: "staging",
             helm_opts: ["--force"],
             kubeconfig: "$OPENSHIFT_KUBECONFIG",
@@ -189,7 +189,7 @@ local jobs = {
         },
         stage: stages.deploy_staging,
         script+: [
-            "curl -X POST --data-urlencode \"payload={\\\"text\\\": \\\"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${OPENSHIFT_HOST}/k8s/ns/tectonic-system/deployments/alm-operator\\\"}\" ${TEAMUI_SLACK_URL}",
+            "curl -X POST --data-urlencode \"payload={\\\"text\\\": \\\"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${OPENSHIFT_HOST}/k8s/ns/operator-lifecycle-manager/deployments/alm-operator\\\"}\" ${TEAMUI_SLACK_URL}",
         ],
         environment+: {
             name: "openshift",

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,8 +71,8 @@ container-release:
 deploy-openshift:
   before_script:
   - 'echo "version: 1.0.0-${CI_COMMIT_REF_SLUG}-pre" >> deploy/chart/Chart.yaml'
-  - 'echo "{\"alm.image.ref\": \"quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8}\", \"catalog.image.ref\": \"quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8}\", \"catalog_namespace\": \"openshift\",
-    \"namespace\": \"openshift\", \"watchedNamespaces\": \"\"}" > params.json'
+  - 'echo "{\"alm.image.ref\": \"quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8}\", \"catalog.image.ref\": \"quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8}\", \"catalog_namespace\": \"operator-lifecycle-manager\",
+    \"namespace\": \"operator-lifecycle-manager\", \"watchedNamespaces\": \"\"}" > params.json'
   - cat params.json
   environment:
     name: openshift
@@ -83,22 +83,22 @@ deploy-openshift:
   script:
   - echo $OPENSHIFT_KUBECONFIG | base64 -d > kubeconfig
   - export KUBECONFIG=./kubeconfig
-  - kubectl create ns openshift || true
-  - kubectl create secret docker-registry coreos-pull-secret --docker-server quay.io --docker-username $DOCKER_USER --docker-password $DOCKER_PASS --docker-email ignored@example.com --namespace=openshift
+  - kubectl create ns operator-lifecycle-manager || true
+  - kubectl create secret docker-registry coreos-pull-secret --docker-server quay.io --docker-username $DOCKER_USER --docker-password $DOCKER_PASS --docker-email ignored@example.com --namespace=operator-lifecycle-manager
     || true
-  - charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`;mkdir -p ${charttmpdir};pushd deploy/chart/templates;filenames=$(ls *.yaml);popd;for f in ${filenames};do helm template --set namespace=openshift
-    deploy/chart -x templates/${f} --set alm.image.ref=quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog.image.ref=quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog_namespace=openshift
-    --set namespace=openshift --set watchedNamespaces= > ${charttmpdir}/${f};done;kubectl apply -f ${charttmpdir}
-  - kubectl rollout status -w deployment/alm-operator --namespace=openshift
-  - kubectl rollout status -w deployment/catalog-operator --namespace=openshift
-  - 'curl -X POST --data-urlencode "payload={\"text\": \"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${OPENSHIFT_HOST}/k8s/ns/tectonic-system/deployments/alm-operator\"}"
+  - charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`;mkdir -p ${charttmpdir};pushd deploy/chart/templates;filenames=$(ls *.yaml);popd;for f in ${filenames};do helm template --set namespace=operator-lifecycle-manager
+    deploy/chart -x templates/${f} --set alm.image.ref=quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog.image.ref=quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog_namespace=operator-lifecycle-manager
+    --set namespace=operator-lifecycle-manager --set watchedNamespaces= > ${charttmpdir}/${f};done;kubectl apply -f ${charttmpdir}
+  - kubectl rollout status -w deployment/alm-operator --namespace=operator-lifecycle-manager
+  - kubectl rollout status -w deployment/catalog-operator --namespace=operator-lifecycle-manager
+  - 'curl -X POST --data-urlencode "payload={\"text\": \"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${OPENSHIFT_HOST}/k8s/ns/operator-lifecycle-manager/deployments/alm-operator\"}"
     ${TEAMUI_SLACK_URL}'
   stage: deploy_staging
   tags:
   - kubernetes
   variables:
     ALM_DOMAIN: console.apps.ui-preserve.origin-gce.dev.openshift.com
-    K8S_NAMESPACE: openshift
+    K8S_NAMESPACE: operator-lifecycle-manager
 deploy-preview:
   before_script:
   - 'echo "version: 1.0.0-${CI_COMMIT_REF_SLUG}-pre" >> deploy/chart/Chart.yaml'
@@ -166,7 +166,7 @@ deploy-teamui:
   before_script:
   - 'echo "version: 1.0.0-${CI_COMMIT_REF_SLUG}-pre" >> deploy/chart/Chart.yaml'
   - 'echo "{\"alm.image.ref\": \"quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8}\", \"catalog.image.ref\": \"quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8}\", \"catalog_namespace\": \"tectonic-system\",
-    \"namespace\": \"tectonic-system\", \"watchedNamespaces\": \"\"}" > params.json'
+    \"namespace\": \"operator-lifecycle-manager\", \"watchedNamespaces\": \"\"}" > params.json'
   - cat params.json
   environment:
     name: teamui
@@ -177,22 +177,22 @@ deploy-teamui:
   script:
   - echo $TEAMUI_KUBECONFIG | base64 -d > kubeconfig
   - export KUBECONFIG=./kubeconfig
-  - kubectl create ns tectonic-system || true
-  - kubectl create secret docker-registry coreos-pull-secret --docker-server quay.io --docker-username $DOCKER_USER --docker-password $DOCKER_PASS --docker-email ignored@example.com --namespace=tectonic-system
+  - kubectl create ns operator-lifecycle-manager || true
+  - kubectl create secret docker-registry coreos-pull-secret --docker-server quay.io --docker-username $DOCKER_USER --docker-password $DOCKER_PASS --docker-email ignored@example.com --namespace=operator-lifecycle-manager
     || true
-  - charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`;mkdir -p ${charttmpdir};pushd deploy/chart/templates;filenames=$(ls *.yaml);popd;for f in ${filenames};do helm template --set namespace=tectonic-system
+  - charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`;mkdir -p ${charttmpdir};pushd deploy/chart/templates;filenames=$(ls *.yaml);popd;for f in ${filenames};do helm template --set namespace=operator-lifecycle-manager
     deploy/chart -x templates/${f} --set alm.image.ref=quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog.image.ref=quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog_namespace=tectonic-system
-    --set namespace=tectonic-system --set watchedNamespaces= > ${charttmpdir}/${f};done;kubectl apply -f ${charttmpdir}
-  - kubectl rollout status -w deployment/alm-operator --namespace=tectonic-system
-  - kubectl rollout status -w deployment/catalog-operator --namespace=tectonic-system
-  - 'curl -X POST --data-urlencode "payload={\"text\": \"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${TEAMUI_HOST}/k8s/ns/tectonic-system/deployments/alm-operator\"}"
+    --set namespace=operator-lifecycle-manager --set watchedNamespaces= > ${charttmpdir}/${f};done;kubectl apply -f ${charttmpdir}
+  - kubectl rollout status -w deployment/alm-operator --namespace=operator-lifecycle-manager
+  - kubectl rollout status -w deployment/catalog-operator --namespace=operator-lifecycle-manager
+  - 'curl -X POST --data-urlencode "payload={\"text\": \"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${TEAMUI_HOST}/k8s/ns/operator-lifecycle-manager/deployments/alm-operator\"}"
     ${TEAMUI_SLACK_URL}'
   stage: deploy_staging
   tags:
   - kubernetes
   variables:
     ALM_DOMAIN: teamui.console.team.coreos.systems
-    K8S_NAMESPACE: tectonic-system
+    K8S_NAMESPACE: operator-lifecycle-manager
 e2e-setup:
   before_script:
   - 'echo "version: 1.0.0-${CI_COMMIT_REF_SLUG}-pre" >> deploy/chart/Chart.yaml'


### PR DESCRIPTION
### Description

This will ensure the e2e tests for `openshift/console` will pass when using the hard-coded `operator-lifecycle-manager` namespace in `openshift/console`.