### PR TITLE
feat(csv): requeue csvs on change to CRDs

### DIFF
--- a/pkg/controller/operators/olm/requirements_test.go
+++ b/pkg/controller/operators/olm/requirements_test.go
@@ -612,7 +612,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 			test.existingObjs = append(test.existingObjs, namespaceObj)
 			stopCh := make(chan struct{})
 			defer func() { stopCh <- struct{}{} }()
-			op, _, err := NewFakeOperator([]runtime.Object{test.csv}, test.existingObjs, test.existingExtObjs, nil, &install.StrategyResolver{}, nil, []string{namespace}, stopCh)
+			op, _, err := NewFakeOperator([]runtime.Object{test.csv}, test.existingObjs, test.existingExtObjs, nil, &install.StrategyResolver{}, nil, nil, []string{namespace}, stopCh)
 			require.NoError(t, err)
 
 			// Get the permission status

--- a/pkg/controller/registry/resolver/labeler.go
+++ b/pkg/controller/registry/resolver/labeler.go
@@ -1,0 +1,62 @@
+package resolver
+
+import (
+	"fmt"
+
+	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	// APILabelKeyPrefix is the key prefix for a CSV's APIs label
+	APILabelKeyPrefix = "olm.api."
+)
+
+// LabelSetsFor returns API label sets for the given object.
+// Concrete types other than OperatorSurface and CustomResource definition no-op.
+func LabelSetsFor(obj interface{}) []labels.Set {
+	var labelSets []labels.Set
+	switch v := obj.(type) {
+	case OperatorSurface:
+		labelSets = labelSetsForOperatorSurface(v)
+	case *extv1beta1.CustomResourceDefinition:
+		labelSets = labelSetsForCRD(v)
+	}
+
+	return labelSets
+}
+
+func labelSetsForOperatorSurface(surface OperatorSurface) []labels.Set {
+	labelSet := labels.Set{}
+	for key := range surface.ProvidedAPIs().StripPlural() {
+		labelSet[APILabelKeyPrefix+APIKeyToGVKString(key)] = "provided"
+	}
+	for key := range surface.RequiredAPIs().StripPlural() {
+		labelSet[APILabelKeyPrefix+APIKeyToGVKString(key)] = "required"
+	}
+
+	return []labels.Set{labelSet}
+}
+
+func labelSetsForCRD(crd *extv1beta1.CustomResourceDefinition) []labels.Set {
+	labelSets := []labels.Set{}
+	if crd == nil {
+		return labelSets
+	}
+
+	// Add label sets for each version
+	for _, version := range crd.Spec.Versions {
+		key := fmt.Sprintf("%s%s.%s.%s", APILabelKeyPrefix, crd.Spec.Names.Kind, version.Name, crd.Spec.Group)
+		sets := []labels.Set{
+			{
+				key: "provided",
+			},
+			{
+				key: "required",
+			},
+		}
+		labelSets = append(labelSets, sets...)
+	}
+
+	return labelSets
+}

--- a/pkg/controller/registry/resolver/labeler_test.go
+++ b/pkg/controller/registry/resolver/labeler_test.go
@@ -1,0 +1,80 @@
+package resolver
+
+import (
+	"testing"
+
+	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestLabelSetsFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      interface{}
+		expected []labels.Set
+	}{
+		{
+			name:     "Nil/Nil",
+			obj:      nil,
+			expected: nil,
+		},
+		{
+			name:     "NotOperatorSurfaceOrCRD/Nil",
+			obj:      struct{ data string }{"some-data"},
+			expected: nil,
+		},
+		{
+			name: "CRD/ProvidedAndRequired",
+			obj: crd(opregistry.APIKey{
+				Group:   "ghouls",
+				Version: "v1alpha1",
+				Kind:    "Ghost",
+				Plural:  "Ghosts",
+			}),
+			expected: []labels.Set{
+				{
+					APILabelKeyPrefix + "Ghost.v1alpha1.ghouls": "provided",
+				},
+				{
+					APILabelKeyPrefix + "Ghost.v1alpha1.ghouls": "required",
+				},
+			},
+		},
+		{
+			name: "OperatorSurface/Provided",
+			obj: &Operator{
+				providedAPIs: map[opregistry.APIKey]struct{}{
+					opregistry.APIKey{Group: "ghouls", Version: "v1alpha1", Kind: "Ghost", Plural: "Ghosts"}: {},
+				},
+			},
+			expected: []labels.Set{
+				{
+					APILabelKeyPrefix + "Ghost.v1alpha1.ghouls": "provided",
+				},
+			},
+		},
+		{
+			name: "OperatorSurface/ProvidedAndRequired",
+			obj: &Operator{
+				providedAPIs: map[opregistry.APIKey]struct{}{
+					opregistry.APIKey{Group: "ghouls", Version: "v1alpha1", Kind: "Ghost", Plural: "Ghosts"}: {},
+				},
+				requiredAPIs: map[opregistry.APIKey]struct{}{
+					opregistry.APIKey{Group: "ghouls", Version: "v1alpha1", Kind: "Goblin", Plural: "Goblins"}: {},
+				},
+			},
+			expected: []labels.Set{
+				{
+					APILabelKeyPrefix + "Ghost.v1alpha1.ghouls":  "provided",
+					APILabelKeyPrefix + "Goblin.v1alpha1.ghouls": "required",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ElementsMatch(t, tt.expected, LabelSetsFor(tt.obj))
+		})
+	}
+}

--- a/pkg/controller/registry/resolver/operators.go
+++ b/pkg/controller/registry/resolver/operators.go
@@ -6,9 +6,8 @@ import (
 	"strings"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type CatalogKey struct {

--- a/pkg/lib/index/label.go
+++ b/pkg/lib/index/label.go
@@ -1,0 +1,60 @@
+package indexer
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// MetaLabelIndexFuncKey is the recommended key to use for registering the index func with an indexer.
+	MetaLabelIndexFuncKey string = "metalabelindexfunc"
+)
+
+// MetaLabelIndexFunc returns indicies from the labels of the given object.
+func MetaLabelIndexFunc(obj interface{}) ([]string, error) {
+	indicies := []string{}
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return indicies, fmt.Errorf("object has no meta: %v", err)
+	}
+
+	for k, v := range m.GetLabels() {
+		indicies = append(indicies, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return indicies, nil
+}
+
+// LabelIndexKeys returns the union of indexed cache keys in the given indexers matching the same labels as the given selector
+func LabelIndexKeys(indexers map[string]cache.Indexer, labelSets ...labels.Set) ([]string, error) {
+	keySet := map[string]struct{}{}
+	keys := []string{}
+	for _, indexer := range indexers {
+		for _, labelSet := range labelSets {
+			for key, value := range labelSet {
+				apiLabelKey := fmt.Sprintf("%s=%s", key, value)
+				cacheKeys, err := indexer.IndexKeys(MetaLabelIndexFuncKey, apiLabelKey)
+				if err != nil {
+					return nil, err
+				}
+
+				for _, cacheKey := range cacheKeys {
+					// Detect duplication
+					if _, ok := keySet[cacheKey]; ok {
+						continue
+					}
+
+					// Add to set
+					keySet[cacheKey] = struct{}{}
+					keys = append(keys, cacheKey)
+				}
+
+			}
+		}
+	}
+
+	return keys, nil
+}

--- a/pkg/lib/labeler/labeler.go
+++ b/pkg/lib/labeler/labeler.go
@@ -1,0 +1,19 @@
+package labeler
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Labeler can provide label sets that describe an object
+type Labeler interface {
+	// LabelSetsFor returns label sets that describe the given object
+	LabelSetsFor(obj interface{}) []labels.Set
+}
+
+// Func is a function type that implements the Labeler interface
+type Func func(obj interface{}) []labels.Set
+
+// LabelSetsFor calls LabelSetsFor on itself to satisfy the Labeler interface
+func (l Func) LabelSetsFor(obj interface{}) []labels.Set {
+	return l(obj)
+}

--- a/pkg/lib/notify/notify.go
+++ b/pkg/lib/notify/notify.go
@@ -1,1 +1,0 @@
-package notify

--- a/pkg/lib/queueinformer/queueindexer.go
+++ b/pkg/lib/queueinformer/queueindexer.go
@@ -20,7 +20,7 @@ type QueueIndexer struct {
 	log *logrus.Logger
 }
 
-// enqueue adds a key to the queue. If obj is a key already it gets added directly.
+// Enqueue adds a key to the queue. If obj is a key already it gets added directly.
 // Otherwise, the key is extracted via keyFunc.
 func (q *QueueIndexer) Enqueue(obj interface{}) {
 	if obj == nil {

--- a/pkg/lib/queueinformer/resourcequeue.go
+++ b/pkg/lib/queueinformer/resourcequeue.go
@@ -2,23 +2,50 @@ package queueinformer
 
 import (
 	"fmt"
+	"strings"
+	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 )
 
-type ResourceQueueSet map[string]workqueue.RateLimitingInterface
+// ResourceQueueSet is a set of workqueues that is assumed to be keyed by namespace
+type ResourceQueueSet struct {
+	queueSet map[string]workqueue.RateLimitingInterface
+	mutex    sync.RWMutex
+}
 
-func (r ResourceQueueSet) Requeue(name, namespace string) error {
+// NewResourceQueueSet returns a new queue set with the given queue map
+func NewResourceQueueSet(queueSet map[string]workqueue.RateLimitingInterface) *ResourceQueueSet {
+	return &ResourceQueueSet{queueSet: queueSet}
+}
+
+// NewEmptyResourceQueueSet returns a new queue set with an empty but initialized queue map
+func NewEmptyResourceQueueSet() *ResourceQueueSet {
+	return &ResourceQueueSet{queueSet: make(map[string]workqueue.RateLimitingInterface)}
+}
+
+// Set sets the queue at the given key
+func (r *ResourceQueueSet) Set(key string, queue workqueue.RateLimitingInterface) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.queueSet[key] = queue
+}
+
+// Requeue requeues the resource in the set with the given name and namespace
+func (r *ResourceQueueSet) Requeue(name, namespace string) error {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
 	// We can build the key directly, will need to change if queue uses different key scheme
 	key := fmt.Sprintf("%s/%s", namespace, name)
 
-	if queue, ok := r[metav1.NamespaceAll]; len(r) == 1 && ok {
+	if queue, ok := r.queueSet[metav1.NamespaceAll]; len(r.queueSet) == 1 && ok {
 		queue.Add(key)
 		return nil
 	}
 
-	if queue, ok := r[namespace]; ok {
+	if queue, ok := r.queueSet[namespace]; ok {
 		queue.Add(key)
 		return nil
 	}
@@ -26,16 +53,43 @@ func (r ResourceQueueSet) Requeue(name, namespace string) error {
 	return fmt.Errorf("couldn't find queue for resource")
 }
 
-func (r ResourceQueueSet) Remove(name, namespace string) error {
+// RequeueByKey adds the given key to the resource queue that should contain it
+func (r *ResourceQueueSet) RequeueByKey(key string) error {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	if queue, ok := r.queueSet[metav1.NamespaceAll]; len(r.queueSet) == 1 && ok {
+		queue.Add(key)
+		return nil
+	}
+
+	parts := strings.Split(key, "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("non-namespaced key %s cannot be used with namespaced queues", key)
+	}
+
+	if queue, ok := r.queueSet[parts[0]]; ok {
+		queue.Add(key)
+		return nil
+	}
+
+	return fmt.Errorf("couldn't find queue for resource")
+}
+
+// Remove removes the resource in the set with the given name and namespace
+func (r *ResourceQueueSet) Remove(name, namespace string) error {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
 	// We can build the key directly, will need to change if queue uses different key scheme
 	key := fmt.Sprintf("%s/%s", namespace, name)
 
-	if queue, ok := r[metav1.NamespaceAll]; len(r) == 1 && ok {
+	if queue, ok := r.queueSet[metav1.NamespaceAll]; len(r.queueSet) == 1 && ok {
 		queue.Forget(key)
 		return nil
 	}
 
-	if queue, ok := r[namespace]; ok {
+	if queue, ok := r.queueSet[namespace]; ok {
 		queue.Forget(key)
 		return nil
 	}


### PR DESCRIPTION
To make CSV syncing more responsive to CRD changes, this PR adds the following:

- Label CSVs with their provided and required APIs
- Index CSV cache by labels
- Lookup and requeue CSVs on CRD create/update/delete