### PR TITLE
Always Return Global `PackageManifests`

### DIFF
--- a/cmd/package-server/main.go
+++ b/cmd/package-server/main.go
@@ -38,6 +38,7 @@ func init() {
 
 	// flags.BoolVar(&options.InsecureKubeletTLS, "kubelet-insecure-tls", options.InsecureKubeletTLS, "Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.")
 	flags.DurationVar(&options.WakeupInterval, "interval", options.WakeupInterval, "Interval at which to re-sync CatalogSources")
+	flags.StringVar(&options.GlobalNamespace, "global-namespace", options.GlobalNamespace, "Name of the namespace where the global CatalogSources are located")
 	flags.StringSliceVar(&options.WatchedNamespaces, "watched-namespaces", options.WatchedNamespaces, "List of namespaces the package-server will watch watch for CatalogSources")
 	flags.StringVar(&options.Kubeconfig, "kubeconfig", options.Kubeconfig, "The path to the kubeconfig used to connect to the Kubernetes API server and the Kubelets (defaults to in-cluster config)")
 	flags.BoolVar(&options.Debug, "debug", options.Debug, "use debug log level")

--- a/deploy/chart/templates/30_13-packageserver.yaml
+++ b/deploy/chart/templates/30_13-packageserver.yaml
@@ -109,6 +109,8 @@ spec:
         - --watched-namespaces
         - {{ .Values.watchedNamespaces }}
         {{- end }}
+        - --global-namespace
+        - {{ .Values.namespace }}
         - --debug
         {{- if .Values.package.commandArgs }}
         - {{ .Values.package.commandArgs }}

--- a/pkg/package-server/provider/interfaces.go
+++ b/pkg/package-server/provider/interfaces.go
@@ -9,5 +9,5 @@ type PackageChan <-chan v1alpha1.PackageManifest
 type PackageManifestProvider interface {
 	Get(namespace, name string) (*v1alpha1.PackageManifest, error)
 	List(namespace string) (*v1alpha1.PackageManifestList, error)
-	Subscribe(stopCh <-chan struct{}) (add, modify, delete PackageChan, err error)
+	Subscribe(namespace string, stopCh <-chan struct{}) (add, modify, delete PackageChan, err error)
 }

--- a/pkg/package-server/provider/provider_fake.go
+++ b/pkg/package-server/provider/provider_fake.go
@@ -36,7 +36,7 @@ func (f *FakeProvider) List(namespace string) (*v1alpha1.PackageManifestList, er
 	return nil, nil
 }
 
-func (f *FakeProvider) Subscribe(stopCh <-chan struct{}) (PackageChan, PackageChan, PackageChan, error) {
+func (f *FakeProvider) Subscribe(namespace string, stopCh <-chan struct{}) (PackageChan, PackageChan, PackageChan, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/pkg/package-server/server/server.go
+++ b/pkg/package-server/server/server.go
@@ -62,8 +62,9 @@ type PackageServerOptions struct {
 	Authorization  *genericoptions.DelegatingAuthorizationOptions
 	Features       *genericoptions.FeatureOptions
 
-	WakeupInterval    time.Duration
+	GlobalNamespace   string
 	WatchedNamespaces []string
+	WakeupInterval    time.Duration
 
 	Kubeconfig string
 
@@ -177,7 +178,7 @@ func (o *PackageServerOptions) Run(stopCh <-chan struct{}) error {
 		return err
 	}
 
-	sourceProvider := provider.NewInMemoryProvider(catsrcSharedIndexInformers, queueOperator)
+	sourceProvider := provider.NewInMemoryProvider(catsrcSharedIndexInformers, queueOperator, o.GlobalNamespace)
 	config.ProviderConfig.Provider = sourceProvider
 	// we should never need to resync, since we're not worried about missing events,
 	// and resync is actually for regular interval-based reconciliation these days,

--- a/pkg/package-server/storage/packagemanifest/watcher.go
+++ b/pkg/package-server/storage/packagemanifest/watcher.go
@@ -43,7 +43,7 @@ func NewWatcher(namespace, name, resourceVersion string, labelSelector labels.Se
 // Run is a blocking method which starts the watch by subscribing to the source.
 // Should run in a goroutine.
 func (w *Watcher) Run(ctx context.Context) {
-	add, modify, delete, err := w.source.Subscribe(w.stop)
+	add, modify, delete, err := w.source.Subscribe(w.namespace, w.stop)
 	if err != nil {
 		return
 	}
@@ -81,21 +81,21 @@ func (w *Watcher) ResultChan() <-chan watch.Event {
 
 func (w *Watcher) Add(manifest v1alpha1.PackageManifest) {
 	// TODO: Handle `resourceVersion`
-	if matches(manifest, w.name, w.namespace, w.labelSelector) {
+	if matches(manifest, w.name, w.labelSelector) {
 		w.send(watch.Event{Type: watch.Added, Object: &manifest})
 	}
 }
 
 func (w *Watcher) Modify(manifest v1alpha1.PackageManifest) {
 	// TODO: Handle `resourceVersion`
-	if matches(manifest, w.name, w.namespace, w.labelSelector) {
+	if matches(manifest, w.name, w.labelSelector) {
 		w.send(watch.Event{Type: watch.Modified, Object: &manifest})
 	}
 }
 
 func (w *Watcher) Delete(lastValue v1alpha1.PackageManifest) {
 	// TODO: Handle `resourceVersion`
-	if matches(lastValue, w.name, w.namespace, w.labelSelector) {
+	if matches(lastValue, w.name, w.labelSelector) {
 		w.send(watch.Event{Type: watch.Deleted, Object: &lastValue})
 	}
 }


### PR DESCRIPTION
### Description

Various improvements to the `package-server`.

### Changes

- Correctly return `HTTP 404` when appropriate
- Add end-to-end test
- Add `PackageManifests` from "global" `CatalogSources` when fetching for a specific namespace

Addresses https://jira.coreos.com/browse/ALM-735
Addresses https://jira.coreos.com/browse/ALM-718
Fixes https://jira.coreos.com/browse/ALM-736