### PR TITLE
fix(build): Fix install_local.sh calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,13 @@ run-local:
 	. ./scripts/build_local.sh
 	mkdir -p build/resources
 	. ./scripts/package-release.sh 1.0.0-local build/resources Documentation/install/local-values.yaml
-	. ./scripts/install_local.sh local build/resources
+	. ./scripts/install_local.sh local build/resources/templates
 
 run-local-shift:
 	. ./scripts/build_local_shift.sh
 	mkdir -p build/resources
 	. ./scripts/package-release.sh 1.0.0-local build/resources Documentation/install/local-values-shift.yaml
-	. ./scripts/install_local.sh local build/resources
+	. ./scripts/install_local.sh local build/resources/templates
 
 e2e-local:
 	. ./scripts/build_local.sh


### PR DESCRIPTION
Update the template directory of the install_local.sh calls in the run-local and run-local-shift targets.