### PR TITLE
feat(build): allow skipping minikube during local builds

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -5,9 +5,11 @@
 
 set -e
 
-ps x | grep -q [m]inikube || minikube start --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
-eval $(minikube docker-env) || { echo 'Cannot switch to minikube docker'; exit 1; }
-kubectl config use-context minikube
+if [ -z "$NO_MINIKUBE" ]; then
+  ps x | grep -q [m]inikube || minikube start --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
+  eval $(minikube docker-env) || { echo 'Cannot switch to minikube docker'; exit 1; }
+  kubectl config use-context minikube
+fi
 docker build -f e2e.Dockerfile .
 docker tag $(docker images --filter 'label=stage=olm' --format '{{.CreatedAt}}\t{{.ID}}' | sort -nr | head -n 1 | cut -f2) quay.io/coreos/olm:local
 docker tag $(docker images --filter 'label=stage=e2e' --format '{{.CreatedAt}}\t{{.ID}}' | sort -nr | head -n 1 | cut -f2) quay.io/coreos/olm-e2e:local


### PR DESCRIPTION
This only changes behavior if the NO_MINIKUBE variable is set, otherwise minikube calls will be done exactly as before. (This probably only helps me out, but I'd really appreciate not having to comment out lines or apply a patch for each new branch I work on!)