### PR TITLE
Add CatalogSource Namespace To CRD Validation

### DIFF
--- a/deploy/chart/templates/07-subscription.crd.yaml
+++ b/deploy/chart/templates/07-subscription.crd.yaml
@@ -34,6 +34,10 @@ spec:
               type: string
               description: Name of a CatalogSource that defines where and how to find the channel
 
+            sourceNamespace:
+              type: string
+              description: The Kubernetes namespace where the CatalogSource used is located
+
             name:
               type: string
               description: Name of the package that defines the application


### PR DESCRIPTION
### Description

It was added to the Go types, but not the CRD manifest itself.

Addresses https://jira.coreos.com/browse/ALM-644