### PR TITLE
fix 30_14-imagestream.yaml formatting

### DIFF
--- a/deploy/ocp/manifests/0.7.1/30_14-imagestream.yaml
+++ b/deploy/ocp/manifests/0.7.1/30_14-imagestream.yaml
@@ -14,6 +14,6 @@ spec:
       kind: DockerImage
       Name:  quay.io/coreos/catalog@sha256:57eb45f2a519c65041d3fad0d7a5199f2ce5ba6a72992606ec4839d3307c5b5f
   - name: package-server
-     from:
+    from:
       kind: DockerImage
       Name:  quay.io/coreos/package-server@sha256:cc18b5711fb2126329c969f077f67f41981c87f800f6b2ceae5981422c14917b

--- a/manifests/30_14-imagestream.yaml
+++ b/manifests/30_14-imagestream.yaml
@@ -14,6 +14,6 @@ spec:
       kind: DockerImage
       Name:  quay.io/coreos/catalog@sha256:57eb45f2a519c65041d3fad0d7a5199f2ce5ba6a72992606ec4839d3307c5b5f
   - name: package-server
-     from:
+    from:
       kind: DockerImage
       Name:  quay.io/coreos/package-server@sha256:cc18b5711fb2126329c969f077f67f41981c87f800f6b2ceae5981422c14917b


### PR DESCRIPTION
This PR should fix the following bootkube failure: 
```
Oct 05 15:11:59 dev-bootstrap bootkube.sh[3929]: F1005 15:11:59.158817       1 image.go:36] error: error loading update payload from "/": error loading manifests from /: err
or parsing 99_olm_30_14-imagestream.yaml: error parsing: error converting YAML to JSON: yaml: line 17: mapping values are not allowed in this context                       
```