### PR TITLE
add view rbac to 'admin' and 'edit' default roles

### DIFF
--- a/deploy/chart/templates/0000_50_olm_08-aggregated.clusterrole.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-aggregated.clusterrole.yaml
@@ -16,7 +16,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "view" default roles
+    # Add these permissions to the "admin", "edit" and "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]

--- a/deploy/ocp/manifests/0.7.1/0000_30_12-aggregated.clusterrole.yaml
+++ b/deploy/ocp/manifests/0.7.1/0000_30_12-aggregated.clusterrole.yaml
@@ -18,7 +18,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "view" default roles
+    # Add these permissions to the "admin", "edit" and "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]

--- a/deploy/ocp/manifests/0.7.1/0000_30_12-aggregated.clusterrole.yaml
+++ b/deploy/ocp/manifests/0.7.1/0000_30_12-aggregated.clusterrole.yaml
@@ -18,9 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "admin", "edit" and "view" default roles
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    # Add these permissions to the "view" default roles
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]

--- a/deploy/ocp/manifests/0.7.2/0000_30_12-aggregated.clusterrole.yaml
+++ b/deploy/ocp/manifests/0.7.2/0000_30_12-aggregated.clusterrole.yaml
@@ -18,7 +18,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "view" default roles
+    # Add these permissions to the "admin", "edit" and "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]

--- a/deploy/ocp/manifests/0.7.4/0000_30_12-aggregated.clusterrole.yaml
+++ b/deploy/ocp/manifests/0.7.4/0000_30_12-aggregated.clusterrole.yaml
@@ -18,7 +18,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "view" default roles
+    # Add these permissions to the "admin", "edit" and "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]

--- a/deploy/ocp/manifests/0.8.1/0000_50_olm_08-aggregated.clusterrole.yaml
+++ b/deploy/ocp/manifests/0.8.1/0000_50_olm_08-aggregated.clusterrole.yaml
@@ -18,7 +18,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "view" default roles
+    # Add these permissions to the "admin", "edit" and "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]

--- a/deploy/okd/manifests/0.8.1/0000_50_olm_08-aggregated.clusterrole.yaml
+++ b/deploy/okd/manifests/0.8.1/0000_50_olm_08-aggregated.clusterrole.yaml
@@ -18,7 +18,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "view" default roles
+    # Add these permissions to the "admin", "edit" and "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]

--- a/deploy/upstream/manifests/0.8.1/0000_50_olm_08-aggregated.clusterrole.yaml
+++ b/deploy/upstream/manifests/0.8.1/0000_50_olm_08-aggregated.clusterrole.yaml
@@ -18,7 +18,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "view" default roles
+    # Add these permissions to the "admin", "edit" and "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]

--- a/manifests/0000_50_olm_08-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_08-aggregated.clusterrole.yaml
@@ -16,7 +16,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aggregate-olm-view
   labels:
-    # Add these permissions to the "view" default roles
+    # Add these permissions to the "admin", "edit" and "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]


### PR DESCRIPTION
Project admins *can* create/update/delete objects but *cannot* get/list/watch them. This allows OLM to work as expected for users who are not cluster-admins.

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>