### PR TITLE
Fix Local Console Script with Minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ This will keep the etcd `ClusterServiceVersion` up to date as new versions becom
 
 Use the OpenShift admin console (compatible with upstream Kubernetes) to interact with and visualize the resources managed by OLM. Create subscriptions, approve install plans, identify Operator-managed resources, and more.
 
-Ensure `$KUBECONFIG` environment variable is set and run:
+Ensure `kubectl` is pointing at a cluster and run:
 
 ```shell
 $ ./scripts/run_console_local.sh
 ```
 
-Then visit `http://localhost:9000` to view the console
+Then visit `http://localhost:9000` to view the console.
 
 **Subscription detail view:**
 ![screenshot_20180628_165240](https://user-images.githubusercontent.com/11700385/42060125-c3cde42c-7af3-11e8-87ec-e5910a554902.png)

--- a/scripts/run_console_local.sh
+++ b/scripts/run_console_local.sh
@@ -3,8 +3,13 @@
 secretname=$(kubectl get serviceaccount default --namespace=kube-system -o jsonpath='{.secrets[0].name}')
 endpoint=$(kubectl config view -o json | jq '{myctx: .["current-context"], ctxs: .contexts[], clusters: .clusters[]}' | jq 'select(.myctx == .ctxs.name)' | jq 'select(.ctxs.context.cluster ==  .clusters.name)' | jq '.clusters.cluster.server' -r)
 
+args="--net=host"
+if [[ $OSTYPE == darwin* ]]; then 
+  args="-p 9000:9000"
+fi
+
 echo "Using $endpoint"
-docker run -it -p 9000:9000 \
+docker run -it $args \
   -e BRIDGE_USER_AUTH="disabled" \
   -e BRIDGE_K8S_MODE="off-cluster" \
   -e BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$endpoint \


### PR DESCRIPTION
### Description

Need to use `--net=host` when running against a locally hosted cluster (like `minikube` or `oc cluster up`).

Fixes https://github.com/operator-framework/operator-lifecycle-manager/issues/437