### PR TITLE
add all-in-one yaml and helper script

### DIFF
--- a/deploy/upstream/quickstart/olm.yaml
+++ b/deploy/upstream/quickstart/olm.yaml
@@ -1,0 +1,1450 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: olm
+  labels:
+    openshift.io/run-level: "1"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: operators
+  labels:
+    openshift.io/run-level: "1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:controller:operator-lifecycle-manager
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+- nonResourceURLs: ["*"]
+  verbs: ["*"]
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: olm-operator-serviceaccount
+  namespace: olm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: olm-operator-binding-olm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:controller:operator-lifecycle-manager
+subjects:
+- kind: ServiceAccount
+  name: olm-operator-serviceaccount
+  namespace: olm
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterserviceversions.operators.coreos.com
+  annotations:
+    displayName: Operator Version
+    description: Represents an Operator that should be running on the cluster, including requirements and install strategy.
+spec:
+  names:
+    plural: clusterserviceversions
+    singular: clusterserviceversion
+    kind: ClusterServiceVersion
+    listKind: ClusterServiceVersionList
+    shortNames:
+    - csv
+    - csvs
+    categories:
+    - olm
+  additionalPrinterColumns:
+  - name: Display
+    type: string
+    description: The name of the CSV
+    JSONPath: .spec.displayName
+  - name: Version
+    type: string
+    description: The version of the CSV
+    JSONPath: .spec.version
+  - name: Replaces
+    type: string
+    description: The name of a CSV that this one replaces
+    JSONPath: .spec.replaces
+  - name: Phase
+    type: string
+    JSONPath: .status.phase
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a ClusterServiceVersion
+          required:
+          - displayName
+          - install
+          properties:
+            displayName:
+              type: string
+              description: Human readable name of the application that will be displayed in the ALM UI
+
+            description:
+              type: string
+              description: Human readable description of what the application does
+
+            minKubeVersion:
+              type: string
+              description: Minimum kubernetes version requirement on the server to deploy operator
+
+            keywords:
+              type: array
+              description: List of keywords which will be used to discover and categorize app types
+              items:
+                type: string
+
+            maintainers:
+              type: array
+              description: Those responsible for the creation of this specific app type
+              items:
+                type: object
+                description: Information for a single maintainer
+                required:
+                - name
+                - email
+                properties:
+                  name:
+                    type: string
+                    description: Maintainer's name
+                  email:
+                    type: string
+                    description: Maintainer's email address
+                    format: email
+                optionalProperties:
+                  type: string
+                  description: "Any additional key-value metadata you wish to expose about the maintainer, e.g. github: <username>"
+
+            links:
+              type: array
+              description: Interesting links to find more information about the project, such as marketing page, documentation, or github page
+              items:
+                type: object
+                description: A single link to describe one aspect of the project
+                required:
+                - name
+                - url
+                properties:
+                  name:
+                    type: string
+                    description: Name of the link type, e.g. homepage or github url
+                  url:
+                    type: string
+                    description: URL to which the link should point
+                    format: uri
+
+            icon:
+              type: array
+              description: Icon which should be rendered with the application information
+              required:
+              - base64data
+              - mediatype
+              properties:
+                base64data:
+                  type: string
+                  description: Base64 binary representation of the icon image
+                  pattern: ^(?:[A-Za-z0-9+/]{4}){0,16250}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                mediatype:
+                  type: string
+                  description: Mediatype for the binary data specified in the base64data property
+                  enum:
+                  - image/gif
+                  - image/jpeg
+                  - image/png
+                  - image/svg+xml
+            version:
+              type: string
+              description: Version string, recommended that users use semantic versioning
+              pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+            replaces:
+              type: string
+              description: Name of the ClusterServiceVersion custom resource that this version replaces
+
+            maturity:
+              type: string
+              description: What level of maturity the software has achieved at this version
+              enum:
+              - planning
+              - pre-alpha
+              - alpha
+              - beta
+              - stable
+              - mature
+              - inactive
+              - deprecated
+            labels:
+              type: object
+              description: Labels that will be applied to associated resources created by the operator.
+            selector:
+              type: object
+              description: Label selector to find resources associated with or managed by the operator
+              properties:
+                matchLabels:
+                  type: object
+                  description: Label key:value pairs to match directly
+                matchExpressions:
+                  type: array
+                  description: A set of expressions to match against the resource.
+                  items:
+                    allOf:
+                      - type: object
+                        required:
+                        - key
+                        - operator
+                        - values
+                        properties:
+                          key:
+                            type: string
+                            description: the key to match
+                          operator:
+                            type: string
+                            description: the operator for the expression
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                          values:
+                            type: array
+                            description: set of values for the expression
+            nativeAPIs:
+              type: array
+              description: What resources are required by the Operator, but must be provided by the underlying cluster and not as an extension.
+              items:
+                type: object
+                required:
+                - group
+                - version
+                - kind
+                properties:
+                  group:
+                    type: string
+                    description: Group of the API resource
+                  version:
+                    type: string
+                    description: Version of the API resource
+                  kind:
+                    type: string
+                    description: Kind of the API resource
+            apiservicedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                    - group
+                    - version
+                    - kind
+                    - name
+                    - deploymentName
+                    - displayName
+                    - description
+                    properties:
+                      group:
+                        type: string
+                        description: Group of the APIService (e.g. app.coreos.com)
+                      name:
+                        type: string
+                        description: The plural name for the APIService provided
+                      version:
+                        type: string
+                        description: The version field of the APIService
+                      kind:
+                        type: string
+                        description: The kind field of the APIService
+                      deploymentName:
+                        type: string
+                        description: Name of the extension api-server's deployment
+                      containerPort:
+                        type: number
+                        description: Port where the extension api-server serves TLS traffic
+                      displayName:
+                        type: string
+                        description: A human-readable name for the APIService.
+                      description:
+                        type: string
+                        description: A description of the APIService
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the APIService
+                          required:
+                          - kind
+                          - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a APIService, the fully qualified name of the APIService (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the API resource
+                          required:
+                          - path
+                          - displayName
+                          - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the API resource where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this status is the same for all instances of the API resource and can be found here instead of on the API resource.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the APIService resource.
+                          required:
+                          - path
+                          - displayName
+                          - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the API resource where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this spec is the same for all instances of the API Resource and can be found here instead of on the API resource.
+                      actionDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for actions that can be performed on instances of the API resource
+                          required:
+                          - path
+                          - displayName
+                          - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the API resource where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the action.
+                            description:
+                              type: string
+                              description: A description of the action.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the action that indicate the meaning of the action.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this action is the same for all instances of the API resource and can be found here instead of on the API resource.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                    - group
+                    - version
+                    - kind
+                    - name
+                    - displayName
+                    - description
+                    properties:
+                      group:
+                        type: string
+                        description: Group of the APIService (e.g. app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the APIService
+                      kind:
+                        type: string
+                        description: The kind field of the APIService
+                      name:
+                        type: string
+                        description: The plural name for the APIService provided
+                      deploymentName:
+                        type: string
+                        description: Name of the extension api-server's deployment
+                      containerPort:
+                        type: number
+                        description: Port where the extension api-server serves TLS traffic
+                      displayName:
+                        type: string
+                        description: A human-readable name for the APIService.
+                      description:
+                        type: string
+                        description: A description of the APIService
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the APIService
+                          required:
+                          - path
+                          - displayName
+                          - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the API Resource where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this status is the same for all instances of the API Resource and can be found here instead of on the API Resource.
+
+            customresourcedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the CRD
+                          required:
+                            - kind
+                            - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a CRD, the fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR.
+                      actionDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for actions that can be performed on instances of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the action.
+                            description:
+                              type: string
+                              description: A description of the action.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the action that indicate the meaning of the action.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this action is the same for all instances of the CRD and can be found here instead of on the CR.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+
+
+            install:
+              type: object
+              description: Information required to install this specific version of the operator software
+              oneOf:
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['image']
+                  spec:
+                    type: object
+                    required:
+                    - image
+                    properties:
+                      image:
+                        type: string
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['deployment']
+                  spec:
+                    type: object
+                    required:
+                    - deployments
+                    properties:
+                      installModes:
+                        type: array
+                        description: List of supported install modes for the operator
+                        items:
+                          type: object
+                          description: A tuple representing a mode of installation and whether the operator supports it
+                          required:
+                            - type
+                            - supported
+                          properties:
+                            type:
+                              type: string
+                              description: A type of install mode
+                              enum:
+                                - OwnNamespace
+                                - SingleNamespace
+                                - MultiNamespace
+                                - AllNamespaces
+                            supported:
+                              type: boolean
+                              description: Represents if the install mode type is supported
+                      deployments:
+                        type: array
+                        description: List of deployments to create
+                        items:
+                          type: object
+                          description: A name and deployment to create in the cluster
+                          required:
+                            - name
+                            - spec
+                          properties:
+                            name:
+                              type: string
+                              description: the consistent name of the deployment
+                            spec:
+                              type: object
+                              description: The deployment spec to create in the cluster
+                      permissions:
+                        type: array
+                        description: Permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                            - serviceAccountName
+                            - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                        - "*"
+                                        - assign
+                                        - get
+                                        - list
+                                        - watch
+                                        - create
+                                        - update
+                                        - patch
+                                        - delete
+                                        - deletecollection
+                                        - initialize
+                      clusterPermissions:
+                        type: array
+                        description: Cluster permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                          - serviceAccountName
+                          - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - verbs
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  nonResourceURLs:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                      - "*"
+                                      - assign
+                                      - get
+                                      - list
+                                      - watch
+                                      - create
+                                      - update
+                                      - patch
+                                      - put
+                                      - post
+                                      - delete
+                                      - deletecollection
+                                      - initialize
+                                      - use
+        status:
+          type: object
+          description: Status for a ClusterServiceVersion
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installplans.operators.coreos.com
+  annotations:
+    displayName: Install Plan
+    description: Represents a plan to install and resolve dependencies for Cluster Services
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: installplans
+    singular: installplan
+    kind: InstallPlan
+    listKind: InstallPlanList
+    shortNames:
+    - ip
+    categories:
+    - olm
+  additionalPrinterColumns:
+  - name: CSV
+    type: string
+    description: The first CSV in the list of clusterServiceVersionNames
+    JSONPath: .spec.clusterServiceVersionNames[0]
+  - name: Source
+    type: string
+    description: The catalog source for the specified CSVs.
+    JSONPath: .spec.source
+  - name: Approval
+    type: string
+    description: The approval mode
+    JSONPath: .spec.approval
+  - name: Approved
+    type: boolean
+    JSONPath: .spec.approved
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for an InstallPlan
+          required:
+          - clusterServiceVersionNames
+          - approval
+          properties:
+            source:
+              type: string
+              description: Name of the preferred CatalogSource
+            sourceNamespace:
+              type: string
+              description: Namespace that contains the preffered CatalogSource
+            clusterServiceVersionNames:
+              type: array
+              description: A list of the names of the Cluster Services
+              items:
+                type: string
+          anyOf:
+            - properties:
+                approval:
+                  enum:
+                    - Manual
+                approved:
+                  type: boolean
+              required:
+                - approved
+            - properties:
+                approval:
+                  enum:
+                    - Automatic
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.operators.coreos.com
+  annotations:
+    displayName: Subscription
+    description: Subcribes service catalog to a source and channel to recieve updates for packages.
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: subscriptions
+    singular: subscription
+    kind: Subscription
+    listKind: SubscriptionList
+    shortNames:
+    - sub
+    - subs
+    categories:
+    - olm
+  additionalPrinterColumns:
+  - name: Package
+    type: string
+    description: The package subscribed to
+    JSONPath: .spec.name
+  - name: Source
+    type: string
+    description: The catalog source for the specified package
+    JSONPath: .spec.source
+  - name: Channel
+    type: string
+    description: The channel of updates to subscribe to
+    JSONPath: .spec.channel
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a Subscription
+          required:
+          - source
+          - name
+          properties:
+            source:
+              type: string
+              description: Name of a CatalogSource that defines where and how to find the channel
+            sourceNamespace:
+              type: string
+              description: The Kubernetes namespace where the CatalogSource used is located
+            name:
+              type: string
+              description: Name of the package that defines the application
+            channel:
+              type: string
+              description: Name of the channel to track
+            startingCSV:
+              type: string
+              description: Name of the AppType that this subscription tracks
+            installPlanApproval:
+              type: string
+              description: Approval mode for emitted InstallPlans
+              enum:
+              - Manual
+              - Automatic
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogsources.operators.coreos.com
+  annotations:
+    displayName: CatalogSource
+    description: A source configured to find packages and updates.
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: catalogsources
+    singular: catalogsource
+    kind: CatalogSource
+    listKind: CatalogSourceList
+    shortNames:
+    - catsrc
+    categories:
+    - olm
+  additionalPrinterColumns:
+  - name: Name
+    type: string
+    description: The pretty name of the catalog
+    JSONPath: .spec.displayName
+  - name: Type
+    type: string
+    description: The type of the catalog
+    JSONPath: .spec.sourceType
+  - name: Publisher
+    type: string
+    description: The publisher of the catalog
+    JSONPath: .spec.publisher
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a catalog source.
+          required:
+          - sourceType
+          properties:
+            sourceType:
+              type: string
+              description: The type of the source. `configmap` is the new name for `internal`
+              enum:
+              - internal   # deprecated
+              - configmap
+              - grpc
+
+            configMap:
+              type: string
+              description: The name of a ConfigMap that holds the entries for an in-memory catalog.
+
+            address:
+              type: string
+              description: An optional address. When set, directs OLM to connect to use a pre-existing registry server at this address.
+
+            image:
+              type: string
+              description: An image that serves a grpc registry. Only valid for `grpc` sourceType. If both image and address are set, OLM does not use the address field.
+
+            displayName:
+              type: string
+              description: Pretty name for display
+
+            publisher:
+              type: string
+              description: The name of an entity that publishes this catalog
+
+            secrets:
+              type: array
+              description: A set of secrets that can be used to access the contents of the catalog. It is best to keep this list small, since each will need to be tried for every catalog entry.
+              items:
+                type: string
+                description: A name of a secret in the namespace where the CatalogSource is defined.
+        status:
+          type: object
+          description: The status of the CatalogSource
+          properties:
+            configMapReference:
+              type: object
+              description: If sourceType is `internal` or `configmap`, then this holds a reference to the configmap associated with this CatalogSource.
+              properties:
+                name:
+                  type: string
+                  description: name of the configmap
+                namespace:
+                  type: string
+                  description: namespace of the configmap
+                resourceVersion:
+                  type: string
+                  description: resourceVersion of the configmap
+                uid:
+                  type: string
+                  description: uid of the configmap
+            registryService:
+              type: object
+              properties:
+                protocol:
+                  type: string
+                  description: protocol of the registry service
+                  enum:
+                    - grpc
+                serviceName:
+                  type: string
+                  description: name of the registry service
+                serviceNamespace:
+                  type: string
+                  description: namespace of the registry service
+                port:
+                  type: string
+                  description: port of the registry service
+            lastSync:
+                type: string
+                description: the last time the catalog was updated. If this time is less than the last updated time on the object, the catalog will be re-cached.
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: olm-operator
+  namespace: olm
+  labels:
+    app: olm-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: olm-operator
+  template:
+    metadata:
+      labels:
+        app: olm-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: olm-operator
+          command:
+          - /bin/olm
+          args:
+          - -writeStatusName
+          - ""
+          image: quay.io/openshift/origin-operator-lifecycle-manager:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: olm-operator
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  namespace: olm
+  labels:
+    app: catalog-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      labels:
+        app: catalog-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: catalog-operator
+          command:
+          - /bin/catalog
+          args:
+          - '-namespace'
+          - olm
+          - -configmapServerImage=quay.io/operatorframework/configmap-operator-registry:latest
+          image: quay.io/openshift/origin-operator-lifecycle-manager:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  verbs: ["create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatorgroups.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  names:
+    plural: operatorgroups
+    singular: operatorgroup
+    kind: OperatorGroup
+    listKind: OperatorGroupList
+    shortNames:
+      - og
+    categories:
+      - olm
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            selector:
+              type: object
+              description: Optional label selector to find resources associated with or managed by the operator
+              properties:
+                matchLabels:
+                  type: object
+                  description: Label key:value pairs to match directly
+                matchExpressions:
+                  type: array
+                  description: A set of expressions to match against the resource.
+                  items:
+                    allOf:
+                      - type: object
+                        required:
+                        - key
+                        - operator
+                        - values
+                        properties:
+                          key:
+                            type: string
+                            description: the key to match
+                          operator:
+                            type: string
+                            description: the operator for the expression
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                          values:
+                            type: array
+                            description: set of values for the expression
+            targetNamespaces:
+              type: array
+              description: Optional list of target namespaces. If set, OLM will ignore selector.
+              items:
+                type: string
+                pattern: ^\S+$
+            serviceAccountName:
+              type: string
+            staticProvidedAPIs:
+              type: boolean
+              description: If true, OLM will not modify the OperatorGroup's providedAPIs annotation.
+          type: object
+        status:
+          properties:
+            lastUpdated:
+              format: date-time
+              type: string
+            namespaces:
+              items:
+                type: string
+              type: array
+          required:
+          - namespaces
+          - lastUpdated
+          type: object
+      required:
+      - metadata
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: olm-operators
+  namespace: olm
+
+data:
+  customResourceDefinitions: |-
+  clusterServiceVersions: |-
+    
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: packageserver.v4.0.0-olm
+        namespace: olm
+      spec:
+        displayName: Package Server
+        description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
+        minKubeVersion: 1.11.0
+        keywords: ['packagemanifests', 'olm', 'packages']
+        maintainers:
+        - name: Red Hat
+          email: openshift-operators@redhat.com
+        provider:
+          name: Red Hat
+        links:
+        - name: Package Server
+          url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server
+        installModes:
+        - type: OwnNamespace
+          supported: true
+        - type: SingleNamespace
+          supported: true
+        - type: MultiNamespace
+          supported: true
+        - type: AllNamespaces
+          supported: true
+        install:
+          strategy: deployment
+          spec:
+            clusterPermissions:
+            - serviceAccountName: packageserver
+              rules:
+              - apiGroups:
+                - ""
+                resources:
+                - configmaps
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - "operators.coreos.com"
+                resources:
+                - catalogsources
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - "packages.apps.redhat.com"
+                resources:
+                - packagemanifests
+                verbs:
+                - get
+                - list
+            deployments:
+            - name: packageserver
+              spec:
+                replicas: 2
+                strategy:
+                  type: RollingUpdate
+                selector:
+                  matchLabels:
+                    app: packageserver
+                template:
+                  metadata:
+                    labels:
+                      app: packageserver
+                  spec:
+                    serviceAccountName: packageserver
+                    nodeSelector:
+                      beta.kubernetes.io/os: linux
+                      
+                    containers:
+                    - name: packageserver
+                      command:
+                      - /bin/package-server
+                      - -v=4
+                      - --secure-port
+                      - "5443"
+                      - --global-namespace
+                      - olm
+                      image: quay.io/openshift/origin-operator-lifecycle-manager:latest
+                      imagePullPolicy: Always
+                      ports:
+                      - containerPort: 5443
+                      livenessProbe:
+                          httpGet:
+                            scheme: HTTPS
+                            path: /healthz
+                            port: 5443
+                      readinessProbe:
+                          httpGet:
+                            scheme: HTTPS
+                            path: /healthz
+                            port: 5443
+        maturity: alpha
+        version: 4.0.0-olm
+        apiservicedefinitions:
+          owned:
+          - group: packages.apps.redhat.com
+            version: v1alpha1
+            kind: PackageManifest
+            displayName: PackageManifest
+            description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
+            deploymentName: packageserver
+            containerPort: 5443
+  packages: |-
+    
+    - packageName: packageserver
+      channels:
+      - name: alpha
+        currentCSV: packageserver.v4.0.0-olm
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: olm-operators
+  namespace: olm
+spec:
+  sourceType: internal
+  configMap: olm-operators
+  displayName: OLM Operators
+  publisher: Red Hat
+---
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: global-operators
+  namespace: operators
+---
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: olm-operators
+  namespace: olm
+spec:
+  targetNamespaces:
+    - olm
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: packageserver
+  namespace: olm
+spec:
+  source: olm-operators
+  sourceNamespace: olm
+  name: packageserver
+  channel: alpha

--- a/deploy/upstream/values.yaml
+++ b/deploy/upstream/values.yaml
@@ -7,21 +7,21 @@ writeStatusName: '""'
 olm:
   replicaCount: 1
   image:
-    ref: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
+    ref: quay.io/openshift/origin-operator-lifecycle-manager:latest
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
 catalog:
   replicaCount: 1
   image:
-    ref: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
+    ref: quay.io/openshift/origin-operator-lifecycle-manager:latest
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
 package:
   replicaCount: 2
   image:
-    ref: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
+    ref: quay.io/openshift/origin-operator-lifecycle-manager:latest
     pullPolicy: Always
   service:
     internalPort: 5443

--- a/scripts/package-quickstart.sh
+++ b/scripts/package-quickstart.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# requires helm to be installed
+
+if [[ ${#@} < 3 ]]; then
+    echo "Usage: $0 semver chart values"
+    echo "* semver: semver-formatted version for this package"
+    echo "* file: the output manifest file containing all chart manifests with YAML concatenated"
+    echo "* values: the values file"
+    exit 1
+fi
+
+version=$1
+manifest=$2
+values=$3
+
+charttmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'charttmpdir'`
+
+charttmpdir=${charttmpdir}/chart
+
+cp -R deploy/chart/ ${charttmpdir}
+echo "Version: $1" >> ${charttmpdir}/Chart.yaml
+
+helm template -n olm -f ${values} ${charttmpdir} --output-dir ${charttmpdir}
+
+awk 'BEGINFILE {print "---"} !/^[[:space:]]*#/{print}' ${charttmpdir}/olm/templates/*.yaml > ${manifest} && \
+   echo "Wrote manifest to ${manifest}"


### PR DESCRIPTION
add a helper script that takes all manifests generated by helm and concatenates them into a single YAML for simple direct installation using `kubectl -f https://raw.githubusercontent.com/dmesser/operator-lifecycle-manager/quickstart/deploy/upstream/quickstart/olm.yaml`