### PR TITLE
fix(e2e): remove deployment cleanup

### DIFF
--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -77,6 +77,7 @@ func fetchInstallPlan(t *testing.T, c versioned.Interface, name string, checkPha
 		if err != nil || fetchedInstallPlan == nil {
 			return false, err
 		}
+
 		return checkPhase(fetchedInstallPlan), nil
 	})
 	return fetchedInstallPlan, err

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -47,8 +47,6 @@ var (
 	nonPersistentCatalogsFieldSelector   = createFieldNotEqualSelector("metadata.name", persistentCatalogNames...)
 	persistentConfigMapNames             = []string{ocsConfigMap}
 	nonPersistentConfigMapsFieldSelector = createFieldNotEqualSelector("metadata.name", persistentConfigMapNames...)
-	persistentDeploymentNames            = []string{"alm-operator", "catalog-operator"}
-	nonPersistentDeploymentFieldSelector = createFieldNotEqualSelector("metadata.name", persistentDeploymentNames...)
 )
 
 func init() {
@@ -289,9 +287,6 @@ func cleanupOLM(t *testing.T, namespace string) {
 
 	// Cleanup non persistent configmaps
 	require.NoError(t, c.KubernetesInterface().CoreV1().ConfigMaps(namespace).DeleteCollection(deleteOptions, metav1.ListOptions{FieldSelector: nonPersistentConfigMapsFieldSelector}))
-
-	// Cleanup non persistent deployments
-	require.NoError(t, c.KubernetesInterface().AppsV1().Deployments(namespace).DeleteCollection(deleteOptions, metav1.ListOptions{FieldSelector: nonPersistentDeploymentFieldSelector}))
 }
 
 func buildCatalogSourceCleanupFunc(t *testing.T, crc versioned.Interface, namespace string, catalogSource *v1alpha1.CatalogSource) cleanupFunc {


### PR DESCRIPTION
### Description

Removes deployment cleanup from cleanupOLM. 

Cleaning up deployments between tests can sometimes cause an infinite wait in the operatorclient's
waitForDeploymentRollout method.