### PR TITLE
Add Service to Owned Resources for Prometheus Operator

### DIFF
--- a/deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -201,6 +201,8 @@ spec:
         version: v1
       - kind: ConfigMap
         version: v1
+      - kind: Service
+        version: v1
       specDescriptors:
       - description: Desired number of Pods for the cluster
         displayName: Size
@@ -260,6 +262,8 @@ spec:
       - kind: StatefulSet
         version: v1beta2
       - kind: Pod
+        version: v1
+      - kind: Service
         version: v1
       specDescriptors:
       - description: Desired number of Pods for the cluster


### PR DESCRIPTION
### Description

The Prometheus Operator will create a [`Service` with `ownerReferences`](https://github.com/coreos/prometheus-operator/pull/1946) for each `Prometheus`/`Alertmanager` custom resources, so add them to the CSV.