### PR TITLE
Grant namespace list to global operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ container:
 clean-e2e:
 	kubectl delete crds --all
 	kubectl delete apiservices.apiregistration.k8s.io v1alpha1.packages.apps.redhat.com || true
-	for i in {1..40}; do kubectl delete namespace "ns-$i" || true; done
 	kubectl delete -f test/e2e/resources/0000_50_olm_00-namespace.yaml
 
 clean:

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -3362,7 +3362,11 @@ func TestSyncOperatorGroups(t *testing.T) {
 								"olm.owner.kind":      "ClusterServiceVersion",
 							},
 						},
-						Rules: permissions[0].Rules,
+						Rules: append(permissions[0].Rules, rbacv1.PolicyRule{
+							Verbs:     ViewVerbs,
+							APIGroups: []string{corev1.GroupName},
+							Resources: []string{"namespaces"},
+						}),
 					},
 					&rbacv1.ClusterRoleBinding{
 						TypeMeta: metav1.TypeMeta{
@@ -3475,7 +3479,11 @@ func TestSyncOperatorGroups(t *testing.T) {
 								"olm.owner.kind":      "ClusterServiceVersion",
 							},
 						},
-						Rules: permissions[0].Rules,
+						Rules: append(permissions[0].Rules, rbacv1.PolicyRule{
+							Verbs:     ViewVerbs,
+							APIGroups: []string{corev1.GroupName},
+							Resources: []string{"namespaces"},
+						}),
 					},
 					&rbacv1.ClusterRoleBinding{
 						TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -359,7 +359,11 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 					Name:   r.GetName(),
 					Labels: r.GetLabels(),
 				},
-				Rules: r.Rules,
+				Rules: append(r.Rules, rbacv1.PolicyRule{
+					Verbs:     ViewVerbs,
+					APIGroups: []string{corev1.GroupName},
+					Resources: []string{"namespaces"},
+				}),
 			}
 			if _, err := a.OpClient.CreateClusterRole(clusterRole); err != nil {
 				return err

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -14,7 +14,7 @@ docker build -f upstream.Dockerfile .
 docker tag $(docker images --filter 'label=stage=olm' --format '{{.CreatedAt}}\t{{.ID}}' | sort -nr | head -n 1 | cut -f2) quay.io/operator-framework/olm:local
 docker tag $(docker images --filter 'label=stage=builder' --format '{{.CreatedAt}}\t{{.ID}}' | sort -nr | head -n 1 | cut -f2) quay.io/operator-framework/olm-e2e:local
 
-for i in {1..40}
-do
-	kubectl create namespace "ns-$i" || true
-done
+if [ -x "$(command -v kind)" ]; then
+  kind load docker-image quay.io/operator-framework/olm:local
+  kind load docker-image quay.io/operator-framework/olm-e2e:local
+fi


### PR DESCRIPTION
Operators that support both single and all namespace installation should
request the smallest scope of permissions they need. A single-namespace
operator shouldn't require any cluster-level permissions. When placing
it into an operatorgroup selecting all namespaces, it will need list
and watch on namespaces

