### PR TITLE
[WIP] feat(catalog): add namespace awareness to plan execution

### DIFF
--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -1,0 +1,32 @@
+package errors
+
+import "fmt"
+
+// MultipleExistingCRDOwnersError is an error that denotes multiple owners of a CRD exist
+// simultaneously in the same namespace
+type MultipleExistingCRDOwnersError struct {
+	CSVNames  []string
+	CRDName   string
+	Namespace string
+}
+
+func (m MultipleExistingCRDOwnersError) Error() string {
+	return fmt.Sprintf("Existing CSVs %v in namespace %s all claim to own CRD %s", m.CSVNames, m.Namespace, m.CRDName)
+}
+
+func NewMultipleExistingCRDOwnersError(csvNames []string, crdName string, namespace string) MultipleExistingCRDOwnersError {
+	return MultipleExistingCRDOwnersError{
+		CSVNames:  csvNames,
+		CRDName:   crdName,
+		Namespace: namespace,
+	}
+}
+
+func IsMultipleExistingCRDOwnersError(err error) bool {
+	switch err.(type) {
+	case MultipleExistingCRDOwnersError:
+		return true
+	}
+
+	return false
+}

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -304,7 +304,7 @@ func TestCompetingCRDOwnersExist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			competing, err := competingCRDOwnersExist(testNamespace, tt.csv, tt.existingCRDOwners)
+			competing, err := competingCRDOwnersExist(testNamespace, &tt.csv, tt.existingCRDOwners)
 
 			// Assert the error is as expected
 			if tt.expectedErr == nil {

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -305,7 +305,14 @@ func TestCompetingCRDOwnersExist(t *testing.T) {
 			t.Parallel()
 
 			competing, err := competingCRDOwnersExist(testNamespace, tt.csv, tt.existingCRDOwners)
-			require.Equal(t, err, tt.expectedErr)
+
+			// Assert the error is as expected
+			if tt.expectedErr == nil {
+				require.Nil(t, err)
+			} else {
+				require.Equal(t, tt.expectedErr, err)
+			}
+
 			require.Equal(t, competing, tt.expectedResult)
 		})
 	}

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"fmt"
 
+	olmerrors "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
@@ -198,7 +199,7 @@ func (resolver *MultiSourceResolver) resolveCRDDescription(sourceRefs []registry
 	case 1:
 		ownerName = owners[0]
 	default:
-		return v1alpha1.StepResource{}, "", fmt.Errorf("More than one existing owner for CRD %s in namespace %s found: %v", crdKey.Name, planNamespace, owners)
+		return v1alpha1.StepResource{}, "", olmerrors.NewMultipleExistingCRDOwnersError(owners, crdKey.Name, planNamespace)
 	}
 
 	// Check empty name

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -2,9 +2,9 @@ package resolver
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
+	olmerrors "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -425,7 +425,7 @@ func namespaceAndChannelAwareResolveInstallPlan(t *testing.T, resolver Dependenc
 			map[string][]string{
 				"cheese": []string{"cheese-alpha", "cheese-beta"},
 			},
-			fmt.Errorf("More than one existing owner for CRD %s in namespace %s found: %v", "cheese", "default", []string{"cheese-alpha", "cheese-beta"}),
+			olmerrors.NewMultipleExistingCRDOwnersError([]string{"cheese-alpha", "cheese-beta"}, "cheese", "default"),
 			nil,
 		},
 	}

--- a/pkg/lib/operatorclient/deployment.go
+++ b/pkg/lib/operatorclient/deployment.go
@@ -164,10 +164,8 @@ func (c *Client) waitForDeploymentRollout(dep *appsv1.Deployment) error {
 	return wait.PollInfinite(deploymentRolloutPollInterval, func() (bool, error) {
 		d, err := c.GetDeployment(dep.Namespace, dep.Name)
 		if err != nil {
-			// Do not return error here, as we could be updating the API Server itself, in which case we
-			// want to continue waiting.
 			glog.Errorf("error getting Deployment %s during rollout: %v", dep.Name, err)
-			return false, nil
+			return false, err
 		}
 		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedReplicas == d.Status.Replicas && d.Status.UnavailableReplicas == 0 {
 			return true, nil

--- a/pkg/lib/operatorclient/deployment.go
+++ b/pkg/lib/operatorclient/deployment.go
@@ -164,8 +164,10 @@ func (c *Client) waitForDeploymentRollout(dep *appsv1.Deployment) error {
 	return wait.PollInfinite(deploymentRolloutPollInterval, func() (bool, error) {
 		d, err := c.GetDeployment(dep.Namespace, dep.Name)
 		if err != nil {
+			// Do not return error here, as we could be updating the API Server itself, in which case we
+			// want to continue waiting.
 			glog.Errorf("error getting Deployment %s during rollout: %v", dep.Name, err)
-			return false, err
+			return false, nil
 		}
 		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedReplicas == d.Status.Replicas && d.Status.UnavailableReplicas == 0 {
 			return true, nil

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -175,6 +175,8 @@ func waitForCSVToDelete(t *testing.T, c versioned.Interface, name string) error 
 
 // TODO: same test but missing serviceaccount instead
 func TestCreateCSVWithUnmetRequirements(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 
@@ -230,6 +232,8 @@ func TestCreateCSVWithUnmetRequirements(t *testing.T) {
 
 // TODO: same test but create serviceaccount instead
 func TestCreateCSVRequirementsMet(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 
@@ -313,6 +317,8 @@ func TestCreateCSVRequirementsMet(t *testing.T) {
 }
 
 func TestUpdateCSVSameDeploymentName(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 
@@ -516,6 +522,8 @@ func TestUpdateCSVSameDeploymentName(t *testing.T) {
 }
 
 func TestUpdateCSVDifferentDeploymentName(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 
@@ -657,6 +665,8 @@ func TestUpdateCSVDifferentDeploymentName(t *testing.T) {
 }
 
 func TestUpdateCSVMultipleIntermediates(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 

--- a/test/e2e/ocs_e2e_test.go
+++ b/test/e2e/ocs_e2e_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestInstallEtcdOCS(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 
@@ -159,6 +161,8 @@ func TestInstallEtcdOCS(t *testing.T) {
 }
 
 func TestInstallPrometheusOCS(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -264,7 +264,6 @@ func fetchSubscription(t *testing.T, crc versioned.Interface, namespace, name st
 		if err != nil || fetchedSubscription == nil {
 			return false, err
 		}
-		// t.Logf("%s (%s): %s", fetchedSubscription.Status.State, fetchedSubscription.Status.Install.Name, fetchedSubscription.Status.CurrentCSV)
 		return checker(fetchedSubscription), nil
 	})
 	return fetchedSubscription, err

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -257,7 +257,7 @@ func fetchSubscription(t *testing.T, crc versioned.Interface, namespace, name st
 		if err != nil || fetchedSubscription == nil {
 			return false, err
 		}
-		t.Logf("%s (%s): %s", fetchedSubscription.Status.State, fetchedSubscription.Status.Install.Name, fetchedSubscription.Status.CurrentCSV)
+		// t.Logf("%s (%s): %s", fetchedSubscription.Status.State, fetchedSubscription.Status.Install.Name, fetchedSubscription.Status.CurrentCSV)
 		return checker(fetchedSubscription), nil
 	})
 	return fetchedSubscription, err
@@ -316,7 +316,8 @@ func checkForCSV(t *testing.T, c operatorclient.ClientInterface, name string) (*
 //   I. Creating a new subscription
 //      A. If package is not installed, creating a subscription should install latest version
 func TestCreateNewSubscription(t *testing.T) {
-	cleanupOLM(t, testNamespace)
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 	require.NoError(t, initCatalog(t, c))
@@ -342,7 +343,8 @@ func TestCreateNewSubscription(t *testing.T) {
 //      B. If package is already installed, creating a subscription should upgrade it to the latest
 //         version
 func TestCreateNewSubscriptionAgain(t *testing.T) {
-	defer cleanupOLM(t, testNamespace)
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 	require.NoError(t, initCatalog(t, c))
@@ -370,7 +372,8 @@ func TestCreateNewSubscriptionAgain(t *testing.T) {
 
 // If installPlanApproval is set to manual, the installplans created should be created with approval: manual
 func TestCreateNewSubscriptionManualApproval(t *testing.T) {
-	defer cleanupOLM(t, testNamespace)
+	defer cleaner.NotifyTestComplete(t, true)
+
 	c := newKubeClient(t)
 	crc := newCRClient(t)
 

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -39,14 +39,16 @@ const (
 )
 
 var (
-	testNamespace  = metav1.NamespaceDefault
-	genName        = names.SimpleNameGenerator.GenerateName
-	skipCleanupOLM = false
+	cleaner       *namespaceCleaner
+	testNamespace = metav1.NamespaceDefault
+	genName       = names.SimpleNameGenerator.GenerateName
 
 	persistentCatalogNames               = []string{ocsConfigMap}
 	nonPersistentCatalogsFieldSelector   = createFieldNotEqualSelector("metadata.name", persistentCatalogNames...)
 	persistentConfigMapNames             = []string{ocsConfigMap}
 	nonPersistentConfigMapsFieldSelector = createFieldNotEqualSelector("metadata.name", persistentConfigMapNames...)
+	persistentDeploymentNames            = []string{"alm-operator", "catalog-operator"}
+	nonPersistentDeploymentFieldSelector = createFieldNotEqualSelector("metadata.name", persistentDeploymentNames...)
 )
 
 func init() {
@@ -56,6 +58,33 @@ func init() {
 	}
 	flag.Set("logtostderr", "true")
 	flag.Parse()
+	cleaner = newNamespaceCleaner(testNamespace)
+}
+
+type namespaceCleaner struct {
+	namespace      string
+	skipCleanupOLM bool
+}
+
+func newNamespaceCleaner(namespace string) *namespaceCleaner {
+	return &namespaceCleaner{
+		namespace:      namespace,
+		skipCleanupOLM: false,
+	}
+}
+
+// notifyOnFailure checks if a test has failed or cleanup is true before cleaning a namespace
+func (c *namespaceCleaner) NotifyTestComplete(t *testing.T, cleanup bool) {
+	if t.Failed() {
+		c.skipCleanupOLM = true
+	}
+
+	if c.skipCleanupOLM || !cleanup {
+		t.Log("skipping cleanup")
+		return
+	}
+
+	cleanupOLM(t, c.namespace)
 }
 
 // newKubeClient configures a client to talk to the cluster defined by KUBECONFIG
@@ -244,21 +273,19 @@ func createFieldNotEqualSelector(field string, names ...string) string {
 	return builder.String()
 }
 
-func cleanupOLM(t *testing.T, namespace string) {
-	if skipCleanupOLM || t.Failed() {
-		// Skip cleaning up if the test has failed
-		skipCleanupOLM = true
-		t.Log("skipping cleanup")
-		return
+func logDeleteWaitingMessage(t *testing.T, objects []metav1.Object) {
+	for i, object := range objects {
+		t.Logf("waiting for %s (%d/%d) %s to be deleted...", object.GetSelfLink(), i+1, len(objects), object.GetName())
 	}
+}
 
-	var immediate int64 = 0
+func cleanupOLM(t *testing.T, namespace string) {
 	crc := newCRClient(t)
 	c := newKubeClient(t)
 
 	// Cleanup non persistent OLM CRs
 	t.Log("Cleaning up any remaining non persistent resources...")
-	deleteOptions := &metav1.DeleteOptions{GracePeriodSeconds: &immediate}
+	deleteOptions := &metav1.DeleteOptions{}
 	listOptions := metav1.ListOptions{}
 	require.NoError(t, crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).DeleteCollection(deleteOptions, listOptions))
 	require.NoError(t, crc.OperatorsV1alpha1().InstallPlans(namespace).DeleteCollection(deleteOptions, listOptions))
@@ -267,6 +294,72 @@ func cleanupOLM(t *testing.T, namespace string) {
 
 	// Cleanup non persistent configmaps
 	require.NoError(t, c.KubernetesInterface().CoreV1().ConfigMaps(namespace).DeleteCollection(deleteOptions, metav1.ListOptions{FieldSelector: nonPersistentConfigMapsFieldSelector}))
+
+	// Cleanup non persistent deployments
+	require.NoError(t, c.KubernetesInterface().AppsV1().Deployments(namespace).DeleteCollection(deleteOptions, metav1.ListOptions{FieldSelector: nonPersistentDeploymentFieldSelector}))
+
+	// Wait for deletion
+	listOptions.IncludeUninitialized = true
+	require.NoError(t, wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		// Count remaining resources
+		remaining := 0
+		csvs, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(listOptions)
+		if err != nil {
+			return false, err
+		}
+		for i, csv := range csvs.Items {
+			t.Logf("waiting for csv (%d/%d) %s to be deleted...", i+1, len(csvs.Items), csv.GetName())
+		}
+		remaining += len(csvs.Items)
+
+		installPlans, err := crc.OperatorsV1alpha1().InstallPlans(namespace).List(listOptions)
+		if err != nil {
+			return false, err
+		}
+		for i, installPlan := range installPlans.Items {
+			t.Logf("waiting for installplan (%d/%d) %s to be deleted...", i+1, len(installPlans.Items), installPlan.GetName())
+		}
+		remaining += len(installPlans.Items)
+
+		subscriptions, err := crc.OperatorsV1alpha1().Subscriptions(namespace).List(listOptions)
+		if err != nil {
+			return false, err
+		}
+		for i, subscription := range subscriptions.Items {
+			t.Logf("waiting for subscription (%d/%d) %s to be deleted...", i+1, len(subscriptions.Items), subscription.GetName())
+		}
+		remaining += len(subscriptions.Items)
+
+		catalogSources, err := crc.OperatorsV1alpha1().CatalogSources(namespace).List(metav1.ListOptions{FieldSelector: nonPersistentConfigMapsFieldSelector, IncludeUninitialized: true})
+		if err != nil {
+			return false, err
+		}
+		for i, catalogSource := range catalogSources.Items {
+			t.Logf("waiting for catalogsource (%d/%d) %s to be deleted...", i+1, len(catalogSources.Items), catalogSource.GetName())
+		}
+		remaining += len(catalogSources.Items)
+
+		configMaps, err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).List(metav1.ListOptions{FieldSelector: nonPersistentConfigMapsFieldSelector, IncludeUninitialized: true})
+		if err != nil {
+			return false, err
+		}
+		for i, configMap := range configMaps.Items {
+			t.Logf("waiting for configmap (%d/%d) %s to be deleted...", i+1, len(configMaps.Items), configMap.GetName())
+		}
+		remaining += len(configMaps.Items)
+
+		deployments, err := c.KubernetesInterface().AppsV1().Deployments(namespace).List(metav1.ListOptions{FieldSelector: nonPersistentDeploymentFieldSelector, IncludeUninitialized: true})
+		if err != nil {
+			return false, err
+		}
+		for i, deployment := range deployments.Items {
+			t.Logf("waiting for deployment (%d/%d) %s to be deleted...", i+1, len(deployments.Items), deployment.GetName())
+		}
+		remaining += len(deployments.Items)
+		t.Logf("Remaining resources: %d", remaining)
+
+		return remaining == 0, nil
+	}))
 }
 
 func buildCatalogSourceCleanupFunc(t *testing.T, crc versioned.Interface, namespace string, catalogSource *v1alpha1.CatalogSource) cleanupFunc {


### PR DESCRIPTION
### Description

Adds namespace awareness to installplan execution. 

Executing an installplan will now fail if a resolved CSV step resource shares an owned CRD with any pre-existing CSVs in the installplan's namespace. If the pre-existing CSV is the same as the resolved CSV step or the resolved CSV step is directly referenced by the installplan (i.e. present in InstallPlan.Spec.ClusterServiceVersionNames), execution continues normally.

Related to [ALM-469](https://jira.coreos.com/browse/ALM-469)