### PR TITLE
Add node-selector annotation to namespace

### DIFF
--- a/deploy/chart/templates/0000_50_olm_00-namespace.yaml
+++ b/deploy/chart/templates/0000_50_olm_00-namespace.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
   {{ if and .Values.installType (eq .Values.installType "ocp") }}
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
@@ -13,6 +15,8 @@ kind: Namespace
 metadata:
   name: {{ .Values.operator_namespace }}
   {{ if and .Values.installType (eq .Values.installType "ocp") }}
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "1"
   {{ end }}

--- a/deploy/ocp/manifests/0.7.1/0000_30_00-namespace.yaml
+++ b/deploy/ocp/manifests/0.7.1/0000_30_00-namespace.yaml
@@ -6,3 +6,5 @@ metadata:
   name: openshift-operator-lifecycle-manager
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/deploy/ocp/manifests/0.7.2/0000_30_00-namespace.yaml
+++ b/deploy/ocp/manifests/0.7.2/0000_30_00-namespace.yaml
@@ -6,3 +6,5 @@ metadata:
   name: openshift-operator-lifecycle-manager
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/deploy/ocp/manifests/0.7.4/0000_30_00-namespace.yaml
+++ b/deploy/ocp/manifests/0.7.4/0000_30_00-namespace.yaml
@@ -6,3 +6,5 @@ metadata:
   name: openshift-operator-lifecycle-manager
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/deploy/ocp/manifests/0.8.1/0000_50_olm_00-namespace.yaml
+++ b/deploy/ocp/manifests/0.8.1/0000_50_olm_00-namespace.yaml
@@ -6,6 +6,8 @@ metadata:
   name: openshift-operator-lifecycle-manager
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""
 ---
 apiVersion: v1
 kind: Namespace
@@ -13,3 +15,5 @@ metadata:
   name: openshift-operators
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/deploy/ocp/manifests/0.9.0/0000_50_olm_00-namespace.yaml
+++ b/deploy/ocp/manifests/0.9.0/0000_50_olm_00-namespace.yaml
@@ -4,7 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
-  
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
@@ -14,7 +15,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operators
-  
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "1"
   

--- a/deploy/okd/manifests/0.7.2/0000_30_00-namespace.yaml
+++ b/deploy/okd/manifests/0.7.2/0000_30_00-namespace.yaml
@@ -6,3 +6,5 @@ metadata:
   name: openshift-operator-lifecycle-manager
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/deploy/okd/manifests/0.8.0/0000_30_00-namespace.yaml
+++ b/deploy/okd/manifests/0.8.0/0000_30_00-namespace.yaml
@@ -6,6 +6,8 @@ metadata:
   name: openshift-operator-lifecycle-manager
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""
 ---
 apiVersion: v1
 kind: Namespace
@@ -13,3 +15,5 @@ metadata:
   name: openshift-operators
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/deploy/okd/manifests/0.9.0/0000_50_olm_00-namespace.yaml
+++ b/deploy/okd/manifests/0.9.0/0000_50_olm_00-namespace.yaml
@@ -4,10 +4,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
+  annotations:
+    openshift.io/node-selector: ""
   
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operators
+  annotations:
+    openshift.io/node-selector: ""
   

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
-  
+  annotations:
+    openshift.io/node-selector: ""  
   labels:
     openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
@@ -12,7 +13,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operators
-  
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "1"
   


### PR DESCRIPTION
**Why this change?**
When https://github.com/openshift/cluster-kube-apiserver-operator/pull/394 merges, all the pods running openshift cluster will have a [defaultNodeSelector](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#setting-the-cluster-wide-default-node-selector) if it has been set by cluster-admin including pods running in `openshift-*` namespace. The main advantage of having that feature is in a multi-tenant environment, any new project created can be steered towards compute nodes(non-master nodes).

**What should I do?**
If you think, the pods in your namespace shouldn't have defaultNodeSelector set, please review this PR. If not feel free to close this. The annotation added as part of this PR lets all the pods created within your project to not have the defaultNodeSelector set.


/cc @deads2k @sjenning 
