### PR TITLE
test(e2e): wait for deployment to exist in csv replacement test

### DIFF
--- a/deploy/chart/templates/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/deploy/chart/templates/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -25,5 +25,8 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]
-  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["packages.operators.coreos.com"]
+  resources: ["packagemanifests"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Fixes a flake I noticed on https://github.com/operator-framework/operator-lifecycle-manager/pull/830

Might not be the only one, so I'll append more fixes if needed