### PR TITLE
add short names for basic CRD

### DIFF
--- a/Documentation/design/architecture.md
+++ b/Documentation/design/architecture.md
@@ -6,10 +6,10 @@ Each of these Operators are responsible for managing the CRDs that are the basis
 
 | Resource                 | Short Name | Owner   | Description                                                                                |
 |--------------------------|------------|---------|--------------------------------------------------------------------------------------------|
-| ClusterServiceVersion | CSV        | OLM     | application metadata: name, version, icon, required resources, installation, etc...        |
-| InstallPlan           | IP         | Catalog | calculated list of resources to be created in order to automatically install/upgrade a CSV |
-| CatalogSource         | CS         | Catalog | a repository of CSVs, CRDs, and packages that define an application                        |
-| Subscription          | Sub        | Catalog | used to keep CSVs up to date by tracking a channel in a package                            |
+| ClusterServiceVersion | csv        | OLM     | application metadata: name, version, icon, required resources, installation, etc...        |
+| InstallPlan           | ip         | Catalog | calculated list of resources to be created in order to automatically install/upgrade a CSV |
+| CatalogSource         | catsrc     | Catalog | a repository of CSVs, CRDs, and packages that define an application                        |
+| Subscription          | sub        | Catalog | used to keep CSVs up to date by tracking a channel in a package                            |
 | OperatorGroup         | <None>     | OLM     | method to group multiple namespaces and prepare for use by an operator                     |
 
 Each of these Operators are also responsible for creating resources:

--- a/deploy/chart/templates/0000_30_03-installplan.crd.yaml
+++ b/deploy/chart/templates/0000_30_03-installplan.crd.yaml
@@ -18,6 +18,8 @@ spec:
     singular: installplan
     kind: InstallPlan
     listKind: InstallPlanList
+    shortNames:
+    - ip
     categories:
     - all
     - olm

--- a/deploy/chart/templates/0000_30_04-subscription.crd.yaml
+++ b/deploy/chart/templates/0000_30_04-subscription.crd.yaml
@@ -18,6 +18,8 @@ spec:
     singular: subscription
     kind: Subscription
     listKind: SubscriptionList
+    shortNames:
+    - sub
     categories:
     - all
     - olm

--- a/deploy/chart/templates/0000_30_05-catalogsource.crd.yaml
+++ b/deploy/chart/templates/0000_30_05-catalogsource.crd.yaml
@@ -18,6 +18,8 @@ spec:
     singular: catalogsource
     kind: CatalogSource
     listKind: CatalogSourceList
+    shortNames:
+    - catsrc
     categories:
     - all
     - olm

--- a/deploy/ocp/manifests/0.8.0/0000_30_03-installplan.crd.yaml
+++ b/deploy/ocp/manifests/0.8.0/0000_30_03-installplan.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: installplan
     kind: InstallPlan
     listKind: InstallPlanList
+    shortNames:
+    - ip
     categories:
     - all
     - olm

--- a/deploy/ocp/manifests/0.8.0/0000_30_04-subscription.crd.yaml
+++ b/deploy/ocp/manifests/0.8.0/0000_30_04-subscription.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: subscription
     kind: Subscription
     listKind: SubscriptionList
+    shortNames:
+    - sub
     categories:
     - all
     - olm

--- a/deploy/ocp/manifests/0.8.0/0000_30_05-catalogsource.crd.yaml
+++ b/deploy/ocp/manifests/0.8.0/0000_30_05-catalogsource.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: catalogsource
     kind: CatalogSource
     listKind: CatalogSourceList
+    shortNames:
+    - catsrc
     categories:
     - all
     - olm

--- a/deploy/okd/manifests/0.8.0/0000_30_03-installplan.crd.yaml
+++ b/deploy/okd/manifests/0.8.0/0000_30_03-installplan.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: installplan
     kind: InstallPlan
     listKind: InstallPlanList
+    shortNames:
+    - ip
     categories:
     - all
     - olm

--- a/deploy/okd/manifests/0.8.0/0000_30_04-subscription.crd.yaml
+++ b/deploy/okd/manifests/0.8.0/0000_30_04-subscription.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: subscription
     kind: Subscription
     listKind: SubscriptionList
+    shortNames:
+    - sub
     categories:
     - all
     - olm

--- a/deploy/okd/manifests/0.8.0/0000_30_05-catalogsource.crd.yaml
+++ b/deploy/okd/manifests/0.8.0/0000_30_05-catalogsource.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: catalogsource
     kind: CatalogSource
     listKind: CatalogSourceList
+    shortNames:
+    - catsrc
     categories:
     - all
     - olm

--- a/deploy/upstream/manifests/0.8.0/0000_30_03-installplan.crd.yaml
+++ b/deploy/upstream/manifests/0.8.0/0000_30_03-installplan.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: installplan
     kind: InstallPlan
     listKind: InstallPlanList
+    shortNames:
+    - ip
     categories:
     - all
     - olm

--- a/deploy/upstream/manifests/0.8.0/0000_30_04-subscription.crd.yaml
+++ b/deploy/upstream/manifests/0.8.0/0000_30_04-subscription.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: subscription
     kind: Subscription
     listKind: SubscriptionList
+    shortNames:
+    - sub
     categories:
     - all
     - olm

--- a/deploy/upstream/manifests/0.8.0/0000_30_05-catalogsource.crd.yaml
+++ b/deploy/upstream/manifests/0.8.0/0000_30_05-catalogsource.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: catalogsource
     kind: CatalogSource
     listKind: CatalogSourceList
+    shortNames:
+    - catsrc
     categories:
     - all
     - olm

--- a/manifests/0000_30_03-installplan.crd.yaml
+++ b/manifests/0000_30_03-installplan.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: installplan
     kind: InstallPlan
     listKind: InstallPlanList
+    shortNames:
+    - ip
     categories:
     - all
     - olm

--- a/manifests/0000_30_04-subscription.crd.yaml
+++ b/manifests/0000_30_04-subscription.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: subscription
     kind: Subscription
     listKind: SubscriptionList
+    shortNames:
+    - sub
     categories:
     - all
     - olm

--- a/manifests/0000_30_05-catalogsource.crd.yaml
+++ b/manifests/0000_30_05-catalogsource.crd.yaml
@@ -20,6 +20,8 @@ spec:
     singular: catalogsource
     kind: CatalogSource
     listKind: CatalogSourceList
+    shortNames:
+    - catsrc
     categories:
     - all
     - olm


### PR DESCRIPTION
I added the `shortNames` for these CRDs per this [doc](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/architecture.md#architecture). But, there is still a problem here, list it in below.