### PR TITLE
Add view permissions for CRDs on provided APIs

### DIFF
--- a/pkg/controller/registry/resolver/steps.go
+++ b/pkg/controller/registry/resolver/steps.go
@@ -64,7 +64,10 @@ func NewStepResourcesFromCRD(crd *v1beta1.CustomResourceDefinition) ([]v1alpha1.
 				"rbac.authorization.k8s.io/aggregate-to-view": "true",
 			},
 		},
-		Rules: []rbacv1.PolicyRule{{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{crd.Spec.Group}, Resources: []string{crd.Spec.Names.Plural}}},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{crd.Spec.Group}, Resources: []string{crd.Spec.Names.Plural}},
+			{Verbs: []string{"get", "watch"}, APIGroups: []string{v1beta1.GroupName}, Resources: []string{crd.GetName()}},
+		},
 	}
 	viewRoleStep, err := NewStepResourceFromObject(viewRole, viewRole.GetName())
 	if err != nil {

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -381,6 +381,7 @@ func TestOperatorGroup(t *testing.T) {
 	viewRole, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(operatorGroup.Name+"-view", metav1.GetOptions{})
 	require.NoError(t, err)
 	viewPolicyRules := []rbacv1.PolicyRule{
+		{Verbs: []string{"get"}, APIGroups: []string{"apiextensions.k8s.io"}, Resources: []string{"customresourcedefinitions"}, ResourceNames: []string{mainCRDName}},
 		{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{apiGroup}, Resources: []string{mainCRDPlural}},
 	}
 	require.Equal(t, viewPolicyRules, viewRole.Rules)


### PR DESCRIPTION
Adds onto #551 by generating clusterroles for the operatorgroup as well