### PR TITLE
feat(catalog): add aggregated roles for each resolved CRD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@
   - charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`;mkdir -p ${charttmpdir};helm template -n olm --set namespace=operator-lifecycle-manager deploy/chart --set alm.image.ref=quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8}
     --set catalog.image.ref=quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog_namespace=operator-lifecycle-manager --set namespace=operator-lifecycle-manager --set package.image.ref=quay.io/coreos/package-server:${CI_COMMIT_REF_SLUG}-${SHA8}
     --set watchedNamespaces= --output-dir ${charttmpdir};chartfilenames=$(ls ${charttmpdir}/olm/templates/*.yaml);echo ${chartfilenames};for f in ${chartfilenames};do kubectl replace --force -f ${f};done;
-  - kubectl rollout status -w deployment/alm-operator --namespace=operator-lifecycle-manager
+  - kubectl rollout status -w deployment/olm-operator --namespace=operator-lifecycle-manager
   - kubectl rollout status -w deployment/catalog-operator --namespace=operator-lifecycle-manager
   - kubectl rollout status -w deployment/package-server --namespace=operator-lifecycle-manager
   - 'curl -X POST --data-urlencode "payload={\"text\": \"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${TEAMUI_HOST}/k8s/ns/operator-lifecycle-manager/deployments/alm-operator\"}"
@@ -121,7 +121,7 @@ deploy-openshift:
   - charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`;mkdir -p ${charttmpdir};helm template -n olm --set namespace=operator-lifecycle-manager deploy/chart --set alm.image.ref=quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8}
     --set catalog.image.ref=quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog_namespace=operator-lifecycle-manager --set namespace=operator-lifecycle-manager --set package.image.ref=quay.io/coreos/package-server:${CI_COMMIT_REF_SLUG}-${SHA8}
     --set watchedNamespaces= --output-dir ${charttmpdir};chartfilenames=$(ls ${charttmpdir}/olm/templates/*.yaml);echo ${chartfilenames};for f in ${chartfilenames};do kubectl replace --force -f ${f};done;
-  - kubectl rollout status -w deployment/alm-operator --namespace=operator-lifecycle-manager
+  - kubectl rollout status -w deployment/olm-operator --namespace=operator-lifecycle-manager
   - kubectl rollout status -w deployment/catalog-operator --namespace=operator-lifecycle-manager
   - kubectl rollout status -w deployment/package-server --namespace=operator-lifecycle-manager
   - 'curl -X POST --data-urlencode "payload={\"text\": \"New OLM Operator quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHA} deployed to ${OPENSHIFT_HOST}/k8s/ns/operator-lifecycle-manager/deployments/alm-operator\"}"
@@ -158,7 +158,7 @@ deploy-preview:
     --set catalog.image.ref=quay.io/coreos/catalog-ci:${CI_COMMIT_REF_SLUG}-pre --set catalog_namespace=operator-lifecycle-manager --set namespace=ci-alm-${CI_COMMIT_REF_SLUG} --set package.image.ref=quay.io/coreos/package-server-ci:${CI_COMMIT_REF_SLUG}-pre
     --set watchedNamespaces=ci-alm-${CI_COMMIT_REF_SLUG} --output-dir ${charttmpdir};chartfilenames=$(ls ${charttmpdir}/olm/templates/*.yaml);echo ${chartfilenames};for f in ${chartfilenames};do kubectl
     replace --force -f ${f};done;
-  - kubectl rollout status -w deployment/alm-operator --namespace=ci-alm-${CI_COMMIT_REF_SLUG}
+  - kubectl rollout status -w deployment/olm-operator --namespace=ci-alm-${CI_COMMIT_REF_SLUG}
   - kubectl rollout status -w deployment/catalog-operator --namespace=ci-alm-${CI_COMMIT_REF_SLUG}
   - kubectl rollout status -w deployment/package-server --namespace=ci-alm-${CI_COMMIT_REF_SLUG}
   stage: deploy_preview
@@ -190,7 +190,7 @@ deploy-staging:
     --set catalog.image.ref=quay.io/coreos/catalog:${CI_COMMIT_REF_SLUG}-${SHA8} --set catalog_namespace=operator-lifecycle-manager --set namespace=ci-alm-staging --set package.image.ref=quay.io/coreos/package-server:${CI_COMMIT_REF_SLUG}-${SHA8}
     --set watchedNamespaces=ci-alm-staging --output-dir ${charttmpdir};chartfilenames=$(ls ${charttmpdir}/olm/templates/*.yaml);echo ${chartfilenames};for f in ${chartfilenames};do kubectl replace --force
     -f ${f};done;
-  - kubectl rollout status -w deployment/alm-operator --namespace=ci-alm-staging
+  - kubectl rollout status -w deployment/olm-operator --namespace=ci-alm-staging
   - kubectl rollout status -w deployment/catalog-operator --namespace=ci-alm-staging
   - kubectl rollout status -w deployment/package-server --namespace=ci-alm-staging
   stage: deploy_staging
@@ -220,7 +220,7 @@ e2e-setup:
     --set catalog.image.ref=quay.io/coreos/catalog-ci:${CI_COMMIT_REF_SLUG}-pre --set catalog_namespace=e2e-${CI_COMMIT_REF_SLUG}-${SHA8} --set namespace=e2e-${CI_COMMIT_REF_SLUG}-${SHA8} --set package.image.ref=quay.io/coreos/package-server-ci:${CI_COMMIT_REF_SLUG}-pre
     --set watchedNamespaces=e2e-${CI_COMMIT_REF_SLUG}-${SHA8} --output-dir ${charttmpdir};chartfilenames=$(ls ${charttmpdir}/olm/templates/*.yaml);echo ${chartfilenames};for f in ${chartfilenames};do kubectl
     replace --force -f ${f};done;
-  - kubectl rollout status -w deployment/alm-operator --namespace=e2e-${CI_COMMIT_REF_SLUG}-${SHA8}
+  - kubectl rollout status -w deployment/olm-operator --namespace=e2e-${CI_COMMIT_REF_SLUG}-${SHA8}
   - kubectl rollout status -w deployment/catalog-operator --namespace=e2e-${CI_COMMIT_REF_SLUG}-${SHA8}
   - kubectl rollout status -w deployment/package-server --namespace=e2e-${CI_COMMIT_REF_SLUG}-${SHA8}
   stage: test_setup

--- a/.gitlab-ci/base_jobs.libsonnet
+++ b/.gitlab-ci/base_jobs.libsonnet
@@ -127,7 +127,7 @@ local appr = utils.appr;
                                  "$DOCKER_USER",
                                  "$DOCKER_PASS") +
             helm.templateApply("olm", _vars.chart, _vars.namespace, _vars.params) +
-            k8s.waitForDeployment("alm-operator", _vars.namespace) +
+            k8s.waitForDeployment("olm-operator", _vars.namespace) +
             k8s.waitForDeployment("catalog-operator", _vars.namespace) +
             k8s.waitForDeployment("package-server", _vars.namespace),
     } + job_tags,

--- a/deploy/chart/templates/12-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/12-olm-operator.deployment.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: alm-operator
+  name: olm-operator
   namespace: {{ .Values.namespace }}
   labels:
-    app: alm-operator
+    app: olm-operator
 spec:
   strategy:
     type: RollingUpdate
   replicas: {{ .Values.alm.replicaCount }}
   selector:
     matchLabels:
-      app: alm-operator
+      app: olm-operator
   template:
     metadata:
       labels:
-        app: alm-operator
+        app: olm-operator
     spec:
       serviceAccountName: olm-operator-serviceaccount
       containers:
-        - name: alm-operator
+        - name: olm-operator
           command:
           - /bin/olm
           {{- if .Values.watchedNamespaces }}
@@ -47,7 +47,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: OPERATOR_NAME
-            value: alm-operator
+            value: olm-operator
           {{- if .Values.alm.resources }}
           resources:
 {{ toYaml .Values.alm.resources | indent 12 }}

--- a/scripts/install_local.sh
+++ b/scripts/install_local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Note: run from root
+# Note: run from root dir
 
 set -e
 
@@ -14,36 +14,16 @@ fi
 namespace=$1
 chart=$2
 
-# create alm NS
+# create OLM NS
 kubectl create ns ${namespace} || { echo 'ns exists'; }
 
-# create alm
+# create OLM
 for f in ${chart}/*.yaml
 do
 	kubectl replace --force -f ${f}
 done
 
-# wait for deployments to be ready (loop can be removed when rollout status -w actually works)
-n=0
-until [ $n -ge 5 ]
-do
-  kubectl rollout status -w deployment/alm-operator --namespace=${namespace} && break
-  n=$[$n+1]
-  sleep 1
-done
-
-n=0
-until [ $n -ge 5 ]
-do
-  kubectl rollout status -w deployment/catalog-operator --namespace=${namespace} && break
-  n=$[$n+1]
-  sleep 1
-done
-
-n=0
-until [ $n -ge 5 ]
-do
-  kubectl rollout status -w deployment/package-server --namespace=${namespace} && break
-  n=$[$n+1]
-  sleep 1
-done
+# wait for deployments to be ready
+kubectl rollout status -w deployment/olm-operator --namespace=${namespace}
+kubectl rollout status -w deployment/catalog-operator --namespace=${namespace}
+kubectl rollout status -w deployment/package-server --namespace=${namespace}


### PR DESCRIPTION
For each CRD resolved in an installplan, also generate:

- `edit-<crd>-<crd-version>` which gives edit access to the CRs
- `view-<crd>-<crd-version>` which gives view access to the CRs

Both of them get aggregated to the global `view`, `edit`, and `admin` roles
