### PR TITLE
(refactor) Move csv set and replace to a package

### DIFF
--- a/pkg/lib/csv/csvset.go
+++ b/pkg/lib/csv/csvset.go
@@ -1,0 +1,55 @@
+package csv
+
+import (
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// NewSetGenerator returns a new instance of SetGenerator.
+func NewSetGenerator(logger *logrus.Logger, lister operatorlister.OperatorLister) SetGenerator {
+	return &csvSet{
+		logger: logger,
+		lister: lister,
+	}
+}
+
+// SetGenerator is an interface that returns a map of ClusterServiceVersion
+// objects that match a certain set of criteria.
+//
+// SetGenerator gathers all CSV(s) in the given namespace into a map keyed by
+// CSV name; if metav1.NamespaceAll gets the set across all namespaces
+type SetGenerator interface {
+	WithNamespace(namespace string, phase v1alpha1.ClusterServiceVersionPhase) map[string]*v1alpha1.ClusterServiceVersion
+}
+
+type csvSet struct {
+	lister operatorlister.OperatorLister
+	logger *logrus.Logger
+}
+
+// WithNamespace returns all ClusterServiceVersion resource(s) that matches the
+// specified phase from a given namespace.
+func (s *csvSet) WithNamespace(namespace string, phase v1alpha1.ClusterServiceVersionPhase) map[string]*v1alpha1.ClusterServiceVersion {
+	return s.with(namespace, phase, labels.Everything())
+}
+
+func (s *csvSet) with(namespace string, phase v1alpha1.ClusterServiceVersionPhase, selector labels.Selector) map[string]*v1alpha1.ClusterServiceVersion {
+	csvsInNamespace, err := s.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(namespace).List(selector)
+
+	if err != nil {
+		s.logger.Warnf("could not list CSVs while constructing CSV set")
+		return nil
+	}
+
+	csvs := make(map[string]*v1alpha1.ClusterServiceVersion, len(csvsInNamespace))
+	for _, csv := range csvsInNamespace {
+		if phase != v1alpha1.CSVPhaseAny && csv.Status.Phase != phase {
+			continue
+		}
+		csvs[csv.Name] = csv.DeepCopy()
+	}
+
+	return csvs
+}

--- a/pkg/lib/csv/replace_finder.go
+++ b/pkg/lib/csv/replace_finder.go
@@ -1,0 +1,70 @@
+package csv
+
+import (
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewReplaceFinder returns an instance of ReplaceFinder
+func NewReplaceFinder(logger *logrus.Logger, client versioned.Interface) ReplaceFinder {
+	return &replace{
+		logger: logger,
+		client: client,
+	}
+}
+
+// ReplaceFinder is an interface that finds the next or previous
+// ClusterServiceVersion object in the upgrade path for a given CSV.
+type ReplaceFinder interface {
+	IsBeingReplaced(in *v1alpha1.ClusterServiceVersion, csvsInNamespace map[string]*v1alpha1.ClusterServiceVersion) (replacedBy *v1alpha1.ClusterServiceVersion)
+	IsReplacing(in *v1alpha1.ClusterServiceVersion) *v1alpha1.ClusterServiceVersion
+}
+
+type replace struct {
+	logger *logrus.Logger
+	client versioned.Interface
+}
+
+// IsBeingReplaced returns the corresponding ClusterServiceVersion object that
+// is replacing the given CSV specified.
+//
+// If the corresponding ClusterServiceVersion is not found nil is returned.
+func (r *replace) IsBeingReplaced(in *v1alpha1.ClusterServiceVersion, csvsInNamespace map[string]*v1alpha1.ClusterServiceVersion) (replacedBy *v1alpha1.ClusterServiceVersion) {
+	for _, csv := range csvsInNamespace {
+		if csv.IsCopied() {
+			continue
+		}
+
+		r.logger.Infof("checking %s", csv.GetName())
+
+		if csv.Spec.Replaces == in.GetName() {
+			r.logger.Infof("%s replaced by %s", in.GetName(), csv.GetName())
+			replacedBy = csv
+			return
+		}
+	}
+
+	return
+}
+
+// IsReplacing returns the corresponding ClusterServiceVersion object that the
+// given CSV specified replaces.
+//
+// If the corresponding ClusterServiceVersion is not found nil is returned.
+func (r *replace) IsReplacing(in *v1alpha1.ClusterServiceVersion) *v1alpha1.ClusterServiceVersion {
+	r.logger.Debugf("checking if csv is replacing an older version")
+	if in.Spec.Replaces == "" {
+		return nil
+	}
+
+	// using the client instead of a lister; missing an object because of a cache sync can cause upgrades to fail
+	previous, err := r.client.OperatorsV1alpha1().ClusterServiceVersions(in.GetNamespace()).Get(in.Spec.Replaces, metav1.GetOptions{})
+	if err != nil {
+		r.logger.WithField("replacing", in.Spec.Replaces).WithError(err).Debugf("unable to get previous csv")
+		return nil
+	}
+
+	return previous
+}


### PR DESCRIPTION
Promote csv set and replace logic within olm operator to a reusable
package in lib so that it can be reused by other units.

Note:
- No behavior of the operator has changed as part of this refactor.