### PR TITLE
Add Graceful Shutdown to PackageManifest Server

### DIFF
--- a/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
+++ b/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
@@ -55,11 +55,6 @@
             verbs:
             - get
             - list
-            - watch
-            - create
-            - delete
-            - patch
-            - update
         deployments:
         - name: packageserver
           spec:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -28,7 +28,7 @@ catalog:
     beta.kubernetes.io/os: linux
 
 package:
-  replicaCount: 1
+  replicaCount: 2
   image:
     ref: quay.io/coreos/olm:master
     pullPolicy: Always

--- a/deploy/ocp/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
+++ b/deploy/ocp/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
@@ -66,15 +66,10 @@ data:
                 verbs:
                 - get
                 - list
-                - watch
-                - create
-                - delete
-                - patch
-                - update
             deployments:
             - name: packageserver
               spec:
-                replicas: 1
+                replicas: 2
                 strategy:
                   type: RollingUpdate
                 selector:

--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -29,7 +29,7 @@ catalog:
   tolerations:
   - operator: Exists
 package:
-  replicaCount: 1
+  replicaCount: 2
   image:
     ref: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
     pullPolicy: Always

--- a/deploy/okd/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
+++ b/deploy/okd/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
@@ -66,15 +66,10 @@ data:
                 verbs:
                 - get
                 - list
-                - watch
-                - create
-                - delete
-                - patch
-                - update
             deployments:
             - name: packageserver
               spec:
-                replicas: 1
+                replicas: 2
                 strategy:
                   type: RollingUpdate
                 selector:

--- a/deploy/okd/values.yaml
+++ b/deploy/okd/values.yaml
@@ -19,7 +19,7 @@ catalog:
   service:
     internalPort: 8080
 package:
-  replicaCount: 1
+  replicaCount: 2
   image:
     ref: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
     pullPolicy: Always

--- a/deploy/upstream/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
+++ b/deploy/upstream/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
@@ -66,15 +66,10 @@ data:
                 verbs:
                 - get
                 - list
-                - watch
-                - create
-                - delete
-                - patch
-                - update
             deployments:
             - name: packageserver
               spec:
-                replicas: 1
+                replicas: 2
                 strategy:
                   type: RollingUpdate
                 selector:

--- a/deploy/upstream/values.yaml
+++ b/deploy/upstream/values.yaml
@@ -19,7 +19,7 @@ catalog:
   service:
     internalPort: 8080
 package:
-  replicaCount: 1
+  replicaCount: 2
   image:
     ref: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
     pullPolicy: Always

--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,7 @@ github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.9+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/etcd v3.3.11+incompatible h1:U0wJghY374q+UrjOM2mfROHSwEspsQVkCACB1PGka1g=
+github.com/coreos/etcd v3.3.11+incompatible h1:0gCnqKsq7XxMi69JsnbmMc1o+RJH3XH64sV9aiTTYko=
 github.com/coreos/etcd v3.3.11+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -112,7 +112,7 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f h1:ShTPMJQes6tubcjzGMODIVG5hlrCeImaBnZzKF2N8SM=
 github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:BWIsLfhgKhV5g/oF34aRjniBHLTZe5DNekSjbAjIS6c=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -318,5 +318,5 @@ k8s.io/kube-openapi v0.0.0-20181031203759-72693cb1fadd h1:ggv/Vfza0i5xuhUZyYyxcc
 k8s.io/kube-openapi v0.0.0-20181031203759-72693cb1fadd/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kubernetes v1.11.7-beta.0.0.20181219023948-b875d52ea96d/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.11.8-beta.0.0.20190124204751-3a10094374f2/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
-k8s.io/kubernetes v1.11.8-beta.0.0.20190208223919-e6f6fa1f2dd1 h1:7vUXpxFc5F5qLOKT07j2EZa1M+6xl6Es2WyRxleFCeM=
+k8s.io/kubernetes v1.11.8-beta.0.0.20190208223919-e6f6fa1f2dd1 h1:KXhECItYGlIqgwjGvb46A8eZ4qB3WgTmunAcEecVsE8=
 k8s.io/kubernetes v1.11.8-beta.0.0.20190208223919-e6f6fa1f2dd1/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=

--- a/manifests/0000_50_olm_10-olm-operators.configmap.yaml
+++ b/manifests/0000_50_olm_10-olm-operators.configmap.yaml
@@ -64,15 +64,10 @@ data:
                 verbs:
                 - get
                 - list
-                - watch
-                - create
-                - delete
-                - patch
-                - update
             deployments:
             - name: packageserver
               spec:
-                replicas: 1
+                replicas: 2
                 strategy:
                   type: RollingUpdate
                 selector:


### PR DESCRIPTION
### Description

The queue informer provider was sharing the same stop channel as the API server, but the API server continues to accept requests for a certain grace period while the provider stopped immediately. Changed them to use different channels. Also updates the `PackageManifest` server to run with 2 replicas.

Fixes https://jira.coreos.com/browse/ALM-910