### PR TITLE
increase memory limits on all service catalog pods

### DIFF
--- a/deploy/chart/catalog_resources/rh-operators/svcat.v0.1.34.clusterserviceversion.yaml
+++ b/deploy/chart/catalog_resources/rh-operators/svcat.v0.1.34.clusterserviceversion.yaml
@@ -122,10 +122,10 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 30Mi
+                    memory: 60Mi
                   requests:
                     cpu: 100m
-                    memory: 20Mi
+                    memory: 40Mi
                 args:
                 - apiserver
                 - --enable-admission-plugins
@@ -171,7 +171,7 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 70Mi
+                    memory: 150Mi
                   requests:
                     cpu: 100m
                     memory: 50Mi
@@ -232,10 +232,10 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 30Mi
+                    memory: 60Mi
                   requests:
                     cpu: 100m
-                    memory: 20Mi
+                    memory: 40Mi
                 env:
                 - name: K8S_NAMESPACE
                   valueFrom:


### PR DESCRIPTION
fighting issues with continuous restarts on pods, bumping up memory a bit, need to do a round of performance runs but need immediate relief for broker developers.