### PR TITLE
chore(package-server): enable auth by default

### DIFF
--- a/pkg/package-server/server/server.go
+++ b/pkg/package-server/server/server.go
@@ -90,7 +90,7 @@ func NewPackageServerOptions(out, errOut io.Writer) *PackageServerOptions {
 		WatchedNamespaces: []string{v1.NamespaceAll},
 		WakeupInterval:    5 * time.Minute,
 
-		DisableAuthForTesting: true,
+		DisableAuthForTesting: false,
 		Debug:                 false,
 
 		StdOut: out,


### PR DESCRIPTION
### Description
Enables authentication and authorization by default for the `package-server`.