### PR TITLE
feat(ci): push tags to quay

### DIFF
--- a/.gitlab-ci.jsonnet
+++ b/.gitlab-ci.jsonnet
@@ -63,7 +63,7 @@ local jobs = {
     },
 
     'container-release': baseJob.dockerBuild {
-        // ! Only master/tags
+        // ! Only master
         // push the container to the 'prod' repository
         stage: stages.docker_release,
         before_script+: ["mkdir -p $PWD/bin"],
@@ -72,8 +72,21 @@ local jobs = {
             docker.rename(images.prerelease.catalog.name, images.release.catalog.name) +
             docker.rename(images.prerelease.package.name, images.release.package.name) +
             docker.rename(images.e2e.name, images.e2elatest.name),
+        only: ['master'],
+    },
 
-    } + onlyMaster,
+    'tag-release': baseJob.dockerBuild {
+        // ! Only tags
+        // push the container to the 'prod' repository
+        stage: stages.docker_release,
+        before_script+: ["mkdir -p $PWD/bin"],
+        script:
+            docker.rename(images.prerelease.alm.name, images.tag.alm.name) +
+            docker.rename(images.prerelease.catalog.name, images.tag.catalog.name) +
+            docker.rename(images.prerelease.package.name, images.tag.package.name) +
+            docker.rename(images.e2e.name, images.e2elatest.name),
+        only: ['tags'],
+    },
 
     'wait-in-queue': baseJob.WaitInQueue {
         stage: stages.wait_in_queue,

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,6 @@ container-release:
   image: docker:git
   only:
   - master
-  - tags
   script:
   - docker pull quay.io/coreos/alm-ci:${CI_COMMIT_REF_SLUG}-pre
   - docker tag quay.io/coreos/alm-ci:${CI_COMMIT_REF_SLUG}-pre quay.io/coreos/olm:${CI_COMMIT_REF_SLUG}-${SHA8}
@@ -308,6 +307,32 @@ stop-preview:
     GIT_STRATEGY: none
     K8S_NAMESPACE: ci-alm-${CI_COMMIT_REF_SLUG}
   when: manual
+tag-release:
+  before_script:
+  - docker login -u $DOCKER_USER -p $DOCKER_PASS quay.io
+  - mkdir -p $PWD/bin
+  image: docker:git
+  only:
+  - tags
+  script:
+  - docker pull quay.io/coreos/alm-ci:${CI_COMMIT_REF_SLUG}-pre
+  - docker tag quay.io/coreos/alm-ci:${CI_COMMIT_REF_SLUG}-pre quay.io/coreos/olm:${CI_COMMIT_TAG}
+  - docker push quay.io/coreos/olm:${CI_COMMIT_TAG}
+  - docker pull quay.io/coreos/catalog-ci:${CI_COMMIT_REF_SLUG}-pre
+  - docker tag quay.io/coreos/catalog-ci:${CI_COMMIT_REF_SLUG}-pre quay.io/coreos/catalog:${CI_COMMIT_TAG}
+  - docker push quay.io/coreos/catalog:${CI_COMMIT_TAG}
+  - docker pull quay.io/coreos/package-server-ci:${CI_COMMIT_REF_SLUG}-pre
+  - docker tag quay.io/coreos/package-server-ci:${CI_COMMIT_REF_SLUG}-pre quay.io/coreos/package-server:${CI_COMMIT_TAG}
+  - docker push quay.io/coreos/package-server:${CI_COMMIT_TAG}
+  - docker pull quay.io/coreos/alm-e2e:${CI_COMMIT_REF_SLUG}-${SHA8}
+  - docker tag quay.io/coreos/alm-e2e:${CI_COMMIT_REF_SLUG}-${SHA8} quay.io/coreos/alm-e2e:latest
+  - docker push quay.io/coreos/alm-e2e:latest
+  stage: docker_release
+  tags:
+  - kubernetes
+  variables:
+    DOCKER_DRIVER: overlay2
+    DOCKER_HOST: tcp://docker-host.gitlab.svc.cluster.local:2375
 unit-tests:
   before_script:
   - mkdir -p $GOPATH/src/github.com/operator-framework/operator-lifecycle-manager

--- a/.gitlab-ci/vars.libsonnet
+++ b/.gitlab-ci/vars.libsonnet
@@ -44,6 +44,25 @@ local utils = import "utils.libsonnet";
             },
         },
 
+        tag: {
+            alm: {
+                repo: "quay.io/coreos/olm",
+                tag: "${CI_COMMIT_TAG}",
+                name: utils.containerName(self.repo, self.tag),
+            },
+            catalog: {
+                repo: "quay.io/coreos/catalog",
+                tag: "${CI_COMMIT_TAG}",
+                name: utils.containerName(self.repo, self.tag),
+            },
+            package: {
+                repo: "quay.io/coreos/package-server",
+                tag: "${CI_COMMIT_TAG}",
+                name: utils.containerName(self.repo, self.tag),
+            },
+        },
+
+
         ci: {
             alm: {
                 repo: "quay.io/coreos/alm-ci",


### PR DESCRIPTION
This (should) build tags with the same pipeline as master, but then push to the named tag in quay (e.g. 0.7.0).

The release process gets a tiny bit simpler:

- Bump OLM_VERSION, make a PR, merge
- Tag master with OLM_VERSION
- Run `make release` locally
- Push, make a PR, merge

Not great, but not the worst.