### PR TITLE
fix(build) make run-local must honour NO_MINIKUBE flag

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-if [ -z "$NO_MINIKUBE" ] || [ -x "$(command -v minikube)" ]; then
+if [ -z "$NO_MINIKUBE" ] && [ -x "$(command -v minikube)" ]; then
   ps x | grep -q [m]inikube || minikube start --kubernetes-version="v1.12.0" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
   eval $(minikube docker-env) || { echo 'Cannot switch to minikube docker'; exit 1; }
   kubectl config use-context minikube


### PR DESCRIPTION
Previously running `NO_MINIKUBE=true make run-local` would still
start minikube as the condition ` [ -z "$NO_MINIKUBE" ] || [ -x "$(command -v minikube)" ]`
gets evaluated to `true`.

This patch fixes it by changing `||` to `&&`