### PR TITLE
Correct URL for Package Server CSV Link

### DIFF
--- a/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
+++ b/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
@@ -16,7 +16,7 @@
       name: Red Hat
     links:
     - name: Package Server
-      url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/packageserver
+      url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server
     installModes:
     - type: OwnNamespace
       supported: true


### PR DESCRIPTION
### Description

Updates the link to the directory in the GitHub repository.

Fixes https://jira.coreos.com/browse/ALM-873