### PR TITLE
feat(subscription): add dedicated currentCSV field to subscription

### DIFF
--- a/pkg/api/apis/operators/v1alpha1/subscription_types.go
+++ b/pkg/api/apis/operators/v1alpha1/subscription_types.go
@@ -48,8 +48,9 @@ type Subscription struct {
 }
 
 type SubscriptionStatus struct {
-	CurrentCSV string                `json:"installedCSV,omitempty"`
-	Install    *InstallPlanReference `json:"installplan,omitempty"`
+	CurrentCSV   string                `json:"currentCSV,omitempty"`
+	InstalledCSV string                `json:"installedCSV, omitempty"`
+	Install      *InstallPlanReference `json:"installplan,omitempty"`
 
 	State       SubscriptionState `json:"state,omitempty"`
 	Reason      ConditionReason   `json:"reason,omitempty"`

--- a/pkg/controller/operators/catalog/subscriptions.go
+++ b/pkg/controller/operators/catalog/subscriptions.go
@@ -119,6 +119,9 @@ func (o *Operator) syncSubscription(in *v1alpha1.Subscription) (*v1alpha1.Subscr
 		return out, nil
 	}
 
+	// Set the installed CSV
+	out.Status.InstalledCSV = out.Status.CurrentCSV
+
 	// Poll catalog for an update
 	repl, err := catalog.FindReplacementCSVForPackageNameUnderChannel(out.Spec.Package, out.Spec.Channel, out.Status.CurrentCSV)
 	if err != nil {

--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -813,9 +813,10 @@ func TestSyncSubscription(t *testing.T) {
 						Channel:       "magical",
 					},
 					Status: v1alpha1.SubscriptionStatus{
-						CurrentCSV: "next",
-						Install:    nil,
-						State:      v1alpha1.SubscriptionStateUpgradeAvailable,
+						CurrentCSV:   "next",
+						InstalledCSV: "toupgrade",
+						Install:      nil,
+						State:        v1alpha1.SubscriptionStateUpgradeAvailable,
 					},
 				},
 			},


### PR DESCRIPTION
### Description

Adds a dedicated currentCSV field to subscription status and only sets
the installedCSV field when a CSV is successfully installed.

Addresses [ALM-605](https://jira.coreos.com/browse/ALM-605)