### PR TITLE
fix(olm): don't annotate target namespace on copied CSVs

### DIFF
--- a/pkg/api/apis/operators/v1alpha2/operatorgroup_types.go
+++ b/pkg/api/apis/operators/v1alpha2/operatorgroup_types.go
@@ -32,3 +32,9 @@ type OperatorGroupList struct {
 
 	Items []OperatorGroup `json:"items"`
 }
+
+const (
+	OperatorGroupAnnotationKey          = "olm.operatorGroup"
+	OperatorGroupNamespaceAnnotationKey = "olm.operatorNamespace"
+	OperatorGroupTargetsAnnotationKey   = "olm.targetNamespaces"
+)

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -345,12 +345,12 @@ func (a *Operator) deleteClusterServiceVersion(obj interface{}) {
 		"phase":     clusterServiceVersion.Status.Phase,
 	})
 
-	targetNamespaces, ok := clusterServiceVersion.Annotations["olm.targetNamespaces"]
+	targetNamespaces, ok := clusterServiceVersion.Annotations[v1alpha2.OperatorGroupTargetsAnnotationKey]
 	if !ok {
 		logger.Debugf("Ignoring CSV with no annotation")
 	}
 
-	operatorNamespace, ok := clusterServiceVersion.Annotations["olm.operatorNamespace"]
+	operatorNamespace, ok := clusterServiceVersion.Annotations[v1alpha2.OperatorGroupNamespaceAnnotationKey]
 	if !ok {
 		logger.Debugf("missing operator namespace annotation on CSV")
 	}
@@ -375,7 +375,7 @@ func (a *Operator) removeDanglingChildCSVs(csv *v1alpha1.ClusterServiceVersion) 
 		"phase":     csv.Status.Phase,
 	})
 
-	operatorNamespace, ok := csv.Annotations["olm.operatorNamespace"]
+	operatorNamespace, ok := csv.Annotations[v1alpha2.OperatorGroupNamespaceAnnotationKey]
 	if !ok {
 		logger.Debug("missing operator namespace annotation on copied CSV")
 		return fmt.Errorf("missing operator namespace annotation on copied CSV")
@@ -427,7 +427,7 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 		return
 	}
 
-	operatorNamespace, ok := clusterServiceVersion.GetAnnotations()[operatorGroupNamespaceAnnotationKey]
+	operatorNamespace, ok := clusterServiceVersion.GetAnnotations()[v1alpha2.OperatorGroupNamespaceAnnotationKey]
 
 	if clusterServiceVersion.Status.Reason == v1alpha1.CSVReasonCopied ||
 		ok && clusterServiceVersion.GetNamespace() != operatorNamespace {
@@ -484,12 +484,12 @@ func (a *Operator) operatorGroupForActiveCSV(logger *logrus.Entry, csv *v1alpha1
 	}
 
 	// not in the operatorgroup namespace
-	if annotations[operatorGroupNamespaceAnnotationKey] != csv.GetNamespace() {
+	if annotations[v1alpha2.OperatorGroupNamespaceAnnotationKey] != csv.GetNamespace() {
 		logger.Info("not in operatorgroup namespace, skipping")
 		return nil
 	}
 
-	operatorGroupName, ok := annotations[operatorGroupAnnotationKey]
+	operatorGroupName, ok := annotations[v1alpha2.OperatorGroupAnnotationKey]
 
 	// no operatorgroup annotation
 	if !ok {
@@ -507,7 +507,7 @@ func (a *Operator) operatorGroupForActiveCSV(logger *logrus.Entry, csv *v1alpha1
 	}
 
 	// target namespaces don't match
-	if annotations[operatorGroupTargetsAnnotationKey] != strings.Join(operatorGroup.Status.Namespaces, ",") {
+	if annotations[v1alpha2.OperatorGroupTargetsAnnotationKey] != strings.Join(operatorGroup.Status.Namespaces, ",") {
 		logger.Info("target namespace annotation doesn't match operatorgroup namespace list")
 		return nil
 	}

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -2385,7 +2385,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					annotatedDeployment,
 				},
 				targetNamespace: {
-					withAnnotations(targetCSV.DeepCopy(), map[string]string{"olm.targetNamespaces": targetNamespace + "," + operatorNamespace, "olm.operatorGroup": "operator-group-1", "olm.operatorNamespace": operatorNamespace}),
+					withAnnotations(targetCSV.DeepCopy(), map[string]string{"olm.operatorGroup": "operator-group-1", "olm.operatorNamespace": operatorNamespace}),
 					&rbacv1.Role{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "Role",
@@ -2477,7 +2477,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 			},
 			final: final{objects: map[string][]runtime.Object{
 				operatorNamespace: {
-					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{"olm.targetNamespaces": "", "olm.operatorGroup": "operator-group-1", "olm.operatorNamespace": operatorNamespace}),
+					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{v1alpha2.OperatorGroupTargetsAnnotationKey: "", v1alpha2.OperatorGroupAnnotationKey: "operator-group-1", v1alpha2.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 					annotatedGlobalDeployment,
 				},
 				"": {
@@ -2528,7 +2528,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 				},
 				targetNamespace: {
-					withAnnotations(targetCSV.DeepCopy(), map[string]string{"olm.targetNamespaces": "", "olm.operatorGroup": "operator-group-1", "olm.operatorNamespace": operatorNamespace}),
+					withAnnotations(targetCSV.DeepCopy(), map[string]string{v1alpha2.OperatorGroupAnnotationKey: "operator-group-1", v1alpha2.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 				},
 			}},
 		},

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -634,9 +634,9 @@ func TestTransitionCSV(t *testing.T) {
 	}
 
 	templateAnnotations := map[string]string{
-		operatorGroupTargetsAnnotationKey:   namespace,
-		operatorGroupNamespaceAnnotationKey: namespace,
-		operatorGroupAnnotationKey:          operatorGroup.GetName(),
+		v1alpha2.OperatorGroupTargetsAnnotationKey:   namespace,
+		v1alpha2.OperatorGroupNamespaceAnnotationKey: namespace,
+		v1alpha2.OperatorGroupAnnotationKey:          operatorGroup.GetName(),
 	}
 
 	// Generate valid and expired CA fixtures
@@ -2232,14 +2232,14 @@ func TestSyncOperatorGroups(t *testing.T) {
 	ownerutil.AddNonBlockingOwner(ownedDeployment, operatorCSV)
 
 	annotatedDeployment := ownedDeployment.DeepCopy()
-	annotatedDeployment.Spec.Template.SetAnnotations(map[string]string{"olm.targetNamespaces": targetNamespace + "," + operatorNamespace, "olm.operatorGroup": "operator-group-1", "olm.operatorNamespace": operatorNamespace})
+	annotatedDeployment.Spec.Template.SetAnnotations(map[string]string{v1alpha2.OperatorGroupTargetsAnnotationKey: targetNamespace + "," + operatorNamespace, v1alpha2.OperatorGroupAnnotationKey: "operator-group-1", v1alpha2.OperatorGroupNamespaceAnnotationKey: operatorNamespace})
 	annotatedDeployment.SetLabels(map[string]string{
 		"olm.owner":           "csv1",
 		"olm.owner.namespace": "operator-ns",
 	})
 
 	annotatedGlobalDeployment := ownedDeployment.DeepCopy()
-	annotatedGlobalDeployment.Spec.Template.SetAnnotations(map[string]string{"olm.targetNamespaces": "", "olm.operatorGroup": "operator-group-1", "olm.operatorNamespace": operatorNamespace})
+	annotatedGlobalDeployment.Spec.Template.SetAnnotations(map[string]string{v1alpha2.OperatorGroupTargetsAnnotationKey: "", v1alpha2.OperatorGroupAnnotationKey: "operator-group-1", v1alpha2.OperatorGroupNamespaceAnnotationKey: operatorNamespace})
 	annotatedGlobalDeployment.SetLabels(map[string]string{
 		"olm.owner":           "csv1",
 		"olm.owner.namespace": "operator-ns",
@@ -2381,11 +2381,11 @@ func TestSyncOperatorGroups(t *testing.T) {
 			},
 			final: final{objects: map[string][]runtime.Object{
 				operatorNamespace: {
-					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{"olm.targetNamespaces": targetNamespace + "," + operatorNamespace, "olm.operatorGroup": "operator-group-1", "olm.operatorNamespace": operatorNamespace}),
+					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{v1alpha2.OperatorGroupTargetsAnnotationKey: targetNamespace + "," + operatorNamespace, v1alpha2.OperatorGroupAnnotationKey: "operator-group-1", v1alpha2.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 					annotatedDeployment,
 				},
 				targetNamespace: {
-					withAnnotations(targetCSV.DeepCopy(), map[string]string{"olm.operatorGroup": "operator-group-1", "olm.operatorNamespace": operatorNamespace}),
+					withAnnotations(targetCSV.DeepCopy(), map[string]string{v1alpha2.OperatorGroupAnnotationKey: "operator-group-1", v1alpha2.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 					&rbacv1.Role{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "Role",

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -305,19 +305,21 @@ func (a *Operator) copyCsvToTargetNamespace(csv *v1alpha1.ClusterServiceVersion,
 	}
 
 	logger := a.Log.WithField("operator-ns", operatorGroup.GetNamespace())
+	newCSV := csv.DeepCopy()
+	delete(newCSV.Annotations, v1alpha2.OperatorGroupTargetsAnnotationKey)
 	for _, ns := range namespaces {
 		if ns == operatorGroup.GetNamespace() {
 			continue
 		}
 		logger = logger.WithField("target-ns", ns)
 
-		fetchedCSV, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ns).Get(csv.GetName())
+		fetchedCSV, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ns).Get(newCSV.GetName())
 
 		logger = logger.WithField("csv", csv.GetName())
 		if fetchedCSV != nil {
 			logger.Debug("checking annotations")
-			if !reflect.DeepEqual(fetchedCSV.Annotations, csv.Annotations) {
-				fetchedCSV.Annotations = csv.Annotations
+			if !reflect.DeepEqual(fetchedCSV.Annotations, newCSV.Annotations) {
+				fetchedCSV.Annotations = newCSV.Annotations
 				// CRs don't support strategic merge patching, but in the future if they do this should be updated to patch
 				logger.Debug("updating target CSV")
 				if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(ns).Update(fetchedCSV); err != nil {
@@ -327,7 +329,6 @@ func (a *Operator) copyCsvToTargetNamespace(csv *v1alpha1.ClusterServiceVersion,
 			}
 
 			logger.Debug("checking status")
-			newCSV := fetchedCSV.DeepCopy()
 			newCSV.Status = csv.Status
 			newCSV.Status.Reason = v1alpha1.CSVReasonCopied
 			newCSV.Status.Message = fmt.Sprintf("The operator is running in %s but is managing this namespace", csv.GetNamespace())
@@ -344,7 +345,6 @@ func (a *Operator) copyCsvToTargetNamespace(csv *v1alpha1.ClusterServiceVersion,
 
 			continue
 		} else if k8serrors.IsNotFound(err) {
-			newCSV := csv.DeepCopy()
 			newCSV.SetNamespace(ns)
 			newCSV.SetResourceVersion("")
 

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -18,14 +18,11 @@ import (
 )
 
 const (
-	operatorGroupAnnotationKey          = "olm.operatorGroup"
-	operatorGroupNamespaceAnnotationKey = "olm.operatorNamespace"
-	operatorGroupTargetsAnnotationKey   = "olm.targetNamespaces"
-	operatorGroupAggregrationKeyPrefix  = "olm.opgroup.permissions/aggregate-to-"
-	kubeRBACAggregationKeyPrefix        = "rbac.authorization.k8s.io/aggregate-to-"
-	AdminSuffix                         = "admin"
-	EditSuffix                          = "edit"
-	ViewSuffix                          = "view"
+	operatorGroupAggregrationKeyPrefix = "olm.opgroup.permissions/aggregate-to-"
+	kubeRBACAggregationKeyPrefix       = "rbac.authorization.k8s.io/aggregate-to-"
+	AdminSuffix                        = "admin"
+	EditSuffix                         = "edit"
+	ViewSuffix                         = "view"
 )
 
 var (
@@ -371,9 +368,9 @@ func (a *Operator) copyCsvToTargetNamespace(csv *v1alpha1.ClusterServiceVersion,
 }
 
 func (a *Operator) addOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *v1alpha2.OperatorGroup) {
-	metav1.SetMetaDataAnnotation(obj, operatorGroupTargetsAnnotationKey, strings.Join(op.Status.Namespaces, ","))
-	metav1.SetMetaDataAnnotation(obj, operatorGroupNamespaceAnnotationKey, op.GetNamespace())
-	metav1.SetMetaDataAnnotation(obj, operatorGroupAnnotationKey, op.GetName())
+	metav1.SetMetaDataAnnotation(obj, v1alpha2.OperatorGroupTargetsAnnotationKey, strings.Join(op.Status.Namespaces, ","))
+	metav1.SetMetaDataAnnotation(obj, v1alpha2.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
+	metav1.SetMetaDataAnnotation(obj, v1alpha2.OperatorGroupAnnotationKey, op.GetName())
 }
 
 func namespacesChanged(clusterNamespaces []string, statusNamespaces []string) bool {


### PR DESCRIPTION
This removes target namespace information on all copied CSVs and supercedes https://github.com/operator-framework/operator-lifecycle-manager/pull/601.

I believe the approach of deleting the annotation is clearer than adding separate specific annotations for copied CSVs.

ALM-824