### PR TITLE
Watch all namespaces in local setup by removing watchedNamespaces in local-values

### DIFF
--- a/Documentation/install/local-values.yaml
+++ b/Documentation/install/local-values.yaml
@@ -1,6 +1,5 @@
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: local
-watchedNamespaces: local
 catalog_namespace: local
 operator_namespace: local-operators
 debug: true


### PR DESCRIPTION
This causes the olm components to watch all namespaces, which allows OLM
to process subscriptions, and other resources outside of the `local`
namespace in minikube.