### PR TITLE
templates: Update CSV CRD to support "csvs" as a shortname

### DIFF
--- a/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+++ b/deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
@@ -13,6 +13,7 @@ spec:
     listKind: ClusterServiceVersionList
     shortNames:
     - csv
+    - csvs
     categories:
     - all
     - olm
@@ -198,7 +199,7 @@ spec:
                     description: Version of the API resource
                   kind:
                     type: string
-                    description: Kind of the API resource        
+                    description: Kind of the API resource
             apiservicedefinitions:
               type: object
               properties:


### PR DESCRIPTION
Enables `kubectl get csvs` which is the plural of `kubectl get csv`.
I make this typo a lot, I'm sure others do too so I figured it worthy of
updating.