### PR TITLE
Add `ConfigMap` as an Owned Resource for Prometheus

### DIFF
--- a/deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -199,6 +199,8 @@ spec:
         version: v1beta2
       - kind: Pod
         version: v1
+      - kind: ConfigMap
+        version: v1
       specDescriptors:
       - description: Desired number of Pods for the cluster
         displayName: Size


### PR DESCRIPTION
### Description

Apparently `Prometheus` instances write owner references to `ConfigMaps`.

![screenshot_20181019_152255](https://user-images.githubusercontent.com/11700385/47239300-e5551d00-d3b2-11e8-9c4b-b59a94295807.png)


