### PR TITLE
fix(operatorgroup): No targetNamespaces matched namespace selector

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -719,6 +719,9 @@ func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logg
 				logger.WithError(err).Warn("error adding operatorgroup annotations")
 				return nil, err
 			}
+			if targetNamespaceList, err := a.getOperatorGroupTargets(operatorGroup); err == nil && len(targetNamespaceList) == 0 {
+				csv.SetPhaseWithEventIfChanged(v1alpha1.CSVPhaseFailed, v1alpha1.CSVReasonNoTargetNamespaces, "no targetNamespaces are matched operatorgroups namespace selection", now, a.recorder)
+			}
 			return nil, nil
 		}
 		logger.Info("csv in operatorgroup")

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -3345,6 +3345,23 @@ func TestSyncOperatorGroups(t *testing.T) {
 		},
 	}
 
+	// Failed CSV due to operatorgroup namespace selector doesn't any existing namespaces
+	operatorCSVFailedNoTargetNS := operatorCSV.DeepCopy()
+	operatorCSVFailedNoTargetNS.Status.Phase = v1alpha1.CSVPhaseFailed
+	operatorCSVFailedNoTargetNS.Status.Message = "no targetNamespaces are matched operatorgroups namespace selection"
+	operatorCSVFailedNoTargetNS.Status.Reason = v1alpha1.CSVReasonNoTargetNamespaces
+	operatorCSVFailedNoTargetNS.Status.LastUpdateTime = timeNow()
+	operatorCSVFailedNoTargetNS.Status.LastTransitionTime = timeNow()
+	operatorCSVFailedNoTargetNS.Status.Conditions = []v1alpha1.ClusterServiceVersionCondition{
+		{
+			Phase:              v1alpha1.CSVPhaseFailed,
+			Reason:             v1alpha1.CSVReasonNoTargetNamespaces,
+			Message:            "no targetNamespaces are matched operatorgroups namespace selection",
+			LastUpdateTime:     timeNow(),
+			LastTransitionTime: timeNow(),
+		},
+	}
+
 	targetCSV := operatorCSVFinal.DeepCopy()
 	targetCSV.SetNamespace(targetNamespace)
 	targetCSV.Status.Reason = v1alpha1.CSVReasonCopied
@@ -3458,6 +3475,47 @@ func TestSyncOperatorGroups(t *testing.T) {
 				},
 			},
 			expectedStatus: v1.OperatorGroupStatus{},
+		},
+		{
+			name:          "NoMatchingNamespace/CSVPresent",
+			expectedEqual: true,
+			initial: initial{
+				operatorGroup: &v1.OperatorGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "operator-group-1",
+						Namespace: operatorNamespace,
+					},
+					Spec: v1.OperatorGroupSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"a": "app-a"},
+						},
+					},
+				},
+				clientObjs: []runtime.Object{operatorCSV},
+				k8sObjs: []runtime.Object{
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: operatorNamespace,
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: targetNamespace,
+						},
+					},
+					ownedDeployment,
+					serviceAccount,
+					role,
+					roleBinding,
+				},
+				crds: []runtime.Object{crd},
+			},
+			expectedStatus: v1.OperatorGroupStatus{},
+			final: final{objects: map[string][]runtime.Object{
+				operatorNamespace: {
+					withAnnotations(operatorCSVFailedNoTargetNS.DeepCopy(), map[string]string{v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
+				},
+			}},
 		},
 		{
 			name:          "MatchingNamespace/NoCSVs",

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -715,6 +715,8 @@ func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]str
 		matchedNamespaces, err := a.lister.CoreV1().NamespaceLister().List(selector)
 		if err != nil {
 			return nil, err
+		} else if len(matchedNamespaces) == 0 {
+			a.Log.Debugf("No matched TargetNamespaces are found for given selector: %#v\n", selector)
 		}
 
 		for _, ns := range matchedNamespaces {


### PR DESCRIPTION
If no namespaces are matched selector in operatorgroup, CSV should have a failure
status to indicate OperatorGroup NoTargetNamspaces. Also, a warning message for
no-matched namespaces is added for visibility.

Signed-off-by: Vu Dinh <vdinh@redhat.com>