### PR TITLE
feat(catalogsource): allow grpc source types that don't require an image

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -99,4 +99,3 @@ func main() {
 	_, done := catalogOperator.Run(stopCh)
 	<-done
 }
-

--- a/deploy/chart/templates/0000_50_olm_05-catalogsource.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_05-catalogsource.crd.yaml
@@ -62,9 +62,13 @@ spec:
               type: string
               description: The name of a ConfigMap that holds the entries for an in-memory catalog.
 
+            address:
+              type: string
+              description: An optional address. When set, directs OLM to connect to use a pre-existing registry server at this address.
+
             image:
               type: string
-              description: An image that serves a grpc registry. Only valid for `grpc` sourceType.
+              description: An image that serves a grpc registry. Only valid for `grpc` sourceType. If both image and address are set, OLM does not use the address field.
 
             displayName:
               type: string

--- a/deploy/ocp/manifests/0.8.1/0000_50_olm_05-catalogsource.crd.yaml
+++ b/deploy/ocp/manifests/0.8.1/0000_50_olm_05-catalogsource.crd.yaml
@@ -64,9 +64,13 @@ spec:
               type: string
               description: The name of a ConfigMap that holds the entries for an in-memory catalog.
 
+            address:
+              type: string
+              description: An optional address. When set, directs OLM to connect to use a pre-existing registry server at this address.
+
             image:
               type: string
-              description: An image that serves a grpc registry. Only valid for `grpc` sourceType.
+              description: An image that serves a grpc registry. Only valid for `grpc` sourceType. If both image and address are set, OLM does not use the address field.
 
             displayName:
               type: string

--- a/deploy/okd/manifests/0.8.1/0000_50_olm_05-catalogsource.crd.yaml
+++ b/deploy/okd/manifests/0.8.1/0000_50_olm_05-catalogsource.crd.yaml
@@ -64,9 +64,13 @@ spec:
               type: string
               description: The name of a ConfigMap that holds the entries for an in-memory catalog.
 
+            address:
+              type: string
+              description: An optional address. When set, directs OLM to connect to use a pre-existing registry server at this address.
+
             image:
               type: string
-              description: An image that serves a grpc registry. Only valid for `grpc` sourceType.
+              description: An image that serves a grpc registry. Only valid for `grpc` sourceType. If both image and address are set, OLM does not use the address field.
 
             displayName:
               type: string

--- a/deploy/upstream/manifests/0.8.1/0000_50_olm_05-catalogsource.crd.yaml
+++ b/deploy/upstream/manifests/0.8.1/0000_50_olm_05-catalogsource.crd.yaml
@@ -64,9 +64,13 @@ spec:
               type: string
               description: The name of a ConfigMap that holds the entries for an in-memory catalog.
 
+            address:
+              type: string
+              description: An optional address. When set, directs OLM to connect to use a pre-existing registry server at this address.
+
             image:
               type: string
-              description: An image that serves a grpc registry. Only valid for `grpc` sourceType.
+              description: An image that serves a grpc registry. Only valid for `grpc` sourceType. If both image and address are set, OLM does not use the address field.
 
             displayName:
               type: string

--- a/go.mod
+++ b/go.mod
@@ -41,5 +41,5 @@ require (
 	k8s.io/klog v0.2.0 // indirect
 	k8s.io/kube-aggregator v0.0.0-20181204002017-122bac39d429
 	k8s.io/kube-openapi v0.0.0-20181031203759-72693cb1fadd
-	k8s.io/kubernetes v1.11.8-beta.0.0.20190208223919-e6f6fa1f2dd1
+	k8s.io/kubernetes v1.11.8-beta.0.0.20190214232326-4e0b35876724
 )

--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,7 @@ github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.9+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/etcd v3.3.11+incompatible h1:0gCnqKsq7XxMi69JsnbmMc1o+RJH3XH64sV9aiTTYko=
+github.com/coreos/etcd v3.3.11+incompatible h1:U0wJghY374q+UrjOM2mfROHSwEspsQVkCACB1PGka1g=
 github.com/coreos/etcd v3.3.11+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -112,7 +112,7 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f h1:ShTPMJQes6tubcjzGMODIVG5hlrCeImaBnZzKF2N8SM=
 github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:BWIsLfhgKhV5g/oF34aRjniBHLTZe5DNekSjbAjIS6c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -297,6 +297,7 @@ k8s.io/apimachinery v0.0.0-20181203235515-3d8ee2261517/go.mod h1:ccL7Eh7zubPUSh9
 k8s.io/apimachinery v0.0.0-20190118094746-1525e4dadd2d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20190208202428-1a579f8a7b42 h1:ju2lLx7i6XE8A9QLtwxlQngelP8SosMIjK4IYE/TLFI=
 k8s.io/apimachinery v0.0.0-20190208202428-1a579f8a7b42/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/apimachinery v0.0.0-20190213190008-5eb658cbe970 h1:alS6VCwjuZxqOAhOnpSY/TbMvwVRAOWSTeE63v5Iz+M=
 k8s.io/apiserver v0.0.0-20181026151315-13cfe3978170 h1:CqI85nZvPaV+7JFono0nAOGOx2brocqefcOhDPVhHKI=
 k8s.io/apiserver v0.0.0-20181026151315-13cfe3978170/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
 k8s.io/client-go v0.0.0-20180718001006-59698c7d9724/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
@@ -318,5 +319,5 @@ k8s.io/kube-openapi v0.0.0-20181031203759-72693cb1fadd h1:ggv/Vfza0i5xuhUZyYyxcc
 k8s.io/kube-openapi v0.0.0-20181031203759-72693cb1fadd/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kubernetes v1.11.7-beta.0.0.20181219023948-b875d52ea96d/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.11.8-beta.0.0.20190124204751-3a10094374f2/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
-k8s.io/kubernetes v1.11.8-beta.0.0.20190208223919-e6f6fa1f2dd1 h1:KXhECItYGlIqgwjGvb46A8eZ4qB3WgTmunAcEecVsE8=
-k8s.io/kubernetes v1.11.8-beta.0.0.20190208223919-e6f6fa1f2dd1/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/kubernetes v1.11.8-beta.0.0.20190214232326-4e0b35876724 h1:THwYErr8LUBf1Je2gh9lzarMPzLxN6SsdtuiLLZMtoQ=
+k8s.io/kubernetes v1.11.8-beta.0.0.20190214232326-4e0b35876724/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=

--- a/manifests/0000_50_olm_05-catalogsource.crd.yaml
+++ b/manifests/0000_50_olm_05-catalogsource.crd.yaml
@@ -62,9 +62,13 @@ spec:
               type: string
               description: The name of a ConfigMap that holds the entries for an in-memory catalog.
 
+            address:
+              type: string
+              description: An optional address. When set, directs OLM to connect to use a pre-existing registry server at this address.
+
             image:
               type: string
-              description: An image that serves a grpc registry. Only valid for `grpc` sourceType.
+              description: An image that serves a grpc registry. Only valid for `grpc` sourceType. If both image and address are set, OLM does not use the address field.
 
             displayName:
               type: string

--- a/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
+++ b/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
@@ -18,16 +18,43 @@ const (
 type SourceType string
 
 const (
-	SourceTypeInternal  SourceType = "internal"
+	// SourceTypeInternal (deprecated) specifies a CatalogSource of type SourceTypeConfigmap
+	SourceTypeInternal SourceType = "internal"
+
+	// SourceTypeConfigmap specifies a CatalogSource that generates a configmap-server registry
 	SourceTypeConfigmap SourceType = "configmap"
-	SourceTypeGrpc      SourceType = "grpc"
+
+	// SourceTypeGrpc specifies a CatalogSource that can use an operator registry image to generate a
+	// registry-server or connect to a pre-existing registry at an address.
+	SourceTypeGrpc SourceType = "grpc"
 )
 
 type CatalogSourceSpec struct {
+	// SourceType is the type of source
 	SourceType SourceType `json:"sourceType"`
-	ConfigMap  string     `json:"configMap,omitempty"`
-	Image      string     `json:"image,omitempty"`
-	Secrets    []string   `json:"secrets,omitempty"`
+
+	// ConfigMap is the name of the ConfigMap to be used to back a configmap-server registry.
+	// Only used when SourceType = SourceTypeConfigmap or SourceTypeInternal.
+	// +Optional
+	ConfigMap string `json:"configMap,omitempty"`
+
+	// Address is a host that OLM can use to connect to a pre-existing registry.
+	// Format: <registry-host or ip>:<port>
+	// Only used when SourceType = SourceTypeGrpc.
+	// Ignored when the Image field is set.
+	// +Optional
+	Address string `json:"address,omitempty"`
+
+	// Image is an operator-registry container image to instantiate a registry-server with.
+	// Only used when SourceType = SourceTypeGrpc.
+	// If present, the address field is ignored.
+	// +Optional
+	Image string `json:"image,omitempty"`
+
+	// Secrets represent set of secrets that can be used to access the contents of the catalog.
+	// It is best to keep this list small, since each will need to be tried for every catalog entry.
+	// +Optional
+	Secrets []string `json:"secrets,omitempty"`
 
 	// Metadata
 	DisplayName string `json:"displayName,omitempty"`
@@ -53,6 +80,7 @@ type CatalogSourceStatus struct {
 	RegistryServiceStatus *RegistryServiceStatus      `json:"registryService,omitempty"`
 	LastSync              metav1.Time                 `json:"lastSync,omitempty"`
 }
+
 type ConfigMapResourceReference struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
@@ -69,6 +97,13 @@ type CatalogSource struct {
 
 	Spec   CatalogSourceSpec   `json:"spec"`
 	Status CatalogSourceStatus `json:"status"`
+}
+
+func (c *CatalogSource) Address() string {
+	if c.Spec.Address != "" {
+		return c.Spec.Address
+	}
+	return c.Status.RegistryServiceStatus.Address()
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -499,7 +499,7 @@ func TestSyncSubscriptions(t *testing.T) {
 			require.NoError(t, err)
 
 			o.reconciler = &fakes.FakeReconcilerFactory{
-				ReconcilerForSourceTypeStub: func(sourceType v1alpha1.SourceType) reconciler.RegistryReconciler {
+				ReconcilerForSourceStub: func(source *v1alpha1.CatalogSource) reconciler.RegistryReconciler {
 					return &fakes.FakeRegistryReconciler{
 						EnsureRegistryServerStub: func(source *v1alpha1.CatalogSource) error {
 							return nil

--- a/pkg/controller/registry/reconciler/grpc_address.go
+++ b/pkg/controller/registry/reconciler/grpc_address.go
@@ -1,0 +1,19 @@
+package reconciler
+
+import (
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+)
+
+type GrpcAddressRegistryReconciler struct{}
+
+var _ RegistryReconciler = &GrpcAddressRegistryReconciler{}
+
+func (g *GrpcAddressRegistryReconciler) EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error {
+	
+	catalogSource.Status.RegistryServiceStatus = &v1alpha1.RegistryServiceStatus{
+		CreatedAt:        timeNow(),
+		Protocol:         "grpc",
+	}
+
+	return nil
+}

--- a/pkg/fakes/fake_reconciler_reconciler.go
+++ b/pkg/fakes/fake_reconciler_reconciler.go
@@ -9,77 +9,77 @@ import (
 )
 
 type FakeReconcilerFactory struct {
-	ReconcilerForSourceTypeStub        func(v1alpha1.SourceType) reconciler.RegistryReconciler
-	reconcilerForSourceTypeMutex       sync.RWMutex
-	reconcilerForSourceTypeArgsForCall []struct {
-		arg1 v1alpha1.SourceType
+	ReconcilerForSourceStub        func(*v1alpha1.CatalogSource) reconciler.RegistryReconciler
+	reconcilerForSourceMutex       sync.RWMutex
+	reconcilerForSourceArgsForCall []struct {
+		arg1 *v1alpha1.CatalogSource
 	}
-	reconcilerForSourceTypeReturns struct {
+	reconcilerForSourceReturns struct {
 		result1 reconciler.RegistryReconciler
 	}
-	reconcilerForSourceTypeReturnsOnCall map[int]struct {
+	reconcilerForSourceReturnsOnCall map[int]struct {
 		result1 reconciler.RegistryReconciler
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceType(arg1 v1alpha1.SourceType) reconciler.RegistryReconciler {
-	fake.reconcilerForSourceTypeMutex.Lock()
-	ret, specificReturn := fake.reconcilerForSourceTypeReturnsOnCall[len(fake.reconcilerForSourceTypeArgsForCall)]
-	fake.reconcilerForSourceTypeArgsForCall = append(fake.reconcilerForSourceTypeArgsForCall, struct {
-		arg1 v1alpha1.SourceType
+func (fake *FakeReconcilerFactory) ReconcilerForSource(arg1 *v1alpha1.CatalogSource) reconciler.RegistryReconciler {
+	fake.reconcilerForSourceMutex.Lock()
+	ret, specificReturn := fake.reconcilerForSourceReturnsOnCall[len(fake.reconcilerForSourceArgsForCall)]
+	fake.reconcilerForSourceArgsForCall = append(fake.reconcilerForSourceArgsForCall, struct {
+		arg1 *v1alpha1.CatalogSource
 	}{arg1})
-	fake.recordInvocation("ReconcilerForSourceType", []interface{}{arg1})
-	fake.reconcilerForSourceTypeMutex.Unlock()
-	if fake.ReconcilerForSourceTypeStub != nil {
-		return fake.ReconcilerForSourceTypeStub(arg1)
+	fake.recordInvocation("ReconcilerForSource", []interface{}{arg1})
+	fake.reconcilerForSourceMutex.Unlock()
+	if fake.ReconcilerForSourceStub != nil {
+		return fake.ReconcilerForSourceStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.reconcilerForSourceTypeReturns
+	fakeReturns := fake.reconcilerForSourceReturns
 	return fakeReturns.result1
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeCallCount() int {
-	fake.reconcilerForSourceTypeMutex.RLock()
-	defer fake.reconcilerForSourceTypeMutex.RUnlock()
-	return len(fake.reconcilerForSourceTypeArgsForCall)
+func (fake *FakeReconcilerFactory) ReconcilerForSourceCallCount() int {
+	fake.reconcilerForSourceMutex.RLock()
+	defer fake.reconcilerForSourceMutex.RUnlock()
+	return len(fake.reconcilerForSourceArgsForCall)
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeCalls(stub func(v1alpha1.SourceType) reconciler.RegistryReconciler) {
-	fake.reconcilerForSourceTypeMutex.Lock()
-	defer fake.reconcilerForSourceTypeMutex.Unlock()
-	fake.ReconcilerForSourceTypeStub = stub
+func (fake *FakeReconcilerFactory) ReconcilerForSourceCalls(stub func(*v1alpha1.CatalogSource) reconciler.RegistryReconciler) {
+	fake.reconcilerForSourceMutex.Lock()
+	defer fake.reconcilerForSourceMutex.Unlock()
+	fake.ReconcilerForSourceStub = stub
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeArgsForCall(i int) v1alpha1.SourceType {
-	fake.reconcilerForSourceTypeMutex.RLock()
-	defer fake.reconcilerForSourceTypeMutex.RUnlock()
-	argsForCall := fake.reconcilerForSourceTypeArgsForCall[i]
+func (fake *FakeReconcilerFactory) ReconcilerForSourceArgsForCall(i int) *v1alpha1.CatalogSource {
+	fake.reconcilerForSourceMutex.RLock()
+	defer fake.reconcilerForSourceMutex.RUnlock()
+	argsForCall := fake.reconcilerForSourceArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeReturns(result1 reconciler.RegistryReconciler) {
-	fake.reconcilerForSourceTypeMutex.Lock()
-	defer fake.reconcilerForSourceTypeMutex.Unlock()
-	fake.ReconcilerForSourceTypeStub = nil
-	fake.reconcilerForSourceTypeReturns = struct {
+func (fake *FakeReconcilerFactory) ReconcilerForSourceReturns(result1 reconciler.RegistryReconciler) {
+	fake.reconcilerForSourceMutex.Lock()
+	defer fake.reconcilerForSourceMutex.Unlock()
+	fake.ReconcilerForSourceStub = nil
+	fake.reconcilerForSourceReturns = struct {
 		result1 reconciler.RegistryReconciler
 	}{result1}
 }
 
-func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeReturnsOnCall(i int, result1 reconciler.RegistryReconciler) {
-	fake.reconcilerForSourceTypeMutex.Lock()
-	defer fake.reconcilerForSourceTypeMutex.Unlock()
-	fake.ReconcilerForSourceTypeStub = nil
-	if fake.reconcilerForSourceTypeReturnsOnCall == nil {
-		fake.reconcilerForSourceTypeReturnsOnCall = make(map[int]struct {
+func (fake *FakeReconcilerFactory) ReconcilerForSourceReturnsOnCall(i int, result1 reconciler.RegistryReconciler) {
+	fake.reconcilerForSourceMutex.Lock()
+	defer fake.reconcilerForSourceMutex.Unlock()
+	fake.ReconcilerForSourceStub = nil
+	if fake.reconcilerForSourceReturnsOnCall == nil {
+		fake.reconcilerForSourceReturnsOnCall = make(map[int]struct {
 			result1 reconciler.RegistryReconciler
 		})
 	}
-	fake.reconcilerForSourceTypeReturnsOnCall[i] = struct {
+	fake.reconcilerForSourceReturnsOnCall[i] = struct {
 		result1 reconciler.RegistryReconciler
 	}{result1}
 }
@@ -87,8 +87,8 @@ func (fake *FakeReconcilerFactory) ReconcilerForSourceTypeReturnsOnCall(i int, r
 func (fake *FakeReconcilerFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.reconcilerForSourceTypeMutex.RLock()
-	defer fake.reconcilerForSourceTypeMutex.RUnlock()
+	fake.reconcilerForSourceMutex.RLock()
+	defer fake.reconcilerForSourceMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -674,7 +674,7 @@ k8s.io/kube-openapi/pkg/generators/rules
 k8s.io/kube-openapi/pkg/builder
 k8s.io/kube-openapi/pkg/handler
 k8s.io/kube-openapi/pkg/util/sets
-# k8s.io/kubernetes v1.11.8-beta.0.0.20190208223919-e6f6fa1f2dd1
+# k8s.io/kubernetes v1.11.8-beta.0.0.20190214232326-4e0b35876724
 k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac
 k8s.io/kubernetes/pkg/apis/rbac/v1
 k8s.io/kubernetes/pkg/registry/rbac/validation


### PR DESCRIPTION
instead, they provide an address directly. OLM will not have visibility
into the resources required for running the grpc catalog for this case,
but will still connect and health check.

Replaces #684 