### PR TITLE
[WIP] feat(resolver): add namespace and channel awareness

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -253,12 +253,12 @@
   version = "v0.3.6"
 
 [[projects]]
-  digest = "1:0243cffa4a3410f161ee613dfdd903a636d07e838a42d341da95d81f42cd1d41"
+  digest = "1:8e36686e8b139f8fe240c1d5cf3a145bc675c22ff8e707857cdd3ae17b00d728"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
-  version = "1.1.4"
+  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
+  version = "1.1.5"
 
 [[projects]]
   branch = "master"
@@ -442,7 +442,7 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "NUT"
-  revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
+  revision = "f027049dab0ad238e394a753dba2d14753473a04"
 
 [[projects]]
   branch = "master"
@@ -457,7 +457,7 @@
     "idna",
   ]
   pruneopts = "NUT"
-  revision = "f4c29de78a2a91c00474a2e689954305c350adf9"
+  revision = "f9ce57c11b242f0f1599cf25c89d8cb02c45295a"
 
 [[projects]]
   branch = "master"
@@ -472,14 +472,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0710435fba1b90375bbb61cf59572961c72167775854a2162e0859210a381d06"
+  digest = "1:50f05222003d4bacd6cee17200c7ecbd86415a1e745818abe2f06393d6345c63"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "NUT"
-  revision = "3dc4335d56c789b04b0ba99b7a37249d9b614314"
+  revision = "acbc56fc7007d2a01796d5bde54f39e3b3e95945"
 
 [[projects]]
   digest = "1:e33513a825fcd765e97b5de639a2f7547542d1a8245df0cef18e1fd390b778a9"
@@ -592,7 +592,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "2d6f90ab1293a1fb871cf149423ebb72aa7423aa"
+  revision = "61b11ee6533278ae17d77fd36825d0b47ec3a293"
 
 [[projects]]
   branch = "release-1.11"
@@ -611,7 +611,7 @@
     "pkg/features",
   ]
   pruneopts = "NUT"
-  revision = "bbc52469f98bf18f81d6010a32c3377726cbfd84"
+  revision = "aaea8ffc60577d42bca6f1ea93a10ec85ec4f54e"
 
 [[projects]]
   branch = "release-1.11"
@@ -665,7 +665,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NT"
-  revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
+  revision = "1c9f4d20e8d7ca63f4ce98dc22110138cd6a365f"
 
 [[projects]]
   branch = "release-1.11"
@@ -676,7 +676,7 @@
     "pkg/util/feature",
   ]
   pruneopts = "NUT"
-  revision = "2e70abc0a65576011b14eb7e25b8ab31f9d343b7"
+  revision = "411ef4930e781d48ddc815a227fe5377c191cf1a"
 
 [[projects]]
   digest = "1:4f1bf46ac4a71f14e731a99e43568e381c7fce09708bb0e81dec5d24dbb5b03a"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,350 +2,451 @@
 
 
 [[projects]]
+  digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  digest = "1:5a23cd3a5496a0b2da7e3b348d14e77b11a210738c398200d7d6f04ea8cf3bd8"
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ccb8e960c48f04d6935e72476ae4a51028f9e22f"
   version = "v9"
 
 [[projects]]
   branch = "master"
+  digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "NUT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
   name = "github.com/coreos/go-semver"
   packages = ["semver"]
+  pruneopts = "NUT"
   revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:cefb8c8e8cd96a2098e63a8709c0c42391779f0289efc4d7cdb6d74ae6decdc3"
   name = "github.com/go-openapi/analysis"
   packages = ["."]
-  revision = "863ac7f90e00e88e507095639a8457bbbf3c2ec9"
+  pruneopts = "NUT"
+  revision = "3c8fe72ed5d307113ef76c7c3035964d7e4d4b73"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:747665117585f3d9e2f6c7635aac0410570289139f9a52b3a514f0e8b93ea517"
   name = "github.com/go-openapi/errors"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b2b2befaf267d082d779bcef52d682a47c779517"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:cc4186672d13bce6e14f7b39c6f51b2f8c5126532a020ced03841e7175886651"
   name = "github.com/go-openapi/loads"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2a2b323bab96e6b1fdee110e57d959322446e9c9"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:8d1839c72c12a18e7c5d68994da2ff3baefe4ea90010967cf76c703ae30d4d1f"
   name = "github.com/go-openapi/runtime"
   packages = ["."]
-  revision = "c0cae94704c76c8643896d8054080f91e920105b"
+  pruneopts = "NUT"
+  revision = "9a3091f566c0811ef4d54b535179bc0fc484a11f"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:87216dc20d985010c4cbe3301b4f9d4c81eaea407a289bd6338d2ac66d61b5a4"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "bcff419492eeeb01f76e77d2ebc714dc97b607f5"
+  pruneopts = "NUT"
+  revision = "bce47c9386f9ecd6b86f450478a80103c3fe1402"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:d9091d7447932ed64fe3584eabda47ad19753760f28b58bc6262e38155a5c1d9"
   name = "github.com/go-openapi/strfmt"
   packages = ["."]
-  revision = "481808443b00a14745fada967cb5eeff0f9b1df2"
+  pruneopts = "NUT"
+  revision = "913ee058e387ac83a67e2d9f13acecdcd5769fc6"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:d6dca21942524b423bf8d3e273c61874f7cd5511c2797e67685c33f4ab971f57"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  revision = "811b1089cde9dad18d4d0c2d09fbdbf28dbd27a5"
+  pruneopts = "NUT"
+  revision = "2b0bd4f193d011c203529df626a65d63cb8a79e8"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:a8af48041a45879378f5fcf14bf5f856f8c10dafefb0adf603ba86bc26d9fd62"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  revision = "9286f6d0e5c1ffc7cf2bda1d59291dc3c4f2f828"
+  pruneopts = "NUT"
+  revision = "9a6e517cddf1ddd47449be5d06a6a786e51d9986"
+  version = "0.15.0"
 
 [[projects]]
+  digest = "1:8679b8a64f3613e9749c5640c3535c83399b8e69f67ce54d91dc73f6d77373af"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
-  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
-  version = "v1.0.0"
+  pruneopts = "NUT"
+  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:bc38c7c481812e178d85160472e231c5e1c9a7f5845d67e23ee4e706933c10d8"
   name = "github.com/golang/mock"
   packages = ["gomock"]
+  pruneopts = "NUT"
   revision = "c34cdb4725f4c3844d095133c6e40e448b86589b"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:03e14cff610a8a58b774e36bd337fa979482be86aab01be81fb8bbd6d0f07fc8"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:245bd4eb633039cd66106a5d340ae826d87f4e36a8602fcc940e14176fd26ea7"
   name = "github.com/google/btree"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
   branch = "master"
+  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:06a7dadb7b760767341ffb6c8d377238d68a1226f2b21b5d497d2e3f6ecf6b4e"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
-  revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
-  version = "v0.1.0"
+  pruneopts = "NUT"
+  revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
+  version = "v0.2.0"
 
 [[projects]]
+  digest = "1:c01767916c59f084bb7c41a7d5877c0f3099b1595cfa066e84ec6ad6b084dd89"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:bf5cf1d53d703332e9bd8984c69784645b73a938317bf5ace9aadf20ac49379a"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:7fdf3223c7372d1ced0b98bf53457c5e89d89aecbad9a77ba9fcc6e01f9e5621"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
+  pruneopts = "NUT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
   branch = "master"
+  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "NUT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
+  digest = "1:9a52adf44086cead3b384e5d0dbf7a1c1cce65e67552ee3383a8561c42a18cd3"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "9d5f1277e9a8ed20c3684bda8fde67c05628518c"
-  version = "v0.3.4"
+  pruneopts = "NUT"
+  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
+  version = "v0.3.6"
 
 [[projects]]
+  digest = "1:0243cffa4a3410f161ee613dfdd903a636d07e838a42d341da95d81f42cd1d41"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
   version = "1.1.4"
 
 [[projects]]
   branch = "master"
+  digest = "1:84a5a2b67486d5d67060ac393aa255d05d24ed5ee41daecd5635ec22657b6492"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
-  revision = "8b799c424f57fa123fc63a99d6383bc6e4c02578"
+  pruneopts = "NUT"
+  revision = "03f2033d19d5860aef995fe360ac7d395cd8ce65"
 
 [[projects]]
+  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
-  version = "v1.0.0"
+  pruneopts = "NUT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:5fe20cfe4ef484c237cec9f947b2a6fa90bad4b8610fd014f0e4211e13d82d5d"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
+  pruneopts = "NUT"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
+  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:c6aca19413b13dc59c220ad7430329e2ec454cc310bc6d8de2c7e2b93c18a0f6"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = "NUT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:6c6d91dc326ed6778783cff869c49fb2f61303cdd2ebbcf90abe53505793f3b6"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:8658f775ba5edb37ede96d8ec9eaecdfe06bc4aef1776152070185e6513dc0cc"
   name = "github.com/pmorie/go-open-service-broker-client"
   packages = ["v2"]
+  pruneopts = "NUT"
   revision = "dca737037ce636eb282e84e3a1c7479c9692e884"
   version = "0.0.10"
 
 [[projects]]
+  digest = "1:65f55cb1d33a320785f7359dbb2f2c187ebb1075b76c70669154da76f0ea0f15"
   name = "github.com/pmorie/osb-broker-lib"
   packages = [
     "pkg/broker",
     "pkg/metrics",
     "pkg/rest",
-    "pkg/server"
+    "pkg/server",
   ]
+  pruneopts = "NUT"
   revision = "f4ca270ef323318b363f986229bd10bccb2d28b1"
   version = "0.0.10"
 
 [[projects]]
+  digest = "1:03bca087b180bf24c4f9060775f137775550a0834e18f0bca0520a868679dbd7"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "NUT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+  pruneopts = "NUT"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
+  digest = "1:fad5a35eea6a1a33d6c8f949fbc146f24275ca809ece854248187683f52cc30b"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
-  revision = "d811d2e9bf898806ecfb6ef6296774b13ffc314c"
+  pruneopts = "NUT"
+  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
 
 [[projects]]
   branch = "master"
+  digest = "1:6621142cd60b7150ab66f38ff36303ca55843dc5a635c1f9a28f95ecddab72b4"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
-  revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
+  pruneopts = "NUT"
+  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
+  digest = "1:b2339e83ce9b5c4f79405f949429a7f68a9a904fed903c672aac1e7ceb7f5f02"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
-  version = "v1.0.5"
+  pruneopts = "NUT"
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
 
 [[projects]]
+  digest = "1:15e5c398fbd9d2c439b635a08ac161b13d04f0c2aa587fe256b65dc0c3efe8b7"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:0331452965d8695c0a5633e0f509012987681a654f388f2ad0c3b2d7f7004b1c"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  pruneopts = "NUT"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
+  digest = "1:d8800a0f624ff60b3e5f8969018592a48d59ab9599dd8436d1fef6a7171318a0"
   name = "github.com/writeas/go-strip-markdown"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "135c36d3fc27c66a8cfe556f1d6d33d3e84d5213"
   version = "v2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
+  pruneopts = "NUT"
+  revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
+  digest = "1:d82e8640ebc91f35b2343968f1d6849c83ef4b5900d7ee9ac7c4fa796301c338"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -353,29 +454,35 @@
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna"
+    "idna",
   ]
-  revision = "2491c5de3490fced2f6cff376127c667efeed857"
+  pruneopts = "NUT"
+  revision = "f4c29de78a2a91c00474a2e689954305c350adf9"
 
 [[projects]]
   branch = "master"
+  digest = "1:806685616259192286b80e5924f92aad0a1cd880959cecd6441925f393a4a34d"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal"
+    "internal",
   ]
-  revision = "cdc340f7c179dbbfa4afd43b7614e8fcadde4269"
+  pruneopts = "NUT"
+  revision = "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
 
 [[projects]]
   branch = "master"
+  digest = "1:0710435fba1b90375bbb61cf59572961c72167775854a2162e0859210a381d06"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
-  revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
+  pruneopts = "NUT"
+  revision = "3dc4335d56c789b04b0ba99b7a37249d9b614314"
 
 [[projects]]
+  digest = "1:e33513a825fcd765e97b5de639a2f7547542d1a8245df0cef18e1fd390b778a9"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -392,18 +499,22 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width"
+    "width",
   ]
+  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "NUT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
+  digest = "1:af71cb57ffcbc389c2f8af1e6a763c0d2e6f08d2ceb64140c0fd4c57fdbc2898"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -412,34 +523,42 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
-  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
-  version = "v1.0.0"
+  pruneopts = "NUT"
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
   branch = "v2"
+  digest = "1:2642fd0b6900c77247d61d80cf2eb59a374ef4ffc2d25a1b95b87dc355b2894e"
   name = "gopkg.in/mgo.v2"
   packages = [
     "bson",
-    "internal/json"
+    "internal/json",
   ]
-  revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
+  pruneopts = "NUT"
+  revision = "9856a29383ce1c59f308dd1cf0363a79b5bef6b5"
 
 [[projects]]
+  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "release-1.11"
+  digest = "1:ef716a2116d8a040e16fbcd7fca71d3354915a94720de6af22c7a09970234296"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -470,12 +589,14 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "NUT"
   revision = "2d6f90ab1293a1fb871cf149423ebb72aa7423aa"
 
 [[projects]]
   branch = "release-1.11"
+  digest = "1:26a7eddcd549163693e58e4722b0885a90a4778db813347b5184e8f23d8b3055"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -487,12 +608,14 @@
     "pkg/client/clientset/clientset/scheme",
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake",
-    "pkg/features"
+    "pkg/features",
   ]
+  pruneopts = "NUT"
   revision = "bbc52469f98bf18f81d6010a32c3377726cbfd84"
 
 [[projects]]
   branch = "release-1.11"
+  digest = "1:b07bf863262aae765494d60f0d524483f211b29f9bb27d445a79c13af8676bf2"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -539,20 +662,24 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "NT"
   revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
 
 [[projects]]
   branch = "release-1.11"
+  digest = "1:6803af90fa2d41287bcc3a11b4a726093d36cfa5a296367d68aeca5e3fe34f8a"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/storage/names",
-    "pkg/util/feature"
+    "pkg/util/feature",
   ]
+  pruneopts = "NUT"
   revision = "2e70abc0a65576011b14eb7e25b8ab31f9d343b7"
 
 [[projects]]
+  digest = "1:4f1bf46ac4a71f14e731a99e43568e381c7fce09708bb0e81dec5d24dbb5b03a"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -710,19 +837,84 @@
     "util/homedir",
     "util/integer",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = "NUT"
   revision = "59698c7d9724b0f95f9dc9e7f7dfdcc3dfeceb82"
   version = "kubernetes-1.11.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a2c842a1e0aed96fd732b535514556323a6f5edfded3b63e5e0ab1bce188aa54"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
-  revision = "d8ea2fe547a448256204cfc68dfee7b26c720acb"
+  pruneopts = "NUT"
+  revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "04d23635403d1e65b9f7744b9b8bc480783be766563545bcb437e51973005ac5"
+  input-imports = [
+    "github.com/coreos/go-semver/semver",
+    "github.com/ghodss/yaml",
+    "github.com/golang/glog",
+    "github.com/golang/mock/gomock",
+    "github.com/pkg/errors",
+    "github.com/pmorie/go-open-service-broker-client/v2",
+    "github.com/pmorie/osb-broker-lib/pkg/broker",
+    "github.com/pmorie/osb-broker-lib/pkg/metrics",
+    "github.com/pmorie/osb-broker-lib/pkg/rest",
+    "github.com/pmorie/osb-broker-lib/pkg/server",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/sirupsen/logrus",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "github.com/writeas/go-strip-markdown",
+    "k8s.io/api/apps/v1",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
+    "k8s.io/api/rbac/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation",
+    "k8s.io/apiextensions-apiserver/pkg/apiserver/validation",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme",
+    "k8s.io/apimachinery/pkg/api/equality",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
+    "k8s.io/apimachinery/pkg/api/validation",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/conversion",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/runtime/serializer/json",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/diff",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/strategicpatch",
+    "k8s.io/apimachinery/pkg/util/validation/field",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/apiserver/pkg/storage/names",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/informers",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/fake",
+    "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/core/v1/fake",
+    "k8s.io/client-go/plugin/pkg/client/auth/oidc",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/workqueue",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/controller/operators/catalog/subscriptions.go
+++ b/pkg/controller/operators/catalog/subscriptions.go
@@ -44,7 +44,7 @@ func (o *Operator) syncSubscription(in *v1alpha1.Subscription) (*v1alpha1.Subscr
 	if catalogNamespace == "" {
 		catalogNamespace = o.namespace
 	}
-	catalog, ok := o.sources[registry.SourceKey{Name: out.Spec.CatalogSource, Namespace: catalogNamespace}]
+	catalog, ok := o.sources[registry.ResourceKey{Name: out.Spec.CatalogSource, Namespace: catalogNamespace}]
 	if !ok {
 		return out, fmt.Errorf("unknown catalog source %s in namespace %s", out.Spec.CatalogSource, catalogNamespace)
 	}

--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -947,8 +947,8 @@ func TestSyncSubscription(t *testing.T) {
 			op := &Operator{
 				client:    clientFake,
 				namespace: "ns",
-				sources: map[registry.SourceKey]registry.Source{
-					registry.SourceKey{Name: tt.initial.catalogName, Namespace: "ns"}: catalogFake,
+				sources: map[registry.ResourceKey]registry.Source{
+					registry.ResourceKey{Name: tt.initial.catalogName, Namespace: "ns"}: catalogFake,
 				},
 				sourcesLastUpdate:  tt.initial.sourcesLastUpdate,
 				dependencyResolver: &resolver.MultiSourceResolver{},

--- a/pkg/controller/registry/configmap_loader.go
+++ b/pkg/controller/registry/configmap_loader.go
@@ -106,7 +106,7 @@ func (d *ConfigMapCatalogResourceLoader) LoadCatalogResourcesFromConfigMap(catal
 		}
 		for _, packageManifest := range parsedPackageManifests {
 			found = true
-			if err := catalog.addPackageManifest(packageManifest); err != nil {
+			if err := catalog.AddPackageManifest(packageManifest); err != nil {
 				return err
 			}
 		}

--- a/pkg/controller/registry/manifest.go
+++ b/pkg/controller/registry/manifest.go
@@ -61,7 +61,7 @@ func LoadPackageFromFile(m *InMem, filepath string) (*PackageManifest, error) {
 
 	err = json.Unmarshal([]byte(packageJson), &pkg)
 
-	if err = m.addPackageManifest(pkg); err != nil {
+	if err = m.AddPackageManifest(pkg); err != nil {
 		return nil, fmt.Errorf("unable to set package found in catalog: %v", err)
 	}
 	return &pkg, nil

--- a/pkg/controller/registry/mem.go
+++ b/pkg/controller/registry/mem.go
@@ -140,7 +140,7 @@ func (m *InMem) FindCSVForPackageNameUnderChannel(packageName string, channelNam
 }
 
 // addPackageManifest adds a new package manifest to the in memory catalog.
-func (m *InMem) addPackageManifest(pkg PackageManifest) error {
+func (m *InMem) AddPackageManifest(pkg PackageManifest) error {
 	if len(pkg.PackageName) == 0 {
 		return fmt.Errorf("Empty package name")
 	}

--- a/pkg/controller/registry/mem_test.go
+++ b/pkg/controller/registry/mem_test.go
@@ -109,7 +109,7 @@ func TestFindCSVForPackageNameUnderChannel(t *testing.T) {
 	catalog.AddOrReplaceService(testCSVResourceAlpha)
 	catalog.AddOrReplaceService(testCSVResourceStable)
 
-	catalog.addPackageManifest(PackageManifest{
+	catalog.AddPackageManifest(PackageManifest{
 		PackageName: "mockservice",
 		Channels: []PackageChannel{
 			{
@@ -143,7 +143,7 @@ func TestFindCSVForPackageNameUnderChannel(t *testing.T) {
 func TestInvalidPackageManifest(t *testing.T) {
 	catalog := NewInMem()
 
-	err := catalog.addPackageManifest(PackageManifest{
+	err := catalog.AddPackageManifest(PackageManifest{
 		PackageName: "mockservice",
 		Channels: []PackageChannel{
 			{
@@ -254,7 +254,7 @@ func TestFindReplacementCSVForPackageNameUnderChannel(t *testing.T) {
 	catalog.AddOrReplaceService(testCSVResourceStable)
 	catalog.AddOrReplaceService(testCSVResourceReplaced)
 
-	catalog.addPackageManifest(PackageManifest{
+	catalog.AddPackageManifest(PackageManifest{
 		PackageName:        "mockservice",
 		DefaultChannelName: "stable",
 		Channels: []PackageChannel{
@@ -374,7 +374,7 @@ func TestListLatestCSVsForCRD(t *testing.T) {
 	catalog.AddOrReplaceService(testCSVResourceStable)
 	catalog.AddOrReplaceService(testCSVResourceReplaced)
 
-	catalog.addPackageManifest(PackageManifest{
+	catalog.AddPackageManifest(PackageManifest{
 		PackageName:        "mockservice",
 		DefaultChannelName: "stable",
 		Channels: []PackageChannel{

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -184,21 +184,21 @@ func (resolver *MultiSourceResolver) resolveCRDDescription(sourceRefs []registry
 	}
 
 	var ownerName string
-	if owners, ok := existingCRDOwners[crdKey.Name]; ok && len(owners) > 0 {
-		if len(owners) > 1 {
-			return v1alpha1.StepResource{}, "", fmt.Errorf("More than one existing owner for CRD %s in namespace %s found: %v", crdKey.Name, planNamespace, owners)
-		}
-
-		// Pre-existing owner found
-		ownerName = owners[0]
-	} else {
+	owners := existingCRDOwners[crdKey.Name]
+	switch len(owners) {
+	case 0:
 		// No pre-existing owner found
 		for _, csv := range csvs {
 			// Check for the default channel
 			if csv.IsDefaultChannel {
 				ownerName = csv.CSV.Name
+				break
 			}
 		}
+	case 1:
+		ownerName = owners[0]
+	default:
+		return v1alpha1.StepResource{}, "", fmt.Errorf("More than one existing owner for CRD %s in namespace %s found: %v", crdKey.Name, planNamespace, owners)
 	}
 
 	// Check empty name

--- a/pkg/controller/registry/types.go
+++ b/pkg/controller/registry/types.go
@@ -31,14 +31,16 @@ type Source interface {
 	ListLatestCSVsForCRD(key CRDKey) ([]CSVAndChannelInfo, error)
 }
 
-type SourceKey struct {
+// ResourceKey contains metadata to uniquely identify a resource
+type ResourceKey struct {
 	Name      string
+	Kind      string
 	Namespace string
 }
 
 // SourceRef associates a Source with it's SourceKey
 type SourceRef struct {
-	SourceKey SourceKey
+	SourceKey ResourceKey
 	Source    Source
 }
 

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -39,34 +39,47 @@ var installPlanFailedChecker = func(fip *v1alpha1.InstallPlan) bool {
 	return fip.Status.Phase == v1alpha1.InstallPlanPhaseFailed
 }
 
+var installPlanCompleteOrFailedChecker = func(fip *v1alpha1.InstallPlan) bool {
+	return installPlanCompleteChecker(fip) || installPlanFailedChecker(fip)
+}
+
 var installPlanRequiresApprovalChecker = func(fip *v1alpha1.InstallPlan) bool {
 	return fip.Status.Phase == v1alpha1.InstallPlanPhaseRequiresApproval
 }
 
-func buildInstallPlanCleanupFunc(c versioned.Interface, installPlan *v1alpha1.InstallPlan) cleanupFunc {
+func buildInstallPlanCleanupFunc(crc versioned.Interface, namespace string, installPlan *v1alpha1.InstallPlan) cleanupFunc {
 	return func() {
 		for _, step := range installPlan.Status.Plan {
 			if step.Resource.Kind == v1alpha1.ClusterServiceVersionKind {
-				if err := c.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(step.Resource.Name, &metav1.DeleteOptions{}); err != nil {
+				if err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).Delete(step.Resource.Name, &metav1.DeleteOptions{}); err != nil {
 					fmt.Println(err)
 				}
 			}
 		}
-		if err := c.OperatorsV1alpha1().InstallPlans(testNamespace).Delete(installPlan.GetName(), &metav1.DeleteOptions{}); err != nil {
+		if err := crc.OperatorsV1alpha1().InstallPlans(namespace).Delete(installPlan.GetName(), &metav1.DeleteOptions{}); err != nil {
+			fmt.Println(err)
+		}
+
+		err := waitForDelete(func() error {
+			_, err := crc.OperatorsV1alpha1().InstallPlans(namespace).Get(installPlan.GetName(), metav1.GetOptions{})
+			return err
+		})
+
+		if err != nil {
 			fmt.Println(err)
 		}
 	}
 }
 
-func decorateCommonAndCreateInstallPlan(c versioned.Interface, plan v1alpha1.InstallPlan) (cleanupFunc, error) {
+func decorateCommonAndCreateInstallPlan(crc versioned.Interface, namespace string, plan v1alpha1.InstallPlan) (cleanupFunc, error) {
 	plan.Kind = v1alpha1.InstallPlanKind
 	plan.APIVersion = v1alpha1.SchemeGroupVersion.String()
 
-	_, err := c.OperatorsV1alpha1().InstallPlans(testNamespace).Create(&plan)
+	_, err := crc.OperatorsV1alpha1().InstallPlans(namespace).Create(&plan)
 	if err != nil {
 		return nil, err
 	}
-	return buildInstallPlanCleanupFunc(c, &plan), nil
+	return buildInstallPlanCleanupFunc(crc, namespace, &plan), nil
 }
 
 func fetchInstallPlan(t *testing.T, c versioned.Interface, name string, checker installPlanConditionChecker) (*v1alpha1.InstallPlan, error) {
@@ -116,8 +129,8 @@ func TestCreateInstallPlanManualApproval(t *testing.T) {
 		},
 	}
 
-	// Create a new InstallPlan for Etcd with manual approval
-	cleanup, err := decorateCommonAndCreateInstallPlan(crc, etcdInstallPlan)
+	// Create a new InstallPlan for Vault with manual approval
+	cleanup, err := decorateCommonAndCreateInstallPlan(crc, testNamespace, etcdInstallPlan)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -210,7 +223,7 @@ func TestCreateInstallPlanFromInvalidClusterServiceVersionName(t *testing.T) {
 		},
 	}
 
-	cleanup, err := decorateCommonAndCreateInstallPlan(crc, installPlan)
+	cleanup, err := decorateCommonAndCreateInstallPlan(crc, testNamespace, installPlan)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -369,22 +382,19 @@ func TestCreateInstallPlanWithCSVsAcrossMultipleCatalogSources(t *testing.T) {
 	crc := newCRClient(t)
 
 	// Create expected install plan step sources
-	type resourceKey struct {
-		name string
-		kind string
-	}
-
-	expectedStepSources := map[resourceKey]registry.SourceKey{
-		resourceKey{name: crdName, kind: "CustomResourceDefinition"}:                        registry.SourceKey{Name: "mock-ocs-dependent", Namespace: testNamespace},
-		resourceKey{name: dependentPackageStable, kind: v1alpha1.ClusterServiceVersionKind}: registry.SourceKey{Name: "mock-ocs-dependent", Namespace: testNamespace},
-		resourceKey{name: mainPackageStable, kind: v1alpha1.ClusterServiceVersionKind}:      registry.SourceKey{Name: "mock-ocs-main", Namespace: testNamespace},
+	expectedStepSources := map[registry.ResourceKey]registry.ResourceKey{
+		registry.ResourceKey{Name: crdName, Kind: "CustomResourceDefinition"}:                        registry.ResourceKey{Name: "mock-ocs-dependent", Namespace: testNamespace},
+		registry.ResourceKey{Name: dependentPackageStable, Kind: v1alpha1.ClusterServiceVersionKind}: registry.ResourceKey{Name: "mock-ocs-dependent", Namespace: testNamespace},
+		registry.ResourceKey{Name: mainPackageStable, Kind: v1alpha1.ClusterServiceVersionKind}:      registry.ResourceKey{Name: "mock-ocs-main", Namespace: testNamespace},
 	}
 
 	// Create the catalog sources
-	_, err := createInternalCatalogSource(t, c, "mock-ocs-dependent", testNamespace, dependentManifests, []extv1beta1.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{dependentCSV})
+	_, cleanupDependentCatalogSource, err := createInternalCatalogSource(t, c, crc, "mock-ocs-dependent", testNamespace, dependentManifests, []extv1beta1.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{dependentCSV})
 	require.NoError(t, err)
-	_, err = createInternalCatalogSource(t, c, "mock-ocs-main", testNamespace, mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
+	defer cleanupDependentCatalogSource()
+	_, cleanupMainCatalogSource, err := createInternalCatalogSource(t, c, crc, "mock-ocs-main", testNamespace, mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
 	require.NoError(t, err)
+	defer cleanupMainCatalogSource()
 
 	// Fetch list of catalog sources
 	installPlan := v1alpha1.InstallPlan{
@@ -402,7 +412,7 @@ func TestCreateInstallPlanWithCSVsAcrossMultipleCatalogSources(t *testing.T) {
 		},
 	}
 
-	cleanup, err := decorateCommonAndCreateInstallPlan(crc, installPlan)
+	cleanup, err := decorateCommonAndCreateInstallPlan(crc, testNamespace, installPlan)
 	require.NoError(t, err)
 	t.Logf("Install plan %s created", installPlan.GetName())
 	defer cleanup()
@@ -421,12 +431,304 @@ func TestCreateInstallPlanWithCSVsAcrossMultipleCatalogSources(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	require.Equal(t, len(fetchedInstallPlan.Status.Plan), len(expectedStepSources))
+	t.Logf("Number of resolved steps matches the number of expected steps")
+
 	// Ensure resolved step resources originate from the correct catalog sources
 	for _, step := range fetchedInstallPlan.Status.Plan {
-		key := resourceKey{name: step.Resource.Name, kind: step.Resource.Kind}
+		key := registry.ResourceKey{Name: step.Resource.Name, Kind: step.Resource.Kind}
 		expectedSource, ok := expectedStepSources[key]
 		require.True(t, ok)
 		require.Equal(t, step.Resource.CatalogSource, expectedSource.Name)
 		require.Equal(t, step.Resource.CatalogSourceNamespace, expectedSource.Namespace)
 	}
+	t.Logf("All expected resources resolved")
+}
+
+func TestCreateInstallPlanWithPreExistingCRDOwners(t *testing.T) {
+	mainPackageName := "nginx"
+	dependentPackageName := "nginxdep"
+
+	mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
+	dependentPackageStable := fmt.Sprintf("%s-stable", dependentPackageName)
+	dependentPackageBeta := fmt.Sprintf("%s-beta", dependentPackageName)
+
+	stableChannel := "stable"
+	betaChannel := "beta"
+
+	// Create manifests
+	mainManifests := []registry.PackageManifest{
+		registry.PackageManifest{
+			PackageName: mainPackageName,
+			Channels: []registry.PackageChannel{
+				registry.PackageChannel{Name: stableChannel, CurrentCSVName: mainPackageStable},
+			},
+			DefaultChannelName: stableChannel,
+		},
+		registry.PackageManifest{
+			PackageName: dependentPackageName,
+			Channels: []registry.PackageChannel{
+				registry.PackageChannel{Name: stableChannel, CurrentCSVName: dependentPackageStable},
+				registry.PackageChannel{Name: betaChannel, CurrentCSVName: dependentPackageBeta},
+			},
+			DefaultChannelName: stableChannel,
+		},
+	}
+
+	// Generate CSVs for each package
+	csvType = metav1.TypeMeta{
+		Kind:       v1alpha1.ClusterServiceVersionKind,
+		APIVersion: v1alpha1.GroupVersion,
+	}
+
+	// Create an install strategy
+	strategy = install.StrategyDetailsDeployment{
+		DeploymentSpecs: []install.StrategyDeploymentSpec{
+			{
+				Name: genName("dep-"),
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nginx"},
+					},
+					Replicas: &doubleInstance,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "nginx"},
+						},
+						Spec: corev1.PodSpec{Containers: []corev1.Container{
+							{
+								Name:  genName("nginx"),
+								Image: "nginx:1.7.9",
+								Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+	strategyRaw, _ = json.Marshal(strategy)
+	installStrategy = v1alpha1.NamedInstallStrategy{
+		StrategyName:    install.InstallStrategyNameDeployment,
+		StrategySpecRaw: strategyRaw,
+	}
+
+	crdPlural := genName("ins")
+	crdName := crdPlural + ".cluster.com"
+
+	dependentCRD := extv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CustomResourceDefinition",
+		},
+		Spec: extv1beta1.CustomResourceDefinitionSpec{
+			Group:   "cluster.com",
+			Version: "v1alpha1",
+			Names: extv1beta1.CustomResourceDefinitionNames{
+				Plural:   crdPlural,
+				Singular: crdPlural,
+				Kind:     crdPlural,
+				ListKind: "list" + crdPlural,
+			},
+			Scope: "Namespaced",
+		},
+	}
+
+	mainCSV := v1alpha1.ClusterServiceVersion{
+		TypeMeta: csvType,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mainPackageStable,
+		},
+		Spec: v1alpha1.ClusterServiceVersionSpec{
+			Replaces:        "",
+			Version:         *semver.New("0.1.0"),
+			InstallStrategy: installStrategy,
+			CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+				Required: []v1alpha1.CRDDescription{
+					{
+						Name:        crdName,
+						Version:     "v1alpha1",
+						Kind:        crdPlural,
+						DisplayName: crdName,
+						Description: crdName,
+					},
+				},
+			},
+		},
+	}
+
+	dependentStableCSV := v1alpha1.ClusterServiceVersion{
+		TypeMeta: csvType,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: dependentPackageStable,
+		},
+		Spec: v1alpha1.ClusterServiceVersionSpec{
+			Replaces:        "",
+			Version:         *semver.New("0.1.0"),
+			InstallStrategy: installStrategy,
+			CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+				Owned: []v1alpha1.CRDDescription{
+					{
+						Name:        crdName,
+						Version:     "v1alpha1",
+						Kind:        crdPlural,
+						DisplayName: crdName,
+						Description: crdName,
+					},
+				},
+			},
+		},
+	}
+
+	dependentBetaCSV := v1alpha1.ClusterServiceVersion{
+		TypeMeta: csvType,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: dependentPackageBeta,
+		},
+		Spec: v1alpha1.ClusterServiceVersionSpec{
+			Replaces:        dependentPackageStable,
+			Version:         *semver.New("0.2.0"),
+			InstallStrategy: installStrategy,
+			CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+				Owned: []v1alpha1.CRDDescription{
+					{
+						Name:        crdName,
+						Version:     "v1alpha1",
+						Kind:        crdPlural,
+						DisplayName: crdName,
+						Description: crdName,
+					},
+				},
+			},
+		},
+	}
+
+	c := newKubeClient(t)
+	crc := newCRClient(t)
+
+	// Create the catalog source
+	_, cleanupCatalogSource, err := createInternalCatalogSource(t, c, crc, "mock-ocs-main", testNamespace, mainManifests, []extv1beta1.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainCSV})
+	require.NoError(t, err)
+	defer cleanupCatalogSource()
+
+	// Fetch list of catalog sources
+	installPlan := v1alpha1.InstallPlan{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.InstallPlanKind,
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "install-nginx",
+			Namespace: testNamespace,
+		},
+		Spec: v1alpha1.InstallPlanSpec{
+			ClusterServiceVersionNames: []string{mainPackageStable},
+			Approval:                   v1alpha1.ApprovalAutomatic,
+		},
+	}
+
+	t.Run("OnePreExistingCRDOwner", func(t *testing.T) {
+		expectedSteps := map[registry.ResourceKey]struct{}{
+			registry.ResourceKey{Name: crdName, Kind: "CustomResourceDefinition"}:                      struct{}{},
+			registry.ResourceKey{Name: dependentPackageBeta, Kind: v1alpha1.ClusterServiceVersionKind}: struct{}{},
+			registry.ResourceKey{Name: mainPackageStable, Kind: v1alpha1.ClusterServiceVersionKind}:    struct{}{},
+		}
+
+		// Create the preexisting CRD and CSV
+		cleanupCRD, err := createCRD(c, dependentCRD)
+		require.NoError(t, err)
+		defer cleanupCRD()
+		cleanupCSV, err := createCSV(t, c, crc, dependentBetaCSV, testNamespace, true)
+		require.NoError(t, err)
+		defer cleanupCSV()
+		t.Log("Dependent CRD and preexisting CSV created")
+
+		cleanupInstallPlan, err := decorateCommonAndCreateInstallPlan(crc, testNamespace, installPlan)
+		require.NoError(t, err)
+		t.Logf("Install plan %s created", installPlan.GetName())
+		defer cleanupInstallPlan()
+
+		// Wait for InstallPlan to be status: Complete before checking resource presence
+		fetchedInstallPlan, err := fetchInstallPlan(t, crc, installPlan.GetName(), installPlanCompleteOrFailedChecker)
+		require.NoError(t, err)
+		t.Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
+
+		require.Equal(t, v1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
+
+		// Fetch installplan again to check for unnecessary control loops
+		fetchedInstallPlan, err = fetchInstallPlan(t, crc, fetchedInstallPlan.GetName(), func(fip *v1alpha1.InstallPlan) bool {
+			compareResources(t, fetchedInstallPlan, fip)
+			return true
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, len(fetchedInstallPlan.Status.Plan), len(expectedSteps))
+		t.Logf("Number of resolved steps matches the number of expected steps")
+
+		// Ensure resolved step resources originate from the correct catalog sources
+		for _, step := range fetchedInstallPlan.Status.Plan {
+			key := registry.ResourceKey{Name: step.Resource.Name, Kind: step.Resource.Kind}
+			_, ok := expectedSteps[key]
+			require.True(t, ok)
+		}
+		t.Logf("All expected resources resolved")
+	})
+
+	t.Run("TwoPreExistingCRDOwners", func(t *testing.T) {
+		secondOwnerCSV := v1alpha1.ClusterServiceVersion{
+			TypeMeta: csvType,
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "second-owner",
+			},
+			Spec: v1alpha1.ClusterServiceVersionSpec{
+				Replaces:        "",
+				Version:         *semver.New("0.2.0"),
+				InstallStrategy: installStrategy,
+				CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+					Owned: []v1alpha1.CRDDescription{
+						{
+							Name:        crdName,
+							Version:     "v1alpha1",
+							Kind:        crdPlural,
+							DisplayName: crdName,
+							Description: crdName,
+						},
+					},
+				},
+			},
+		}
+
+		// Create the preexisting CRD and CSV
+		cleanupCRD, err := createCRD(c, dependentCRD)
+		require.NoError(t, err)
+		defer cleanupCRD()
+		cleanupBetaCSV, err := createCSV(t, c, crc, dependentBetaCSV, testNamespace, true)
+		require.NoError(t, err)
+		defer cleanupBetaCSV()
+		cleanupSecondOwnerCSV, err := createCSV(t, c, crc, secondOwnerCSV, testNamespace, true)
+		require.NoError(t, err)
+		defer cleanupSecondOwnerCSV()
+		t.Log("Dependent CRD and preexisting CSVs created")
+
+		cleanupInstallPlan, err := decorateCommonAndCreateInstallPlan(crc, testNamespace, installPlan)
+		require.NoError(t, err)
+		t.Logf("Install plan %s created", installPlan.GetName())
+		defer cleanupInstallPlan()
+
+		// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
+		fetchedInstallPlan, err := fetchInstallPlan(t, crc, installPlan.GetName(), installPlanCompleteOrFailedChecker)
+		require.NoError(t, err)
+		t.Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
+
+		require.Equal(t, v1alpha1.InstallPlanPhaseFailed, fetchedInstallPlan.Status.Phase)
+
+		// Fetch installplan again to check for unnecessary control loops
+		_, err = fetchInstallPlan(t, crc, fetchedInstallPlan.GetName(), func(fip *v1alpha1.InstallPlan) bool {
+			compareResources(t, fetchedInstallPlan, fip)
+			return true
+		})
+		require.NoError(t, err)
+	})
 }

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -270,7 +270,7 @@ func buildSubscriptionCleanupFunc(t *testing.T, crc versioned.Interface, subscri
 			// Get installplan and create/execute cleanup function
 			installPlan, err := crc.OperatorsV1alpha1().InstallPlans(subscription.GetNamespace()).Get(installPlanRef.Name, metav1.GetOptions{})
 			if err == nil {
-				buildInstallPlanCleanupFunc(crc, installPlan)()
+				buildInstallPlanCleanupFunc(crc, subscription.GetNamespace(), installPlan)()
 			} else {
 				t.Logf("Could not get installplan %s while building subscription %s's cleanup function", installPlan.GetName(), subscription.GetName())
 			}
@@ -357,7 +357,7 @@ func TestCreateNewSubscriptionAgain(t *testing.T) {
 	require.NoError(t, initCatalog(t, c))
 
 	// Will be cleaned up by the upgrade process
-	_, err := createCSV(t, c, crc, stableCSV, true)
+	_, err := createCSV(t, c, crc, stableCSV, testNamespace, true)
 	require.NoError(t, err)
 
 	subscriptionCleanup := createSubscription(t, crc, testNamespace, testSubscriptionName, alphaChannel, v1alpha1.ApprovalAutomatic)

--- a/test/schema/catalog_versions_test.go
+++ b/test/schema/catalog_versions_test.go
@@ -100,7 +100,7 @@ func resolveCatalogs(t *testing.T, catalogs []registry.SourceRef, dependencyReso
 		}
 
 		// Attempt to resolve the install plan
-		_, _, err = dependencyResolver.ResolveInstallPlan(catalogs, "", plan)
+		_, _, err = dependencyResolver.ResolveInstallPlan(catalogs, nil, "", plan)
 
 	}
 
@@ -163,7 +163,7 @@ func VerifyCatalogVersions(t *testing.T, manifestDir string) {
 
 				// Store by version
 				sourceRef := registry.SourceRef{
-					SourceKey: registry.SourceKey{
+					SourceKey: registry.ResourceKey{
 						Name:      loadedCatalog.Name,
 						Namespace: "default", // namespace is irrelevant (everything is loaded from files)
 					},


### PR DESCRIPTION
### Description

Makes dependency resolution aware of default package channels and preexisting CSVs in an install plan's namespace.

Roughly addresses [ALM-641](https://jira.coreos.com/browse/ALM-641) and [ALM-469](https://jira.coreos.com/browse/ALM-469)