### PR TITLE
Fix olm pod name so log to be written correctly to olm.log

### DIFF
--- a/scripts/run_e2e_local.sh
+++ b/scripts/run_e2e_local.sh
@@ -26,10 +26,10 @@ function cleanupAndExit {
 	exitCode=$?
 	if [ "$exitCode" -ne "0" ]; then
 		echo "error running tests. logs written to olm.log, catalog.log, and package.log";
-		kubectl -n ${namespace} logs -l app=alm-operator > olm.log;
+		kubectl -n ${namespace} logs -l app=olm-operator > olm.log;
 		kubectl -n ${namespace} logs -l app=catalog-operator > catalog.log;
 		kubectl -n ${namespace} logs -l app=package-server > package.log
-	else 
+	else
 		cleanup
 	fi
 


### PR DESCRIPTION
The olm pod name is incorrect as "alm-operator". It should be
"olm-operator". This issue causes the olm log never being written
into olm.log after the e2e test is run.

Signed-off-by: Vu Dinh <vdinh@redhat.com>