### PR TITLE
chore(deploy): use runlevel label on namespace

### DIFF
--- a/deploy/ocp/manifests/0.7.1/0000_30_00-namespace.yaml
+++ b/deploy/ocp/manifests/0.7.1/0000_30_00-namespace.yaml
@@ -4,3 +4,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
+  labels:
+    openshift.io/run-level: "1"

--- a/deploy/ocp/manifests/0.7.1/30_00-namespace.yaml
+++ b/deploy/ocp/manifests/0.7.1/30_00-namespace.yaml
@@ -4,3 +4,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
+  labels:
+    openshift.io/run-level: "1"

--- a/deploy/okd/manifests/0.7.1/0000_30_00-namespace.yaml
+++ b/deploy/okd/manifests/0.7.1/0000_30_00-namespace.yaml
@@ -4,3 +4,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
+  labels:
+    openshift.io/run-level: "1"

--- a/deploy/okd/manifests/0.7.1/30_00-namespace.yaml
+++ b/deploy/okd/manifests/0.7.1/30_00-namespace.yaml
@@ -4,3 +4,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
+  labels:
+    openshift.io/run-level: "1"

--- a/manifests/0000_30_00-namespace.yaml
+++ b/manifests/0000_30_00-namespace.yaml
@@ -4,3 +4,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
+  labels:
+    openshift.io/run-level: "1"


### PR DESCRIPTION
All namespaces created before the openshift apiserver are up need a run-level

With the move to a namespace prefix, OLM now blocks later controllers (including
machine API) because some caches aren't filled on admission. Causes installer
to hang trying to apply the service account:

```
E1009 01:37:54.959270       1 sync.go:52] error running apply for (/v1, Kind=ServiceAccount) openshift-operator-lifecycle-manager/olm-operator-serviceaccount: serviceaccounts "olm-operator-serviceaccount" is forbidden: caches not synchronized
```