### PR TITLE
Verify Native APIs Present for ClusterServiceVersion

### DIFF
--- a/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
@@ -180,7 +180,25 @@ spec:
                           values:
                             type: array
                             description: set of values for the expression
-                            
+            nativeAPIs:
+              type: array
+              description: What resources are required by the Operator, but must be provided by the underlying cluster and not as an extension.
+              items:
+                type: object
+                required:
+                - group
+                - version
+                - kind
+                properties:
+                  group:
+                    type: string
+                    description: Group of the API resource
+                  version:
+                    type: string
+                    description: Version of the API resource
+                  kind:
+                    type: string
+                    description: Kind of the API resource        
             apiservicedefinitions:
               type: object
               properties:

--- a/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
@@ -102,14 +102,15 @@ type APIServiceDefinitions struct {
 	Required []APIServiceDescription `json:"required,omitempty"`
 }
 
-// ClusterServiceVersionSpec declarations tell the OLM how to install an operator
-// that can manage apps for given version and AppType.
+// ClusterServiceVersionSpec declarations tell OLM how to install an operator
+// that can manage apps for a given version.
 type ClusterServiceVersionSpec struct {
 	InstallStrategy           NamedInstallStrategy      `json:"install"`
 	Version                   semver.Version            `json:"version,omitempty"`
 	Maturity                  string                    `json:"maturity,omitempty"`
 	CustomResourceDefinitions CustomResourceDefinitions `json:"customresourcedefinitions,omitempty"`
 	APIServiceDefinitions     APIServiceDefinitions     `json:"apiservicedefinitions,omitempty"`
+	NativeAPIs                []metav1.GroupVersionKind `json:"nativeAPIs,omitempty"`
 	DisplayName               string                    `json:"displayName"`
 	Description               string                    `json:"description,omitempty"`
 	Keywords                  []string                  `json:"keywords,omitempty"`

--- a/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
@@ -402,6 +402,11 @@ func (in *ClusterServiceVersionSpec) DeepCopyInto(out *ClusterServiceVersionSpec
 	out.Version = in.Version
 	in.CustomResourceDefinitions.DeepCopyInto(&out.CustomResourceDefinitions)
 	in.APIServiceDefinitions.DeepCopyInto(&out.APIServiceDefinitions)
+	if in.NativeAPIs != nil {
+		in, out := &in.NativeAPIs, &out.NativeAPIs
+		*out = make([]v1.GroupVersionKind, len(*in))
+		copy(*out, *in)
+	}
 	if in.Keywords != nil {
 		in, out := &in.Keywords, &out.Keywords
 		*out = make([]string, len(*in))

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -212,7 +212,12 @@ func installStrategy(deploymentName string, permissions []install.StrategyDeploy
 	}
 }
 
-func csv(name, namespace, replaces string, installStrategy v1alpha1.NamedInstallStrategy, owned, required []*v1beta1.CustomResourceDefinition, phase v1alpha1.ClusterServiceVersionPhase) *v1alpha1.ClusterServiceVersion {
+func csv(
+	name, namespace, replaces string,
+	installStrategy v1alpha1.NamedInstallStrategy,
+	owned, required []*v1beta1.CustomResourceDefinition,
+	phase v1alpha1.ClusterServiceVersionPhase,
+) *v1alpha1.ClusterServiceVersion {
 	requiredCRDDescs := make([]v1alpha1.CRDDescription, 0)
 	for _, crd := range required {
 		requiredCRDDescs = append(requiredCRDDescs, v1alpha1.CRDDescription{Name: crd.GetName(), Version: crd.Spec.Versions[0].Name, Kind: crd.Spec.Names.Kind})


### PR DESCRIPTION
### Description

Adds the ability to enforce that certain "native" APIs exist in a Kubernetes cluster in order to install an Operator using a `ClusterServiceVersion`. This is a more complete solution than depending on some "version" of Kubernetes, because there are so many flavors and distributions that may or may not contain the APIs consumed by the Operator.

### Changes

- Adds `spec.nativeAPIs` field to `ClusterServiceVersion` (array of `GroupVersionKinds`)
- Verifies required native APIs are present using basic discovery as part of CSV control loop
- Writes out to `requirementStatus` just like CRDs and apiservices

Addresses https://jira.coreos.com/browse/ALM-666