### PR TITLE
Make e2e more robust

### DIFF
--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -147,8 +147,9 @@ func newCSV(name, namespace, replaces string, version semver.Version, owned []ap
 			Namespace: namespace,
 		},
 		Spec: v1alpha1.ClusterServiceVersionSpec{
-			Replaces: replaces,
-			Version:  version,
+			Replaces:       replaces,
+			Version:        version,
+			MinKubeVersion: "0.0.0",
 			InstallModes: []v1alpha1.InstallMode{
 				{
 					Type:      v1alpha1.InstallModeTypeOwnNamespace,


### PR DESCRIPTION
These are commits that I had to make in order to make https://github.com/operator-framework/operator-lifecycle-manager/pull/675 pass reliably. Since that PR is going to be delayed to allow more important operator group fixes in, go ahead and merge this.

Hoping that it'll help @dinhxuanvu with some of his e2e woes.