### PR TITLE
fix(deploy): add missing descriptions

### DIFF
--- a/deploy/chart/templates/0000_50_olm_03-clusterserviceversion.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_03-clusterserviceversion.crd.yaml
@@ -44,6 +44,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Represents an Operator that should be running on the cluster, including requirements and install strategy.
       properties:
         spec:
           type: object

--- a/deploy/chart/templates/0000_50_olm_04-installplan.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_04-installplan.crd.yaml
@@ -43,6 +43,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Represents a plan to install and resolve dependencies for Cluster Services.
       properties:
         spec:
           type: object

--- a/deploy/chart/templates/0000_50_olm_05-subscription.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_05-subscription.crd.yaml
@@ -4,7 +4,7 @@ metadata:
   name: subscriptions.operators.coreos.com
   annotations:
     displayName: Subscription
-    description: Subcribes service catalog to a source and channel to recieve updates for packages.
+    description: Subscribes service catalog to a source and channel to recieve updates for packages.
 spec:
   group: operators.coreos.com
   version: v1alpha1
@@ -41,6 +41,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: Subscribes service catalog to a source and channel to recieve updates for packages.
       properties:
         spec:
           type: object

--- a/deploy/chart/templates/0000_50_olm_06-catalogsource.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_06-catalogsource.crd.yaml
@@ -43,6 +43,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: A source configured to find packages and updates.
       properties:
         spec:
           type: object

--- a/deploy/chart/templates/0000_50_olm_10-operatorgroup.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_10-operatorgroup.crd.yaml
@@ -27,6 +27,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: A grouping of namespaces for usage with an operator.
       properties:
         spec:
           properties:


### PR DESCRIPTION
This fixes missing text when querying from kubectl explain <crd>.
(https://bugzilla.redhat.com/show_bug.cgi?id=1705746)