### PR TITLE
Fix gRPC registry pod recreation

### DIFF
--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -14,15 +14,16 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/fakes"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clientfake"
 )
 
 func TestSyncSubscriptions(t *testing.T) {
 	now := metav1.Date(2018, time.January, 26, 20, 40, 0, 0, time.UTC)
 	timeNow = func() metav1.Time { return now }
-
 	testNamespace := "testNamespace"
+
 	type fields struct {
-		fakeClientOptions []fakeClientOption
+		clientOptions     []clientfake.Option
 		sourcesLastUpdate metav1.Time
 		resolveSteps      []*v1alpha1.Step
 		resolveSubs       []*v1alpha1.Subscription
@@ -51,7 +52,7 @@ func TestSyncSubscriptions(t *testing.T) {
 		{
 			name: "NoStatus/NoCurrentCSV/FoundInCatalog",
 			fields: fields{
-				fakeClientOptions: []fakeClientOption{withSelfLinks(t)},
+				clientOptions: []clientfake.Option{clientfake.WithSelfLinks(t)},
 				existingOLMObjs: []runtime.Object{
 					&v1alpha1.Subscription{
 						ObjectMeta: metav1.ObjectMeta{
@@ -182,7 +183,7 @@ func TestSyncSubscriptions(t *testing.T) {
 		{
 			name: "Status/HaveCurrentCSV/UpdateFoundInCatalog",
 			fields: fields{
-				fakeClientOptions: []fakeClientOption{withSelfLinks(t)},
+				clientOptions: []clientfake.Option{clientfake.WithSelfLinks(t)},
 				existingOLMObjs: []runtime.Object{
 					&v1alpha1.ClusterServiceVersion{
 						ObjectMeta: metav1.ObjectMeta{
@@ -322,7 +323,7 @@ func TestSyncSubscriptions(t *testing.T) {
 		{
 			name: "Status/HaveCurrentCSV/UpdateFoundInCatalog/UpdateRequiresDependency",
 			fields: fields{
-				fakeClientOptions: []fakeClientOption{withSelfLinks(t)},
+				clientOptions: []clientfake.Option{clientfake.WithSelfLinks(t)},
 				existingOLMObjs: []runtime.Object{
 					&v1alpha1.ClusterServiceVersion{
 						ObjectMeta: metav1.ObjectMeta{
@@ -514,7 +515,7 @@ func TestSyncSubscriptions(t *testing.T) {
 			// Create test operator
 			stopCh := make(chan struct{})
 			defer func() { stopCh <- struct{}{} }()
-			o, err := NewFakeOperator(testNamespace, []string{testNamespace}, stopCh, withClientObjs(tt.fields.existingOLMObjs...), withK8sObjs(tt.fields.existingObjects...), withFakeClientOptions(tt.fields.fakeClientOptions...))
+			o, err := NewFakeOperator(testNamespace, []string{testNamespace}, stopCh, withClientObjs(tt.fields.existingOLMObjs...), withK8sObjs(tt.fields.existingObjects...), withFakeClientOptions(tt.fields.clientOptions...))
 			require.NoError(t, err)
 
 			o.reconciler = &fakes.FakeRegistryReconcilerFactory{

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -26,26 +26,36 @@ type configMapCatalogSourceDecorator struct {
 	*v1alpha1.CatalogSource
 }
 
+const (
+	// ConfigMapServerPostfix is a postfix appended to the names of resources generated for a ConfigMap server.
+	ConfigMapServerPostfix string = "-configmap-server"
+)
+
 func (s *configMapCatalogSourceDecorator) serviceAccountName() string {
-	return s.GetName() + "-configmap-server"
+	return s.GetName() + ConfigMapServerPostfix
 }
 
 func (s *configMapCatalogSourceDecorator) roleName() string {
-	return s.GetName() + "-configmap-reader"
+	return s.GetName() + ConfigMapServerPostfix
 }
 
 func (s *configMapCatalogSourceDecorator) Selector() map[string]string {
 	return map[string]string{
-		"olm.catalogSource": s.GetName(),
+		CatalogSourceLabelKey: s.GetName(),
 	}
 }
 
+const (
+	// ConfigMapRVLabelKey is the key for a label used to track the resource version of a related ConfigMap.
+	ConfigMapRVLabelKey string = "olm.configMapResourceVersion"
+)
+
 func (s *configMapCatalogSourceDecorator) Labels() map[string]string {
 	labels := map[string]string{
-		"olm.catalogSource": s.GetName(),
+		CatalogSourceLabelKey: s.GetName(),
 	}
 	if s.Spec.SourceType == v1alpha1.SourceTypeInternal || s.Spec.SourceType == v1alpha1.SourceTypeConfigmap {
-		labels["olm.configMapResourceVersion"] = s.Status.ConfigMapResource.ResourceVersion
+		labels[ConfigMapRVLabelKey] = s.Status.ConfigMapResource.ResourceVersion
 	}
 	return labels
 }
@@ -123,7 +133,7 @@ func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
 					Operator: v1.TolerationOpExists,
 				},
 			},
-			ServiceAccountName: s.GetName() + "-configmap-server",
+			ServiceAccountName: s.GetName() + ConfigMapServerPostfix,
 		},
 	}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)
@@ -160,10 +170,15 @@ func (s *configMapCatalogSourceDecorator) Role() *rbacv1.Role {
 	return role
 }
 
+const (
+	// ConfigMapReaderPostfix is the postfix applied to the name of reader RoleBinding generated for a ConfigMap server.
+	ConfigMapReaderPostfix string = ConfigMapServerPostfix + "-reader"
+)
+
 func (s *configMapCatalogSourceDecorator) RoleBinding() *rbacv1.RoleBinding {
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.GetName() + "-server-configmap-reader",
+			Name:      s.GetName() + ConfigMapReaderPostfix,
 			Namespace: s.GetNamespace(),
 		},
 		Subjects: []rbacv1.Subject{
@@ -442,7 +457,7 @@ func (c *ConfigMapRegistryReconciler) CheckRegistryServer(catalogSource *v1alpha
 		c.currentRole(source) == nil ||
 		c.currentRoleBinding(source) == nil ||
 		c.currentService(source) == nil ||
-		len(c.currentPods(source, c.Image)) != 1 {
+		len(c.currentPods(source, c.Image)) < 1 {
 		healthy = false
 		return
 	}

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -36,7 +36,7 @@ func (s *configMapCatalogSourceDecorator) serviceAccountName() string {
 }
 
 func (s *configMapCatalogSourceDecorator) roleName() string {
-	return s.GetName() + ConfigMapServerPostfix
+	return s.GetName() + "-configmap-reader"
 }
 
 func (s *configMapCatalogSourceDecorator) Selector() map[string]string {
@@ -170,15 +170,10 @@ func (s *configMapCatalogSourceDecorator) Role() *rbacv1.Role {
 	return role
 }
 
-const (
-	// ConfigMapReaderPostfix is the postfix applied to the name of reader RoleBinding generated for a ConfigMap server.
-	ConfigMapReaderPostfix string = ConfigMapServerPostfix + "-reader"
-)
-
 func (s *configMapCatalogSourceDecorator) RoleBinding() *rbacv1.RoleBinding {
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.GetName() + ConfigMapReaderPostfix,
+			Name:      s.GetName() + "-server-configmap-reader",
 			Namespace: s.GetNamespace(),
 		},
 		Subjects: []rbacv1.Subject{

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -3,16 +3,17 @@ package reconciler
 import (
 	"fmt"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 )
 
 // grpcCatalogSourceDecorator wraps CatalogSource to add additional methods
@@ -22,13 +23,13 @@ type grpcCatalogSourceDecorator struct {
 
 func (s *grpcCatalogSourceDecorator) Selector() labels.Selector {
 	return labels.SelectorFromValidatedSet(map[string]string{
-		"olm.catalogSource": s.GetName(),
+		CatalogSourceLabelKey: s.GetName(),
 	})
 }
 
 func (s *grpcCatalogSourceDecorator) Labels() map[string]string {
 	return map[string]string{
-		"olm.catalogSource": s.GetName(),
+		CatalogSourceLabelKey: s.GetName(),
 	}
 }
 

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -214,7 +214,7 @@ func (c *GrpcRegistryReconciler) CheckRegistryServer(catalogSource *v1alpha1.Cat
 
 	// Check on registry resources
 	// TODO: add gRPC health check
-	if len(c.currentPodsWithCorrectImage(source)) == 1 ||
+	if len(c.currentPodsWithCorrectImage(source)) < 1 ||
 		c.currentService(source) == nil {
 		healthy = false
 		return

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -7,6 +7,11 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 )
 
+const (
+	// CatalogSourceLabelKey is the key for a label containing a CatalogSource name.
+	CatalogSourceLabelKey string = "olm.catalogSource"
+)
+
 // RegistryEnsurer describes methods for ensuring a registry exists.
 type RegistryEnsurer interface {
 	// EnsureRegistryServer ensures a registry server exists for the given CatalogSource.

--- a/pkg/lib/clientfake/client_options.go
+++ b/pkg/lib/clientfake/client_options.go
@@ -1,0 +1,53 @@
+package clientfake
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	clitesting "k8s.io/client-go/testing"
+)
+
+// Option configures a ClientsetDecorator
+type Option func(ClientsetDecorator)
+
+// WithSelfLinks returns a fakeClientOption that configures a ClientsetDecorator to write selfLinks to all OLM types on create.
+func WithSelfLinks(t *testing.T) Option {
+	return func(c ClientsetDecorator) {
+		c.PrependReactor("create", "*", func(a clitesting.Action) (bool, runtime.Object, error) {
+			ca, ok := a.(clitesting.CreateAction)
+			if !ok {
+				t.Fatalf("expected CreateAction")
+			}
+
+			obj := ca.GetObject()
+			accessor, err := meta.Accessor(obj)
+			if err != nil {
+				return false, nil, err
+			}
+			if accessor.GetSelfLink() != "" {
+				// SelfLink is already set
+				return false, nil, nil
+			}
+
+			gvr := ca.GetResource()
+			accessor.SetSelfLink(BuildSelfLink(gvr.GroupVersion().String(), gvr.Resource, accessor.GetNamespace(), accessor.GetName()))
+
+			return false, obj, nil
+		})
+	}
+}
+
+// WithNameGeneration returns a fakeK8sClientOption that configures a Clientset to write generated names to all types on create.
+func WithNameGeneration(t *testing.T) Option {
+	return func(c ClientsetDecorator) {
+		c.PrependReactor("create", "*", func(a clitesting.Action) (bool, runtime.Object, error) {
+			ca, ok := a.(clitesting.CreateAction)
+			if !ok {
+				t.Fatalf("expected CreateAction")
+			}
+
+			return false, AddSimpleGeneratedName(ca.GetObject()), nil
+		})
+	}
+}

--- a/pkg/lib/clientfake/decorator.go
+++ b/pkg/lib/clientfake/decorator.go
@@ -1,26 +1,13 @@
-/*
-Copyright 2019 Red Hat, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-package fake
+package clientfake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	fake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clientfake"
 )
+
+// This is used to prepend reactors to the k8s fake client. should be removed when client go is updated.
+// TODO: see if we can merge the OLM ClientsetDecorator and this one.
 
 // ClientsetDecorator defines decorator methods for a Clientset.
 type ClientsetDecorator interface {
@@ -33,22 +20,22 @@ type ClientsetDecorator interface {
 // is a stopgap until we can upgrade to client-go v11.0, where the behavior is the default
 // (see https://github.com/kubernetes/client-go/blob/6ee68ca5fd8355d024d02f9db0b3b667e8357a0f/testing/fake.go#L130).
 type ReactionForwardingClientsetDecorator struct {
-	Clientset
+	fake.Clientset
 	ReactionChain []testing.Reactor // shadow embedded ReactionChain
 	actions       []testing.Action  // these may be castable to other types, but "Action" is the minimum
 }
 
 // NewReactionForwardingClientsetDecorator returns the ReactionForwardingClientsetDecorator wrapped Clientset result
 // of calling NewSimpleClientset with the given objects.
-func NewReactionForwardingClientsetDecorator(objects []runtime.Object, options ...clientfake.Option) *ReactionForwardingClientsetDecorator {
+func NewReactionForwardingClientsetDecorator(objects []runtime.Object, options ...Option) *ReactionForwardingClientsetDecorator {
 	decorator := &ReactionForwardingClientsetDecorator{
-		Clientset: *NewSimpleClientset(objects...),
+		Clientset: *fake.NewSimpleClientset(objects...),
 	}
 
 	// Swap out the embedded ReactionChain with a Reactor that reduces over the decorator's ReactionChain.
 	decorator.ReactionChain = decorator.Clientset.ReactionChain
 	decorator.Clientset.ReactionChain = []testing.Reactor{&testing.SimpleReactor{"*", "*", decorator.reduceReactions}}
-	
+
 	// Apply options
 	for _, option := range options {
 		option(decorator)

--- a/pkg/lib/clientfake/meta.go
+++ b/pkg/lib/clientfake/meta.go
@@ -1,0 +1,45 @@
+package clientfake
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage/names"
+)
+
+// BuildSelfLink returns a selflink for the given group version, plural, namespace, and name.
+func BuildSelfLink(groupVersion, plural, namespace, name string) string {
+	if namespace == metav1.NamespaceAll {
+		return fmt.Sprintf("/apis/%s/%s/%s", groupVersion, plural, name)
+	}
+	return fmt.Sprintf("/apis/%s/namespaces/%s/%s/%s", groupVersion, namespace, plural, name)
+}
+
+// AddSimpleGeneratedName returns the given object with a simple generated name added to its metadata.
+// If a name already exists, there is no GenerateName field set, or there is an issue accessing the object's metadata
+// the object is returned unmodified.
+func AddSimpleGeneratedName(obj runtime.Object) runtime.Object {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return obj
+	}
+	if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
+		// TODO: for tests, it would be nice to be able to retrieve this name later
+		accessor.SetName(names.SimpleNameGenerator.GenerateName(accessor.GetGenerateName()))
+	}
+
+	return obj
+}
+
+// AddSimpleGeneratedNames returns the list objects with simple generated names added to their metadata.
+// If a name already exists, there is no GenerateName field set, or there is an issue accessing the object's metadata
+// the object is returned unmodified.
+func AddSimpleGeneratedNames(objs ...runtime.Object) []runtime.Object {
+	for i, obj := range objs {
+		objs[i] = AddSimpleGeneratedName(obj)
+	}
+
+	return objs
+}

--- a/test/e2e/setup_bare_test.go
+++ b/test/e2e/setup_bare_test.go
@@ -37,8 +37,15 @@ var (
 	olmNamespace = flag.String(
 		"olmNamespace", "", "namespace where olm is running")
 
+	communityOperators = flag.String(
+		"communityOperators",
+		"quay.io/operator-framework/upstream-community-operators@sha256:098457dc5e0b6ca9599bd0e7a67809f8eca397907ca4d93597380511db478fec",
+		"reference to upstream-community-operators image")
+	
+
 	testNamespace     = ""
 	operatorNamespace = ""
+	communityOperatorsImage = ""
 )
 
 func TestMain(m *testing.M) {
@@ -56,6 +63,8 @@ func TestMain(m *testing.M) {
 		testNamespace = string(testNamespaceBytes)
 	}
 	operatorNamespace = *olmNamespace
+	communityOperatorsImage = *communityOperators
+
 	cleaner = newNamespaceCleaner(testNamespace)
 	namespaces := strings.Split(*watchedNamespaces, ",")
 

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -23,8 +23,14 @@ var (
 	olmNamespace = flag.String(
 		"olmNamespace", "", "namespace where olm is running")
 
-	testNamespace     = ""
-	operatorNamespace = ""
+	communityOperators = flag.String(
+		"communityOperators",
+		"quay.io/operator-framework/upstream-community-operators@sha256:098457dc5e0b6ca9599bd0e7a67809f8eca397907ca4d93597380511db478fec",
+		"reference to upstream-community-operators image")
+
+	testNamespace           = ""
+	operatorNamespace       = ""
+	communityOperatorsImage = ""
 )
 
 func TestMain(m *testing.M) {
@@ -35,8 +41,9 @@ func TestMain(m *testing.M) {
 
 	testNamespace = *namespace
 	operatorNamespace = *olmNamespace
-	cleaner = newNamespaceCleaner(testNamespace)
+	communityOperatorsImage = *communityOperators
 
+	cleaner = newNamespaceCleaner(testNamespace)
 	c, err := client.NewClient(*kubeConfigPath)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Addresses fixes deleted gRPC registry pod recreation; the other half of [OLM-902](https://jira.coreos.com/browse/OLM-902).
- Corrects a bad gRPC registry pod check causing them to not be recreated when missing
- Factors out common fake client decorator options into separate package
- Fixes some gRPC unit tests that were checking for `internal` catalog resources

This steals some test tools from #816 (e.g. k8s fake client decorator, simple name generator option)