### PR TITLE
Dropping label for origin releasepayload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN make build
 FROM openshift/origin-base
 
 ADD manifests/ /manifests
-LABEL io.openshift.release.operator=true
 
 # Copy the binary to a standard location where it will run.
 COPY --from=builder /go/src/github.com/operator-framework/operator-lifecycle-manager/bin/olm /bin/olm


### PR DESCRIPTION
The olm manifests are blocking ClusterVersionOperator intergration in
`openshift/installer`. 

xref: https://github.com/openshift/installer/pull/330#issuecomment-426119496
cc @smarterclayton 