### PR TITLE
Garbage Collection for OperatorGroup RBAC

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -299,7 +299,7 @@ func NewOperator(logger *logrus.Logger, crClient versioned.Interface, opClient o
 		// Register queue and QueueInformer
 		queueName := fmt.Sprintf("%s/operatorgroups", namespace)
 		operatorGroupQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), queueName)
-		operatorGroupQueueInformer := queueinformer.NewInformer(operatorGroupQueue, operatorGroupInformer.Informer(), op.syncOperatorGroups, nil, queueName, metrics.NewMetricsNil(), logger)
+		operatorGroupQueueInformer := queueinformer.NewInformer(operatorGroupQueue, operatorGroupInformer.Informer(), op.syncOperatorGroups, &cache.ResourceEventHandlerFuncs{DeleteFunc: op.operatorGroupDeleted}, queueName, metrics.NewMetricsNil(), logger)
 		op.RegisterQueueInformer(operatorGroupQueueInformer)
 		op.ogQueueSet.Set(namespace, operatorGroupQueue)
 	}

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -3935,6 +3935,10 @@ func TestSyncOperatorGroups(t *testing.T) {
 					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{v1.OperatorGroupTargetsAnnotationKey: "", v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 					annotatedGlobalDeployment,
 					&v1.OperatorGroup{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       v1.OperatorGroupKind,
+							APIVersion: strings.Join([]string{v1.GroupName, v1.GroupVersion}, "/"),
+						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "operator-group-1",
 							Namespace: operatorNamespace,


### PR DESCRIPTION
### Description

Use `OwnerLabels` to garbage collect the `ClusterRoles` associated with an `OperatorGroup` after it is deleted.

Addresses https://jira.coreos.com/browse/OLM-974