### PR TITLE
Add Termination Message to Failing OLM Pods

### DIFF
--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -63,6 +63,7 @@ spec:
             httpGet:
               path: /healthz
               port: {{ .Values.olm.service.internalPort }}
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
         {{ if and .Values.installType (eq .Values.installType "ocp") }}
           - name: RELEASE_VERSION

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -65,6 +65,7 @@ spec:
             httpGet:
               path: /healthz
               port: {{ .Values.catalog.service.internalPort }}
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
           {{ if and .Values.installType (eq .Values.installType "ocp") }}
           - name: RELEASE_VERSION

--- a/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -56,4 +56,5 @@ spec:
             scheme: HTTPS
             path: /healthz
             port: {{ .Values.package.service.internalPort }}
+        terminationMessagePolicy: FallbackToLogsOnError
 {{- end -}}

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -45,6 +45,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
         
           - name: RELEASE_VERSION

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -48,6 +48,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
           
           - name: RELEASE_VERSION

--- a/manifests/0000_50_olm_16-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_16-packageserver.clusterserviceversion.yaml
@@ -107,6 +107,7 @@ spec:
                     scheme: HTTPS
                     path: /healthz
                     port: 5443
+                terminationMessagePolicy: FallbackToLogsOnError
   maturity: alpha
   version: 0.9.0
   apiservicedefinitions:

--- a/manifests/0000_50_olm_17-packageserver.deployment.yaml
+++ b/manifests/0000_50_olm_17-packageserver.deployment.yaml
@@ -49,3 +49,4 @@ spec:
             scheme: HTTPS
             path: /healthz
             port: 5443
+        terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
### Description

Improves debugging crashing OLM pods by [setting `terminationMessagePolicy: FallbackToLogsOnError`](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message).

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1707071

