### PR TITLE
Fix API Validation for `OperatorGroup` Spec

### DIFF
--- a/deploy/chart/templates/0000_50_olm_09-operatorgroup.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_09-operatorgroup.crd.yaml
@@ -30,35 +30,41 @@ spec:
             selector:
               type: object
               description: Optional label selector to find resources associated with or managed by the operator
-              properties:
-                matchLabels:
-                  type: object
-                  description: Label key:value pairs to match directly
-                matchExpressions:
-                  type: array
-                  description: A set of expressions to match against the resource.
-                  items:
-                    allOf:
-                      - type: object
-                        required:
-                        - key
-                        - operator
-                        - values
-                        properties:
-                          key:
-                            type: string
-                            description: the key to match
-                          operator:
-                            type: string
-                            description: the operator for the expression
-                            enum:
-                            - In
-                            - NotIn
-                            - Exists
-                            - DoesNotExist
-                          values:
-                            type: array
-                            description: set of values for the expression
+              anyOf:
+                - properties:
+                    matchLabels:
+                      type: object
+                      description: Label key:value pairs to match directly
+                  required:
+                    - matchLabels
+                - properties:
+                    matchExpressions:
+                      type: array
+                      description: A set of expressions to match against the resource.
+                      items:
+                        allOf:
+                          - type: object
+                            required:
+                            - key
+                            - operator
+                            - values
+                            properties:
+                              key:
+                                type: string
+                                description: the key to match
+                              operator:
+                                type: string
+                                description: the operator for the expression
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                              values:
+                                type: array
+                                description: set of values for the expression
+                  required:
+                    - matchExpressions
             targetNamespaces:
               type: array
               description: Optional list of target namespaces. If set, OLM will ignore selector.


### PR DESCRIPTION
### Description

Previously was not enforcing proper `selector` fields, causing [this issue](https://github.com/openshift/cluster-monitoring-operator/pull/254) with `cluster-monitoring-operator`.

Addresses https://jira.coreos.com/browse/ALM-913