### PR TITLE
Rewrite Namespace when Fetching Global PackageManifests

### DIFF
--- a/pkg/package-server/provider/inmem.go
+++ b/pkg/package-server/provider/inmem.go
@@ -248,6 +248,7 @@ func (m *InMemoryProvider) Get(namespace, name string) (*packagev1alpha1.Package
 
 	for key, pm := range m.manifests {
 		if key.packageName == name && (key.catalogSourceNamespace == namespace || key.catalogSourceNamespace == m.globalNamespace) {
+			pm.SetNamespace(namespace)
 			return &pm, nil
 		}
 	}
@@ -265,6 +266,9 @@ func (m *InMemoryProvider) List(namespace string) (*packagev1alpha1.PackageManif
 		var matching []packagev1alpha1.PackageManifest
 		for key, pm := range m.manifests {
 			if namespace == metav1.NamespaceAll || key.catalogSourceNamespace == namespace || key.catalogSourceNamespace == m.globalNamespace {
+				if namespace != metav1.NamespaceAll && pm.GetNamespace() != namespace {
+					pm.SetNamespace(namespace)
+				}
 				matching = append(matching, pm)
 			}
 		}

--- a/pkg/package-server/provider/inmem_test.go
+++ b/pkg/package-server/provider/inmem_test.go
@@ -46,7 +46,7 @@ func TestList(t *testing.T) {
 		{
 			namespace:        "default",
 			storedPackages:   []packageValue{{name: "etcd", namespace: "default"}, {name: "prometheus", namespace: "global"}, {name: "vault", namespace: "local"}},
-			expectedPackages: []packageValue{{name: "etcd", namespace: "default"}, {name: "prometheus", namespace: "global"}},
+			expectedPackages: []packageValue{{name: "etcd", namespace: "default"}, {name: "prometheus", namespace: "default"}},
 			description:      "FilterNamespaceWithGlobal",
 		},
 		{
@@ -107,7 +107,7 @@ func TestGet(t *testing.T) {
 			namespace:       "default",
 			packageName:     "etcd",
 			storedPackages:  []packageValue{{name: "etcd", namespace: "global"}, {name: "prometheus", namespace: "local"}},
-			expectedPackage: packageValue{name: "etcd", namespace: "global"},
+			expectedPackage: packageValue{name: "etcd", namespace: "default"},
 			description:     "MatchesGlobal",
 		},
 		{


### PR DESCRIPTION
### Description

Ensures that all the the `PackageManifests` returned have the same `metadata.namespace` value.

Fixes https://jira.coreos.com/browse/ALM-752