### PR TITLE
feat(olm): attempt to cleanup namespace annotations on shutdown

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -103,6 +103,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("error configuring operator: %s", err.Error())
 	}
+	defer operator.Cleanup()
 
 	// Serve a health check.
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is just a best-effort attempt at cleaning up for now. Longer term strategy is to not rely on namespace annotations.