### PR TITLE
Revert "chore(cvo): remove ClusterOperator from manifests"

### DIFF
--- a/deploy/chart/templates/0000_50_olm_15-operatorstatus.yaml
+++ b/deploy/chart/templates/0000_50_olm_15-operatorstatus.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.imagestream }}
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: {{ .Values.writeStatusName }}
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"
+---
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: {{ .Values.writeStatusNameCatalog }}
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"
+{{- end }}

--- a/manifests/0000_50_olm_15-operatorstatus.yaml
+++ b/manifests/0000_50_olm_15-operatorstatus.yaml
@@ -1,0 +1,18 @@
+
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: operator-lifecycle-manager
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"
+---
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: operator-lifecycle-manager-catalog
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"


### PR DESCRIPTION
Inadvertantly force-merged this instead of a different PR. This may be fine but staging this in case we need to revert