### PR TITLE
Add missing binary to fix run-local-shift

### DIFF
--- a/e2e-local-shift.Dockerfile
+++ b/e2e-local-shift.Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.10
 WORKDIR /go/src/github.com/operator-framework/operator-lifecycle-manager
 COPY . .
-RUN make build && cp bin/olm /bin/olm && cp bin/catalog /bin/catalog
+RUN make build && cp bin/olm /bin/olm && cp bin/catalog /bin/catalog && cp bin/package-server /bin/package-server
 
 COPY deploy/chart/catalog_resources /var/catalog_resources
 


### PR DESCRIPTION
Fixes the following error when running `make run-local-shift`:
```bash
Waiting for deployment "package-server" rollout to finish: 0 of 1 updated replicas are available...


error: deployment "package-server" exceeded its progress deadline
```
/cc @ecordell 