### PR TITLE
fix(unit): Remove leftover println causing excessive log in unit test

### DIFF
--- a/pkg/controller/registry/resolver/util_test.go
+++ b/pkg/controller/registry/resolver/util_test.go
@@ -211,7 +211,6 @@ func crd(key opregistry.APIKey) *v1beta1.CustomResourceDefinition {
 }
 
 func u(object runtime.Object) *unstructured.Unstructured {
-	fmt.Println(object)
 	unst, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Leftover debugging printlf statement in util_test causes excessive
logging in many unit tests.

Signed-off-by: Vu Dinh <vdinh@redhat.com>