### PR TITLE
fix(olm): Fix CSVs api-servers battle for ownership of APIServices

### DIFF
--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -10,6 +10,22 @@ type MultipleExistingCRDOwnersError struct {
 	Namespace string
 }
 
+type UnadoptableError struct {
+	resourceNamespace string
+	resourceName      string
+}
+
+func (err UnadoptableError) Error() string {
+	if err.resourceNamespace == "" {
+		return fmt.Sprintf("%s is unadoptable", err.resourceName)
+	}
+	return fmt.Sprintf("%s/%s is unadoptable", err.resourceNamespace, err.resourceName)
+}
+
+func NewUnadoptableError(resourceNamespace, resourceName string) UnadoptableError {
+	return UnadoptableError{resourceNamespace, resourceName}
+}
+
 func (m MultipleExistingCRDOwnersError) Error() string {
 	return fmt.Sprintf("Existing CSVs %v in namespace %s all claim to own CRD %s", m.CSVNames, m.Namespace, m.CRDName)
 }

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/fakes"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 )
 
 type mockTransitioner struct {
@@ -141,11 +141,11 @@ func TestExecutePlan(t *testing.T) {
 						Resource: v1alpha1.StepResource{
 							CatalogSource:          "catalog",
 							CatalogSourceNamespace: namespace,
-							Group:    "",
-							Version:  "v1",
-							Kind:     "Service",
-							Name:     "service",
-							Manifest: toManifest(service("service", namespace)),
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "Service",
+							Name:                   "service",
+							Manifest:               toManifest(service("service", namespace)),
 						},
 						Status: v1alpha1.StepStatusUnknown,
 					},
@@ -153,11 +153,11 @@ func TestExecutePlan(t *testing.T) {
 						Resource: v1alpha1.StepResource{
 							CatalogSource:          "catalog",
 							CatalogSourceNamespace: namespace,
-							Group:    "operators.coreos.com",
-							Version:  "v1alpha1",
-							Kind:     "ClusterServiceVersion",
-							Name:     "csv",
-							Manifest: toManifest(csv("csv", namespace, nil, nil)),
+							Group:                  "operators.coreos.com",
+							Version:                "v1alpha1",
+							Kind:                   "ClusterServiceVersion",
+							Name:                   "csv",
+							Manifest:               toManifest(csv("csv", namespace, nil, nil)),
 						},
 						Status: v1alpha1.StepStatusUnknown,
 					},
@@ -488,8 +488,8 @@ func NewFakeOperator(clientObjs []runtime.Object, k8sObjs []runtime.Object, extO
 	podInformer := informerFactory.Core().V1().Pods()
 	configMapInformer := informerFactory.Core().V1().ConfigMaps()
 	subscriptionInformer := externalversions.NewSharedInformerFactoryWithOptions(clientFake, wakeupInterval, externalversions.WithNamespace(namespace)).Operators().V1alpha1().Subscriptions()
-	installPlanInformer := externalversions.NewSharedInformerFactoryWithOptions(clientFake,  wakeupInterval, externalversions.WithNamespace(namespace)).Operators().V1alpha1().InstallPlans()
-	
+	installPlanInformer := externalversions.NewSharedInformerFactoryWithOptions(clientFake, wakeupInterval, externalversions.WithNamespace(namespace)).Operators().V1alpha1().InstallPlans()
+
 	// register informers
 	registryInformers := []cache.SharedIndexInformer{
 		roleInformer.Informer(),

--- a/pkg/controller/operators/olm/apiservices.go
+++ b/pkg/controller/operators/olm/apiservices.go
@@ -83,7 +83,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 		}
 
 		// Check if the APIService is adoptable
-		if !ownerutil.OwnersIntersect(owners, apiService.GetLabels()) {
+		if !ownerutil.OwnersIntersect(owners, apiService) {
 			err := olmerrors.NewUnadoptableError("", apiServiceName)
 			logger.WithError(err).Warn("found unadoptable apiservice")
 			errs = append(errs, err)
@@ -695,7 +695,7 @@ func (a *Operator) installAPIServiceRequirements(desc v1alpha1.APIServiceDescrip
 			owners = append(owners, replaces)
 		}
 		// check if the APIService is adoptable
-		if !ownerutil.OwnersIntersect(owners, apiService.GetLabels()) {
+		if !ownerutil.OwnersIntersect(owners, apiService) {
 			return nil, fmt.Errorf("pre-existing APIService %s is not adoptable", apiServiceName)
 		}
 	}

--- a/pkg/controller/operators/olm/apiservices.go
+++ b/pkg/controller/operators/olm/apiservices.go
@@ -62,7 +62,12 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 	errs := []error{}
 	owners := []ownerutil.Owner{csv}
 	// Get replacing CSV if exists
-	replacement, _ := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(csv.GetNamespace()).Get(csv.Spec.Replaces)
+	replacement, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(csv.GetNamespace()).Get(csv.Spec.Replaces)
+	if err != nil && k8serrors.IsNotFound(err) == false {
+		a.Log.Debugf("Replacement error regarding CSV (%v): %v", csv.GetName(), err)
+		errs = append(errs, err)
+		return errs
+	}
 	if replacement != nil {
 		owners = append(owners, replacement)
 	}

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -19,14 +19,14 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	kagg "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
-	
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
+
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha2"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/certs"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/event"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
@@ -49,13 +49,13 @@ const (
 
 type Operator struct {
 	*queueinformer.Operator
-	csvQueueSet queueinformer.ResourceQueueSet
-	ogQueueSet queueinformer.ResourceQueueSet
-	client      versioned.Interface
-	resolver    install.StrategyResolverInterface
+	csvQueueSet   queueinformer.ResourceQueueSet
+	ogQueueSet    queueinformer.ResourceQueueSet
+	client        versioned.Interface
+	resolver      install.StrategyResolverInterface
 	apiReconciler resolver.APIIntersectionReconciler
-	lister      operatorlister.OperatorLister
-	recorder    record.EventRecorder
+	lister        operatorlister.OperatorLister
+	recorder      record.EventRecorder
 }
 
 func NewOperator(logger *logrus.Logger, crClient versioned.Interface, opClient operatorclient.ClientInterface, strategyResolver install.StrategyResolverInterface, wakeupInterval time.Duration, namespaces []string) (*Operator, error) {
@@ -76,14 +76,14 @@ func NewOperator(logger *logrus.Logger, crClient versioned.Interface, opClient o
 	}
 
 	op := &Operator{
-		Operator:    queueOperator,
-		csvQueueSet: make(queueinformer.ResourceQueueSet),
-		ogQueueSet:  make(queueinformer.ResourceQueueSet),
-		client:      crClient,
-		resolver:    strategyResolver,
+		Operator:      queueOperator,
+		csvQueueSet:   make(queueinformer.ResourceQueueSet),
+		ogQueueSet:    make(queueinformer.ResourceQueueSet),
+		client:        crClient,
+		resolver:      strategyResolver,
 		apiReconciler: resolver.APIIntersectionReconcileFunc(resolver.ReconcileAPIIntersection),
-		lister:      operatorlister.NewLister(),
-		recorder:    eventRecorder,
+		lister:        operatorlister.NewLister(),
+		recorder:      eventRecorder,
 	}
 
 	// Set up RBAC informers
@@ -431,14 +431,14 @@ func (a *Operator) removeDanglingChildCSVs(csv *v1alpha1.ClusterServiceVersion) 
 	} else if parent != nil && parent.Status.Phase == v1alpha1.CSVPhaseFailed && parent.Status.Reason == v1alpha1.CSVReasonInterOperatorGroupOwnerConflict {
 		logger.Debug("deleting copied CSV since parent has intersecting operatorgroup conflict")
 		delete = true
-	} 
+	}
 
 	if delete {
 		if err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Delete(csv.GetName(), &metav1.DeleteOptions{}); err != nil {
 			return err
 		}
 	}
-	
+
 	return nil
 }
 
@@ -815,8 +815,8 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 		// Check if any generated resources are missing
-		if resErr := a.checkAPIServiceResources(out, certs.PEMSHA256); resErr != nil {
-			out.SetPhase(v1alpha1.CSVPhaseFailed, v1alpha1.CSVReasonAPIServiceResourceIssue, resErr.Error(), now)
+		if resErr := a.checkAPIServiceResources(out, certs.PEMSHA256); len(resErr) > 0 {
+			out.SetPhase(v1alpha1.CSVPhaseFailed, v1alpha1.CSVReasonAPIServiceResourceIssue, resErr[0].Error(), now)
 			return
 		}
 
@@ -879,9 +879,12 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 		// Check if any generated resources are missing
-		if resErr := a.checkAPIServiceResources(out, certs.PEMSHA256); resErr != nil {
-			out.SetPhase(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonAPIServiceResourcesNeedReinstall, resErr.Error(), now)
-			return
+		if resErr := a.checkAPIServiceResources(out, certs.PEMSHA256); len(resErr) > 0 {
+			// Check if API services are adoptable. If not, keep CSV as Failed state
+			if a.apiServiceResourceErrorsActionable(resErr) {
+				out.SetPhase(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonAPIServiceResourcesNeedReinstall, resErr[0].Error(), now)
+				return
+			}
 		}
 
 		// Check if it's time to refresh owned APIService certs

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -1553,7 +1553,7 @@ func TestCreateSameCSVWithOwnedAPIServiceMultiNamespace(t *testing.T) {
 			Namespace: secondNamespaceName,
 		},
 		Spec: v1alpha2.OperatorGroupSpec{
-			Selector: metav1.LabelSelector{
+			Selector: &metav1.LabelSelector{
 				MatchLabels: matchingLabel,
 			},
 		},


### PR DESCRIPTION
Currently, CSVs that install extension api-servers battle for
ownership of APIServices. New CSVs only adopt APIServices that have
OwnerReferences to CSVs in the new CSV's replaces chain.

Signed-off-by: Vu Dinh <vdinh@redhat.com>