### PR TITLE
fix resource creation/deletion after operator group config change

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -3529,9 +3529,9 @@ func TestSyncOperatorGroups(t *testing.T) {
 					withPhase(
 						withInstallModes(
 							withAnnotations(operatorCSV.DeepCopy(), map[string]string{
-								"olm.operatorGroup":     "operator-group-1",
-								"olm.operatorNamespace": "operator-ns",
-								"olm.targetNamespaces":  "",
+								v1alpha2.OperatorGroupTargetsAnnotationKey:   "",
+								v1alpha2.OperatorGroupAnnotationKey:          "operator-group-1",
+								v1alpha2.OperatorGroupNamespaceAnnotationKey: operatorNamespace,
 							}).(*v1alpha1.ClusterServiceVersion),
 							[]v1alpha1.InstallMode{
 								{

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -243,8 +243,8 @@ func awaitCSV(t *testing.T, c versioned.Interface, namespace, name string, check
 				return false, nil
 			}
 			return false, err
-		} 
-		t.Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
+		}
+		t.Logf("name=%v ns=%v, %s (%s): %s", name, namespace, fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
 		return checker(fetched), nil
 	})
 

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -906,21 +906,9 @@ func TestCSVCopyWatchingAllNamespaces(t *testing.T) {
 	crc := newCRClient(t)
 	csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
 
-	opGroupNamespace := genName(testNamespace + "-")
+	opGroupNamespace := testNamespace
 	matchingLabel := map[string]string{"inGroup": opGroupNamespace}
 	otherNamespaceName := genName(opGroupNamespace + "-")
-
-	_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   opGroupNamespace,
-			Labels: matchingLabel,
-		},
-	})
-	require.NoError(t, err)
-	defer func() {
-		err = c.KubernetesInterface().CoreV1().Namespaces().Delete(opGroupNamespace, &metav1.DeleteOptions{})
-		require.NoError(t, err)
-	}()
 
 	t.Log("Creating CRD")
 	mainCRDPlural := genName("opgroup")
@@ -929,20 +917,9 @@ func TestCSVCopyWatchingAllNamespaces(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanupCRD()
 
-	t.Log("Creating operator group")
-	operatorGroup := v1alpha2.OperatorGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      genName("e2e-operator-group-"),
-			Namespace: opGroupNamespace,
-		},
-		// no spec, watches all namespaces
-	}
-	_, err = crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Create(&operatorGroup)
+	t.Logf("Getting default operator group 'global-operators' installed via operatorgroup-default.yaml %v", opGroupNamespace)
+	operatorGroup, err := crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Get("global-operators", metav1.GetOptions{})
 	require.NoError(t, err)
-	defer func() {
-		err = crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Delete(operatorGroup.Name, &metav1.DeleteOptions{})
-		require.NoError(t, err)
-	}()
 
 	expectedOperatorGroupStatus := v1alpha2.OperatorGroupStatus{
 		Namespaces: []string{metav1.NamespaceAll},
@@ -1045,7 +1022,7 @@ func TestCSVCopyWatchingAllNamespaces(t *testing.T) {
 			t.Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
 			return false, fetchErr
 		}
-		if checkOperatorGroupAnnotations(fetchedCSV, &operatorGroup, true, corev1.NamespaceAll) == nil {
+		if checkOperatorGroupAnnotations(fetchedCSV, operatorGroup, true, corev1.NamespaceAll) == nil {
 			return true, nil
 		}
 		return false, nil
@@ -1070,32 +1047,48 @@ func TestCSVCopyWatchingAllNamespaces(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	t.Log("Waiting to ensure copied CSV shows up in new namespace")
+	t.Log("Waiting to ensure copied CSV shows up in other namespace")
 	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(csvName, metav1.GetOptions{})
 		if fetchErr != nil {
 			if errors.IsNotFound(fetchErr) {
 				return false, nil
 			}
-			t.Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
+			t.Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
 			return false, fetchErr
 		}
-		if checkOperatorGroupAnnotations(fetchedCSV, &operatorGroup, false, "") == nil {
+		if checkOperatorGroupAnnotations(fetchedCSV, operatorGroup, false, "") == nil {
 			return true, nil
 		}
 		return false, nil
 	})
 	require.NoError(t, err)
 
-	// ensure deletion cleans up copied CSV
-	t.Log("deleting parent csv")
-	err = crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Delete(csvName, &metav1.DeleteOptions{})
+	// verify created CSV is cleaned up after operator group is "contracted"
+	t.Log("Modifying operator group to no longer watch all namespaces")
+	currentOperatorGroup, err := crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Get(operatorGroup.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	currentOperatorGroup.Spec.TargetNamespaces = []string{opGroupNamespace}
+	_, err = crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Update(currentOperatorGroup)
 	require.NoError(t, err)
 
-	t.Log("waiting for orphaned csv to be deleted")
-	err = waitForDelete(func() error {
-		_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(csvName, metav1.GetOptions{})
-		return err
+	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		_, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(csvName, metav1.GetOptions{})
+		if fetchErr != nil {
+			if errors.IsNotFound(fetchErr) {
+				return true, nil
+			}
+			t.Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())
+			return false, fetchErr
+		}
+		return false, nil
 	})
+	require.NoError(t, err)
+
+	t.Log("Re-modifying operator group to be watching all namespaces")
+	currentOperatorGroup, err = crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Get(operatorGroup.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	currentOperatorGroup.Spec = v1alpha2.OperatorGroupSpec{}
+	_, err = crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Update(currentOperatorGroup)
 	require.NoError(t, err)
 }

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -901,3 +901,201 @@ func TestStaticProviderOperatorGroup(t *testing.T) {
 // TODO: Test OperatorGroup resizing collisions
 // TODO: Test Subscriptions with depedencies and transitive dependencies in intersecting OperatorGroups
 // TODO: Test Subscription upgrade paths with + and - providedAPIs
+func TestCSVCopyWatchingAllNamespaces(t *testing.T) {
+	c := newKubeClient(t)
+	crc := newCRClient(t)
+	csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
+
+	opGroupNamespace := genName(testNamespace + "-")
+	matchingLabel := map[string]string{"inGroup": opGroupNamespace}
+	otherNamespaceName := genName(opGroupNamespace + "-")
+
+	_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   opGroupNamespace,
+			Labels: matchingLabel,
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		err = c.KubernetesInterface().CoreV1().Namespaces().Delete(opGroupNamespace, &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}()
+
+	t.Log("Creating CRD")
+	mainCRDPlural := genName("opgroup")
+	mainCRD := newCRD(mainCRDPlural)
+	cleanupCRD, err := createCRD(c, mainCRD)
+	require.NoError(t, err)
+	defer cleanupCRD()
+
+	t.Log("Creating operator group")
+	operatorGroup := v1alpha2.OperatorGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      genName("e2e-operator-group-"),
+			Namespace: opGroupNamespace,
+		},
+		// no spec, watches all namespaces
+	}
+	_, err = crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Create(&operatorGroup)
+	require.NoError(t, err)
+	defer func() {
+		err = crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Delete(operatorGroup.Name, &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}()
+
+	expectedOperatorGroupStatus := v1alpha2.OperatorGroupStatus{
+		Namespaces: []string{metav1.NamespaceAll},
+	}
+
+	t.Log("Waiting on operator group to have correct status")
+	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		fetched, fetchErr := crc.OperatorsV1alpha2().OperatorGroups(opGroupNamespace).Get(operatorGroup.Name, metav1.GetOptions{})
+		if fetchErr != nil {
+			return false, fetchErr
+		}
+		if len(fetched.Status.Namespaces) > 0 {
+			require.ElementsMatch(t, expectedOperatorGroupStatus.Namespaces, fetched.Status.Namespaces)
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	t.Log("Creating CSV")
+	// Generate permissions
+	serviceAccountName := genName("nginx-sa")
+	permissions := []install.StrategyDeploymentPermissions{
+		{
+			ServiceAccountName: serviceAccountName,
+			Rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{rbac.VerbAll},
+					APIGroups: []string{mainCRD.Spec.Group},
+					Resources: []string{mainCRDPlural},
+				},
+			},
+		},
+	}
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: opGroupNamespace,
+			Name:      serviceAccountName,
+		},
+	}
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: opGroupNamespace,
+			Name:      serviceAccountName + "-role",
+		},
+		Rules: permissions[0].Rules,
+	}
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: opGroupNamespace,
+			Name:      serviceAccountName + "-rb",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccountName,
+				Namespace: opGroupNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: role.GetName(),
+		},
+	}
+	_, err = c.CreateServiceAccount(serviceAccount)
+	require.NoError(t, err)
+	_, err = c.CreateRole(role)
+	require.NoError(t, err)
+	_, err = c.CreateRoleBinding(roleBinding)
+	require.NoError(t, err)
+
+	// Create a new NamedInstallStrategy
+	deploymentName := genName("operator-deployment")
+	namedStrategy := newNginxInstallStrategy(deploymentName, permissions, nil)
+
+	aCSV := newCSV(csvName, opGroupNamespace, "", *semver.New("0.0.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, namedStrategy)
+	aCSV.Labels = map[string]string{"label": t.Name()}
+	createdCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Create(&aCSV)
+	require.NoError(t, err)
+
+	t.Log("wait for CSV to succeed")
+	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		fetched, err := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(createdCSV.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		t.Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
+		return csvSucceededChecker(fetched), nil
+	})
+	require.NoError(t, err)
+
+	t.Log("Waiting for operator namespace csv to have annotations")
+	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(csvName, metav1.GetOptions{})
+		if fetchErr != nil {
+			if errors.IsNotFound(fetchErr) {
+				return false, nil
+			}
+			t.Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
+			return false, fetchErr
+		}
+		if checkOperatorGroupAnnotations(fetchedCSV, &operatorGroup, true, corev1.NamespaceAll) == nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	csvList, err := crc.OperatorsV1alpha1().ClusterServiceVersions(corev1.NamespaceAll).List(metav1.ListOptions{LabelSelector: "label=TestCSVCopyWatchingAllNamespaces"})
+	require.NoError(t, err)
+	t.Logf("Found CSV count of %v", len(csvList.Items))
+
+	t.Log("Create other namespace")
+	otherNamespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   otherNamespaceName,
+			Labels: matchingLabel,
+		},
+	}
+	_, err = c.KubernetesInterface().CoreV1().Namespaces().Create(&otherNamespace)
+	require.NoError(t, err)
+	defer func() {
+		err = c.KubernetesInterface().CoreV1().Namespaces().Delete(otherNamespaceName, &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}()
+
+	t.Log("Waiting to ensure copied CSV shows up in new namespace")
+	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(csvName, metav1.GetOptions{})
+		if fetchErr != nil {
+			if errors.IsNotFound(fetchErr) {
+				return false, nil
+			}
+			t.Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
+			return false, fetchErr
+		}
+		if checkOperatorGroupAnnotations(fetchedCSV, &operatorGroup, false, "") == nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	// ensure deletion cleans up copied CSV
+	t.Log("deleting parent csv")
+	err = crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Delete(csvName, &metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	t.Log("waiting for orphaned csv to be deleted")
+	err = waitForDelete(func() error {
+		_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(csvName, metav1.GetOptions{})
+		return err
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This fixes scenario(s) where CSVs were not being copied.

Commit message:
~This changes the operator group target namespace format specifically
when watching all namespaces. Instead of only including "", the
annotation has been updated to additionally include all the namespaces
seen. The new behavior fixes syncing issues when a new namespace is
created after the initial CSVs have been copied, again only when
watching all namespaces.~
Doesn't change format, just fixes OperatorGroup managed resources.

Requeuing changes:
When namespaces are updated, matching operator groups are requeued.
When operator group annotations change, CSVs in that namspace are
requeued.

ALM-665