### PR TITLE
Updated MongoDB Operator to 0.6

### DIFF
--- a/deploy/chart/catalog_resources/certified-operators/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
+++ b/deploy/chart/catalog_resources/certified-operators/mongodb-enterprise.v0.3.2.clusterserviceversion.yaml
@@ -243,7 +243,7 @@ spec:
 
               containers:
               - name: mongodb-enterprise-operator
-                image: quay.io/mongodb/mongodb-enterprise-operator:0.3
+                image: registry.connect.redhat.com/mongodb/enterprise-operator
                 imagePullPolicy: Always
                 resources:
                   limits:
@@ -263,7 +263,7 @@ spec:
                 - name: OPERATOR_ENV
                   value: prod
                 - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
-                  value: quay.io/mongodb/mongodb-enterprise-database:0.3
+                  value: registry.connect.redhat.com/mongodb/enterprise-database
                 - name: IMAGE_PULL_POLICY
                   value: Always
                 - name: IMAGE_PULL_SECRETS


### PR DESCRIPTION
This updates the `ClusterServiceVersion` file for the MongoDB operator to latest release, just pushed to RedHat's Container Catalog.

This latest version of the MongoDB Operator has been rebuilt on top of the operator-sdk.