### PR TITLE
[WIP] fix(ci): add pipeline queueing

### DIFF
--- a/.gitlab-ci.jsonnet
+++ b/.gitlab-ci.jsonnet
@@ -9,6 +9,7 @@ local stages_list = [
     'docker_base',
     'docker_build',
     'deploy_preview',
+    'wait_in_queue',
     'test_setup',
     'tests',
     'test_teardown',
@@ -74,6 +75,10 @@ local jobs = {
 
     } + onlyMaster,
 
+    'wait-in-queue': baseJob.WaitInQueue {
+        stage: stages.wait_in_queue,
+    },
+    
     // Unit-tests
     local unittest_stage = baseJob.AlmTest {
         stage: stages.tests,
@@ -89,9 +94,6 @@ local jobs = {
         ],
     },
 
-    'wait-in-queue': baseJob.WaitInQueue {
-        stage: stages.test_setup,
-    },
 
     'e2e-setup': baseJob.Deploy {
         local _vars = self.localvars,
@@ -110,7 +112,7 @@ local jobs = {
         },
         stage: stages.test_teardown,
     },
-    
+
     // End2End tests
     local integration_test = baseJob.EndToEndTest {
         stage: stages.tests,

--- a/.gitlab-ci.jsonnet
+++ b/.gitlab-ci.jsonnet
@@ -89,6 +89,10 @@ local jobs = {
         ],
     },
 
+    'wait-in-queue': baseJob.WaitInQueue {
+        stage: stages.test_setup,
+    },
+
     'e2e-setup': baseJob.Deploy {
         local _vars = self.localvars,
         localvars+:: {
@@ -106,7 +110,7 @@ local jobs = {
         },
         stage: stages.test_teardown,
     },
-
+    
     // End2End tests
     local integration_test = baseJob.EndToEndTest {
         stage: stages.tests,

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -325,3 +325,10 @@ unit-tests:
 variables:
   FAILFASTCI_NAMESPACE: operator-framework
   GET_SOURCES_ATTEMPTS: '10'
+wait-in-queue:
+  image: quay.io/coreos/alm-e2e
+  script:
+  - . ${CI_PROJECT_DIR}/scripts/wait_in_queue.sh $CI_PROJECT_URL $CI_PIPELINE_ID
+  stage: test_setup
+  tags:
+  - kubernetes

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,6 +275,7 @@ stages:
 - docker_base
 - docker_build
 - deploy_preview
+- wait_in_queue
 - test_setup
 - tests
 - test_teardown
@@ -329,6 +330,6 @@ wait-in-queue:
   image: quay.io/coreos/alm-e2e
   script:
   - . ${CI_PROJECT_DIR}/scripts/wait_in_queue.sh $CI_PROJECT_URL $CI_PIPELINE_ID
-  stage: test_setup
+  stage: wait_in_queue
   tags:
   - kubernetes

--- a/.gitlab-ci/base_jobs.libsonnet
+++ b/.gitlab-ci/base_jobs.libsonnet
@@ -30,6 +30,14 @@ local appr = utils.appr;
         image: vars.images.ci.alm.name,
     } + job_tags,
 
+    WaitInQueue: {
+        image: vars.images.e2e.repo,
+        script:
+            [
+                ". ${CI_PROJECT_DIR}/scripts/wait_in_queue.sh $CI_PROJECT_URL $CI_PIPELINE_ID",
+            ],
+    } + job_tags,
+
 
     EndToEndTest: {
         local _vars = self.localvars,

--- a/scripts/wait_in_queue.sh
+++ b/scripts/wait_in_queue.sh
@@ -17,7 +17,7 @@ gitlab_pipeline_id="$2"
 function is_head {
     ids="$(curl -s $gitlab_project_url | jq -c '.pipelines | map(.id) | sort')"
     length="$(echo $ids | jq -c 'length')"
-    if [[ length -gt 0 ]] && [[ "$gitlab_pipeline_id" -ne "$(echo $ids | jq -c '.[0]')" ]]; then
+    if [[ length -gt 1 ]] && [[ "$gitlab_pipeline_id" -ne "$(echo $ids | jq -c '.[0]')" ]]; then
         return 1
     fi
     echo "at head of pipeline queue. exiting"

--- a/scripts/wait_in_queue.sh
+++ b/scripts/wait_in_queue.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ ${#@} < 2 ]]; then
+    echo "Usage: $0 gitlab_project_url"
+    echo "* gitlab_project_url: URL of the gitlab project to queue on"
+    echo "* gitlab_pipeline_id: ID of the gitlab pipeline to queue as"
+    # echo "* gitlab_api_token: API token to use when accessing gitlab"
+    exit 1
+fi
+
+gitlab_project_url="${1}/pipelines.json/?scope=running"
+gitlab_pipeline_id="$2"
+# gitlab_api_token="$3"
+
+function isHead {
+    ids="$(curl -s $gitlab_project_url | jq -c '.pipelines | map(.id) | sort')"
+    length="$(echo $ids | jq -c 'length')"
+    if [[ length -gt 0 ]] && [[ "$gitlab_pipeline_id" -ne "$(echo $ids | jq -c '.[0]')" ]]; then
+        return 1
+    fi
+    echo "at head of pipeline queue. exiting"
+}
+
+# wait until the current pipeline is at the 
+# head of the queue before exiting
+while ! isHead ; do
+    echo "waiting in pipeline queue..."
+    sleep 5
+done

--- a/scripts/wait_in_queue.sh
+++ b/scripts/wait_in_queue.sh
@@ -14,7 +14,7 @@ gitlab_project_url="${1}/pipelines.json/?scope=running"
 gitlab_pipeline_id="$2"
 # gitlab_api_token="$3"
 
-function isHead {
+function is_head {
     ids="$(curl -s $gitlab_project_url | jq -c '.pipelines | map(.id) | sort')"
     length="$(echo $ids | jq -c 'length')"
     if [[ length -gt 0 ]] && [[ "$gitlab_pipeline_id" -ne "$(echo $ids | jq -c '.[0]')" ]]; then
@@ -25,7 +25,7 @@ function isHead {
 
 # wait until the current pipeline is at the 
 # head of the queue before exiting
-while ! isHead ; do
+while ! is_head ; do
     echo "waiting in pipeline queue..."
     sleep 5
 done


### PR DESCRIPTION
### Description

Adds a `wait-in-queue` job to CI which forces a pipeline to wait until it is at the head of the "pipeline queue" (ie. oldest/only pipeline) before applying any Kubernetes resources for end-to-end testing. 

### Motivation

An aggregated-apiserver (package-server) has recently been introduced into OLM's deployment. The aggregated-apiserver requires a cluster-wide APIService resource to be handled by the aggregator. Concurrently running pipelines can replace this resource mid-test and cause confounding results. 
