### PR TITLE
Refactor to avoid cache races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ IMAGE_REPO := quay.io/operator-framework/olm
 IMAGE_TAG ?= "dev"
 KUBE_DEPS := api apiserver apimachinery apiextensions-apiserver kube-aggregator code-generator cli-runtime
 KUBE_RELEASE := release-1.12
+SPECIFIC_UNIT_TEST := $(if $(TEST),-run $(TEST),)
 
 .PHONY: build test run clean vendor schema-check \
 	vendor-update coverage coverage-html e2e .FORCE
@@ -24,7 +25,7 @@ all: test build
 test: clean cover.out
 
 unit:
-	go test $(MOD_FLAGS) -v -race -tags=json1 -count=1 ./pkg/...
+	go test $(MOD_FLAGS) $(SPECIFIC_UNIT_TEST) -v -race -tags=json1 -count=1 ./pkg/...
 
 schema-check:
 

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -27,6 +27,7 @@ import (
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	aextv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -3248,6 +3249,9 @@ func TestUpdates(t *testing.T) {
 					if expectedCurrent != expectedPrevious {
 						err = wait.PollImmediate(1*time.Millisecond, 5*time.Second, func() (bool, error) {
 							updated, err := op.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(namespace).Get(csv.GetName())
+							if k8serrors.IsNotFound(err) {
+								return false, nil
+							}
 							return !equality.Semantic.DeepEqual(updated, fetched), err
 						})
 						require.NoError(t, err)


### PR DESCRIPTION
This is essentially a fix for unit tests that I noticed locally. It involves making sure a newly created CSV is not attempted to be retrieved using a lister within the same sync loop.

Obsoletes https://github.com/operator-framework/operator-lifecycle-manager/pull/814.

As much as I'd like to say this fixes every flake, this might only fix one of them. But I haven't seen any locally with this fix.