### PR TITLE
Update metering InstallModes to support SingleNamespace

### DIFF
--- a/deploy/chart/catalog_resources/rh-operators/metering-operator.v0.12.0.clusterserviceversion.yaml
+++ b/deploy/chart/catalog_resources/rh-operators/metering-operator.v0.12.0.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ spec:
   - type: OwnNamespace
     supported: true
   - type: SingleNamespace
-    supported: false
+    supported: true
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces


### PR DESCRIPTION
metering-operator doesn't support watching namespaces other than it's
own, but this is required for OLM validation to not error