### PR TITLE
Subscription Status InstallPlan References

### DIFF
--- a/pkg/api/apis/operators/reference.go
+++ b/pkg/api/apis/operators/reference.go
@@ -1,0 +1,12 @@
+package operators
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/reference"
+)
+
+// GetReference returns an ObjectReference for a given object whose concrete value is an OLM type.
+func GetReference(obj runtime.Object) (*corev1.ObjectReference, error) {
+	return reference.GetReference(scheme, obj)
+}

--- a/pkg/api/apis/operators/reference_test.go
+++ b/pkg/api/apis/operators/reference_test.go
@@ -1,0 +1,179 @@
+package operators
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+)
+
+func TestGetReference(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+	}
+	type want struct {
+		ref *corev1.ObjectReference
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "Nil/Error",
+			args: args{obj: nil},
+			want: want{
+				ref: nil,
+				err: fmt.Errorf("can't reference a nil object"),
+			},
+		},
+		{
+			name: "v1/Pod/NotRegistered/Error",
+			args: args{&corev1.Pod{}},
+			want: want{
+				ref: nil,
+				err: runtime.NewNotRegisteredErrForType(scheme.Name(), reflect.TypeOf(corev1.Pod{})),
+			},
+		},
+		{
+			name: "v1alpha1/ClusterServiceVersion",
+			args: args{
+				&v1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "csv",
+						UID:       types.UID("uid"),
+						SelfLink:  buildSelfLink(v1alpha1.SchemeGroupVersion.String(), "clusterserviceversions", "ns", "csv"),
+					},
+				},
+			},
+			want: want{
+				ref: &corev1.ObjectReference{
+					Namespace:  "ns",
+					Name:       "csv",
+					UID:        types.UID("uid"),
+					Kind:       v1alpha1.ClusterServiceVersionKind,
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "v1alpha1/InstallPlan",
+			args: args{
+				&v1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "ip",
+						UID:       types.UID("uid"),
+						SelfLink:  buildSelfLink(v1alpha1.SchemeGroupVersion.String(), "installplans", "ns", "ip"),
+					},
+				},
+			},
+			want: want{
+				ref: &corev1.ObjectReference{
+					Namespace:  "ns",
+					Name:       "ip",
+					UID:        types.UID("uid"),
+					Kind:       v1alpha1.InstallPlanKind,
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "v1alpha1/Subscription",
+			args: args{
+				&v1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "sub",
+						UID:       types.UID("uid"),
+						SelfLink:  buildSelfLink(v1alpha1.SchemeGroupVersion.String(), "subscriptions", "ns", "sub"),
+					},
+				},
+			},
+			want: want{
+				ref: &corev1.ObjectReference{
+					Namespace:  "ns",
+					Name:       "sub",
+					UID:        types.UID("uid"),
+					Kind:       v1alpha1.SubscriptionKind,
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "v1alpha1/CatalogSource",
+			args: args{
+				&v1alpha1.CatalogSource{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "catsrc",
+						UID:       types.UID("uid"),
+						SelfLink:  buildSelfLink(v1alpha1.SchemeGroupVersion.String(), "catalogsources", "ns", "catsrc"),
+					},
+				},
+			},
+			want: want{
+				ref: &corev1.ObjectReference{
+					Namespace:  "ns",
+					Name:       "catsrc",
+					UID:        types.UID("uid"),
+					Kind:       v1alpha1.CatalogSourceKind,
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "v1/OperatorGroup",
+			args: args{
+				&v1.OperatorGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "og",
+						UID:       types.UID("uid"),
+						SelfLink:  buildSelfLink(v1.SchemeGroupVersion.String(), "operatorgroups", "ns", "og"),
+					},
+				},
+			},
+			want: want{
+				ref: &corev1.ObjectReference{
+					Namespace:  "ns",
+					Name:       "og",
+					UID:        types.UID("uid"),
+					Kind:       v1.OperatorGroupKind,
+					APIVersion: v1.SchemeGroupVersion.String(),
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := GetReference(tt.args.obj)
+			require.Equal(t, tt.want.err, err)
+			require.Equal(t, tt.want.ref, ref)
+		})
+	}
+}
+
+// buildSelfLink returns a selfLink.
+func buildSelfLink(groupVersion, plural, namespace, name string) string {
+	if namespace == metav1.NamespaceAll {
+		return fmt.Sprintf("/apis/%s/%s/%s", groupVersion, plural, name)
+	}
+	return fmt.Sprintf("/apis/%s/namespaces/%s/%s/%s", groupVersion, namespace, plural, name)
+}

--- a/pkg/api/apis/operators/register.go
+++ b/pkg/api/apis/operators/register.go
@@ -1,3 +1,27 @@
 package operators
 
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+)
+
+// GroupName is the API group name.
 const GroupName = "operators.coreos.com"
+
+var (
+	scheme             = runtime.NewScheme()
+	localSchemeBuilder = runtime.SchemeBuilder{
+		v1alpha1.AddToScheme,
+		v1.AddToScheme,
+	}
+
+	// AddToScheme adds all types in the operators.coreos.com group to the given scheme.
+	AddToScheme = localSchemeBuilder.AddToScheme
+)
+
+func init() {
+	utilruntime.Must(AddToScheme(scheme))
+}

--- a/pkg/api/apis/operators/v1/operatorgroup_types.go
+++ b/pkg/api/apis/operators/v1/operatorgroup_types.go
@@ -13,6 +13,8 @@ const (
 	OperatorGroupNamespaceAnnotationKey    = "olm.operatorNamespace"
 	OperatorGroupTargetsAnnotationKey      = "olm.targetNamespaces"
 	OperatorGroupProvidedAPIsAnnotationKey = "olm.providedAPIs"
+
+	OperatorGroupKind = "OperatorGroup"
 )
 
 type OperatorGroupSpec struct {

--- a/pkg/api/apis/operators/v1/register.go
+++ b/pkg/api/apis/operators/v1/register.go
@@ -6,8 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators"
 )
 
 const (
@@ -16,7 +14,7 @@ const (
 )
 
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: operators.GroupName, Version: GroupVersion}
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) schema.GroupKind {

--- a/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
+++ b/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
@@ -5,12 +5,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators"
 )
 
 const (
-	CatalogSourceCRDAPIVersion = operators.GroupName + "/" + GroupVersion
+	CatalogSourceCRDAPIVersion = GroupName + "/" + GroupVersion
 	CatalogSourceKind          = "CatalogSource"
 )
 

--- a/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/api/apis/operators/v1alpha1/clusterserviceversion_types.go
@@ -9,12 +9,10 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators"
 )
 
 const (
-	ClusterServiceVersionAPIVersion     = operators.GroupName + "/" + GroupVersion
+	ClusterServiceVersionAPIVersion     = GroupName + "/" + GroupVersion
 	ClusterServiceVersionKind           = "ClusterServiceVersion"
 	OperatorGroupNamespaceAnnotationKey = "olm.operatorNamespace"
 )

--- a/pkg/api/apis/operators/v1alpha1/installplan_types.go
+++ b/pkg/api/apis/operators/v1alpha1/installplan_types.go
@@ -6,13 +6,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators"
 )
 
 const (
 	InstallPlanKind       = "InstallPlan"
-	InstallPlanAPIVersion = operators.GroupName + "/" + GroupVersion
+	InstallPlanAPIVersion = GroupName + "/" + GroupVersion
 )
 
 // Approval is the user approval policy for an InstallPlan.

--- a/pkg/api/apis/operators/v1alpha1/register.go
+++ b/pkg/api/apis/operators/v1alpha1/register.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,7 +12,7 @@ const (
 )
 
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: operators.GroupName, Version: GroupVersion}
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) schema.GroupKind {

--- a/pkg/api/apis/operators/v1alpha1/subscription_types.go
+++ b/pkg/api/apis/operators/v1alpha1/subscription_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -36,6 +37,43 @@ type SubscriptionSpec struct {
 	InstallPlanApproval    Approval `json:"installPlanApproval,omitempty"`
 }
 
+type SubscriptionStatus struct {
+	// CurrentCSV is the CSV the Subscription is progressing to.
+	// +optional
+	CurrentCSV string `json:"currentCSV,omitempty"`
+
+	// InstalledCSV is the CSV currently installed by the Subscription.
+	// +optional
+	InstalledCSV string `json:"installedCSV,omitempty"`
+
+	// Install is a reference to the latest InstallPlan generated for the Subscription.
+	// DEPRECATED: InstallPlanRef
+	// +optional
+	Install *InstallPlanReference `json:"installplan,omitempty"`
+
+	// State represents the current state of the Subscription
+	// +optional
+	State SubscriptionState `json:"state,omitempty"`
+
+	// Reason is the reason the Subscription was transitioned to its current state.
+	// +optional
+	Reason ConditionReason `json:"reason,omitempty"`
+
+	// InstallPlanRef is a reference to the latest InstallPlan that contains the Subscription's current CSV.
+	// +optional
+	InstallPlanRef *corev1.ObjectReference `json:"installPlanRef,omitempty"`
+
+	// LastUpdated represents the last time that the Subscription status was updated.
+	LastUpdated metav1.Time `json:"lastUpdated"`
+}
+
+type InstallPlanReference struct {
+	APIVersion string    `json:"apiVersion"`
+	Kind       string    `json:"kind"`
+	Name       string    `json:"name"`
+	UID        types.UID `json:"uuid"`
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient
 type Subscription struct {
@@ -44,23 +82,6 @@ type Subscription struct {
 
 	Spec   *SubscriptionSpec  `json:"spec"`
 	Status SubscriptionStatus `json:"status"`
-}
-
-type SubscriptionStatus struct {
-	CurrentCSV   string                `json:"currentCSV,omitempty"`
-	InstalledCSV string                `json:"installedCSV, omitempty"`
-	Install      *InstallPlanReference `json:"installplan,omitempty"`
-
-	State       SubscriptionState `json:"state,omitempty"`
-	Reason      ConditionReason   `json:"reason,omitempty"`
-	LastUpdated metav1.Time       `json:"lastUpdated"`
-}
-
-type InstallPlanReference struct {
-	APIVersion string    `json:"apiVersion"`
-	Kind       string    `json:"kind"`
-	Name       string    `json:"name"`
-	UID        types.UID `json:"uuid"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -77,4 +98,14 @@ func (s *Subscription) GetInstallPlanApproval() Approval {
 		return ApprovalManual
 	}
 	return ApprovalAutomatic
+}
+
+// NewInstallPlanReference returns an InstallPlanReference for the given ObjectReference.
+func NewInstallPlanReference(ref *corev1.ObjectReference) *InstallPlanReference {
+	return &InstallPlanReference{
+		APIVersion: ref.APIVersion,
+		Kind:       ref.Kind,
+		Name:       ref.Name,
+		UID:        ref.UID,
+	}
 }

--- a/pkg/api/apis/operators/v1alpha1/subscription_types.go
+++ b/pkg/api/apis/operators/v1alpha1/subscription_types.go
@@ -1,14 +1,13 @@
 package v1alpha1
 
 import (
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	SubscriptionKind          = "Subscription"
-	SubscriptionCRDAPIVersion = operators.GroupName + "/" + GroupVersion
+	SubscriptionCRDAPIVersion = GroupName + "/" + GroupVersion
 )
 
 // SubscriptionState tracks when updates are available, installing, or service is up to date

--- a/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 import (
 	json "encoding/json"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -1022,6 +1023,11 @@ func (in *SubscriptionStatus) DeepCopyInto(out *SubscriptionStatus) {
 	if in.Install != nil {
 		in, out := &in.Install, &out.Install
 		*out = new(InstallPlanReference)
+		**out = **in
+	}
+	if in.InstallPlanRef != nil {
+		in, out := &in.InstallPlanRef, &out.InstallPlanRef
+		*out = new(corev1.ObjectReference)
 		**out = **in
 	}
 	in.LastUpdated.DeepCopyInto(&out.LastUpdated)

--- a/pkg/api/client/clientset/versioned/fake/decorator.go
+++ b/pkg/api/client/clientset/versioned/fake/decorator.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package fake
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+)
+
+// ClientsetDecorator defines decorator methods for a Clientset.
+type ClientsetDecorator interface {
+	// PrependReactor adds a reactor to the beginning of the chain.
+	PrependReactor(verb, resource string, reaction testing.ReactionFunc)
+}
+
+// ReactionForwardingClientsetDecorator wraps a Clientset and "forwards" Action object mutations
+// from all successful non-handling Reactors along the chain to the first handling Reactor. This is
+// is a stopgap until we can upgrade to client-go v11.0, where the behavior is the default
+// (see https://github.com/kubernetes/client-go/blob/6ee68ca5fd8355d024d02f9db0b3b667e8357a0f/testing/fake.go#L130).
+type ReactionForwardingClientsetDecorator struct {
+	Clientset
+	ReactionChain []testing.Reactor // shadow embedded ReactionChain
+	actions       []testing.Action  // these may be castable to other types, but "Action" is the minimum
+}
+
+// NewReactionForwardingClientsetDecorator returns the ReactionForwardingClientsetDecorator wrapped Clientset result
+// of calling NewSimpleClientset with the given objects.
+func NewReactionForwardingClientsetDecorator(objects ...runtime.Object) *ReactionForwardingClientsetDecorator {
+	decorator := &ReactionForwardingClientsetDecorator{
+		Clientset: *NewSimpleClientset(objects...),
+	}
+
+	// Swap out the embedded ReactionChain with a Reactor that reduces over the decorator's ReactionChain.
+	decorator.ReactionChain = decorator.Clientset.ReactionChain
+	decorator.Clientset.ReactionChain = []testing.Reactor{&testing.SimpleReactor{"*", "*", decorator.reduceReactions}}
+
+	return decorator
+}
+
+// reduceReactions reduces over all reactions in the chain while "forwarding" Action object mutations
+// from all successful non-handling Reactors along the chain to the first handling Reactor.
+func (c *ReactionForwardingClientsetDecorator) reduceReactions(action testing.Action) (handled bool, ret runtime.Object, err error) {
+	// The embedded Client set is already locked, so there's no need to lock again
+	actionCopy := action.DeepCopy()
+	c.actions = append(c.actions, action.DeepCopy())
+	for _, reactor := range c.ReactionChain {
+		if !reactor.Handles(actionCopy) {
+			continue
+		}
+
+		handled, ret, err = reactor.React(actionCopy)
+		if !handled {
+			continue
+		}
+
+		return
+	}
+
+	return
+}
+
+// PrependReactor adds a reactor to the beginning of the chain.
+func (c *ReactionForwardingClientsetDecorator) PrependReactor(verb, resource string, reaction testing.ReactionFunc) {
+	c.ReactionChain = append([]testing.Reactor{&testing.SimpleReactor{verb, resource, reaction}}, c.ReactionChain...)
+}


### PR DESCRIPTION
Adds InstallPlan ObjectReferences to SubscriptionStatus and cleans up unit test configuration.

This is the first part in implementing the [improved subscription status proposal](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/contributors/design-proposals/subscription-status.md).