### PR TITLE
change go build to use 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM openshift/origin-base as builder
+FROM openshift/origin-release:golang-1.10 as builder
 RUN yum update -y
-RUN yum install -y golang make git
+RUN yum install -y make git
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
Currently only 1.9 is available in the yum repos for CentOS. Using a
build container that has go 1.10 makes Dockerfile maintenance much
easier than using RPM installation via SCL.