### PR TITLE
Change Global Catalog Namespace for OpenShift

### DIFF
--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -1,7 +1,7 @@
 installType: ocp
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: openshift-operator-lifecycle-manager
-catalog_namespace: openshift-operator-lifecycle-manager
+catalog_namespace: openshift-marketplace
 operator_namespace: openshift-operators
 imagestream: true
 writeStatusName: operator-lifecycle-manager

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -25,7 +25,7 @@ spec:
           - /bin/catalog
           args:
           - '-namespace'
-          - openshift-operator-lifecycle-manager
+          - openshift-marketplace
           - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
           - -writeStatusName
           - operator-lifecycle-manager-catalog

--- a/manifests/0000_50_olm_16-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_16-packageserver.clusterserviceversion.yaml
@@ -102,7 +102,7 @@ spec:
                 - --secure-port
                 - "5443"
                 - --global-namespace
-                - openshift-operator-lifecycle-manager
+                - openshift-marketplace
                 image: quay.io/operator-framework/olm@sha256:93751ae9d398d571c2cb3d11b0ac4ae052117fd1726025364a6f2f3a5caef68e
                 imagePullPolicy: IfNotPresent
                 ports:


### PR DESCRIPTION
### Description

Changes the `-namespace` and `-global-namespace` flags for `catalog-operator` and `packageserver` respectively. This allows creating `Subscriptions` directly to `CatalogSources` in the `openshift-marketplace` namespace without the indirection of creating a `CatalogSourceConfig`.

Addresses https://jira.coreos.com/browse/OLM-1080
Unblocks https://jira.coreos.com/browse/MKTPLC-367