### PR TITLE
Documentation: Change to full path

### DIFF
--- a/Documentation/install/install.md
+++ b/Documentation/install/install.md
@@ -5,14 +5,14 @@ OLM deployment resources are templated so that they can be easily configured for
 ## Install the latest released version of OLM for upstream Kubernetes
 
 ```bash
-kubectl create -f deploy/upstream/manifests/latest
+kubectl create -f deploy/upstream/manifests/latest/
 ```
 
 ## Install the latest release version of OLM for okd
 
 ```bash
 oc create namespace operator-lifecycle-manager
-oc create -f deploy/okd/manifests/latest
+oc create -f deploy/okd/manifests/latest/
 ```
 
 ## Install with Ansible for openshift


### PR DESCRIPTION
Because directory is a symlink kubectl create fails to read the dir,
adding a / at the end prevents that from happening.