### PR TITLE
Requeue subscriptions on catalogsource change

### DIFF
--- a/deploy/chart/templates/0000_30_17-packageserver.subscription.yaml
+++ b/deploy/chart/templates/0000_30_17-packageserver.subscription.yaml
@@ -7,5 +7,6 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   source: olm-operators
+  sourceNamespace: {{ .Values.namespace }}
   name: packageserver
   channel: alpha

--- a/manifests/0000_30_17-packageserver.subscription.yaml
+++ b/manifests/0000_30_17-packageserver.subscription.yaml
@@ -9,5 +9,6 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
 spec:
   source: olm-operators
+  sourceNamespace: openshift-operator-lifecycle-manager
   name: packageserver
   channel: alpha

--- a/pkg/controller/operators/catalog/subscriptions.go
+++ b/pkg/controller/operators/catalog/subscriptions.go
@@ -46,7 +46,7 @@ func (o *Operator) syncSubscription(in *v1alpha1.Subscription) (*v1alpha1.Subscr
 	}
 	catalog, ok := o.sources[registry.ResourceKey{Name: out.Spec.CatalogSource, Namespace: catalogNamespace}]
 	if !ok {
-		out.Status.State = v1alpha1.SubscriptionStateAtLatest
+		out.Status.State = v1alpha1.SubscriptionStateFailed
 		out.Status.Reason = v1alpha1.SubscriptionReasonInvalidCatalog
 		return out, fmt.Errorf("unknown catalog source %s in namespace %s", out.Spec.CatalogSource, catalogNamespace)
 	}


### PR DESCRIPTION
This PR attempts to clean up several issues:

- Subscriptions shouldn't be set to `AtLatestKnown` if we haven't created a CSV
- Requeue dependent subscriptions when catalogsources change
- Add sourceNamespace to packages subscription