### PR TITLE
fix(operatorclient): remove wait for deployment rollout

### DIFF
--- a/pkg/lib/operatorclient/deployment.go
+++ b/pkg/lib/operatorclient/deployment.go
@@ -145,9 +145,6 @@ func (c *Client) RollingPatchDeploymentMigrations(namespace, name string, f Patc
 	if err != nil {
 		return nil, false, err
 	}
-	if err = c.waitForDeploymentRollout(updated); err != nil {
-		return nil, false, err
-	}
 
 	return updated, current.GetResourceVersion() != updated.GetResourceVersion(), nil
 }


### PR DESCRIPTION
### Description

Removes infinite wait for deployment rollout and allows transitionCSVState(...) to handle deployment status checks.