### PR TITLE
docs: install OLM with 'kubectl create -f' instead of 'kubectl apply -f'

### DIFF
--- a/Documentation/install/install.md
+++ b/Documentation/install/install.md
@@ -5,7 +5,7 @@ OLM deployment resources are templated so that they can be easily configured for
 ## Install the latest released version of OLM for upstream Kubernetes
 
 ```sh
-kubectl apply -f deploy/upstream/manifests/0.4.0
+kubectl create -f deploy/upstream/manifests/0.6.0
 ```
 
 ## Install with Ansible for openshift


### PR DESCRIPTION
## Changes:
 - `kubectl apply -f` to `kubectl create -f`
 - OLM manifest from `0.4.0` to `0.6.0` to reflect latest release

## Rationale:
Trying to install OLM release 0.6.0 onto Origin v3.11 with `oc apply -f` leads to the error shown below:

```bash
$ oc apply -f deploy/upstream/manifests/0.6.0/
serviceaccount/olm-operator-serviceaccount created
clusterrolebinding.rbac.authorization.k8s.io/olm-operator-binding-kube-system created
customresourcedefinition.apiextensions.k8s.io/clusterserviceversions.operators.coreos.com created
customresourcedefinition.apiextensions.k8s.io/catalogsources.operators.coreos.com created
customresourcedefinition.apiextensions.k8s.io/installplans.operators.coreos.com created
customresourcedefinition.apiextensions.k8s.io/subscriptions.operators.coreos.com created
catalogsource.operators.coreos.com/ocs created
deployment.apps/alm-operator created
deployment.apps/catalog-operator created
clusterrole.rbac.authorization.k8s.io/aggregate-olm-edit created
clusterrole.rbac.authorization.k8s.io/aggregate-olm-view created
The ConfigMap "ocs" is invalid: metadata.annotations: Too long: must have at most 262144 characters
```


Using `oc create -f` instead allows for successful creation of resources:
```bash
$ oc create -f deploy/upstream/manifests/0.6.0/
serviceaccount/olm-operator-serviceaccount created
clusterrolebinding.rbac.authorization.k8s.io/olm-operator-binding-kube-system created
customresourcedefinition.apiextensions.k8s.io/clusterserviceversions.operators.coreos.com created
customresourcedefinition.apiextensions.k8s.io/catalogsources.operators.coreos.com created
customresourcedefinition.apiextensions.k8s.io/installplans.operators.coreos.com created
customresourcedefinition.apiextensions.k8s.io/subscriptions.operators.coreos.com created
configmap/ocs created
catalogsource.operators.coreos.com/ocs created
deployment.apps/alm-operator created
deployment.apps/catalog-operator created
clusterrole.rbac.authorization.k8s.io/aggregate-olm-edit created
clusterrole.rbac.authorization.k8s.io/aggregate-olm-view created
```