### PR TITLE
Make use a valid clusterPermissions rule verb

### DIFF
--- a/manifests/30_02-clusterserviceversion.crd.yaml
+++ b/manifests/30_02-clusterserviceversion.crd.yaml
@@ -644,6 +644,7 @@ spec:
                                         - patch
                                         - delete
                                         - deletecollection
+                                        - use
                       clusterPermissions:
                         type: array
                         description: Cluster permissions needed by the deployement to run correctly


### PR DESCRIPTION
"use" is a valid verb for RBAC in openshift 3.11 for SCCs, i.e. when the `resource` is security.openshift.io/securitycontextconstraints.

see: https://github.com/openshift/openshift-docs/pull/10376