### PR TITLE
feat(rbac): restrict permissions for namespace admins

### DIFF
--- a/deploy/chart/templates/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/deploy/chart/templates/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -8,8 +8,11 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]
-  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  resources: ["subscriptions"]
   verbs: ["create", "update", "patch", "delete"]
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions"]
+  verbs: ["delete"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -8,8 +8,11 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]
-  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  resources: ["subscriptions"]
   verbs: ["create", "update", "patch", "delete"]
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions"]
+  verbs: ["delete"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Namespace Admins now get:
 - full control over subscription objects
 - delete access to all olm types
 - view access to all olm types

This is so that namespace admins can add/remove services that are
available to them for install, but not add their own new services
(which can potentially escalate privileges in the current model)