### PR TITLE
Fix template values for 'olm' parameters

### DIFF
--- a/Documentation/install/install.md
+++ b/Documentation/install/install.md
@@ -59,7 +59,7 @@ watchedNamespaces: local
 catalog_namespace: local
 
 # OLM operator run configuration
-alm:
+olm:
   # OLM operator doesn't do any leader election (yet), set to 1
   replicaCount: 1
   # The image to run. If not building a local image, use sha256 image references

--- a/Documentation/install/local-values-shift.yaml
+++ b/Documentation/install/local-values-shift.yaml
@@ -4,7 +4,7 @@ watchedNamespaces: local
 catalog_namespace: local
 debug: true
 
-alm:
+olm:
   replicaCount: 1
   image:
     ref: quay.io/coreos/olm:local


### PR DESCRIPTION
as it was still referring to 'alm' instead of 'olm', which breaks `make run-local-shift`