### PR TITLE
feat(test): adds CSV phase reporting for package server

### DIFF
--- a/scripts/run_e2e_local.sh
+++ b/scripts/run_e2e_local.sh
@@ -36,6 +36,9 @@ function cleanupAndExit {
 		kubectl -n "${namespace}" logs -l app=olm-operator > olm.log;
 		kubectl -n "${namespace}" logs -l app=catalog-operator > catalog.log;
 		kubectl -n "${namespace}" logs -l app=packageserver > package.log
+
+		# make it obvious if a pod is crashing or has restarted
+		kubectl get po --all-namespaces
 	else
 		cleanup
 	fi

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -41,8 +41,9 @@ const (
 	pollInterval = 1 * time.Second
 	pollDuration = 3 * time.Minute
 
-	ocsConfigMap     = "rh-operators"
-	olmConfigMap     = "olm-operators"
+	ocsConfigMap = "rh-operators"
+	olmConfigMap = "olm-operators"
+	// sync name with scripts/install_local.sh
 	packageServerCSV = "packageserver.v1.0.0"
 )
 


### PR DESCRIPTION
This PR is optional, but I think it helps. Since deploying the package server is one of the longest running operations that happens without status updates, I added output on each phase change. It looks like this:

Waiting for deployment "olm-operator" rollout to finish: 0 of 1 updated replicas are available...
deployment "olm-operator" successfully rolled out
Waiting for deployment "catalog-operator" rollout to finish: 0 of 1 updated replicas are available...
deployment "catalog-operator" successfully rolled out
Package server phase: Waiting for CSV to appear
Package server phase: Pending
Package server phase: InstallReady
Package server phase: Installing
Package server phase: Succeeded
deployment "packageserver" successfully rolled out

This also adds some additional output for when a test fails. I will not miss a restarted container again!