### PR TITLE
Pass Annotations to PackageManifests

### DIFF
--- a/pkg/package-server/apis/packagemanifest/v1alpha1/packagemanifest.go
+++ b/pkg/package-server/apis/packagemanifest/v1alpha1/packagemanifest.go
@@ -11,6 +11,7 @@ func CreateCSVDescription(csv *operatorsv1alpha1.ClusterServiceVersion) CSVDescr
 			Name: csv.Spec.Provider.Name,
 			URL:  csv.Spec.Provider.URL,
 		},
+		Annotations: csv.GetAnnotations(),
 	}
 
 	icons := make([]Icon, len(csv.Spec.Icon))

--- a/pkg/package-server/apis/packagemanifest/v1alpha1/packagemanifest_types.go
+++ b/pkg/package-server/apis/packagemanifest/v1alpha1/packagemanifest_types.go
@@ -93,7 +93,8 @@ type CSVDescription struct {
 	Version semver.Version `json:"version,omitempty"`
 
 	// Provider is the CSV's provider
-	Provider AppLink `json:"provider,omitempty"`
+	Provider    AppLink           `json:"provider,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // AppLink defines a link to an application

--- a/pkg/package-server/apis/packagemanifest/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/package-server/apis/packagemanifest/v1alpha1/zz_generated.deepcopy.go
@@ -50,6 +50,13 @@ func (in *CSVDescription) DeepCopyInto(out *CSVDescription) {
 	}
 	out.Version = in.Version
 	out.Provider = in.Provider
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
### Description

Adds `annotations` field to CSV descriptions on the `PackageManifest` object, which are propagated from the stored `ClusterServiceVersion`.

Addresses https://jira.coreos.com/browse/ALM-774