### PR TITLE
fix(catalog): fix issue where subscriptions sometimes get "stuck"

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1099,9 +1099,6 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			syncError = fmt.Errorf("CSV marked as replacement, but no replacmenet CSV found in cluster.")
 		}
 	case v1alpha1.CSVPhaseDeleting:
-		if err := a.csvQueueSet.Remove(out.GetName(), out.GetNamespace()); err != nil {
-			logger.WithError(err).Debug("error removing from queue")
-		}
 		syncError = a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Delete(out.GetName(), metav1.NewDeleteOptions(0))
 		if syncError != nil {
 			logger.Debugf("unable to get delete csv marked for deletion: %s", syncError.Error())

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -544,6 +544,10 @@ func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, o
 }
 
 func (a *Operator) copyToNamespace(csv *v1alpha1.ClusterServiceVersion, namespace string) error {
+	if csv.GetNamespace() == namespace {
+		return nil
+	}
+
 	logger := a.Log.WithField("operator-ns", csv.GetNamespace()).WithField("target-ns", namespace)
 	newCSV := csv.DeepCopy()
 	delete(newCSV.Annotations, v1.OperatorGroupTargetsAnnotationKey)

--- a/test/e2e/e2e-values.yaml
+++ b/test/e2e/e2e-values.yaml
@@ -1,4 +1,5 @@
 writeStatusName: '""'
+debug: true
 
 olm:
   replicaCount: 1
@@ -7,7 +8,6 @@ olm:
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
-  commandArgs: -debug
 
 catalog:
   replicaCount: 1
@@ -16,7 +16,6 @@ catalog:
     pullPolicy: IfNotPresent
   service:
     internalPort: 8080
-  commandArgs: -debug
 
 package:
   replicaCount: 1
@@ -25,7 +24,6 @@ package:
     pullPolicy: IfNotPresent
   service:
     internalPort: 5443
-  commandArgs: --debug
 
 e2e:
   image:


### PR DESCRIPTION
we were not resetting the client when updating a catalogsource, which
meant it was possible for the client to be stale and never attempt
a reconnect if it didn't go unhealthy "in time" for us to detect and
reconnect.

I ran `InstallPlanWithCSVsAcrossMultipleCatalogSources` 20 times in a row to verify it no longer flakes (previously it would error within ~5 tries)