### PR TITLE
fix(olm): Remove the "v" prefix in minKubeVersion if presents

### DIFF
--- a/Documentation/design/building-your-csv.md
+++ b/Documentation/design/building-your-csv.md
@@ -232,7 +232,7 @@ The metadata section contains general metadata around the name, version and othe
 
 **Description**: A markdown blob that describes the Operator. Important information to include: features, limitations and common use-cases for the Operator. If your Operator manages different types of installs, eg. standalone vs clustered, it is useful to give an overview of how each differs from each other, or which ones are supported for production use.
 
-**MinKubeVersion**: A minimum version of Kubernetes that server is supposed to have so operator(s) can be deployed.
+**MinKubeVersion**: A minimum version of Kubernetes that server is supposed to have so operator(s) can be deployed. The Kubernetes version must be in "Major.Major.Patch" format (e.g: 1.11.0).
 
 **Labels** (optional): Any key/value pairs used to organize and categorize this CSV object.
 

--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -50,7 +50,7 @@ func (a *Operator) minKubeVersionStatus(name string, minKubeVersion string) (met
 		return
 	}
 
-	csvVersionInfo, err := semver.NewVersion(minKubeVersion)
+	csvVersionInfo, err := semver.NewVersion(strings.TrimPrefix(minKubeVersion, "v"))
 	if err != nil {
 		status.Status = v1alpha1.RequirementStatusReasonPresentNotSatisfied
 		status.Message = "CSV version parsing error"


### PR DESCRIPTION
Sometimes users may enter Kubernetes version as "v1.1.1" format
which will cause failture as the code currently only accept "1.1.1"
format. This PR will trim the prefix in advance to avoid this issue.

Signed-off-by: Vu Dinh <vdinh@redhat.com>