### PR TITLE
Service Catalog CSV: update resource limitations

### DIFF
--- a/deploy/chart/catalog_resources/rh-operators/svcat.v0.1.34.clusterserviceversion.yaml
+++ b/deploy/chart/catalog_resources/rh-operators/svcat.v0.1.34.clusterserviceversion.yaml
@@ -171,10 +171,10 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 40Mi
+                    memory: 70Mi
                   requests:
                     cpu: 100m
-                    memory: 30Mi
+                    memory: 50Mi
                 env:
                 - name: ETCD_DATA_DIR
                   value: /etcd-data-dir


### PR DESCRIPTION
 Some users are getting errors with etcd container unable to allocate memory.  I think these were copied from a default template - we've never had resource limitations on our containers in either OpenShift Service Catalog or upstream.