### PR TITLE
fix(ocp): add csv and deployment for package server

### DIFF
--- a/deploy/chart/templates/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/deploy/chart/templates/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -1,0 +1,74 @@
+{{ if (.Values.installType) and eq .Values.installType "ocp" }}
+# keep in sync with _packageserver.clusterserviceversion.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: packageserver.v{{ .Chart.Version }}
+  namespace: {{ .Values.namespace }}
+spec:
+  displayName: Package Server
+  description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
+  minKubeVersion: {{ .Values.minKubeVersion }}
+  keywords: ['packagemanifests', 'olm', 'packages']
+  maintainers:
+  - name: Red Hat
+    email: openshift-operators@redhat.com
+  provider:
+    name: Red Hat
+  links:
+  - name: Package Server
+    url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: true
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: packageserver
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - packages.apps.redhat.com
+          resources:
+          - packagemanifests
+          verbs:
+          - get
+          - list
+      deployments:
+      - name: packageserver
+{{- include "packageserver.deployment-spec" . | indent 8 }}
+  maturity: alpha
+  version: {{ .Chart.Version }}
+  apiservicedefinitions:
+    owned:
+    - group: packages.apps.redhat.com
+      version: v1alpha1
+      kind: PackageManifest
+      name: packagemanifest
+      displayName: PackageManifest
+      description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
+      deploymentName: packageserver
+      containerPort: {{ .Values.package.service.internalPort }}
+{{ end }}

--- a/deploy/chart/templates/0000_50_olm_16-packageserver.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_16-packageserver.deployment.yaml
@@ -1,0 +1,10 @@
+{{ if (.Values.installType) and eq .Values.installType "ocp" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: packageserver
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: packageserver
+{{- include "packageserver.deployment-spec" . }}
+{{ end }}

--- a/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -1,0 +1,56 @@
+{{- define "packageserver.deployment-spec" }}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: {{ .Values.package.replicaCount }}
+  selector:
+    matchLabels:
+      app: packageserver
+  template:
+    metadata:
+      labels:
+        app: packageserver
+    spec:
+      serviceAccountName: packageserver
+      {{- if .Values.olm.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.package.nodeSelector | indent 18 }}
+      {{- end }}
+      {{- if .Values.olm.tolerations  }}
+      tolerations:
+{{ toYaml .Values.package.tolerations | indent 18 }}
+      {{- end }}
+      containers:
+      - name: packageserver
+        command:
+        - /bin/package-server
+        - -v=4
+        {{- if .Values.watchedNamespaces }}
+        - --watched-namespaces
+        - {{ .Values.watchedNamespaces }}
+        {{- end }}
+        - --secure-port
+        - {{ .Values.package.service.internalPort | quote }}
+        - --global-namespace
+        - {{ .Values.namespace }}
+        {{- if .Values.debug }}
+        - --debug
+        {{- end }}
+        {{- if .Values.package.commandArgs }}
+        - {{ .Values.package.commandArgs }}
+        {{- end }}
+        image: {{ .Values.package.image.ref }}
+        imagePullPolicy: {{ .Values.package.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.package.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: {{ .Values.package.service.internalPort }}
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: {{ .Values.package.service.internalPort }}
+{{- end }}

--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -1,3 +1,4 @@
+installType: ocp
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: openshift-operator-lifecycle-manager
 catalog_namespace: openshift-operator-lifecycle-manager

--- a/deploy/okd/values.yaml
+++ b/deploy/okd/values.yaml
@@ -1,3 +1,4 @@
+installType: okd
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: openshift-operator-lifecycle-manager
 catalog_namespace: openshift-operator-lifecycle-manager

--- a/deploy/upstream/values.yaml
+++ b/deploy/upstream/values.yaml
@@ -1,3 +1,4 @@
+installType: upstream
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: olm
 catalog_namespace: olm

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -1,0 +1,115 @@
+
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: packageserver.v0.8.1
+  namespace: openshift-operator-lifecycle-manager
+spec:
+  displayName: Package Server
+  description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
+  minKubeVersion: 1.11.0
+  keywords: ['packagemanifests', 'olm', 'packages']
+  maintainers:
+  - name: Red Hat
+    email: openshift-operators@redhat.com
+  provider:
+    name: Red Hat
+  links:
+  - name: Package Server
+    url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: true
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: packageserver
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - packages.apps.redhat.com
+          resources:
+          - packagemanifests
+          verbs:
+          - get
+          - list
+      deployments:
+      - name: packageserver        
+        spec:
+          strategy:
+            type: RollingUpdate
+          replicas: 2
+          selector:
+            matchLabels:
+              app: packageserver
+          template:
+            metadata:
+              labels:
+                app: packageserver
+            spec:
+              serviceAccountName: packageserver
+              nodeSelector:
+                          beta.kubernetes.io/os: linux
+                          node-role.kubernetes.io/master: ""
+                          
+              tolerations:
+                          - operator: Exists
+                          
+              containers:
+              - name: packageserver
+                command:
+                - /bin/package-server
+                - -v=4
+                - --secure-port
+                - "5443"
+                - --global-namespace
+                - openshift-operator-lifecycle-manager
+                image: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
+                imagePullPolicy: IfNotPresent
+                ports:
+                - containerPort: 5443
+                livenessProbe:
+                  httpGet:
+                    scheme: HTTPS
+                    path: /healthz
+                    port: 5443
+                readinessProbe:
+                  httpGet:
+                    scheme: HTTPS
+                    path: /healthz
+                    port: 5443
+  maturity: alpha
+  version: 0.8.1
+  apiservicedefinitions:
+    owned:
+    - group: packages.apps.redhat.com
+      version: v1alpha1
+      kind: PackageManifest
+      name: packagemanifest
+      displayName: PackageManifest
+      description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
+      deploymentName: packageserver
+      containerPort: 5443
+

--- a/manifests/0000_50_olm_16-packageserver.deployment.yaml
+++ b/manifests/0000_50_olm_16-packageserver.deployment.yaml
@@ -1,0 +1,52 @@
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: packageserver
+  namespace: openshift-operator-lifecycle-manager
+  labels:
+    app: packageserver
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 2
+  selector:
+    matchLabels:
+      app: packageserver
+  template:
+    metadata:
+      labels:
+        app: packageserver
+    spec:
+      serviceAccountName: packageserver
+      nodeSelector:
+                  beta.kubernetes.io/os: linux
+                  node-role.kubernetes.io/master: ""
+                  
+      tolerations:
+                  - operator: Exists
+                  
+      containers:
+      - name: packageserver
+        command:
+        - /bin/package-server
+        - -v=4
+        - --secure-port
+        - "5443"
+        - --global-namespace
+        - openshift-operator-lifecycle-manager
+        image: quay.io/coreos/olm@sha256:995a181839f301585a0e115c083619b6d73812c58a8444d7b13b8e407010325f
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5443
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: 5443
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: 5443
+


### PR DESCRIPTION
This is an initial simple approach to allowing CVO upgrades to work properly for the package server. The changes here have been made to only affect OCP installs.