### PR TITLE
Fix copied CSV leaks targeted namespaces

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -40,6 +40,18 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 
 	nsListJoined := strings.Join(targetedNamespaces, ",")
 
+	for _, csv := range csvsInNamespace {
+		if err := a.copyCsvToTargetNamespace(csv, op, targetedNamespaces); err != nil {
+			return err
+		}
+	}
+
+	for _, csv := range csvsInNamespace {
+		if err := a.ensureRBACInTargetNamespace(csv, op, targetedNamespaces); err != nil {
+			return err
+		}
+	}
+
 	// annotate csvs
 	csvsInNamespace := a.csvSet(op.Namespace)
 	for _, csv := range csvsInNamespace {
@@ -50,18 +62,6 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(csv); err != nil {
 				log.Errorf("Update for existing CSV failed: %v", err)
 			}
-		}
-	}
-
-	for _, csv := range csvsInNamespace {
-		if err := a.copyCsvToTargetNamespace(csv, op, targetedNamespaces); err != nil {
-			return err
-		}
-	}
-
-	for _, csv := range csvsInNamespace {
-		if err := a.ensureRBACInTargetNamespace(csv, op, targetedNamespaces); err != nil {
-			return err
 		}
 	}
 	log.Debug("CSV annotation completed")


### PR DESCRIPTION
The CSVs should be copied to targeted namespaces first with the
original contents. Then, the main CSVs are annotated with targeted
namespaces afterwards so that the copied CSVs won't contain object
meta with targeted namespaces information.

Jira: https://jira.coreos.com/browse/ALM-824

Signed-off-by: Vu Dinh <vdinh@redhat.com>