### PR TITLE
add logging and separate muxer for metrics

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -99,22 +99,35 @@ func main() {
 	if *tlsCertPath != "" && *tlsKeyPath == "" || *tlsCertPath == "" && *tlsKeyPath != "" {
 		logger.Warn("both --tls-key and --tls-crt must be provided for TLS to be enabled, falling back to non-https")
 	} else if *tlsCertPath == "" && *tlsKeyPath == "" {
-		logger.Info("TLS keys not set, using non-https")
+		logger.Info("TLS keys not set, using non-https for metrics")
 	} else {
+		logger.Info("TLS keys set, using https for metrics")
 		useTLS = true
 	}
 
 	// Serve a health check.
-	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+	healthMux := http.NewServeMux()
+	healthMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	go http.ListenAndServe(":8080", nil)
+	go http.ListenAndServe(":8080", healthMux)
 
-	http.Handle("/metrics", promhttp.Handler())
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.Handler())
 	if useTLS {
-		go http.ListenAndServeTLS(":8081", *tlsCertPath, *tlsKeyPath, nil)
+		go func() {
+			err := http.ListenAndServeTLS(":8081", *tlsCertPath, *tlsKeyPath, metricsMux)
+			if err != nil {
+				logger.Errorf("Metrics (https) serving failed: %v", err)
+			}
+		}()
 	} else {
-		go http.ListenAndServe(":8081", nil)
+		go func() {
+			err := http.ListenAndServe(":8081", metricsMux)
+			if err != nil {
+				logger.Errorf("Metrics (http) serving failed: %v", err)
+			}
+		}()
 	}
 
 	// create a config client for operator status

--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -88,7 +88,6 @@ spec:
       - name: serving-cert
         secret:
           secretName: olm-operator-serving-cert
-          optional: true
       {{ end }}
     {{- if .Values.olm.nodeSelector }}
       nodeSelector:

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -84,7 +84,6 @@ spec:
       - name: serving-cert
         secret:
           secretName: catalog-operator-serving-cert
-          optional: true
       {{ end }}
     {{- if .Values.catalog.nodeSelector }}
       nodeSelector:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -66,7 +66,6 @@ spec:
       - name: serving-cert
         secret:
           secretName: olm-operator-serving-cert
-          optional: true
       
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -63,7 +63,6 @@ spec:
       - name: serving-cert
         secret:
           secretName: catalog-operator-serving-cert
-          optional: true
       
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
This is to hopefully help debug a strange issue I've seen where https metrics are not being served upon initial pod launch. (However, if the pod is restarted, metrics are served as expected.) These changes might be good enough to keep even if they don't fix the problem, especially the mux change.

(BZ #1689836)