### PR TITLE
Add possible nonResourceURL verbs to validation

### DIFF
--- a/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
@@ -653,6 +653,8 @@ spec:
                                         - create
                                         - update
                                         - patch
+                                        - put
+                                        - post
                                         - delete
                                         - deletecollection
                                         - initialize
@@ -699,6 +701,8 @@ spec:
                                       - create
                                       - update
                                       - patch
+                                      - put
+                                      - post
                                       - delete
                                       - deletecollection
                                       - initialize


### PR DESCRIPTION
The controller is unable to create a CSV that contains the following `nonResourceURL` verbs without this validation.