### PR TITLE
Multiple fixes

### DIFF
--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -25,5 +25,8 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]
-  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["packages.operators.coreos.com"]
+  resources: ["packagemanifests"]
   verbs: ["get", "list", "watch"]

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -435,8 +435,13 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 		return fmt.Errorf("no reconciler for source type %s", catsrc.Spec.SourceType)
 	}
 
+	healthy, err := reconciler.CheckRegistryServer(catsrc)
+	if err != nil {
+		return err
+	}
+
 	// If registry pod hasn't been created or hasn't been updated since the last configmap update, recreate it
-	if catsrc.Status.RegistryServiceStatus == nil || catsrc.Status.RegistryServiceStatus.CreatedAt.Before(&catsrc.Status.LastSync) {
+	if !healthy || catsrc.Status.RegistryServiceStatus == nil || catsrc.Status.RegistryServiceStatus.CreatedAt.Before(&catsrc.Status.LastSync) {
 		logger.Debug("ensuring registry server")
 
 		if err := reconciler.EnsureRegistryServer(out); err != nil {

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -717,7 +717,7 @@ func (o *Operator) nothingToUpdate(logger *logrus.Entry, sub *v1alpha1.Subscript
 		logger.Debugf("skipping update: no new updates to catalog since last sync at %s", sub.Status.LastUpdated.String())
 		return true
 	}
-	if sub.Status.Install != nil && sub.Status.State == v1alpha1.SubscriptionStateUpgradePending {
+	if sub.Status.InstallPlanRef != nil && sub.Status.State == v1alpha1.SubscriptionStateUpgradePending {
 		logger.Debugf("skipping update: installplan already created")
 		return true
 	}
@@ -797,13 +797,14 @@ func (o *Operator) ensureSubscriptionCSVState(logger *logrus.Entry, sub *v1alpha
 	out.Status.LastUpdated = timeNow()
 
 	// Update Subscription with status of transition. Log errors if we can't write them to the status.
-	if sub, err = o.client.OperatorsV1alpha1().Subscriptions(out.GetNamespace()).UpdateStatus(out); err != nil {
+	updatedSub, err := o.client.OperatorsV1alpha1().Subscriptions(out.GetNamespace()).UpdateStatus(out)
+	if err != nil {
 		logger.WithError(err).Info("error updating subscription status")
 		return nil, false, fmt.Errorf("error updating Subscription status: " + err.Error())
 	}
 
 	// subscription status represents cluster state
-	return sub, true, nil
+	return updatedSub, true, nil
 }
 
 func (o *Operator) updateSubscriptionStatus(namespace string, subs []*v1alpha1.Subscription, installPlanRef *corev1.ObjectReference) error {

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -575,7 +575,9 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 		}
 	}
 
-	a.copyQueueIndexer.Enqueue(outCSV)
+	if !outCSV.IsUncopiable() {
+		a.copyQueueIndexer.Enqueue(outCSV)
+	}
 
 	return
 }
@@ -920,7 +922,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		logger.Info("scheduling ClusterServiceVersion for install")
 		out.SetPhaseWithEvent(v1alpha1.CSVPhaseInstallReady, v1alpha1.CSVReasonRequirementsMet, "all requirements found, attempting install", now, a.recorder)
 	case v1alpha1.CSVPhaseInstallReady:
-		installer, strategy, _ := a.parseStrategiesAndUpdateStatus(out)
+		installer, strategy := a.parseStrategiesAndUpdateStatus(out)
 		if strategy == nil {
 			return
 		}
@@ -945,7 +947,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		return
 
 	case v1alpha1.CSVPhaseInstalling:
-		installer, strategy, _ := a.parseStrategiesAndUpdateStatus(out)
+		installer, strategy := a.parseStrategiesAndUpdateStatus(out)
 		if strategy == nil {
 			return
 		}
@@ -966,7 +968,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			return
 		}
 
-		installer, strategy, _ := a.parseStrategiesAndUpdateStatus(out)
+		installer, strategy := a.parseStrategiesAndUpdateStatus(out)
 		if strategy == nil {
 			return
 		}
@@ -1009,7 +1011,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 	case v1alpha1.CSVPhaseFailed:
-		installer, strategy, _ := a.parseStrategiesAndUpdateStatus(out)
+		installer, strategy := a.parseStrategiesAndUpdateStatus(out)
 		if strategy == nil {
 			return
 		}
@@ -1084,75 +1086,33 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			return
 		}
 
-		// If we are a leaf, we should requeue the replacement for processing
+		// If there is a succeeded replacement, mark this for deletion
 		if next := a.isBeingReplaced(out, a.csvSet(out.GetNamespace(), v1alpha1.CSVPhaseAny)); next != nil {
-			err := a.csvQueueSet.Requeue(next.GetName(), next.GetNamespace())
-			if err != nil {
-				a.Log.WithError(err).Warn("error requeuing replacement")
+			if next.Status.Phase == v1alpha1.CSVPhaseSucceeded {
+				out.SetPhaseWithEvent(v1alpha1.CSVPhaseDeleting, v1alpha1.CSVReasonReplaced, "has been replaced by a newer ClusterServiceVersion that has successfully installed.", now, a.recorder)
+			} else {
+				// If there's a replacement, but it's not yet succeeded, requeue both (this is an active replacement)
+				if err := a.csvQueueSet.Requeue(next.GetName(), next.GetNamespace()); err != nil {
+					a.Log.Warn(err.Error())
+				}
+				if err := a.csvQueueSet.Requeue(out.GetName(), out.GetNamespace()); err != nil {
+					a.Log.Warn(err.Error())
+				}
 			}
-		}
-
-		// If we can find a newer version that's successfully installed, we're safe to mark all intermediates
-		for _, csv := range a.findIntermediatesForDeletion(out) {
-			// we only mark them in this step, in case some get deleted but others fail and break the replacement chain
-			csv.SetPhaseWithEvent(v1alpha1.CSVPhaseDeleting, v1alpha1.CSVReasonReplaced, "has been replaced by a newer ClusterServiceVersion that has successfully installed.", now, a.recorder)
-
-			// Ignore errors and success here; this step is just an optimization to speed up GC
-			_, _ = a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).UpdateStatus(csv)
-			err := a.csvQueueSet.Requeue(csv.GetName(), csv.GetNamespace())
-			if err != nil {
-				a.Log.Warn(err.Error())
-			}
-		}
-
-		// If there's no newer version, requeue for processing (likely will be GCable before resync)
-		err := a.csvQueueSet.Requeue(out.GetName(), out.GetNamespace())
-		if err != nil {
-			a.Log.Warn(err.Error())
+		} else {
+			syncError = fmt.Errorf("CSV marked as replacement, but no replacmenet CSV found in cluster.")
 		}
 	case v1alpha1.CSVPhaseDeleting:
-		var immediate int64 = 0
-
 		if err := a.csvQueueSet.Remove(out.GetName(), out.GetNamespace()); err != nil {
 			logger.WithError(err).Debug("error removing from queue")
 		}
-		syncError = a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Delete(out.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &immediate})
+		syncError = a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Delete(out.GetName(), metav1.NewDeleteOptions(0))
 		if syncError != nil {
 			logger.Debugf("unable to get delete csv marked for deletion: %s", syncError.Error())
 		}
 	}
 
 	return
-}
-
-// findIntermediatesForDeletion starts at csv and follows the replacement chain until one is running and active
-func (a *Operator) findIntermediatesForDeletion(csv *v1alpha1.ClusterServiceVersion) (csvs []*v1alpha1.ClusterServiceVersion) {
-	csvsInNamespace := a.csvSet(csv.GetNamespace(), v1alpha1.CSVPhaseAny)
-	current := csv
-
-	// isBeingReplaced returns a copy
-	next := a.isBeingReplaced(current, csvsInNamespace)
-	for next != nil {
-		csvs = append(csvs, current)
-		a.Log.Debugf("checking to see if %s is running so we can delete %s", next.GetName(), csv.GetName())
-		installer, nextStrategy, currentStrategy := a.parseStrategiesAndUpdateStatus(next)
-		if nextStrategy == nil {
-			a.Log.Debugf("couldn't get strategy for %s", next.GetName())
-			continue
-		}
-		if currentStrategy == nil {
-			a.Log.Debugf("couldn't get strategy for %s", next.GetName())
-			continue
-		}
-		installed, _ := installer.CheckInstalled(nextStrategy)
-		if installed && !next.IsObsolete() && next.Status.Phase == v1alpha1.CSVPhaseSucceeded {
-			return csvs
-		}
-		current = next
-		next = a.isBeingReplaced(current, csvsInNamespace)
-	}
-
-	return nil
 }
 
 // csvSet gathers all CSVs in the given namespace into a map keyed by CSV name; if metav1.NamespaceAll gets the set across all namespaces
@@ -1234,11 +1194,11 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 }
 
 // parseStrategiesAndUpdateStatus returns a StrategyInstaller and a Strategy for a CSV if it can, else it sets a status on the CSV and returns
-func (a *Operator) parseStrategiesAndUpdateStatus(csv *v1alpha1.ClusterServiceVersion) (install.StrategyInstaller, install.Strategy, install.Strategy) {
+func (a *Operator) parseStrategiesAndUpdateStatus(csv *v1alpha1.ClusterServiceVersion) (install.StrategyInstaller, install.Strategy) {
 	strategy, err := a.resolver.UnmarshalStrategy(csv.Spec.InstallStrategy)
 	if err != nil {
 		csv.SetPhaseWithEvent(v1alpha1.CSVPhaseFailed, v1alpha1.CSVReasonInvalidStrategy, fmt.Sprintf("install strategy invalid: %s", err), timeNow(), a.recorder)
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	previousCSV := a.isReplacing(csv)
@@ -1257,7 +1217,7 @@ func (a *Operator) parseStrategiesAndUpdateStatus(csv *v1alpha1.ClusterServiceVe
 
 	strName := strategy.GetStrategyName()
 	installer := a.resolver.InstallerForStrategy(strName, a.OpClient, a.lister, csv, csv.Annotations, previousStrategy)
-	return installer, strategy, previousStrategy
+	return installer, strategy
 }
 
 func (a *Operator) crdOwnerConflicts(in *v1alpha1.ClusterServiceVersion, csvsInNamespace map[string]*v1alpha1.ClusterServiceVersion) error {

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1099,9 +1099,6 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			syncError = fmt.Errorf("CSV marked as replacement, but no replacmenet CSV found in cluster.")
 		}
 	case v1alpha1.CSVPhaseDeleting:
-		if err := a.csvQueueSet.Remove(out.GetName(), out.GetNamespace()); err != nil {
-			logger.WithError(err).Debug("error removing from queue")
-		}
 		syncError = a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Delete(out.GetName(), metav1.NewDeleteOptions(0))
 		if syncError != nil {
 			logger.Debugf("unable to get delete csv marked for deletion: %s", syncError.Error())

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1113,7 +1113,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 	case v1alpha1.CSVPhaseDeleting:
 		var immediate int64 = 0
 
-		if err := a.csvQueueSet.Remove(out.GetNamespace(), out.GetName()); err != nil {
+		if err := a.csvQueueSet.Remove(out.GetName(), out.GetNamespace()); err != nil {
 			logger.WithError(err).Debug("error removing from queue")
 		}
 		syncError = a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Delete(out.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &immediate})

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -2466,8 +2466,8 @@ func TestTransitionCSV(t *testing.T) {
 			},
 			expected: expected{
 				csvStates: map[string]csvState{
-					"csv1": {exists: true, phase: v1alpha1.CSVPhaseDeleting},
-					"csv2": {exists: true, phase: v1alpha1.CSVPhaseDeleting},
+					"csv1": {exists: true, phase: v1alpha1.CSVPhaseReplacing},
+					"csv2": {exists: true, phase: v1alpha1.CSVPhaseReplacing},
 					"csv3": {exists: true, phase: v1alpha1.CSVPhaseSucceeded},
 				},
 			},
@@ -3549,8 +3549,9 @@ func TestSyncOperatorGroups(t *testing.T) {
 							APIVersion: rbacv1.GroupName,
 						},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "csv-role",
-							Namespace: targetNamespace,
+							ResourceVersion: "0",
+							Name:            "csv-role",
+							Namespace:       targetNamespace,
 							Labels: map[string]string{
 								"olm.copiedFrom":      "operator-ns",
 								"olm.owner":           "csv1",
@@ -3569,8 +3570,9 @@ func TestSyncOperatorGroups(t *testing.T) {
 							APIVersion: rbacv1.GroupName,
 						},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "csv-rolebinding",
-							Namespace: targetNamespace,
+							ResourceVersion: "0",
+							Name:            "csv-rolebinding",
+							Namespace:       targetNamespace,
 							Labels: map[string]string{
 								"olm.copiedFrom":      "operator-ns",
 								"olm.owner":           "csv1",
@@ -3649,8 +3651,9 @@ func TestSyncOperatorGroups(t *testing.T) {
 							APIVersion: rbacv1.GroupName,
 						},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "csv-role",
-							Namespace: targetNamespace,
+							ResourceVersion: "0",
+							Name:            "csv-role",
+							Namespace:       targetNamespace,
 							Labels: map[string]string{
 								"olm.copiedFrom":      "operator-ns",
 								"olm.owner":           "csv1",
@@ -3669,8 +3672,9 @@ func TestSyncOperatorGroups(t *testing.T) {
 							APIVersion: rbacv1.GroupName,
 						},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "csv-rolebinding",
-							Namespace: targetNamespace,
+							ResourceVersion: "0",
+							Name:            "csv-rolebinding",
+							Namespace:       targetNamespace,
 							Labels: map[string]string{
 								"olm.copiedFrom":      "operator-ns",
 								"olm.owner":           "csv1",

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -544,6 +544,10 @@ func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, o
 }
 
 func (a *Operator) copyToNamespace(csv *v1alpha1.ClusterServiceVersion, namespace string) error {
+	if csv.GetNamespace() == namespace {
+		return nil
+	}
+
 	logger := a.Log.WithField("operator-ns", csv.GetNamespace()).WithField("target-ns", namespace)
 	newCSV := csv.DeepCopy()
 	delete(newCSV.Annotations, v1.OperatorGroupTargetsAnnotationKey)

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -337,7 +337,7 @@ EXPECTED:
 	require.NoError(t, err)
 	require.NotNil(t, dependentSubscription)
 	require.NotNil(t, dependentSubscription.Status.InstallPlanRef)
-	require.Equal(t, v1alpha1.SubscriptionState("AtLatestKnown"), dependentSubscription.Status.State)
+	require.Equal(t, "AtLatestKnown", string(dependentSubscription.Status.State))
 	require.Equal(t, dependentCSV.GetName(), dependentSubscription.Status.CurrentCSV)
 
 	// TODO: update dependent subscription in catalog and wait for csv to update

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -369,24 +369,28 @@ func cleanupOLM(t *testing.T, namespace string) {
 	var err error
 	err = waitForEmptyList(func() (int, error) {
 		res, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(metav1.ListOptions{FieldSelector: nonPersistentCSVFieldSelector})
+		t.Logf("%d %s remaining", len(res.Items), "csvs")
 		return len(res.Items), err
 	})
 	require.NoError(t, err)
 
 	err = waitForEmptyList(func() (int, error) {
 		res, err := crc.OperatorsV1alpha1().InstallPlans(namespace).List(metav1.ListOptions{})
+		t.Logf("%d %s remaining", len(res.Items), "installplans")
 		return len(res.Items), err
 	})
 	require.NoError(t, err)
 
 	err = waitForEmptyList(func() (int, error) {
 		res, err := crc.OperatorsV1alpha1().Subscriptions(namespace).List(metav1.ListOptions{})
+		t.Logf("%d %s remaining", len(res.Items), "subs")
 		return len(res.Items), err
 	})
 	require.NoError(t, err)
 
 	err = waitForEmptyList(func() (int, error) {
 		res, err := crc.OperatorsV1alpha1().CatalogSources(namespace).List(metav1.ListOptions{FieldSelector: nonPersistentCatalogsFieldSelector})
+		t.Logf("%d %s remaining", len(res.Items), "catalogs")
 		return len(res.Items), err
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This only has one more commit on top of #816, but didn't want to mess up the tests on the other PR.

This includes what I believe to be a fix to the reports of subscriptions occasionally getting stuck. Prior to this change, I could run the `TestInstallPlanWithCSVsAcrossMultipleCatalogSources` 10 times and consistently get a failure with a stuck subscription. After this change, resolution always succeeds. (I ran the test 10 times, twice)

If #816 merged I will stage a PR with just the final commit against master and close this.