### PR TITLE
test(catalog_versions): add multi-catalogsource aware resolution tests

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -121,7 +121,8 @@ func (resolver *MultiSourceResolver) resolveCSV(sourceRefs []registry.SourceRef,
 		step.CatalogSourceNamespace = csvSourceKey.Namespace
 
 		// Add the final step for the CSV to the plan.
-		log.Infof("finished step: %v", step)
+		log.Infof("finished step: %s", step.Name)
+		log.Debugf("step %s content: %v", step.Name, step)
 		steps[currentName] = append(steps[currentName], step)
 	}
 

--- a/test/schema/catalog_versions_test.go
+++ b/test/schema/catalog_versions_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,10 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"encoding/json"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/coreos/go-semver/semver"
 	"github.com/ghodss/yaml"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/installplan/v1alpha1"
@@ -20,6 +17,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var manifestDir = os.Getenv("GOPATH") + "/src/github.com/operator-framework/operator-lifecycle-manager" +


### PR DESCRIPTION
### Description

Adds tests for resolving all CSVs across all catalogs for every deployment version.

Addresses [ALM-646](https://jira.coreos.com/browse/ALM-646)