### PR TITLE
All Namespaces Support for PackageManifest API 

### DIFF
--- a/pkg/package-server/provider/inmem.go
+++ b/pkg/package-server/provider/inmem.go
@@ -227,7 +227,6 @@ func (m *InMemoryProvider) syncCatalogSource(obj interface{}) error {
 	return nil
 }
 
-// ListPackageManifests implements PackageManifestProvider.ListPackageManifests()
 func (m *InMemoryProvider) ListPackageManifests(namespace string) (*packagev1alpha1.PackageManifestList, error) {
 	manifestList := &packagev1alpha1.PackageManifestList{}
 
@@ -237,7 +236,7 @@ func (m *InMemoryProvider) ListPackageManifests(namespace string) (*packagev1alp
 	if len(m.manifests) > 0 {
 		var matching []packagev1alpha1.PackageManifest
 		for _, manifest := range m.manifests {
-			if manifest.GetNamespace() == namespace {
+			if namespace == metav1.NamespaceAll || manifest.GetNamespace() == namespace {
 				// tack on the csv spec for each channel
 				matching = append(matching, manifest)
 			}
@@ -249,7 +248,6 @@ func (m *InMemoryProvider) ListPackageManifests(namespace string) (*packagev1alp
 	return manifestList, nil
 }
 
-// GetPackageManifest implements PackageManifestProvider.GetPackageManifest(...)
 func (m *InMemoryProvider) GetPackageManifest(namespace, name string) (*packagev1alpha1.PackageManifest, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/pkg/package-server/provider/inmem_test.go
+++ b/pkg/package-server/provider/inmem_test.go
@@ -1,0 +1,119 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	packagev1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/packagemanifest/v1alpha1"
+)
+
+type packageValue struct {
+	name      string
+	namespace string
+}
+
+func packageManifest(value packageValue) packagev1alpha1.PackageManifest {
+	return packagev1alpha1.PackageManifest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      value.name,
+			Namespace: value.namespace,
+		},
+	}
+}
+
+func TestListPackageManifests(t *testing.T) {
+	tests := []struct {
+		namespace        string
+		storedPackages   []packageValue
+		expectedPackages []packageValue
+		description      string
+	}{
+		{
+			namespace:        "default",
+			storedPackages:   []packageValue{},
+			expectedPackages: []packageValue{},
+			description:      "NoPackages",
+		},
+		{
+			namespace:        "default",
+			storedPackages:   []packageValue{{name: "etcd", namespace: "default"}, {name: "prometheus", namespace: "local"}},
+			expectedPackages: []packageValue{{name: "etcd", namespace: "default"}},
+			description:      "FilterNamespace",
+		},
+		{
+			namespace:        metav1.NamespaceAll,
+			storedPackages:   []packageValue{{name: "etcd", namespace: "default"}, {name: "prometheus", namespace: "local"}},
+			expectedPackages: []packageValue{{name: "etcd", namespace: "default"}, {name: "prometheus", namespace: "local"}},
+			description:      "AllNamespaces",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			storedPackages := make(map[packageKey]packagev1alpha1.PackageManifest)
+			for _, value := range test.storedPackages {
+				storedPackages[packageKey{catalogSourceName: "test", catalogSourceNamespace: "default", packageName: value.name}] = packageManifest(value)
+			}
+
+			prov := &InMemoryProvider{
+				Operator:  &queueinformer.Operator{},
+				manifests: storedPackages,
+			}
+
+			manifests, err := prov.ListPackageManifests(test.namespace)
+
+			require.NoError(t, err)
+			require.Equal(t, len(test.expectedPackages), len(manifests.Items))
+			for _, expected := range test.expectedPackages {
+				require.Contains(t, manifests.Items, packageManifest(expected))
+			}
+		})
+	}
+}
+
+func TestGetPackageManifest(t *testing.T) {
+	tests := []struct {
+		namespace       string
+		packageName     string
+		storedPackages  []packageValue
+		expectedPackage packageValue
+		description     string
+	}{
+		{
+			namespace:       "default",
+			packageName:     "etcd",
+			storedPackages:  []packageValue{},
+			expectedPackage: packageValue{},
+			description:     "NoPackages",
+		},
+		{
+			namespace:       "default",
+			packageName:     "etcd",
+			storedPackages:  []packageValue{{name: "etcd", namespace: "default"}, {name: "prometheus", namespace: "local"}},
+			expectedPackage: packageValue{name: "etcd", namespace: "default"},
+			description:     "SingleMatch",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			storedPackages := make(map[packageKey]packagev1alpha1.PackageManifest)
+			for _, value := range test.storedPackages {
+				storedPackages[packageKey{catalogSourceName: "test", catalogSourceNamespace: "default", packageName: value.name}] = packageManifest(value)
+			}
+
+			prov := &InMemoryProvider{
+				Operator:  &queueinformer.Operator{},
+				manifests: storedPackages,
+			}
+
+			manifest, err := prov.GetPackageManifest(test.namespace, test.packageName)
+
+			require.NoError(t, err)
+			require.EqualValues(t, packageManifest(test.expectedPackage), *manifest)
+		})
+	}
+}

--- a/pkg/package-server/server/server.go
+++ b/pkg/package-server/server/server.go
@@ -6,11 +6,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/provider"
-
-	"github.com/spf13/cobra"
-
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/informers"
@@ -24,6 +22,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apiserver"
 	genericpackagemanifests "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apiserver/generic"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/provider"
 )
 
 // NewCommandStartPackageServer provides a CLI handler for 'start master' command
@@ -87,7 +86,7 @@ func NewPackageServerOptions(out, errOut io.Writer) *PackageServerOptions {
 		Authorization:  genericoptions.NewDelegatingAuthorizationOptions(),
 		Features:       genericoptions.NewFeatureOptions(),
 
-		WatchedNamespaces: []string{"local"},
+		WatchedNamespaces: []string{v1.NamespaceAll},
 		WakeupInterval:    5 * time.Minute,
 
 		Debug: false,


### PR DESCRIPTION
### Description

Ensure that all `PackageManifests` are returned when fetching using `--all-namespaces`.

Fixes https://jira.coreos.com/browse/ALM-721