### PR TITLE
fix(packagesever): add missing name field to api definition

### DIFF
--- a/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
+++ b/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
@@ -118,6 +118,7 @@
       - group: packages.apps.redhat.com
         version: v1alpha1
         kind: PackageManifest
+        name: packagemanifests
         displayName: PackageManifest
         description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
         deploymentName: packageserver

--- a/deploy/ocp/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
+++ b/deploy/ocp/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
@@ -118,6 +118,7 @@ data:
           - group: packages.apps.redhat.com
             version: v1alpha1
             kind: PackageManifest
+            name: packagemanifests
             displayName: PackageManifest
             description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
             deploymentName: packageserver

--- a/deploy/okd/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
+++ b/deploy/okd/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
@@ -114,6 +114,7 @@ data:
           - group: packages.apps.redhat.com
             version: v1alpha1
             kind: PackageManifest
+            name: packagemanifests
             displayName: PackageManifest
             description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
             deploymentName: packageserver

--- a/deploy/upstream/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
+++ b/deploy/upstream/manifests/0.8.1/0000_50_olm_10-olm-operators.configmap.yaml
@@ -114,6 +114,7 @@ data:
           - group: packages.apps.redhat.com
             version: v1alpha1
             kind: PackageManifest
+            name: packagemanifests
             displayName: PackageManifest
             description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
             deploymentName: packageserver

--- a/manifests/0000_50_olm_10-olm-operators.configmap.yaml
+++ b/manifests/0000_50_olm_10-olm-operators.configmap.yaml
@@ -116,6 +116,7 @@ data:
           - group: packages.apps.redhat.com
             version: v1alpha1
             kind: PackageManifest
+            name: packagemanifests
             displayName: PackageManifest
             description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
             deploymentName: packageserver


### PR DESCRIPTION
this was not generating the correct clusterroles/bindings for the
packagemanifest api