### PR TITLE
fix(e2e): make operator group test more robust

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -2522,8 +2522,11 @@ func TestSyncOperatorGroups(t *testing.T) {
 
 			stopCh := make(chan struct{})
 			defer func() { stopCh <- struct{}{} }()
-			op, _, err := NewFakeOperator(tt.initial.clientObjs, tt.initial.k8sObjs, tt.initial.crds, tt.initial.apis, &install.StrategyResolver{}, namespaces, stopCh)
+			op, hasSyncedFns, err := NewFakeOperator(tt.initial.clientObjs, tt.initial.k8sObjs, tt.initial.crds, tt.initial.apis, &install.StrategyResolver{}, namespaces, stopCh)
 			require.NoError(t, err)
+
+			ok := cache.WaitForCacheSync(stopCh, hasSyncedFns...)
+			require.True(t, ok, "wait for cache sync failed")
 
 			err = op.syncOperatorGroups(tt.initial.operatorGroup)
 			require.NoError(t, err)


### PR DESCRIPTION
This PR should be the last of the operator group related PRs since it pulls in fixes from other PRs (and should be rebased on top of them after they get merged). FWIW, some of the lack of robustness here is due to resources unexpectedly existing from other tests.