### PR TITLE
Add CRD to "View" RBAC Role

### DIFF
--- a/pkg/controller/registry/resolver/steps.go
+++ b/pkg/controller/registry/resolver/steps.go
@@ -64,7 +64,10 @@ func NewStepResourcesFromCRD(crd *v1beta1.CustomResourceDefinition) ([]v1alpha1.
 				"rbac.authorization.k8s.io/aggregate-to-view": "true",
 			},
 		},
-		Rules: []rbacv1.PolicyRule{{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{crd.Spec.Group}, Resources: []string{crd.Spec.Names.Plural}}},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{crd.Spec.Group}, Resources: []string{crd.Spec.Names.Plural}},
+			{Verbs: []string{"get", "watch"}, APIGroups: []string{v1beta1.GroupName}, Resources: []string{crd.GetName()}},
+		},
 	}
 	viewRoleStep, err := NewStepResourceFromObject(viewRole, viewRole.GetName())
 	if err != nil {


### PR DESCRIPTION
### Description

When creating the "view" `Role` for instances of a custom resource, add the CRD itself so users can fetch the validation and additional printer columns.

Addresses https://jira.coreos.com/browse/ALM-785