### PR TITLE
remove crds from "all" category

### DIFF
--- a/deploy/ocp/manifests/0.7.1/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/ocp/manifests/0.7.1/0000_30_02-clusterserviceversion.crd.yaml
@@ -16,7 +16,6 @@ spec:
     shortNames:
     - csv
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Display

--- a/deploy/ocp/manifests/0.7.1/0000_30_03-installplan.crd.yaml
+++ b/deploy/ocp/manifests/0.7.1/0000_30_03-installplan.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: InstallPlan
     listKind: InstallPlanList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: CSV

--- a/deploy/ocp/manifests/0.7.1/0000_30_04-subscription.crd.yaml
+++ b/deploy/ocp/manifests/0.7.1/0000_30_04-subscription.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: Subscription
     listKind: SubscriptionList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Package

--- a/deploy/ocp/manifests/0.7.1/0000_30_05-catalogsource.crd.yaml
+++ b/deploy/ocp/manifests/0.7.1/0000_30_05-catalogsource.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: CatalogSource
     listKind: CatalogSourceList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Name

--- a/deploy/ocp/manifests/0.7.2/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/ocp/manifests/0.7.2/0000_30_02-clusterserviceversion.crd.yaml
@@ -16,7 +16,6 @@ spec:
     shortNames:
     - csv
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Display

--- a/deploy/ocp/manifests/0.7.2/0000_30_03-installplan.crd.yaml
+++ b/deploy/ocp/manifests/0.7.2/0000_30_03-installplan.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: InstallPlan
     listKind: InstallPlanList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: CSV

--- a/deploy/ocp/manifests/0.7.2/0000_30_04-subscription.crd.yaml
+++ b/deploy/ocp/manifests/0.7.2/0000_30_04-subscription.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: Subscription
     listKind: SubscriptionList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Package

--- a/deploy/ocp/manifests/0.7.2/0000_30_05-catalogsource.crd.yaml
+++ b/deploy/ocp/manifests/0.7.2/0000_30_05-catalogsource.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: CatalogSource
     listKind: CatalogSourceList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Name

--- a/deploy/ocp/manifests/0.7.4/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/ocp/manifests/0.7.4/0000_30_02-clusterserviceversion.crd.yaml
@@ -16,7 +16,6 @@ spec:
     shortNames:
     - csv
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Display

--- a/deploy/ocp/manifests/0.7.4/0000_30_03-installplan.crd.yaml
+++ b/deploy/ocp/manifests/0.7.4/0000_30_03-installplan.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: InstallPlan
     listKind: InstallPlanList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: CSV

--- a/deploy/ocp/manifests/0.7.4/0000_30_04-subscription.crd.yaml
+++ b/deploy/ocp/manifests/0.7.4/0000_30_04-subscription.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: Subscription
     listKind: SubscriptionList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Package

--- a/deploy/ocp/manifests/0.7.4/0000_30_05-catalogsource.crd.yaml
+++ b/deploy/ocp/manifests/0.7.4/0000_30_05-catalogsource.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: CatalogSource
     listKind: CatalogSourceList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Name

--- a/deploy/ocp/manifests/0.8.0/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/ocp/manifests/0.8.0/0000_30_02-clusterserviceversion.crd.yaml
@@ -16,7 +16,6 @@ spec:
     shortNames:
     - csv
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Display

--- a/deploy/ocp/manifests/0.8.0/0000_30_03-installplan.crd.yaml
+++ b/deploy/ocp/manifests/0.8.0/0000_30_03-installplan.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: InstallPlan
     listKind: InstallPlanList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: CSV

--- a/deploy/ocp/manifests/0.8.0/0000_30_04-subscription.crd.yaml
+++ b/deploy/ocp/manifests/0.8.0/0000_30_04-subscription.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: Subscription
     listKind: SubscriptionList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Package

--- a/deploy/ocp/manifests/0.8.0/0000_30_05-catalogsource.crd.yaml
+++ b/deploy/ocp/manifests/0.8.0/0000_30_05-catalogsource.crd.yaml
@@ -21,7 +21,6 @@ spec:
     kind: CatalogSource
     listKind: CatalogSourceList
     categories:
-    - all
     - olm
   additionalPrinterColumns:
   - name: Name


### PR DESCRIPTION
cc @soltysh

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1658065

CRDs should not register into the "all" category, as that category is reserved for frequently used core resources