### PR TITLE
[WIP] Fix copied CSV leaks targeted namespaces

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -239,6 +239,10 @@ func (a *Operator) copyCsvToTargetNamespace(csv *v1alpha1.ClusterServiceVersion,
 			log.Debugf("Found existing CSV (%v), checking annotations", fetchedCSV.GetName())
 			if reflect.DeepEqual(fetchedCSV.Annotations, csv.Annotations) == false {
 				fetchedCSV.Annotations = csv.Annotations
+				// Remove olm.targetNamespaces annotation on the copied CSV
+				fetchedAnnotations := fetchedCSV.Annotations
+				delete(fetchedAnnotations, "olm.targetNamespaces")
+				fetchedCSV.SetAnnotations(fetchedAnnotations)
 				// CRDs don't support strategic merge patching, but in the future if they do this should be updated to patch
 				log.Debugf("Updating CSV %v in namespace %v", fetchedCSV.GetName(), ns)
 				if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(ns).Update(fetchedCSV); err != nil {


### PR DESCRIPTION
The CSVs should be copied to targeted namespaces first with the
original contents. Then, the main CSVs are annotated with targeted
namespaces afterwards so that the copied CSVs won't contain object
meta with targeted namespaces information.

Jira: https://jira.coreos.com/browse/ALM-824

Signed-off-by: Vu Dinh <vdinh@redhat.com>