### PR TITLE
Add validation details for `spec.maturity` field

### DIFF
--- a/Documentation/design/building-your-csv.md
+++ b/Documentation/design/building-your-csv.md
@@ -220,7 +220,7 @@ The metadata section contains general metadata around the name, version and othe
 
 **Provider**: The name of the publishing entity behind the Operator
 
-**Maturity**: The stability of the Operator, eg. alpha, beta or stable
+**Maturity**: Level of maturity the Operator has achieved at this version, eg. planning, pre-alpha, alpha, beta, stable, mature, inactive, or deprecated.
 
 **Version**: The semanic version of the Operator. This value should be incremented each time a new Operator image is published.
 


### PR DESCRIPTION
Add detailed validation properties for `spec.maturity` field in CSV per CustomResourceDefinition. 

See "maturity" field in https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml