### PR TITLE
Verify CRD's condition to ensure it's registered with k8s API (rebased)

### DIFF
--- a/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
@@ -252,8 +252,10 @@ const (
 	RequirementStatusReasonPresent             StatusReason = "Present"
 	RequirementStatusReasonNotPresent          StatusReason = "NotPresent"
 	RequirementStatusReasonPresentNotSatisfied StatusReason = "PresentNotSatisfied"
-	DependentStatusReasonSatisfied             StatusReason = "Satisfied"
-	DependentStatusReasonNotSatisfied          StatusReason = "NotSatisfied"
+	// The CRD is present but the Established condition is False (not available)
+	RequirementStatusReasonNotAvailable StatusReason = "PresentNotAvailable"
+	DependentStatusReasonSatisfied      StatusReason = "Satisfied"
+	DependentStatusReasonNotSatisfied   StatusReason = "NotSatisfied"
 )
 
 // DependentStatus is the status for a dependent requirement (to prevent infinite nesting)

--- a/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
@@ -274,6 +274,7 @@ type RequirementStatus struct {
 	Kind       string            `json:"kind"`
 	Name       string            `json:"name"`
 	Status     StatusReason      `json:"status"`
+	Message    string            `json:"message"`
 	UUID       string            `json:"uuid,omitempty"`
 	Dependents []DependentStatus `json:"dependents,omitempty"`
 }
@@ -445,3 +446,4 @@ func (csv ClusterServiceVersion) GetOwnedAPIServiceDescriptions() []APIServiceDe
 
 	return descs
 }
+

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -131,7 +131,7 @@ func NewFakeOperator(clientObjs []runtime.Object, k8sObjs []runtime.Object, extO
 	}
 
 	// Create the new operator
-	queueOperator, err := queueinformer.NewOperatorFromClient(opClientFake, logrus.New())
+	queueOperator, err := queueinformer.NewOperatorFromClient(opClientFake, logrus.StandardLogger())
 	op := &Operator{
 		Operator:  queueOperator,
 		client:    clientFake,
@@ -2063,6 +2063,7 @@ func TestTransitionCSV(t *testing.T) {
 }
 
 func TestSyncOperatorGroups(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
 	nowTime := metav1.Date(2006, time.January, 2, 15, 4, 5, 0, time.FixedZone("MST", -7*3600))
 	timeNow = func() metav1.Time { return nowTime }
 

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -2143,6 +2143,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 			Kind:    "CustomResourceDefinition",
 			Name:    crd.GetName(),
 			Status:  v1alpha1.RequirementStatusReasonPresent,
+			Message: "CRD is present and Established condition is true",
 		},
 		{
 			Group:   "",

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -555,6 +555,18 @@ func crd(name string, version string) *v1beta1.CustomResourceDefinition {
 				Kind: name,
 			},
 		},
+		Status: v1beta1.CustomResourceDefinitionStatus{
+			Conditions: []v1beta1.CustomResourceDefinitionCondition{
+				{
+					Type:   v1beta1.Established,
+					Status: v1beta1.ConditionTrue,
+				},
+				{
+					Type:   v1beta1.NamesAccepted,
+					Status: v1beta1.ConditionTrue,
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -30,8 +30,8 @@ func (a *Operator) requirementStatus(strategyDetailsDeployment *install.Strategy
 		// check if CRD exists - this verifies group, version, and kind, so no need for GVK check via discovery
 		crd, err := a.lister.APIExtensionsV1beta1().CustomResourceDefinitionLister().Get(r.Name)
 		if err != nil {
-			a.Log.Debugf("Setting 'met' to false, %v with err: %v", r.Name, err)
 			status.Status = v1alpha1.RequirementStatusReasonNotPresent
+			a.Log.Debugf("Setting 'met' to false, %v with status %v, with err: %v", r.Name, status, err)
 			met = false
 			statuses = append(statuses, status)
 			continue
@@ -53,6 +53,7 @@ func (a *Operator) requirementStatus(strategyDetailsDeployment *install.Strategy
 
 			if !served {
 				status.Status = v1alpha1.RequirementStatusReasonNotPresent
+				a.Log.Debugf("Setting 'met' to false, %v with status %v, CRD version %v not found", r.Name, status, r.Version)
 				met = false
 				statuses = append(statuses, status)
 				continue
@@ -81,6 +82,7 @@ func (a *Operator) requirementStatus(strategyDetailsDeployment *install.Strategy
 		} else {
 			status.Status = v1alpha1.RequirementStatusReasonNotAvailable
 			met = false
+			a.Log.Debugf("Setting 'met' to false, %v with status %v, established=%v, namesAccepted=%v", r.Name, status, established, namesAccepted)
 			statuses = append(statuses, status)
 		}
 	}

--- a/pkg/controller/operators/olm/requirements_test.go
+++ b/pkg/controller/operators/olm/requirements_test.go
@@ -453,6 +453,58 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			description: "RequirementNotMet/NotEstablishedCRDVersion",
+			csv: csv("csv1",
+				namespace,
+				"",
+				installStrategy("csv1-dep", nil, nil),
+				[]*v1beta1.CustomResourceDefinition{crd("c1", "v2")},
+				nil,
+				v1alpha1.CSVPhasePending,
+			),
+			existingObjs: nil,
+			existingExtObjs: []runtime.Object{
+				crd("c1", "v2"),
+			},
+			met: false,
+			expectedRequirementStatuses: map[gvkn]v1alpha1.RequirementStatus{
+				{"apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition", "c1group"}: {
+					Group:   "apiextensions.k8s.io",
+					Version: "v1beta1",
+					Kind:    "CustomResourceDefinition",
+					Name:    "c1group",
+					Status:  v1alpha1.RequirementStatusReasonNotAvailable,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			description: "RequirementNotMet/NamesConflictedCRDVersion",
+			csv: csv("csv1",
+				namespace,
+				"",
+				installStrategy("csv1-dep", nil, nil),
+				[]*v1beta1.CustomResourceDefinition{crd("c1", "v2")},
+				nil,
+				v1alpha1.CSVPhasePending,
+			),
+			existingObjs: nil,
+			existingExtObjs: []runtime.Object{
+				crd("c1", "v2"),
+			},
+			met: false,
+			expectedRequirementStatuses: map[gvkn]v1alpha1.RequirementStatus{
+				{"apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition", "c1group"}: {
+					Group:   "apiextensions.k8s.io",
+					Version: "v1beta1",
+					Kind:    "CustomResourceDefinition",
+					Name:    "c1group",
+					Status:  v1alpha1.RequirementStatusReasonNotAvailable,
+				},
+			},
+			expectedError: nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This is Vu's https://github.com/operator-framework/operator-lifecycle-manager/pull/553, but rebased and with tests passing (should be at least!). It has been modified from his original code slightly - ~mainly instead of creating a crdWithStatus, instead uses crdWithoutStatus which required far less code modification.~