### PR TITLE
Set Status on Subscription with Invalid Catalog Source

### DIFF
--- a/pkg/api/apis/operators/v1alpha1/subscription_types.go
+++ b/pkg/api/apis/operators/v1alpha1/subscription_types.go
@@ -16,9 +16,15 @@ type SubscriptionState string
 
 const (
 	SubscriptionStateNone             = ""
+	SubscriptionStateFailed           = "UpgradeFailed"
 	SubscriptionStateUpgradeAvailable = "UpgradeAvailable"
 	SubscriptionStateUpgradePending   = "UpgradePending"
 	SubscriptionStateAtLatest         = "AtLatestKnown"
+)
+
+const (
+	SubscriptionReasonInvalidCatalog   ConditionReason = "InvalidCatalog"
+	SubscriptionReasonUpgradeSucceeded ConditionReason = "UpgradeSucceeded"
 )
 
 // SubscriptionSpec defines an Application that can be installed
@@ -46,6 +52,7 @@ type SubscriptionStatus struct {
 	Install    *InstallPlanReference `json:"installplan,omitempty"`
 
 	State       SubscriptionState `json:"state,omitempty"`
+	Reason      ConditionReason   `json:"reason,omitempty"`
 	LastUpdated metav1.Time       `json:"lastUpdated"`
 }
 

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -225,10 +225,10 @@ func (o *Operator) syncSubscriptions(obj interface{}) (syncError error) {
 	return
 }
 
-func (a *Operator) requeueInstallPlan(name, namespace string) {
+func (o *Operator) requeueInstallPlan(name, namespace string) {
 	// we can build the key directly, will need to change if queue uses different key scheme
 	key := fmt.Sprintf("%s/%s", namespace, name)
-	a.subQueue.AddRateLimited(key)
+	o.subQueue.AddRateLimited(key)
 	return
 }
 

--- a/pkg/controller/operators/catalog/subscriptions.go
+++ b/pkg/controller/operators/catalog/subscriptions.go
@@ -46,6 +46,8 @@ func (o *Operator) syncSubscription(in *v1alpha1.Subscription) (*v1alpha1.Subscr
 	}
 	catalog, ok := o.sources[registry.ResourceKey{Name: out.Spec.CatalogSource, Namespace: catalogNamespace}]
 	if !ok {
+		out.Status.State = v1alpha1.SubscriptionStateAtLatest
+		out.Status.Reason = v1alpha1.SubscriptionReasonInvalidCatalog
 		return out, fmt.Errorf("unknown catalog source %s in namespace %s", out.Spec.CatalogSource, catalogNamespace)
 	}
 


### PR DESCRIPTION
### Description

Adds a `status` block when a `Subscription` fails to resolve against a non-existent `CatalogSource`. Precursor to adding full `status.conditions`.

Resolves https://jira.coreos.com/browse/ALM-681