### PR TITLE
fix(build): add cleanup for package release files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ container: build
 
 clean:
 	rm -rf bin
+	rm -rf test/e2e/resources
 	rm -rf test/e2e/test-resources
 	rm -rf test/e2e/log
 


### PR DESCRIPTION
scripts/run_e2e_local.sh is slightly different from scripts/run_e2e_docker.sh. Make sure to delete directories for both scenarios.