### PR TITLE
Always set LastTransitionTime in OperatorStatusCondition

### DIFF
--- a/pkg/lib/operatorstatus/status.go
+++ b/pkg/lib/operatorstatus/status.go
@@ -204,7 +204,7 @@ func setOperatorStatusCondition(conditions *[]configv1.ClusterOperatorStatusCond
 
 	if existingCondition.Status != newCondition.Status {
 		existingCondition.Status = newCondition.Status
-		existingCondition.LastTransitionTime = newCondition.LastTransitionTime
+		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
 	}
 
 	existingCondition.Reason = newCondition.Reason


### PR DESCRIPTION
This PR is fixing the problem spotted in https://github.com/openshift/cluster-version-operator/pull/168/:
```
Unable to update cluster operator status: ClusterOperator.config.openshift.io \"operator-lifecycle-manager\" is invalid: []: Invalid value: map[string]interface {}{\"kind\":\"ClusterOperator\", \"metadata\":map[string]interface {}{\"uid\":\"a694fc84-68d4-11e9-a00d-125e210e6730\", \"generation\":1, \"creationTimestamp\":\"2019-04-27T10:10:14Z\", \"resourceVersion\":\"4564\", \"name\":\"operator-lifecycle-manager\"}, \"spec\":map[string]interface {}{}, \"apiVersion\":\"config.openshift.io/v1\", \"status\":map[string]interface {}{\"extension\":interface {}(nil), \"conditions\":[]interface {}{map[string]interface {}{\"type\":\"Degraded\", \"status\":\"False\", \"lastTransitionTime\":\"2019-04-27T10:10:14Z\"}, map[string]interface {}{\"message\":\"Deployed 0.9.0\", \"type\":\"Progressing\", \"status\":\"True\", \"lastTransitionTime\":interface {}(nil)}, map[string]interface {}{\"type\":\"Available\", \"status\":\"True\", \"lastTransitionTime\":\"2019-04-27T10:10:14Z\"}}, \"versions\":[]interface {}{map[string]interface {}{\"version\":\"0.0.1-2019-04-27-095238\", \"name\":\"operator\"}, map[string]interface {}{\"name\":\"operator-lifecycle-manager\", \"version\":\"0.9.0\"}}}}: validation failure list:\nstatus.conditions.lastTransitionTime in body must be of type string: \"null\""
```
/assign @ecordell 
