### PR TITLE
fix(run_console_loca): Fix command and improve output message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,3 +195,12 @@ endif
 ifeq ($(quickstart), true)
 	./scripts/package_quickstart.sh deploy/$(target)/manifests/$(ver) deploy/$(target)/quickstart/olm.yaml
 endif
+
+##########################
+#  OLM - Commands        #
+##########################
+
+.PHONY: run-console-local
+run-console-local:
+	@echo Running script to run the OLM console locally:
+	. ./scripts/run_console_local.sh

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Use the OpenShift admin console (compatible with upstream Kubernetes) to interac
 Ensure `kubectl` is pointing at a cluster and run:
 
 ```shell
-$ ./scripts/run_console_local.sh
+$ make run-console-local
 ```
 
 Then visit `http://localhost:9000` to view the console.

--- a/scripts/run_console_local.sh
+++ b/scripts/run_console_local.sh
@@ -1,21 +1,51 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-secretname=$(kubectl get serviceaccount default --namespace=kube-system -o jsonpath='{.secrets[0].name}')
-endpoint=$(kubectl config view -o json | jq '{myctx: .["current-context"], ctxs: .contexts[], clusters: .clusters[]}' | jq 'select(.myctx == .ctxs.name)' | jq 'select(.ctxs.context.cluster ==  .clusters.name)' | jq '.clusters.cluster.server' -r)
+# Colors definition
+readonly RED=$(tput setaf 1)
+readonly RESET=$(tput sgr0)
+readonly BLUE=$(tput setaf 2)
 
-args="--net=host"
-if [[ $OSTYPE == darwin* ]] || [[ "$(< /proc/version)" == *@(Microsoft|WSL)* ]]; then
-  args="-p 9000:9000"
-fi
+# Add port as 9000:9000 as arg when the SO is MacOS or Win
+add_host_port_arg (){
+    args="--net=host"
+    if [[ "$OSTYPE" == "darwin"* ]] || [[ "$(< /proc/version)" == *"@(Microsoft|WSL)"* ]]; then
+      args="-p 9000:9000"
+    fi
+}
 
-docker pull quay.io/openshift/origin-console:latest
+pull_ocp_console_image (){
+   docker pull quay.io/openshift/origin-console:latest
+}
 
-echo "Using $endpoint"
-docker run -it $args \
-  -e BRIDGE_USER_AUTH="disabled" \
-  -e BRIDGE_K8S_MODE="off-cluster" \
-  -e BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$endpoint \
-  -e BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true \
-  -e BRIDGE_K8S_AUTH="bearer-token" \
-  -e BRIDGE_K8S_AUTH_BEARER_TOKEN=$(kubectl get secret "$secretname" --namespace=kube-system -o template --template='{{.data.token}}' | base64 --decode) \
-  quay.io/openshift/origin-console:latest
+run_docker_console (){
+    secretname=$(kubectl get serviceaccount default --namespace=kube-system -o jsonpath='{.secrets[0].name}')
+    endpoint=$(kubectl config view -o json | jq '{myctx: .["current-context"], ctxs: .contexts[], clusters: .clusters[]}' | jq 'select(.myctx == .ctxs.name)' | jq 'select(.ctxs.context.cluster ==  .clusters.name)' | jq '.clusters.cluster.server' -r)
+
+    echo -e "Using $endpoint"
+    command -v docker run -it $args \
+      -e BRIDGE_USER_AUTH="disabled" \
+      -e BRIDGE_K8S_MODE="off-cluster" \
+      -e BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$endpoint \
+      -e BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true \
+      -e BRIDGE_K8S_AUTH="bearer-token" \
+      -e BRIDGE_K8S_AUTH_BEARER_TOKEN=$(kubectl get secret "$secretname" --namespace=kube-system -o template --template='{{.data.token}}' | base64 --decode) \
+      quay.io/openshift/origin-console:latest &> /dev/null
+
+    docker_exists=${?}; if [[ ${docker_exists} -ne 0 ]]; then
+        echo -e "${BLUE}The OLM is accessible via web console at:${RESET}"
+        echo -e "${BLUE}https://localhost:9000/${RESET}"
+    else
+        echo -e "${RED}Unable to run the console locally. May this port is in usage already. ${RESET}"
+        echo -e "${RED}Check if the OLM is not accessible via web console at: https://localhost:9000/. ${RESET}"
+        exit 1
+    fi
+
+}
+
+
+# Calling the functions
+add_host_port_arg
+pull_ocp_console_image
+run_docker_console
+
+


### PR DESCRIPTION
## Motivation
https://github.com/operator-framework/operator-lifecycle-manager/issues/785

## What
- Fix the script
- Improve output to make clear for the users the URL to check OLM console locally
- Add make command
- Update the readme in order to recommend the usage of the README

## Additional
Following how it will appear when an error is faced.
(The most common scenario is when the OLM is already running)

<img width="1010" alt="Screenshot 2019-05-13 at 09 27 05" src="https://user-images.githubusercontent.com/7708031/57607403-e45c2680-7562-11e9-89b5-0145480975fa.png">

