### PR TITLE
[WIP] feat(catalogsource): allow grpc source types that don't require an image

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -99,4 +99,3 @@ func main() {
 	_, done := catalogOperator.Run(stopCh)
 	<-done
 }
-

--- a/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
+++ b/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
@@ -27,6 +27,7 @@ type CatalogSourceSpec struct {
 	SourceType SourceType `json:"sourceType"`
 	ConfigMap  string     `json:"configMap,omitempty"`
 	Image      string     `json:"image,omitempty"`
+	Address    string     `json:"address,omitempty"`
 	Secrets    []string   `json:"secrets,omitempty"`
 
 	// Metadata
@@ -53,6 +54,7 @@ type CatalogSourceStatus struct {
 	RegistryServiceStatus *RegistryServiceStatus      `json:"registryService,omitempty"`
 	LastSync              metav1.Time                 `json:"lastSync,omitempty"`
 }
+
 type ConfigMapResourceReference struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
@@ -69,6 +71,13 @@ type CatalogSource struct {
 
 	Spec   CatalogSourceSpec   `json:"spec"`
 	Status CatalogSourceStatus `json:"status"`
+}
+
+func (c *CatalogSource) Address() string {
+	if c.Spec.Address != "" {
+		return c.Spec.Address
+	}
+	return c.Status.RegistryServiceStatus.Address()
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -383,7 +383,7 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 		}
 	}
 
-	reconciler := o.reconciler.ReconcilerForSourceType(catsrc.Spec.SourceType)
+	reconciler := o.reconciler.ReconcilerForSource(catsrc)
 	if reconciler == nil {
 		return fmt.Errorf("no reconciler for source type %s", catsrc.Spec.SourceType)
 	}
@@ -421,7 +421,7 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 	func() {
 		o.sourcesLock.Lock()
 		defer o.sourcesLock.Unlock()
-		address := catsrc.Status.RegistryServiceStatus.Address()
+		address := catsrc.Address()
 		currentSource, ok := o.sources[sourceKey]
 		logger = logger.WithField("currentSource", sourceKey)
 		if !ok || currentSource.Address != address || catsrc.Status.LastSync.After(currentSource.LastConnect.Time) {

--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -499,7 +499,7 @@ func TestSyncSubscriptions(t *testing.T) {
 			require.NoError(t, err)
 
 			o.reconciler = &fakes.FakeReconcilerFactory{
-				ReconcilerForSourceTypeStub: func(sourceType v1alpha1.SourceType) reconciler.RegistryReconciler {
+				ReconcilerForSourceStub: func(source *v1alpha1.CatalogSource) reconciler.RegistryReconciler {
 					return &fakes.FakeRegistryReconciler{
 						EnsureRegistryServerStub: func(source *v1alpha1.CatalogSource) error {
 							return nil

--- a/pkg/controller/registry/reconciler/grpc_address.go
+++ b/pkg/controller/registry/reconciler/grpc_address.go
@@ -1,0 +1,13 @@
+package reconciler
+
+import (
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+)
+
+type GrpcAddressRegistryReconciler struct{}
+
+var _ RegistryReconciler = &GrpcAddressRegistryReconciler{}
+
+func (g *GrpcAddressRegistryReconciler) EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error {
+	return nil
+}

--- a/pkg/fakes/fake_reconciler_reconciler.go
+++ b/pkg/fakes/fake_reconciler_reconciler.go
@@ -9,77 +9,77 @@ import (
 )
 
 type FakeReconcilerFactory struct {
-	ReconcilerForSourceTypeStub        func(v1alpha1.SourceType) reconciler.RegistryReconciler
-	reconcilerForSourceTypeMutex       sync.RWMutex
-	reconcilerForSourceTypeArgsForCall []struct {
-		arg1 v1alpha1.SourceType
+	ReconcilerForSourceStub        func(*v1alpha1.CatalogSource) reconciler.RegistryReconciler
+	reconcilerForSourceMutex       sync.RWMutex
+	reconcilerForSourceArgsForCall []struct {
+		arg1 *v1alpha1.CatalogSource
 	}
-	reconcilerForSourceTypeReturns struct {
+	reconcilerForSourceReturns struct {
 		result1 reconciler.RegistryReconciler
 	}
-	reconcilerForSourceTypeReturnsOnCall map[int]struct {
+	reconcilerForSourceReturnsOnCall map[int]struct {
 		result1 reconciler.RegistryReconciler
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceType(arg1 v1alpha1.SourceType) reconciler.RegistryReconciler {
-	fake.reconcilerForSourceTypeMutex.Lock()
-	ret, specificReturn := fake.reconcilerForSourceTypeReturnsOnCall[len(fake.reconcilerForSourceTypeArgsForCall)]
-	fake.reconcilerForSourceTypeArgsForCall = append(fake.reconcilerForSourceTypeArgsForCall, struct {
-		arg1 v1alpha1.SourceType
+func (fake *FakeReconcilerFactory) ReconcilerForSource(arg1 *v1alpha1.CatalogSource) reconciler.RegistryReconciler {
+	fake.reconcilerForSourceMutex.Lock()
+	ret, specificReturn := fake.reconcilerForSourceReturnsOnCall[len(fake.reconcilerForSourceArgsForCall)]
+	fake.reconcilerForSourceArgsForCall = append(fake.reconcilerForSourceArgsForCall, struct {
+		arg1 *v1alpha1.CatalogSource
 	}{arg1})
-	fake.recordInvocation("ReconcilerForSourceType", []interface{}{arg1})
-	fake.reconcilerForSourceTypeMutex.Unlock()
-	if fake.ReconcilerForSourceTypeStub != nil {
-		return fake.ReconcilerForSourceTypeStub(arg1)
+	fake.recordInvocation("ReconcilerForSource", []interface{}{arg1})
+	fake.reconcilerForSourceMutex.Unlock()
+	if fake.ReconcilerForSourceStub != nil {
+		return fake.ReconcilerForSourceStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.reconcilerForSourceTypeReturns
+	fakeReturns := fake.reconcilerForSourceReturns
 	return fakeReturns.result1
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeCallCount() int {
-	fake.reconcilerForSourceTypeMutex.RLock()
-	defer fake.reconcilerForSourceTypeMutex.RUnlock()
-	return len(fake.reconcilerForSourceTypeArgsForCall)
+func (fake *FakeReconcilerFactory) ReconcilerForSourceCallCount() int {
+	fake.reconcilerForSourceMutex.RLock()
+	defer fake.reconcilerForSourceMutex.RUnlock()
+	return len(fake.reconcilerForSourceArgsForCall)
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeCalls(stub func(v1alpha1.SourceType) reconciler.RegistryReconciler) {
-	fake.reconcilerForSourceTypeMutex.Lock()
-	defer fake.reconcilerForSourceTypeMutex.Unlock()
-	fake.ReconcilerForSourceTypeStub = stub
+func (fake *FakeReconcilerFactory) ReconcilerForSourceCalls(stub func(*v1alpha1.CatalogSource) reconciler.RegistryReconciler) {
+	fake.reconcilerForSourceMutex.Lock()
+	defer fake.reconcilerForSourceMutex.Unlock()
+	fake.ReconcilerForSourceStub = stub
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeArgsForCall(i int) v1alpha1.SourceType {
-	fake.reconcilerForSourceTypeMutex.RLock()
-	defer fake.reconcilerForSourceTypeMutex.RUnlock()
-	argsForCall := fake.reconcilerForSourceTypeArgsForCall[i]
+func (fake *FakeReconcilerFactory) ReconcilerForSourceArgsForCall(i int) *v1alpha1.CatalogSource {
+	fake.reconcilerForSourceMutex.RLock()
+	defer fake.reconcilerForSourceMutex.RUnlock()
+	argsForCall := fake.reconcilerForSourceArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeReturns(result1 reconciler.RegistryReconciler) {
-	fake.reconcilerForSourceTypeMutex.Lock()
-	defer fake.reconcilerForSourceTypeMutex.Unlock()
-	fake.ReconcilerForSourceTypeStub = nil
-	fake.reconcilerForSourceTypeReturns = struct {
+func (fake *FakeReconcilerFactory) ReconcilerForSourceReturns(result1 reconciler.RegistryReconciler) {
+	fake.reconcilerForSourceMutex.Lock()
+	defer fake.reconcilerForSourceMutex.Unlock()
+	fake.ReconcilerForSourceStub = nil
+	fake.reconcilerForSourceReturns = struct {
 		result1 reconciler.RegistryReconciler
 	}{result1}
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeReturnsOnCall(i int, result1 reconciler.RegistryReconciler) {
-	fake.reconcilerForSourceTypeMutex.Lock()
-	defer fake.reconcilerForSourceTypeMutex.Unlock()
-	fake.ReconcilerForSourceTypeStub = nil
-	if fake.reconcilerForSourceTypeReturnsOnCall == nil {
-		fake.reconcilerForSourceTypeReturnsOnCall = make(map[int]struct {
+func (fake *FakeReconcilerFactory) ReconcilerForSourceReturnsOnCall(i int, result1 reconciler.RegistryReconciler) {
+	fake.reconcilerForSourceMutex.Lock()
+	defer fake.reconcilerForSourceMutex.Unlock()
+	fake.ReconcilerForSourceStub = nil
+	if fake.reconcilerForSourceReturnsOnCall == nil {
+		fake.reconcilerForSourceReturnsOnCall = make(map[int]struct {
 			result1 reconciler.RegistryReconciler
 		})
 	}
-	fake.reconcilerForSourceTypeReturnsOnCall[i] = struct {
+	fake.reconcilerForSourceReturnsOnCall[i] = struct {
 		result1 reconciler.RegistryReconciler
 	}{result1}
 }
@@ -87,8 +87,8 @@ func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeReturnsOnCall(i int, r
 func (fake *FakeReconcilerFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.reconcilerForSourceTypeMutex.RLock()
-	defer fake.reconcilerForSourceTypeMutex.RUnlock()
+	fake.reconcilerForSourceMutex.RLock()
+	defer fake.reconcilerForSourceMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -276,6 +276,40 @@ func buildServiceAccountCleanupFunc(t *testing.T, c operatorclient.ClientInterfa
 }
 
 func createInternalCatalogSource(t *testing.T, c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensions.CustomResourceDefinition, csvs []v1alpha1.ClusterServiceVersion) (*v1alpha1.CatalogSource, cleanupFunc) {
+	configMap, configMapCleanup := createConfigMapForCatalogData(t, c, name, namespace, manifests, crds, csvs)
+
+	// Create an internal CatalogSource custom resource pointing to the ConfigMap
+	catalogSource := &v1alpha1.CatalogSource{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.CatalogSourceKind,
+			APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.CatalogSourceSpec{
+			SourceType: "internal",
+			ConfigMap:  configMap.GetName(),
+		},
+	}
+	catalogSource.SetNamespace(namespace)
+
+	t.Logf("Creating catalog source %s in namespace %s...", name, namespace)
+	catalogSource, err := crc.OperatorsV1alpha1().CatalogSources(namespace).Create(catalogSource)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+	t.Logf("Catalog source %s created", name)
+
+	cleanupInternalCatalogSource := func() {
+		configMapCleanup()
+		buildCatalogSourceCleanupFunc(t, crc, namespace, catalogSource)()
+	}
+	return catalogSource, cleanupInternalCatalogSource
+}
+
+func createConfigMapForCatalogData(t *testing.T, c operatorclient.ClientInterface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensions.CustomResourceDefinition, csvs []v1alpha1.ClusterServiceVersion) (*corev1.ConfigMap, cleanupFunc) {
 	// Create a config map containing the PackageManifests and CSVs
 	configMapName := fmt.Sprintf("%s-configmap", name)
 	catalogConfigMap := &corev1.ConfigMap{
@@ -314,40 +348,11 @@ func createInternalCatalogSource(t *testing.T, c operatorclient.ClientInterface,
 		catalogConfigMap.Data[registry.ConfigMapCSVName] = string(csvsRaw)
 	}
 
-	_, err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Create(catalogConfigMap)
+	createdConfigMap, err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Create(catalogConfigMap)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		require.NoError(t, err)
 	}
-
-	// Create an internal CatalogSource custom resource pointing to the ConfigMap
-	catalogSource := &v1alpha1.CatalogSource{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.CatalogSourceKind,
-			APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: v1alpha1.CatalogSourceSpec{
-			SourceType: "internal",
-			ConfigMap:  configMapName,
-		},
-	}
-	catalogSource.SetNamespace(namespace)
-
-	t.Logf("Creating catalog source %s in namespace %s...", name, namespace)
-	catalogSource, err = crc.OperatorsV1alpha1().CatalogSources(namespace).Create(catalogSource)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		require.NoError(t, err)
-	}
-	t.Logf("Catalog source %s created", name)
-
-	cleanupInternalCatalogSource := func() {
-		buildConfigMapCleanupFunc(t, c, namespace, catalogConfigMap)()
-		buildCatalogSourceCleanupFunc(t, crc, namespace, catalogSource)()
-	}
-	return catalogSource, cleanupInternalCatalogSource
+	return createdConfigMap, buildConfigMapCleanupFunc(t, c, namespace, createdConfigMap)
 }
 
 func serializeCRD(t *testing.T, crd apiextensions.CustomResourceDefinition) string {


### PR DESCRIPTION
instead, they provide an address directly. OLM will not have visibility
into the resources required for running the grpc catalog for this case,
but will still connect and health check.

Question for reviewers: Do we like the design of top level `grpc` type but doing different things depending on whether we're provided an `image` or an `address`? The alternative is a new `grpc_address` sourcetype.

Test will come soon. 

We need to find out if we need an exception for this. 