### PR TITLE
fix(e2e): fix CSV tests

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -34,7 +34,7 @@ var (
 		"interval", defaultWakeupInterval, "wake up interval")
 
 	watchedNamespaces = flag.String(
-		"watchedNamespaces", "", "comma separated list of namespaces for alm operator to watch. "+
+		"watchedNamespaces", "", "comma separated list of namespaces for olm operator to watch. "+
 			"If not set, or set to the empty string (e.g. `-watchedNamespaces=\"\"`), "+
 			"olm operator will watch all namespaces in the cluster.")
 
@@ -48,7 +48,7 @@ func init() {
 	metrics.Register()
 }
 
-// main function - entrypoint to ALM operator
+// main function - entrypoint to OLM operator
 func main() {
 	stopCh := signals.SetupSignalHandler()
 

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -54,7 +54,7 @@ func TestCatalogLoadingBetweenRestarts(t *testing.T) {
 	require.NoError(t, err)
 
 	// get catalog operator deployment
-	deployment, err := getOperatorDeployment(c, labels.Set{"app": "catalog-operator"})
+	deployment, err := getOperatorDeployment(c, operatorNamespace, labels.Set{"app": "catalog-operator"})
 	require.NoError(t, err)
 	require.NotNil(t, deployment, "Could not find catalog operator deployment")
 
@@ -77,8 +77,8 @@ func TestCatalogLoadingBetweenRestarts(t *testing.T) {
 	t.Logf("Catalog source sucessfully loaded after rescale")
 }
 
-func getOperatorDeployment(c operatorclient.ClientInterface, operatorLabels labels.Set) (*appsv1.Deployment, error) {
-	deployments, err := c.ListDeploymentsWithLabels(operatorNamespace, operatorLabels)
+func getOperatorDeployment(c operatorclient.ClientInterface, namespace string, operatorLabels labels.Set) (*appsv1.Deployment, error) {
+	deployments, err := c.ListDeploymentsWithLabels(namespace, operatorLabels)
 	if err != nil || deployments == nil || len(deployments.Items) != 1 {
 		return nil, fmt.Errorf("Error getting single operator deployment for label: %v", operatorLabels)
 	}
@@ -95,7 +95,7 @@ func rescaleDeployment(c operatorclient.ClientInterface, deployment *appsv1.Depl
 	}
 
 	waitForScaleup := func() (bool, error) {
-		fetchedDeployment, err := c.GetDeployment(operatorNamespace, deployment.GetName())
+		fetchedDeployment, err := c.GetDeployment(deployment.GetNamespace(), deployment.GetName())
 		if err != nil {
 			return true, err
 		}

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -723,19 +723,19 @@ func TestCreateCSVRequirementsMetCRD(t *testing.T) {
 	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		dep, err := c.GetDeployment(testNamespace, depName)
 		if k8serrors.IsNotFound(err) {
-			fmt.Printf("deployment %s not found", depName)
+			fmt.Printf("deployment %s not found\n", depName)
 			return false, nil
 		} else if err != nil {
-			fmt.Printf("unexpected error fetching deployment %s", depName)
+			fmt.Printf("unexpected error fetching deployment %s\n", depName)
 			return false, err
 		}
 		if dep.Status.UpdatedReplicas == *(dep.Spec.Replicas) &&
 			dep.Status.Replicas == *(dep.Spec.Replicas) &&
 			dep.Status.AvailableReplicas == *(dep.Spec.Replicas) {
-			fmt.Printf("deployment ready")
+			fmt.Println("deployment ready")
 			return true, nil
 		}
-		fmt.Printf("deployment not ready")
+		fmt.Println("deployment not ready")
 		return false, nil
 	})
 	require.NoError(t, err)
@@ -1009,12 +1009,12 @@ func TestCreateCSVWithOwnedAPIService(t *testing.T) {
 	// Induce a cert rotation
 	fetchedCSV.Status.CertsLastUpdated = metav1.Now()
 	fetchedCSV.Status.CertsRotateAt = metav1.Now()
-	fetchedCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(operatorNamespace).UpdateStatus(fetchedCSV)
+	fetchedCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).UpdateStatus(fetchedCSV)
 	require.NoError(t, err)
 
 	_, err = fetchCSV(t, crc, csv.Name, func(csv *v1alpha1.ClusterServiceVersion) bool {
 		// Should create deployment
-		dep, err = c.GetDeployment(operatorNamespace, depName)
+		dep, err = c.GetDeployment(testNamespace, depName)
 		require.NoError(t, err)
 
 		// Should have a new ca hash annotation

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -240,7 +240,7 @@ func catalogSourceSynced(catalog *v1alpha1.CatalogSource) bool {
 	if !catalog.Status.LastSync.IsZero() {
 		return true
 	}
-	fmt.Printf("not synced: %#v", catalog)
+
 	return false
 }
 


### PR DESCRIPTION
### Description

- Looks in `testNamespace` instead of `operatorNamespace` for created CSVs and Deployments in `TestCreateCSVWithOwnedAPIService`.
- Creates CSV first before use in CRD OwnerReferences (UID was empty which meant that changes to the CRD would not requeue the CSV).

Supersedes [#582](https://github.com/operator-framework/operator-lifecycle-manager/pull/582)