### PR TITLE
feat(csv): add cert rotation for owned APIServices

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,6 +225,7 @@ e2e-teardown:
   script:
   - echo $CD_KUBECONFIG | base64 -d > kubeconfig
   - export KUBECONFIG=./kubeconfig
+  - kubectl delete apiservice v1alpha1.packages.apps.redhat.com --ignore-not-found=true
   - kubectl delete ns --ignore-not-found=true e2e-${CI_COMMIT_REF_SLUG}-${SHA8}
   - kubectl get pods -o wide -n e2e-${CI_COMMIT_REF_SLUG}-${SHA8}
   stage: test_teardown
@@ -284,6 +285,7 @@ stop-preview:
   script:
   - echo $CD_KUBECONFIG | base64 -d > kubeconfig
   - export KUBECONFIG=./kubeconfig
+  - kubectl delete apiservice v1alpha1.packages.apps.redhat.com --ignore-not-found=true
   - kubectl delete ns --ignore-not-found=true ci-olm-${CI_COMMIT_REF_SLUG}
   - kubectl get pods -o wide -n ci-olm-${CI_COMMIT_REF_SLUG}
   stage: deploy_preview

--- a/.gitlab-ci/base_jobs.libsonnet
+++ b/.gitlab-ci/base_jobs.libsonnet
@@ -136,6 +136,7 @@ local appr = utils.appr;
         before_script: [],
         script:
             k8s.setKubeConfig(self.localvars.kubeconfig) + [
+                "kubectl delete apiservice v1alpha1.packages.apps.redhat.com --ignore-not-found=true",
                 "kubectl delete ns --ignore-not-found=true %s" % self.localvars.namespace,
                 "kubectl get pods -o wide -n %s" % self.localvars.namespace,
             ],

--- a/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
@@ -180,17 +180,7 @@ spec:
                           values:
                             type: array
                             description: set of values for the expression
-            certValidForDays:
-              type: integer
-              description: Number of days generated APIService certs are valid for
-              format: int32
-              minimum: 1
-              maximum: 730
-            certMinFreshSeconds:
-              type: integer
-              description: Minimum freshness of a cert before it is renewed; in seconds
-              format: int32
-              minimum: 10
+                            
             apiservicedefinitions:
               type: object
               properties:

--- a/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
@@ -180,6 +180,17 @@ spec:
                           values:
                             type: array
                             description: set of values for the expression
+            certValidForDays:
+              type: integer
+              description: Number of days generated APIService certs are valid for
+              format: int32
+              minimum: 1
+              maximum: 730
+            certMinFreshSeconds:
+              type: integer
+              description: Minimum freshness of a cert before it is renewed; in seconds
+              format: int32
+              minimum: 10
             apiservicedefinitions:
               type: object
               properties:

--- a/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
@@ -135,6 +135,14 @@ type ClusterServiceVersionSpec struct {
 	// Label selector for related resources.
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,2,opt,name=selector"`
+
+	// Number of days generated owned APIService certs are valid for
+	// +optional
+	CertValidForDays int `json:"certValidFor,omitempty"`
+
+	// Minimum freshness of a cert before it is renewed; in seconds
+	// +optional
+	CertMinFreshSeconds int `json:"certMinFresh,omitempty"`
 }
 
 type Maintainer struct {
@@ -225,7 +233,7 @@ func (csv ClusterServiceVersion) OwnsCRD(name string) bool {
 	return false
 }
 
-// ConditionReason is a camelcased reason for the status of a RequirementStatus or DependentStatus
+// StatusReason is a camelcased reason for the status of a RequirementStatus or DependentStatus
 type StatusReason string
 
 const (
@@ -256,13 +264,6 @@ type RequirementStatus struct {
 	Dependents []DependentStatus `json:"dependents,omitempty"`
 }
 
-type CertExpiration struct {
-	APIServiceGroup   string `json:"apiServiceName"`
-	APIServiceVersion string ``
-	// Time when the APIService cert expires
-	ValidUntil metav1.Time `json:"validUntil"`
-}
-
 // ClusterServiceVersionStatus represents information about the status of a pod. Status may trail the actual
 // state of a system.
 type ClusterServiceVersionStatus struct {
@@ -285,14 +286,14 @@ type ClusterServiceVersionStatus struct {
 	Conditions []ClusterServiceVersionCondition `json:"conditions,omitempty"`
 	// The status of each requirement for this CSV
 	RequirementStatus []RequirementStatus `json:"requirementStatus,omitempty"`
-	// Cert expiration dates for owned APIServices
+	// Time to refresh generated owned APIService certs
 	// +optional
-	CertExpirations []CertExpiration `json:"certExpirations,omitempty"`
+	CertRefresh metav1.Time `json:"requirementStatus,omitempty"`
 }
 
+// ClusterServiceVersion is a Custom Resource of type `ClusterServiceVersionSpec`.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient
-// ClusterServiceVersion is a Custom Resource of type `ClusterServiceVersionSpec`.
 type ClusterServiceVersion struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
@@ -256,6 +256,13 @@ type RequirementStatus struct {
 	Dependents []DependentStatus `json:"dependents,omitempty"`
 }
 
+type CertExpiration struct {
+	APIServiceGroup   string `json:"apiServiceName"`
+	APIServiceVersion string ``
+	// Time when the APIService cert expires
+	ValidUntil metav1.Time `json:"validUntil"`
+}
+
 // ClusterServiceVersionStatus represents information about the status of a pod. Status may trail the actual
 // state of a system.
 type ClusterServiceVersionStatus struct {
@@ -278,6 +285,9 @@ type ClusterServiceVersionStatus struct {
 	Conditions []ClusterServiceVersionCondition `json:"conditions,omitempty"`
 	// The status of each requirement for this CSV
 	RequirementStatus []RequirementStatus `json:"requirementStatus,omitempty"`
+	// Cert expiration dates for owned APIServices
+	// +optional
+	CertExpirations []CertExpiration `json:"certExpirations,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
@@ -135,14 +135,6 @@ type ClusterServiceVersionSpec struct {
 	// Label selector for related resources.
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,2,opt,name=selector"`
-
-	// Number of days generated owned APIService certs are valid for
-	// +optional
-	CertValidForDays int `json:"certValidFor,omitempty"`
-
-	// Minimum freshness of a cert before it is renewed; in seconds
-	// +optional
-	CertMinFreshSeconds int `json:"certMinFresh,omitempty"`
 }
 
 type Maintainer struct {
@@ -189,19 +181,20 @@ const (
 type ConditionReason string
 
 const (
-	CSVReasonRequirementsUnknown ConditionReason = "RequirementsUnknown"
-	CSVReasonRequirementsNotMet  ConditionReason = "RequirementsNotMet"
-	CSVReasonRequirementsMet     ConditionReason = "AllRequirementsMet"
-	CSVReasonOwnerConflict       ConditionReason = "OwnerConflict"
-	CSVReasonComponentFailed     ConditionReason = "InstallComponentFailed"
-	CSVReasonInvalidStrategy     ConditionReason = "InvalidInstallStrategy"
-	CSVReasonWaiting             ConditionReason = "InstallWaiting"
-	CSVReasonInstallSuccessful   ConditionReason = "InstallSucceeded"
-	CSVReasonInstallCheckFailed  ConditionReason = "InstallCheckFailed"
-	CSVReasonComponentUnhealthy  ConditionReason = "ComponentUnhealthy"
-	CSVReasonBeingReplaced       ConditionReason = "BeingReplaced"
-	CSVReasonReplaced            ConditionReason = "Replaced"
-	CSVReasonNeedCertRefresh     ConditionReason = "NeedCertRefresh"
+	CSVReasonRequirementsUnknown     ConditionReason = "RequirementsUnknown"
+	CSVReasonRequirementsNotMet      ConditionReason = "RequirementsNotMet"
+	CSVReasonRequirementsMet         ConditionReason = "AllRequirementsMet"
+	CSVReasonOwnerConflict           ConditionReason = "OwnerConflict"
+	CSVReasonComponentFailed         ConditionReason = "InstallComponentFailed"
+	CSVReasonInvalidStrategy         ConditionReason = "InvalidInstallStrategy"
+	CSVReasonWaiting                 ConditionReason = "InstallWaiting"
+	CSVReasonInstallSuccessful       ConditionReason = "InstallSucceeded"
+	CSVReasonInstallCheckFailed      ConditionReason = "InstallCheckFailed"
+	CSVReasonComponentUnhealthy      ConditionReason = "ComponentUnhealthy"
+	CSVReasonBeingReplaced           ConditionReason = "BeingReplaced"
+	CSVReasonReplaced                ConditionReason = "Replaced"
+	CSVReasonNeedCertRotation        ConditionReason = "NeedCertRotation"
+	CSVReasonAPIServiceResourceIssue ConditionReason = "APIServiceResourceIssue"
 )
 
 // Conditions appear in the status as a record of state transitions on the ClusterServiceVersion
@@ -287,9 +280,12 @@ type ClusterServiceVersionStatus struct {
 	Conditions []ClusterServiceVersionCondition `json:"conditions,omitempty"`
 	// The status of each requirement for this CSV
 	RequirementStatus []RequirementStatus `json:"requirementStatus,omitempty"`
-	// Time to refresh generated owned APIService certs
+	// Last time the owned APIService certs were updated
 	// +optional
-	CertRefresh metav1.Time `json:"certRefresh,omitempty"`
+	CertsLastUpdated metav1.Time `json:"certsLastUpdated,omitempty"`
+	// Time the owned APIService certs will rotate next
+	// +optional
+	CertsRotateAt metav1.Time `json:"certsRotateAt,omitempty"`
 }
 
 // ClusterServiceVersion is a Custom Resource of type `ClusterServiceVersionSpec`.

--- a/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
@@ -201,6 +201,7 @@ const (
 	CSVReasonComponentUnhealthy  ConditionReason = "ComponentUnhealthy"
 	CSVReasonBeingReplaced       ConditionReason = "BeingReplaced"
 	CSVReasonReplaced            ConditionReason = "Replaced"
+	CSVReasonNeedCertRefresh     ConditionReason = "NeedCertRefresh"
 )
 
 // Conditions appear in the status as a record of state transitions on the ClusterServiceVersion
@@ -288,7 +289,7 @@ type ClusterServiceVersionStatus struct {
 	RequirementStatus []RequirementStatus `json:"requirementStatus,omitempty"`
 	// Time to refresh generated owned APIService certs
 	// +optional
-	CertRefresh metav1.Time `json:"requirementStatus,omitempty"`
+	CertRefresh metav1.Time `json:"certRefresh,omitempty"`
 }
 
 // ClusterServiceVersion is a Custom Resource of type `ClusterServiceVersionSpec`.

--- a/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
@@ -478,7 +478,8 @@ func (in *ClusterServiceVersionStatus) DeepCopyInto(out *ClusterServiceVersionSt
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.CertRefresh.DeepCopyInto(&out.CertRefresh)
+	in.CertsLastUpdated.DeepCopyInto(&out.CertsLastUpdated)
+	in.CertsRotateAt.DeepCopyInto(&out.CertsRotateAt)
 	return
 }
 

--- a/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
@@ -478,6 +478,7 @@ func (in *ClusterServiceVersionStatus) DeepCopyInto(out *ClusterServiceVersionSt
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.CertRefresh.DeepCopyInto(&out.CertRefresh)
 	return
 }
 

--- a/pkg/controller/install/rule_checker.go
+++ b/pkg/controller/install/rule_checker.go
@@ -5,13 +5,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	crbacv1 "k8s.io/client-go/listers/rbac/v1"
 	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 )
 
 // RuleChecker is used to verify whether PolicyRules are satisfied by existing Roles or ClusterRoles
@@ -81,7 +81,7 @@ func (c *CSVRuleChecker) GetRole(namespace, name string) (*rbacv1.Role, error) {
 	}
 
 	// check if the Role has an OwnerConflict with the client's CSV
-	if role != nil && c.hasOwnerConflicts(role.GetOwnerReferences()) {
+	if role != nil && ownerutil.HasOwnerConflicts(c.csv, role.GetOwnerReferences()) {
 		return &rbacv1.Role{}, nil
 	}
 
@@ -98,7 +98,7 @@ func (c *CSVRuleChecker) ListRoleBindings(namespace string) ([]*rbacv1.RoleBindi
 	// filter based on OwnerReferences
 	var filtered []*rbacv1.RoleBinding
 	for _, rb := range rbList {
-		if !c.hasOwnerConflicts(rb.GetOwnerReferences()) {
+		if !ownerutil.HasOwnerConflicts(c.csv, rb.GetOwnerReferences()) {
 			filtered = append(filtered, rb)
 		}
 	}
@@ -114,7 +114,7 @@ func (c *CSVRuleChecker) GetClusterRole(name string) (*rbacv1.ClusterRole, error
 	}
 
 	// check if the ClusterRole has an OwnerConflict with the client's CSV
-	if clusterRole != nil && c.hasOwnerConflicts(clusterRole.GetOwnerReferences()) {
+	if clusterRole != nil && ownerutil.HasOwnerConflicts(c.csv, clusterRole.GetOwnerReferences()) {
 		return &rbacv1.ClusterRole{}, nil
 	}
 
@@ -131,7 +131,7 @@ func (c *CSVRuleChecker) ListClusterRoleBindings() ([]*rbacv1.ClusterRoleBinding
 	// filter based on OwnerReferences
 	var filtered []*rbacv1.ClusterRoleBinding
 	for _, crb := range crbList {
-		if !c.hasOwnerConflicts(crb.GetOwnerReferences()) {
+		if !ownerutil.HasOwnerConflicts(c.csv, crb.GetOwnerReferences()) {
 			filtered = append(filtered, crb)
 		}
 	}
@@ -139,31 +139,7 @@ func (c *CSVRuleChecker) ListClusterRoleBindings() ([]*rbacv1.ClusterRoleBinding
 	return filtered, nil
 }
 
-// hasOwnerConflicts checks if the given list of OwnerReferences points to CSVs other than the
-// CSVRuleChecker's. The method returns true if the list of OwnerReferences contains elements of Kind
-// ClusterServiceVersion but does not include an OwnerReference to the CSVRuleChecker's CSV. If there
-// are no OwnerReferences of Kind ClusterServiceVersion, or there is but one element is an OwnerReference
-// to the CSVRuleChecker's CSV, then the method returns false.
-//
-// Note: This is imporant when determining if a Role, RoleBinding, ClusterRole, or ClusterRoleBinding
-// can be used to satisfy permissions of a CSV. If the CSVRuleChecker's CSV is not a member of the RBAC resource's
-// OwnerReferences, then we know the resource can be garbage collected by OLM independently of the CSVRuleChecker's
-// CSV
-func (c *CSVRuleChecker) hasOwnerConflicts(ownerRefs []metav1.OwnerReference) bool {
-	conflicts := false
-	for _, ownerRef := range ownerRefs {
-		if ownerRef.Kind == v1alpha1.ClusterServiceVersionKind {
-			if ownerRef.Name == c.csv.GetName() && ownerRef.UID == c.csv.GetUID() {
-				return false
-			}
-
-			conflicts = true
-		}
-	}
-
-	return conflicts
-}
-
+// ruleValid returns an error if the given PolicyRule is not valid (resource and nonresource attributes defined)
 func ruleValid(rule rbacv1.PolicyRule) error {
 	if len(rule.Verbs) == 0 {
 		return fmt.Errorf("policy rule must have at least one verb")

--- a/pkg/controller/install/rule_checker.go
+++ b/pkg/controller/install/rule_checker.go
@@ -81,7 +81,7 @@ func (c *CSVRuleChecker) GetRole(namespace, name string) (*rbacv1.Role, error) {
 	}
 
 	// check if the Role has an OwnerConflict with the client's CSV
-	if role != nil && ownerutil.HasOwnerConflicts(c.csv, role.GetOwnerReferences()) {
+	if role != nil && ownerutil.HasOwnerConflict(c.csv, role.GetOwnerReferences()) {
 		return &rbacv1.Role{}, nil
 	}
 
@@ -98,7 +98,7 @@ func (c *CSVRuleChecker) ListRoleBindings(namespace string) ([]*rbacv1.RoleBindi
 	// filter based on OwnerReferences
 	var filtered []*rbacv1.RoleBinding
 	for _, rb := range rbList {
-		if !ownerutil.HasOwnerConflicts(c.csv, rb.GetOwnerReferences()) {
+		if !ownerutil.HasOwnerConflict(c.csv, rb.GetOwnerReferences()) {
 			filtered = append(filtered, rb)
 		}
 	}
@@ -114,7 +114,7 @@ func (c *CSVRuleChecker) GetClusterRole(name string) (*rbacv1.ClusterRole, error
 	}
 
 	// check if the ClusterRole has an OwnerConflict with the client's CSV
-	if clusterRole != nil && ownerutil.HasOwnerConflicts(c.csv, clusterRole.GetOwnerReferences()) {
+	if clusterRole != nil && ownerutil.HasOwnerConflict(c.csv, clusterRole.GetOwnerReferences()) {
 		return &rbacv1.ClusterRole{}, nil
 	}
 
@@ -131,7 +131,7 @@ func (c *CSVRuleChecker) ListClusterRoleBindings() ([]*rbacv1.ClusterRoleBinding
 	// filter based on OwnerReferences
 	var filtered []*rbacv1.ClusterRoleBinding
 	for _, crb := range crbList {
-		if !ownerutil.HasOwnerConflicts(c.csv, crb.GetOwnerReferences()) {
+		if !ownerutil.HasOwnerConflict(c.csv, crb.GetOwnerReferences()) {
 			filtered = append(filtered, crb)
 		}
 	}

--- a/pkg/controller/operators/olm/apiservices.go
+++ b/pkg/controller/operators/olm/apiservices.go
@@ -22,13 +22,13 @@ import (
 )
 
 const (
-	// Minimum number of seconds that a min-fresh value can be
+	// CertMinFreshSecondsThreshold is the minimum number of seconds that a min-fresh value can be
 	CertMinFreshSecondsThreshold = 10
-	// Default min-fresh value
+	// DefaultCertMinFreshSeconds is the default min-fresh value
 	DefaultCertMinFreshSeconds = 300
-	// Minimum number of days that a cert can be valid for
+	// CertValidForDaysThreshold is the minimum number of days that a cert can be valid for
 	CertValidForDaysThreshold = 1
-	// Default number of days a cert can be valid for
+	// DefaultCertValidForDays is the default number of days a cert can be valid for
 	DefaultCertValidForDays = 730
 )
 
@@ -45,6 +45,15 @@ func (a *Operator) syncAPIServices(obj interface{}) (syncError error) {
 	}
 
 	return nil
+}
+
+func (a *Operator) shouldRefreshCerts(csv *v1alpha1.ClusterServiceVersion) bool {
+	now := metav1.Now()
+	if !csv.Status.CertRefresh.IsZero() && csv.Status.CertRefresh.Before(&now) {
+		return true
+	}
+
+	return false
 }
 
 func (a *Operator) isAPIServiceAvailable(apiService *apiregistrationv1.APIService) bool {

--- a/pkg/controller/operators/olm/requirements_test.go
+++ b/pkg/controller/operators/olm/requirements_test.go
@@ -43,8 +43,6 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				nil,
 				nil,
 				v1alpha1.CSVPhasePending,
-				0,
-				0,
 			),
 			existingObjs:                nil,
 			existingExtObjs:             nil,
@@ -86,8 +84,6 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				nil,
 				nil,
 				v1alpha1.CSVPhasePending,
-				0,
-				0,
 			),
 			existingObjs: []runtime.Object{
 				&corev1.ServiceAccount{
@@ -218,8 +214,6 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				nil,
 				nil,
 				v1alpha1.CSVPhasePending,
-				0,
-				0,
 			),
 			existingObjs: []runtime.Object{
 				&corev1.ServiceAccount{
@@ -340,8 +334,6 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				[]*v1beta1.CustomResourceDefinition{crd("c1", "v1")},
 				[]*v1beta1.CustomResourceDefinition{crd("c2", "v1")},
 				v1alpha1.CSVPhasePending,
-				0,
-				0,
 			),
 			existingObjs: []runtime.Object{
 				&corev1.ServiceAccount{
@@ -444,8 +436,6 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				[]*v1beta1.CustomResourceDefinition{crd("c1", "v2")},
 				nil,
 				v1alpha1.CSVPhasePending,
-				0,
-				0,
 			),
 			existingObjs: nil,
 			existingExtObjs: []runtime.Object{

--- a/pkg/controller/operators/olm/requirements_test.go
+++ b/pkg/controller/operators/olm/requirements_test.go
@@ -43,6 +43,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				nil,
 				nil,
 				v1alpha1.CSVPhasePending,
+				0,
+				0,
 			),
 			existingObjs:                nil,
 			existingExtObjs:             nil,
@@ -84,6 +86,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				nil,
 				nil,
 				v1alpha1.CSVPhasePending,
+				0,
+				0,
 			),
 			existingObjs: []runtime.Object{
 				&corev1.ServiceAccount{
@@ -214,6 +218,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				nil,
 				nil,
 				v1alpha1.CSVPhasePending,
+				0,
+				0,
 			),
 			existingObjs: []runtime.Object{
 				&corev1.ServiceAccount{
@@ -334,6 +340,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				[]*v1beta1.CustomResourceDefinition{crd("c1", "v1")},
 				[]*v1beta1.CustomResourceDefinition{crd("c2", "v1")},
 				v1alpha1.CSVPhasePending,
+				0,
+				0,
 			),
 			existingObjs: []runtime.Object{
 				&corev1.ServiceAccount{
@@ -436,6 +444,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				[]*v1beta1.CustomResourceDefinition{crd("c1", "v2")},
 				nil,
 				v1alpha1.CSVPhasePending,
+				0,
+				0,
 			),
 			existingObjs: nil,
 			existingExtObjs: []runtime.Object{

--- a/pkg/lib/operatorclient/apiservice.go
+++ b/pkg/lib/operatorclient/apiservice.go
@@ -9,31 +9,31 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
-// CreateRoleBinding creates the roleBinding.
+// CreateAPIService creates the APIService.
 func (c *Client) CreateAPIService(ig *apiregistrationv1.APIService) (*apiregistrationv1.APIService, error) {
 	return c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Create(ig)
 }
 
-// GetRoleBinding returns the existing roleBinding.
+// GetAPIService returns the existing APIService.
 func (c *Client) GetAPIService(name string) (*apiregistrationv1.APIService, error) {
 	return c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Get(name, metav1.GetOptions{})
 }
 
-// DeleteRoleBinding deletes the roleBinding.
+// DeleteAPIService deletes the APIService.
 func (c *Client) DeleteAPIService(name string, options *metav1.DeleteOptions) error {
 	return c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Delete(name, options)
 }
 
-// UpdateRoleBinding will update the given RoleBinding resource.
-func (c *Client) UpdateAPIService(crb *apiregistrationv1.APIService) (*apiregistrationv1.APIService, error) {
-	glog.V(4).Infof("[UPDATE RoleBinding]: %s", crb.GetName())
-	oldCrb, err := c.GetAPIService(crb.GetName())
+// UpdateAPIService will update the given APIService resource.
+func (c *Client) UpdateAPIService(apiService *apiregistrationv1.APIService) (*apiregistrationv1.APIService, error) {
+	glog.V(4).Infof("[UPDATE APIService]: %s", apiService.GetName())
+	oldAPIService, err := c.GetAPIService(apiService.GetName())
 	if err != nil {
 		return nil, err
 	}
-	patchBytes, err := createPatch(oldCrb, crb)
+	patchBytes, err := createPatch(oldAPIService, apiService)
 	if err != nil {
-		return nil, fmt.Errorf("error creating patch for RoleBinding: %v", err)
+		return nil, fmt.Errorf("error creating patch for APIService: %v", err)
 	}
-	return c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Patch(crb.GetName(), types.StrategicMergePatchType, patchBytes)
+	return c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Patch(apiService.GetName(), types.StrategicMergePatchType, patchBytes)
 }

--- a/pkg/lib/operatorlister/apiservice.go
+++ b/pkg/lib/operatorlister/apiservice.go
@@ -1,0 +1,55 @@
+package operatorlister
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	aregv1 "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1"
+)
+
+// UnionAPIServiceLister is a custom implementation of an APIService lister that allows a new
+// Lister to be registered on the fly
+type UnionAPIServiceLister struct {
+	apiServiceLister aregv1.APIServiceLister
+	apiServiceLock   sync.RWMutex
+}
+
+// List lists all APIServices in the indexer.
+func (ual *UnionAPIServiceLister) List(selector labels.Selector) (ret []*v1.APIService, err error) {
+	ual.apiServiceLock.RLock()
+	defer ual.apiServiceLock.RUnlock()
+
+	if ual.apiServiceLister == nil {
+		return nil, fmt.Errorf("no apiService lister registered")
+	}
+	return ual.apiServiceLister.List(selector)
+}
+
+// Get retrieves the APIService with the given name
+func (ual *UnionAPIServiceLister) Get(name string) (*v1.APIService, error) {
+	ual.apiServiceLock.RLock()
+	defer ual.apiServiceLock.RUnlock()
+
+	if ual.apiServiceLister == nil {
+		return nil, fmt.Errorf("no apiService lister registered")
+	}
+	return ual.apiServiceLister.Get(name)
+}
+
+// RegisterAPIServiceLister registers a new APIServiceLister
+func (ual *UnionAPIServiceLister) RegisterAPIServiceLister(lister aregv1.APIServiceLister) {
+	ual.apiServiceLock.Lock()
+	defer ual.apiServiceLock.Unlock()
+
+	ual.apiServiceLister = lister
+}
+
+func (l *apiRegistrationV1Lister) RegisterAPIServiceLister(lister aregv1.APIServiceLister) {
+	l.apiServiceLister.RegisterAPIServiceLister(lister)
+}
+
+func (l *apiRegistrationV1Lister) APIServiceLister() aregv1.APIServiceLister {
+	return l.apiServiceLister
+}

--- a/pkg/lib/operatorlister/clusterrole.go
+++ b/pkg/lib/operatorlister/clusterrole.go
@@ -1,0 +1,51 @@
+package operatorlister
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	rbacv1 "k8s.io/client-go/listers/rbac/v1"
+)
+
+type UnionClusterRoleLister struct {
+	clusterRoleLister rbacv1.ClusterRoleLister
+	clusterRoleLock   sync.RWMutex
+}
+
+// List lists all ClusterRoles in the indexer.
+func (ucl *UnionClusterRoleLister) List(selector labels.Selector) (ret []*v1.ClusterRole, err error) {
+	ucl.clusterRoleLock.RLock()
+	defer ucl.clusterRoleLock.RUnlock()
+
+	if ucl.clusterRoleLister == nil {
+		return nil, fmt.Errorf("no clusterRole lister registered")
+	}
+	return ucl.clusterRoleLister.List(selector)
+}
+
+func (ucl *UnionClusterRoleLister) Get(name string) (*v1.ClusterRole, error) {
+	ucl.clusterRoleLock.RLock()
+	defer ucl.clusterRoleLock.RUnlock()
+
+	if ucl.clusterRoleLister == nil {
+		return nil, fmt.Errorf("no clusterRole lister registered")
+	}
+	return ucl.clusterRoleLister.Get(name)
+}
+
+func (ucl *UnionClusterRoleLister) RegisterClusterRoleLister(lister rbacv1.ClusterRoleLister) {
+	ucl.clusterRoleLock.Lock()
+	defer ucl.clusterRoleLock.Unlock()
+
+	ucl.clusterRoleLister = lister
+}
+
+func (l *rbacV1Lister) RegisterClusterRoleLister(lister rbacv1.ClusterRoleLister) {
+	l.clusterRoleLister.RegisterClusterRoleLister(lister)
+}
+
+func (l *rbacV1Lister) ClusterRoleLister() rbacv1.ClusterRoleLister {
+	return l.clusterRoleLister
+}

--- a/pkg/lib/operatorlister/clusterrolebinding.go
+++ b/pkg/lib/operatorlister/clusterrolebinding.go
@@ -1,0 +1,51 @@
+package operatorlister
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	rbacv1 "k8s.io/client-go/listers/rbac/v1"
+)
+
+type UnionClusterRoleBindingLister struct {
+	clusterRoleBindingLister rbacv1.ClusterRoleBindingLister
+	clusterRoleBindingLock   sync.RWMutex
+}
+
+// List lists all ClusterRoleBindings in the indexer.
+func (ucl *UnionClusterRoleBindingLister) List(selector labels.Selector) (ret []*v1.ClusterRoleBinding, err error) {
+	ucl.clusterRoleBindingLock.RLock()
+	defer ucl.clusterRoleBindingLock.RUnlock()
+
+	if ucl.clusterRoleBindingLister == nil {
+		return nil, fmt.Errorf("no clusterRoleBinding lister registered")
+	}
+	return ucl.clusterRoleBindingLister.List(selector)
+}
+
+func (ucl *UnionClusterRoleBindingLister) Get(name string) (*v1.ClusterRoleBinding, error) {
+	ucl.clusterRoleBindingLock.RLock()
+	defer ucl.clusterRoleBindingLock.RUnlock()
+
+	if ucl.clusterRoleBindingLister == nil {
+		return nil, fmt.Errorf("no clusterRoleBinding lister registered")
+	}
+	return ucl.clusterRoleBindingLister.Get(name)
+}
+
+func (ucl *UnionClusterRoleBindingLister) RegisterClusterRoleBindingLister(lister rbacv1.ClusterRoleBindingLister) {
+	ucl.clusterRoleBindingLock.Lock()
+	defer ucl.clusterRoleBindingLock.Unlock()
+
+	ucl.clusterRoleBindingLister = lister
+}
+
+func (l *rbacV1Lister) RegisterClusterRoleBindingLister(lister rbacv1.ClusterRoleBindingLister) {
+	l.clusterRoleBindingLister.RegisterClusterRoleBindingLister(lister)
+}
+
+func (l *rbacV1Lister) ClusterRoleBindingLister() rbacv1.ClusterRoleBindingLister {
+	return l.clusterRoleBindingLister
+}

--- a/pkg/lib/operatorlister/deployment.go
+++ b/pkg/lib/operatorlister/deployment.go
@@ -1,0 +1,96 @@
+package operatorlister
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	appsv1 "k8s.io/client-go/listers/apps/v1"
+)
+
+type UnionDeploymentLister struct {
+	deploymentListers map[string]appsv1.DeploymentLister
+	deploymentLock    sync.RWMutex
+}
+
+// List lists all Deployments in the indexer.
+func (udl *UnionDeploymentLister) List(selector labels.Selector) (ret []*v1.Deployment, err error) {
+	udl.deploymentLock.RLock()
+	defer udl.deploymentLock.RUnlock()
+
+	var set map[types.UID]*v1.Deployment
+	for _, dl := range udl.deploymentListers {
+		deployments, err := dl.List(selector)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, deployment := range deployments {
+			set[deployment.GetUID()] = deployment
+		}
+	}
+
+	for _, deployment := range set {
+		ret = append(ret, deployment)
+	}
+
+	return
+}
+
+// Deployments returns an object that can list and get Deployments.
+func (udl *UnionDeploymentLister) Deployments(namespace string) appsv1.DeploymentNamespaceLister {
+	udl.deploymentLock.RLock()
+	defer udl.deploymentLock.RUnlock()
+
+	// Check for specific namespace listers
+	if dl, ok := udl.deploymentListers[namespace]; ok {
+		return dl.Deployments(namespace)
+	}
+
+	// Check for any namespace-all listers
+	if dl, ok := udl.deploymentListers[metav1.NamespaceAll]; ok {
+		return dl.Deployments(namespace)
+	}
+
+	// TODO: Return dummy deployment namespace lister
+	return nil
+}
+
+func (udl *UnionDeploymentLister) GetDeploymentsForReplicaSet(rs *v1.ReplicaSet) ([]*v1.Deployment, error) {
+	udl.deploymentLock.RLock()
+	defer udl.deploymentLock.RUnlock()
+
+	// Check for specific namespace listers
+	if dl, ok := udl.deploymentListers[rs.GetNamespace()]; ok {
+		return dl.GetDeploymentsForReplicaSet(rs)
+	}
+
+	// Check for any namespace-all listers
+	if dl, ok := udl.deploymentListers[metav1.NamespaceAll]; ok {
+		return dl.GetDeploymentsForReplicaSet(rs)
+	}
+
+	return nil, fmt.Errorf("no listers found for namespace %s", rs.GetNamespace())
+}
+
+func (udl *UnionDeploymentLister) RegisterDeploymentLister(namespace string, lister appsv1.DeploymentLister) {
+	udl.deploymentLock.Lock()
+	defer udl.deploymentLock.Unlock()
+
+	if udl.deploymentListers == nil {
+		udl.deploymentListers = make(map[string]appsv1.DeploymentLister)
+	}
+
+	udl.deploymentListers[namespace] = lister
+}
+
+func (l *appsV1Lister) RegisterDeploymentLister(namespace string, lister appsv1.DeploymentLister) {
+	l.deploymentLister.RegisterDeploymentLister(namespace, lister)
+}
+
+func (l *appsV1Lister) DeploymentLister() appsv1.DeploymentLister {
+	return l.deploymentLister
+}

--- a/pkg/lib/operatorlister/lister.go
+++ b/pkg/lib/operatorlister/lister.go
@@ -1,0 +1,140 @@
+package operatorlister
+
+import (
+	appsv1 "k8s.io/client-go/listers/apps/v1"
+	corev1 "k8s.io/client-go/listers/core/v1"
+	rbacv1 "k8s.io/client-go/listers/rbac/v1"
+	aregv1 "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1"
+)
+
+// OperatorLister is a union of versioned informer listers
+type OperatorLister interface {
+	AppsV1() AppsV1Lister
+	CoreV1() CoreV1Lister
+	RbacV1() RbacV1Lister
+	APIRegistrationV1() APIRegistrationV1Lister
+}
+
+type AppsV1Lister interface {
+	DeploymentLister() appsv1.DeploymentLister
+
+	RegisterDeploymentLister(namespace string, lister appsv1.DeploymentLister)
+}
+
+type CoreV1Lister interface {
+	RegisterSecretLister(namespace string, lister corev1.SecretLister)
+	RegisterServiceLister(namespace string, lister corev1.ServiceLister)
+	RegisterServiceAccountLister(namespace string, lister corev1.ServiceAccountLister)
+	RegisterNamespaceLister(lister corev1.NamespaceLister)
+
+	SecretLister() corev1.SecretLister
+	ServiceLister() corev1.ServiceLister
+	ServiceAccountLister() corev1.ServiceAccountLister
+	NamespaceLister() corev1.NamespaceLister
+}
+
+type RbacV1Lister interface {
+	RegisterClusterRoleLister(lister rbacv1.ClusterRoleLister)
+	RegisterClusterRoleBindingLister(lister rbacv1.ClusterRoleBindingLister)
+	RegisterRoleLister(namespace string, lister rbacv1.RoleLister)
+	RegisterRoleBindingLister(namespace string, lister rbacv1.RoleBindingLister)
+
+	ClusterRoleLister() rbacv1.ClusterRoleLister
+	ClusterRoleBindingLister() rbacv1.ClusterRoleBindingLister
+	RoleLister() rbacv1.RoleLister
+	RoleBindingLister() rbacv1.RoleBindingLister
+}
+
+type APIRegistrationV1Lister interface {
+	RegisterAPIServiceLister(lister aregv1.APIServiceLister)
+
+	APIServiceLister() aregv1.APIServiceLister
+}
+
+type appsV1Lister struct {
+	deploymentLister *UnionDeploymentLister
+}
+
+func newAppsV1Lister() *appsV1Lister {
+	return &appsV1Lister{
+		deploymentLister: &UnionDeploymentLister{},
+	}
+}
+
+type coreV1Lister struct {
+	secretLister         *UnionSecretLister
+	serviceLister        *UnionServiceLister
+	serviceAccountLister *UnionServiceAccountLister
+	namespaceLister      *UnionNamespaceLister
+}
+
+func newCoreV1Lister() *coreV1Lister {
+	return &coreV1Lister{
+		secretLister:         &UnionSecretLister{},
+		serviceLister:        &UnionServiceLister{},
+		serviceAccountLister: &UnionServiceAccountLister{},
+		namespaceLister:      &UnionNamespaceLister{},
+	}
+}
+
+type rbacV1Lister struct {
+	roleLister               *UnionRoleLister
+	roleBindingLister        *UnionRoleBindingLister
+	clusterRoleLister        *UnionClusterRoleLister
+	clusterRoleBindingLister *UnionClusterRoleBindingLister
+}
+
+func newRbacV1Lister() *rbacV1Lister {
+	return &rbacV1Lister{
+		roleLister:               &UnionRoleLister{},
+		roleBindingLister:        &UnionRoleBindingLister{},
+		clusterRoleLister:        &UnionClusterRoleLister{},
+		clusterRoleBindingLister: &UnionClusterRoleBindingLister{},
+	}
+}
+
+type apiRegistrationV1Lister struct {
+	apiServiceLister *UnionAPIServiceLister
+}
+
+func newAPIRegistrationV1Lister() *apiRegistrationV1Lister {
+	return &apiRegistrationV1Lister{
+		apiServiceLister: &UnionAPIServiceLister{},
+	}
+}
+
+// Interface assertion
+var _ OperatorLister = &lister{}
+
+type lister struct {
+	appsV1Lister            *appsV1Lister
+	coreV1Lister            *coreV1Lister
+	rbacV1Lister            *rbacV1Lister
+	apiRegistrationV1Lister *apiRegistrationV1Lister
+}
+
+func (l *lister) AppsV1() AppsV1Lister {
+	return l.appsV1Lister
+}
+
+func (l *lister) CoreV1() CoreV1Lister {
+	return l.coreV1Lister
+}
+
+func (l *lister) RbacV1() RbacV1Lister {
+	return l.rbacV1Lister
+}
+
+func (l *lister) APIRegistrationV1() APIRegistrationV1Lister {
+	return l.apiRegistrationV1Lister
+}
+
+func NewLister() OperatorLister {
+	// TODO: better initialization
+	return &lister{
+		appsV1Lister:            newAppsV1Lister(),
+		coreV1Lister:            newCoreV1Lister(),
+		rbacV1Lister:            newRbacV1Lister(),
+		apiRegistrationV1Lister: newAPIRegistrationV1Lister(),
+	}
+}

--- a/pkg/lib/operatorlister/namespace.go
+++ b/pkg/lib/operatorlister/namespace.go
@@ -1,0 +1,51 @@
+package operatorlister
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1 "k8s.io/client-go/listers/core/v1"
+)
+
+type UnionNamespaceLister struct {
+	namespaceLister corev1.NamespaceLister
+	namespaceLock   sync.RWMutex
+}
+
+// List lists all Namespaces in the indexer.
+func (unl *UnionNamespaceLister) List(selector labels.Selector) (ret []*v1.Namespace, err error) {
+	unl.namespaceLock.RLock()
+	defer unl.namespaceLock.RUnlock()
+
+	if unl.namespaceLister == nil {
+		return nil, fmt.Errorf("no namespace lister registered")
+	}
+	return unl.namespaceLister.List(selector)
+}
+
+func (unl *UnionNamespaceLister) Get(name string) (*v1.Namespace, error) {
+	unl.namespaceLock.RLock()
+	defer unl.namespaceLock.RUnlock()
+
+	if unl.namespaceLister == nil {
+		return nil, fmt.Errorf("no namespace lister registered")
+	}
+	return unl.namespaceLister.Get(name)
+}
+
+func (unl *UnionNamespaceLister) RegisterNamespaceLister(lister corev1.NamespaceLister) {
+	unl.namespaceLock.Lock()
+	defer unl.namespaceLock.Unlock()
+
+	unl.namespaceLister = lister
+}
+
+func (l *coreV1Lister) RegisterNamespaceLister(lister corev1.NamespaceLister) {
+	l.namespaceLister.RegisterNamespaceLister(lister)
+}
+
+func (l *coreV1Lister) NamespaceLister() corev1.NamespaceLister {
+	return l.namespaceLister
+}

--- a/pkg/lib/operatorlister/role.go
+++ b/pkg/lib/operatorlister/role.go
@@ -1,0 +1,76 @@
+package operatorlister
+
+import (
+	"sync"
+
+	"k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	rbacv1 "k8s.io/client-go/listers/rbac/v1"
+)
+
+type UnionRoleLister struct {
+	roleListers map[string]rbacv1.RoleLister
+	roleLock    sync.RWMutex
+}
+
+// List lists all Roles in the indexer.
+func (rl *UnionRoleLister) List(selector labels.Selector) (ret []*v1.Role, err error) {
+	rl.roleLock.RLock()
+	defer rl.roleLock.RUnlock()
+
+	var set map[types.UID]*v1.Role
+	for _, dl := range rl.roleListers {
+		roles, err := dl.List(selector)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, role := range roles {
+			set[role.GetUID()] = role
+		}
+	}
+
+	for _, role := range set {
+		ret = append(ret, role)
+	}
+
+	return
+}
+
+// Roles returns an object that can list and get Roles.
+func (rl *UnionRoleLister) Roles(namespace string) rbacv1.RoleNamespaceLister {
+	rl.roleLock.RLock()
+	defer rl.roleLock.RUnlock()
+
+	// Check for specific namespace listers
+	if dl, ok := rl.roleListers[namespace]; ok {
+		return dl.Roles(namespace)
+	}
+
+	// Check for any namespace-all listers
+	if dl, ok := rl.roleListers[metav1.NamespaceAll]; ok {
+		return dl.Roles(namespace)
+	}
+
+	return nil
+}
+
+func (rl *UnionRoleLister) RegisterRoleLister(namespace string, lister rbacv1.RoleLister) {
+	rl.roleLock.Lock()
+	defer rl.roleLock.Unlock()
+
+	if rl.roleListers == nil {
+		rl.roleListers = make(map[string]rbacv1.RoleLister)
+	}
+	rl.roleListers[namespace] = lister
+}
+
+func (l *rbacV1Lister) RegisterRoleLister(namespace string, lister rbacv1.RoleLister) {
+	l.roleLister.RegisterRoleLister(namespace, lister)
+}
+
+func (l *rbacV1Lister) RoleLister() rbacv1.RoleLister {
+	return l.roleLister
+}

--- a/pkg/lib/operatorlister/rolebinding.go
+++ b/pkg/lib/operatorlister/rolebinding.go
@@ -1,0 +1,76 @@
+package operatorlister
+
+import (
+	"sync"
+
+	"k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	rbacv1 "k8s.io/client-go/listers/rbac/v1"
+)
+
+type UnionRoleBindingLister struct {
+	roleBindingListers map[string]rbacv1.RoleBindingLister
+	roleBindingLock    sync.RWMutex
+}
+
+// List lists all RoleBindings in the indexer.
+func (rbl *UnionRoleBindingLister) List(selector labels.Selector) (ret []*v1.RoleBinding, err error) {
+	rbl.roleBindingLock.RLock()
+	defer rbl.roleBindingLock.RUnlock()
+
+	var set map[types.UID]*v1.RoleBinding
+	for _, dl := range rbl.roleBindingListers {
+		roleBindings, err := dl.List(selector)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, roleBinding := range roleBindings {
+			set[roleBinding.GetUID()] = roleBinding
+		}
+	}
+
+	for _, roleBinding := range set {
+		ret = append(ret, roleBinding)
+	}
+
+	return
+}
+
+// RoleBindings returns an object that can list and get RoleBindings.
+func (rbl *UnionRoleBindingLister) RoleBindings(namespace string) rbacv1.RoleBindingNamespaceLister {
+	rbl.roleBindingLock.RLock()
+	defer rbl.roleBindingLock.RUnlock()
+
+	// Check for specific namespace listers
+	if dl, ok := rbl.roleBindingListers[namespace]; ok {
+		return dl.RoleBindings(namespace)
+	}
+
+	// Check for any namespace-all listers
+	if dl, ok := rbl.roleBindingListers[metav1.NamespaceAll]; ok {
+		return dl.RoleBindings(namespace)
+	}
+
+	return nil
+}
+
+func (rbl *UnionRoleBindingLister) RegisterRoleBindingLister(namespace string, lister rbacv1.RoleBindingLister) {
+	rbl.roleBindingLock.Lock()
+	defer rbl.roleBindingLock.Unlock()
+
+	if rbl.roleBindingListers == nil {
+		rbl.roleBindingListers = make(map[string]rbacv1.RoleBindingLister)
+	}
+	rbl.roleBindingListers[namespace] = lister
+}
+
+func (l *rbacV1Lister) RegisterRoleBindingLister(namespace string, lister rbacv1.RoleBindingLister) {
+	l.roleBindingLister.RegisterRoleBindingLister(namespace, lister)
+}
+
+func (l *rbacV1Lister) RoleBindingLister() rbacv1.RoleBindingLister {
+	return l.roleBindingLister
+}

--- a/pkg/lib/operatorlister/secret.go
+++ b/pkg/lib/operatorlister/secret.go
@@ -1,0 +1,76 @@
+package operatorlister
+
+import (
+	"sync"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	corev1 "k8s.io/client-go/listers/core/v1"
+)
+
+type UnionSecretLister struct {
+	secretListers map[string]corev1.SecretLister
+	secretLock    sync.RWMutex
+}
+
+// List lists all Secrets in the indexer.
+func (usl *UnionSecretLister) List(selector labels.Selector) (ret []*v1.Secret, err error) {
+	usl.secretLock.RLock()
+	defer usl.secretLock.RUnlock()
+
+	var set map[types.UID]*v1.Secret
+	for _, sl := range usl.secretListers {
+		secrets, err := sl.List(selector)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, secret := range secrets {
+			set[secret.GetUID()] = secret
+		}
+	}
+
+	for _, secret := range set {
+		ret = append(ret, secret)
+	}
+
+	return
+}
+
+// Secrets returns an object that can list and get Secrets.
+func (usl *UnionSecretLister) Secrets(namespace string) corev1.SecretNamespaceLister {
+	usl.secretLock.RLock()
+	defer usl.secretLock.RUnlock()
+
+	// Check for specific namespace listers
+	if sl, ok := usl.secretListers[namespace]; ok {
+		return sl.Secrets(namespace)
+	}
+
+	// Check for any namespace-all listers
+	if sl, ok := usl.secretListers[metav1.NamespaceAll]; ok {
+		return sl.Secrets(namespace)
+	}
+
+	return nil
+}
+
+func (usl *UnionSecretLister) RegisterSecretLister(namespace string, lister corev1.SecretLister) {
+	usl.secretLock.Lock()
+	defer usl.secretLock.Unlock()
+
+	if usl.secretListers == nil {
+		usl.secretListers = make(map[string]corev1.SecretLister)
+	}
+	usl.secretListers[namespace] = lister
+}
+
+func (l *coreV1Lister) RegisterSecretLister(namespace string, lister corev1.SecretLister) {
+	l.secretLister.RegisterSecretLister(namespace, lister)
+}
+
+func (l *coreV1Lister) SecretLister() corev1.SecretLister {
+	return l.secretLister
+}

--- a/pkg/lib/operatorlister/service.go
+++ b/pkg/lib/operatorlister/service.go
@@ -1,0 +1,95 @@
+package operatorlister
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	corev1 "k8s.io/client-go/listers/core/v1"
+)
+
+type UnionServiceLister struct {
+	serviceListers map[string]corev1.ServiceLister
+	serviceLock    sync.RWMutex
+}
+
+// List lists all Services in the indexer.
+func (usl *UnionServiceLister) List(selector labels.Selector) (ret []*v1.Service, err error) {
+	usl.serviceLock.RLock()
+	defer usl.serviceLock.RUnlock()
+
+	var set map[types.UID]*v1.Service
+	for _, sl := range usl.serviceListers {
+		services, err := sl.List(selector)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, service := range services {
+			set[service.GetUID()] = service
+		}
+	}
+
+	for _, service := range set {
+		ret = append(ret, service)
+	}
+
+	return
+}
+
+// Services returns an object that can list and get Services.
+func (usl *UnionServiceLister) Services(namespace string) corev1.ServiceNamespaceLister {
+	usl.serviceLock.RLock()
+	defer usl.serviceLock.RUnlock()
+
+	// Check for specific namespace listers
+	if sl, ok := usl.serviceListers[namespace]; ok {
+		return sl.Services(namespace)
+	}
+
+	// Check for any namespace-all listers
+	if sl, ok := usl.serviceListers[metav1.NamespaceAll]; ok {
+		return sl.Services(namespace)
+	}
+
+	// TODO: Return dummy Service namespace lister
+	return nil
+}
+
+func (usl *UnionServiceLister) GetPodServices(pod *v1.Pod) ([]*v1.Service, error) {
+	usl.serviceLock.RLock()
+	defer usl.serviceLock.RUnlock()
+
+	// Check for specific namespace listers
+	if sl, ok := usl.serviceListers[pod.GetNamespace()]; ok {
+		return sl.GetPodServices(pod)
+	}
+
+	// Check for any namespace-all listers
+	if sl, ok := usl.serviceListers[metav1.NamespaceAll]; ok {
+		return sl.GetPodServices(pod)
+	}
+
+	return nil, fmt.Errorf("could not find service lister registered for namspace %s", pod.GetNamespace())
+}
+
+func (usl *UnionServiceLister) RegisterServiceLister(namespace string, lister corev1.ServiceLister) {
+	usl.serviceLock.Lock()
+	defer usl.serviceLock.Unlock()
+
+	if usl.serviceListers == nil {
+		usl.serviceListers = make(map[string]corev1.ServiceLister)
+	}
+	usl.serviceListers[namespace] = lister
+}
+
+func (l *coreV1Lister) RegisterServiceLister(namespace string, lister corev1.ServiceLister) {
+	l.serviceLister.RegisterServiceLister(namespace, lister)
+}
+
+func (l *coreV1Lister) ServiceLister() corev1.ServiceLister {
+	return l.serviceLister
+}

--- a/pkg/lib/operatorlister/serviceaccount.go
+++ b/pkg/lib/operatorlister/serviceaccount.go
@@ -1,0 +1,77 @@
+package operatorlister
+
+import (
+	"sync"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	corev1 "k8s.io/client-go/listers/core/v1"
+)
+
+type UnionServiceAccountLister struct {
+	serviceAccountListers map[string]corev1.ServiceAccountLister
+	serviceAccountLock    sync.RWMutex
+}
+
+// List lists all ServiceAccounts in the indexer.
+func (usl *UnionServiceAccountLister) List(selector labels.Selector) (ret []*v1.ServiceAccount, err error) {
+	usl.serviceAccountLock.RLock()
+	defer usl.serviceAccountLock.RUnlock()
+
+	var set map[types.UID]*v1.ServiceAccount
+	for _, sl := range usl.serviceAccountListers {
+		serviceAccounts, err := sl.List(selector)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, serviceAccount := range serviceAccounts {
+			set[serviceAccount.GetUID()] = serviceAccount
+		}
+	}
+
+	for _, serviceAccount := range set {
+		ret = append(ret, serviceAccount)
+	}
+
+	return
+}
+
+// ServiceAccounts returns an object that can list and get ServiceAccounts.
+func (usl *UnionServiceAccountLister) ServiceAccounts(namespace string) corev1.ServiceAccountNamespaceLister {
+	usl.serviceAccountLock.RLock()
+	defer usl.serviceAccountLock.RUnlock()
+
+	// Check for specific namespace listers
+	if sl, ok := usl.serviceAccountListers[namespace]; ok {
+		return sl.ServiceAccounts(namespace)
+	}
+
+	// Check for any namespace-all listers
+	if sl, ok := usl.serviceAccountListers[metav1.NamespaceAll]; ok {
+		return sl.ServiceAccounts(namespace)
+	}
+
+	// TODO: Return dummy ServiceAccountNamespaceLister
+	return nil
+}
+
+func (usl *UnionServiceAccountLister) RegisterServiceAccountLister(namespace string, lister corev1.ServiceAccountLister) {
+	usl.serviceAccountLock.Lock()
+	defer usl.serviceAccountLock.Unlock()
+
+	if usl.serviceAccountListers == nil {
+		usl.serviceAccountListers = make(map[string]corev1.ServiceAccountLister)
+	}
+	usl.serviceAccountListers[namespace] = lister
+}
+
+func (l *coreV1Lister) RegisterServiceAccountLister(namespace string, lister corev1.ServiceAccountLister) {
+	l.serviceAccountLister.RegisterServiceAccountLister(namespace, lister)
+}
+
+func (l *coreV1Lister) ServiceAccountLister() corev1.ServiceAccountLister {
+	return l.serviceAccountLister
+}

--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -51,7 +51,9 @@ func GetOwnerByKind(object metav1.Object, ownerKind string) metav1.OwnerReferenc
 func GetOwnersByKind(object metav1.Object, ownerKind string) []metav1.OwnerReference {
 	var orefs []metav1.OwnerReference
 	for _, oref := range object.GetOwnerReferences() {
-		orefs = append(orefs, oref)
+		if oref.Kind == ownerKind {
+			orefs = append(orefs, oref)
+		}
 	}
 	return orefs
 }

--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -3,14 +3,13 @@ package ownerutil
 import (
 	"fmt"
 
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 )
 
 // Owner is used to build an OwnerReference, and we need type and object metadata

--- a/pkg/lib/queueinformer/queueinformer_operator.go
+++ b/pkg/lib/queueinformer/queueinformer_operator.go
@@ -3,12 +3,11 @@ package queueinformer
 import (
 	"fmt"
 
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
-	"github.com/pkg/errors"
 )
 
 // An Operator is a collection of QueueInformers
@@ -47,6 +46,7 @@ func (o *Operator) RegisterQueueInformer(queueInformer *QueueInformer) {
 	if o.queueInformers == nil {
 		o.queueInformers = []*QueueInformer{}
 	}
+
 	o.queueInformers = append(o.queueInformers, queueInformer)
 }
 

--- a/pkg/package-server/generated/openapi/zz_generated.openapi.go
+++ b/pkg/package-server/generated/openapi/zz_generated.openapi.go
@@ -139,6 +139,19 @@ func schema_package_server_apis_packagemanifest_v1alpha1_CSVDescription(ref comm
 							Ref:         ref("github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/packagemanifest/v1alpha1.AppLink"),
 						},
 					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-ps x | grep -q [m]inikube || minikube start --kubernetes-version="v1.11.1" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
+ps x | grep -q [m]inikube || minikube start --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
 eval $(minikube docker-env) || { echo 'Cannot switch to minikube docker'; exit 1; }
 kubectl config use-context minikube
 docker build -f e2e.Dockerfile .

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -3,9 +3,14 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
@@ -15,13 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 )
 
 var singleInstance = int32(1)


### PR DESCRIPTION
### Description
This PR ensures that generated certs for owned APIServices are rotated before they expire by some minimum amount of time. Two fields are added to `ClusterServiceVersionStatus` to track cert rotation, `CertsRotateAt` and `CertsLastUpdated`. 

### Notes:
APIService e2e tests use a repurposed `package-server` deployment. This can interfere with later package-server tests and is generally messy. In or following this PR I hope to incorporate a new configurable extension api-server that allows arbitrary group/versions to be set via a startup flag. This should help to alleviate some of this messiness. 