### PR TITLE
fix(olm): OLM should not attempt to write ClusterStatus by default

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	defaultWakeupInterval = 5 * time.Minute
-	defaultOperatorName   = "operator-lifecycle-manager"
+	defaultOperatorName   = ""
 )
 
 // config flags defined globally so that they appear on the test binary as well


### PR DESCRIPTION
The --writeStatusName flag for writing out a ClusterOperator status
should default to none, instead of currently defaulting to
operator-lifecycle-manager which causes OLM to CrashLoopBackoff in
upstream Kubernetes clusters.

Signed-off-by: Vu Dinh <vdinh@redhat.com>