### PR TITLE
Add upstream catalog

### DIFF
--- a/deploy/chart/templates/0000_50_olm_06-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_06-olm-operator.deployment.yaml
@@ -50,6 +50,10 @@ spec:
               path: /healthz
               port: {{ .Values.olm.service.internalPort }}
           env:
+        {{ if (.Values.installType) and eq .Values.installType "ocp" }}
+          - name: RELEASE_VERSION
+            value: "0.0.1-snapshot"
+        {{ end }}
           - name: OPERATOR_NAMESPACE
             valueFrom:
               fieldRef:

--- a/deploy/chart/templates/0000_50_olm_14-operatorstatus.yaml
+++ b/deploy/chart/templates/0000_50_olm_14-operatorstatus.yaml
@@ -3,4 +3,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: {{ .Values.writeStatusName }}
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"
 {{- end }}

--- a/deploy/chart/templates/0000_50_olm_17-upstream-operators.catalogsource.yaml
+++ b/deploy/chart/templates/0000_50_olm_17-upstream-operators.catalogsource.yaml
@@ -1,0 +1,14 @@
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+{{ if (.Values.installType) and eq .Values.installType "upstream" }}
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: operatorhubio-catalog
+  namespace: {{ .Values.catalog_namespace }}
+spec:
+  sourceType: grpc
+  image: quay.io/operator-framework/upstream-community-operators:latest
+  displayName: Community Operators
+  publisher: OperatorHub.io
+{{ end }}


### PR DESCRIPTION
This adds the operatorhubio catalog as a default catalog for upstream releases.

Also added in the operatorstatus changes to the chart from #748 