### PR TITLE
fix 1663113. Add component image ENV vars to cluster-logging-operator

### DIFF
--- a/deploy/chart/catalog_resources/rh-operators/clusterlogging.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/chart/catalog_resources/rh-operators/clusterlogging.v0.0.1.clusterserviceversion.yaml
@@ -84,6 +84,13 @@ spec:
           - cronjobs
           verbs:
           - "*"
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - "*"
       - serviceAccountName: elasticsearch-operator
         rules:
         - apiGroups:
@@ -163,6 +170,18 @@ spec:
                         fieldPath: metadata.namespace
                   - name: OPERATOR_NAME
                     value: "cluster-logging-operator"
+                  - name: ELASTICSEARCH_IMAGE
+                    value: "docker.io/openshift/origin-logging-elasticsearch5:latest"
+                  - name: FLUENTD_IMAGE
+                    value: "docker.io/openshift/origin-logging-fluentd:latest"
+                  - name: KIBANA_IMAGE
+                    value: "docker.io/openshift/origin-logging-kibana5:latest"
+                  - name: CURATOR_IMAGE
+                    value: "docker.io/openshift/origin-logging-curator5:latest"
+                  - name: OAUTH_PROXY_IMAGE
+                    value: "docker.io/openshift/oauth-proxy:latest"
+                  - name: RSYSLOG_IMAGE
+                    value: "docker.io/viaq/rsyslog:latest"
       - name: elasticsearch-operator
         spec:
           replicas: 1

--- a/manifests/0000_30_00-namespace.yaml
+++ b/manifests/0000_30_00-namespace.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_00-namespace.yaml
 apiVersion: v1
 kind: Namespace

--- a/manifests/0000_30_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_30_01-olm-operator.serviceaccount.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_01-olm-operator.serviceaccount.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/0000_30_02-clusterserviceversion.crd.yaml
+++ b/manifests/0000_30_02-clusterserviceversion.crd.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_02-clusterserviceversion.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/manifests/0000_30_03-installplan.crd.yaml
+++ b/manifests/0000_30_03-installplan.crd.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_03-installplan.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/manifests/0000_30_04-subscription.crd.yaml
+++ b/manifests/0000_30_04-subscription.crd.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_04-subscription.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/manifests/0000_30_05-catalogsource.crd.yaml
+++ b/manifests/0000_30_05-catalogsource.crd.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_05-catalogsource.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/manifests/0000_30_06-rh-operators.configmap.yaml
+++ b/manifests/0000_30_06-rh-operators.configmap.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_06-rh-operators.configmap.yaml
 
 kind: ConfigMap
@@ -10057,6 +10057,13 @@ data:
                 - cronjobs
                 verbs:
                 - "*"
+              - apiGroups:
+                - rbac.authorization.k8s.io
+                resources:
+                - roles
+                - rolebindings
+                verbs:
+                - "*"
             - serviceAccountName: elasticsearch-operator
               rules:
               - apiGroups:
@@ -10136,6 +10143,18 @@ data:
                               fieldPath: metadata.namespace
                         - name: OPERATOR_NAME
                           value: "cluster-logging-operator"
+                        - name: ELASTICSEARCH_IMAGE
+                          value: "docker.io/openshift/origin-logging-elasticsearch5:latest"
+                        - name: FLUENTD_IMAGE
+                          value: "docker.io/openshift/origin-logging-fluentd:latest"
+                        - name: KIBANA_IMAGE
+                          value: "docker.io/openshift/origin-logging-kibana5:latest"
+                        - name: CURATOR_IMAGE
+                          value: "docker.io/openshift/origin-logging-curator5:latest"
+                        - name: OAUTH_PROXY_IMAGE
+                          value: "docker.io/openshift/oauth-proxy:latest"
+                        - name: RSYSLOG_IMAGE
+                          value: "docker.io/viaq/rsyslog:latest"
             - name: elasticsearch-operator
               spec:
                 replicas: 1

--- a/manifests/0000_30_07-certified-operators.configmap.yaml
+++ b/manifests/0000_30_07-certified-operators.configmap.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_07-certified-operators.configmap.yaml
 
 kind: ConfigMap
@@ -1285,7 +1285,7 @@ data:
       
                     containers:
                     - name: mongodb-enterprise-operator
-                      image: quay.io/mongodb/mongodb-enterprise-operator:0.3
+                      image: registry.connect.redhat.com/mongodb/enterprise-operator
                       imagePullPolicy: Always
                       resources:
                         limits:
@@ -1305,7 +1305,7 @@ data:
                       - name: OPERATOR_ENV
                         value: prod
                       - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
-                        value: quay.io/mongodb/mongodb-enterprise-database:0.3
+                        value: registry.connect.redhat.com/mongodb/enterprise-database
                       - name: IMAGE_PULL_POLICY
                         value: Always
                       - name: IMAGE_PULL_SECRETS

--- a/manifests/0000_30_08-certified-operators.catalogsource.yaml
+++ b/manifests/0000_30_08-certified-operators.catalogsource.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_08-certified-operators.catalogsource.yaml
 
 #! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml

--- a/manifests/0000_30_09-rh-operators.catalogsource.yaml
+++ b/manifests/0000_30_09-rh-operators.catalogsource.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_09-rh-operators.catalogsource.yaml
 
 #! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml

--- a/manifests/0000_30_10-olm-operator.deployment.yaml
+++ b/manifests/0000_30_10-olm-operator.deployment.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_10-olm-operator.deployment.yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/0000_30_11-catalog-operator.deployment.yaml
+++ b/manifests/0000_30_11-catalog-operator.deployment.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_11-catalog-operator.deployment.yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/0000_30_12-aggregated.clusterrole.yaml
+++ b/manifests/0000_30_12-aggregated.clusterrole.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_12-aggregated.clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/0000_30_13-operatorgroup.crd.yaml
+++ b/manifests/0000_30_13-operatorgroup.crd.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_13-operatorgroup.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/manifests/0000_30_14-olm-operators.configmap.yaml
+++ b/manifests/0000_30_14-olm-operators.configmap.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_14-olm-operators.configmap.yaml
 kind: ConfigMap
 apiVersion: v1

--- a/manifests/0000_30_15-olm-operators.catalogsource.yaml
+++ b/manifests/0000_30_15-olm-operators.catalogsource.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_15-olm-operators.catalogsource.yaml
 #! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
 #! parse-kind: CatalogSource

--- a/manifests/0000_30_16-operatorgroup-default.yaml
+++ b/manifests/0000_30_16-operatorgroup-default.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_16-operatorgroup-default.yaml
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup

--- a/manifests/0000_30_17-packageserver.subscription.yaml
+++ b/manifests/0000_30_17-packageserver.subscription.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_17-packageserver.subscription.yaml
 #! validate-crd: ./deploy/chart/templates/04-subscription.crd.yaml
 #! parse-kind: Subscription

--- a/manifests/0000_30_18-operatorsource.crd.yaml
+++ b/manifests/0000_30_18-operatorsource.crd.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_18-operatorsource.crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/manifests/0000_30_19-operatorsource-default.yaml
+++ b/manifests/0000_30_19-operatorsource-default.yaml
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/0000_30_19-operatorsource-default.yaml
 apiVersion: "marketplace.redhat.com/v1alpha1"
 kind: "OperatorSource"

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,4 +1,4 @@
-##---
+---
 # Source: olm/templates/image-references
 
 kind: ImageStream


### PR DESCRIPTION
The PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1663113
by adding in the proper ENV vars from the operator manifest