### PR TITLE
Add support for user defined ServiceAccount for OperatorGroup.

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -162,6 +162,7 @@ func main() {
 		olm.WithResyncPeriod(*wakeupInterval),
 		olm.WithExternalClient(crClient),
 		olm.WithOperatorClient(opClient),
+		olm.WithRestConfig(config),
 	)
 	if err != nil {
 		log.Fatalf("error configuring operator: %s", err.Error())

--- a/pkg/api/apis/operators/operatorgroup_types.go
+++ b/pkg/api/apis/operators/operatorgroup_types.go
@@ -29,8 +29,9 @@ type OperatorGroupSpec struct {
 	// +optional
 	TargetNamespaces []string
 
-	// ServiceAccount to bind OperatorGroup roles to.
-	ServiceAccount corev1.ServiceAccount
+	// ServiceAccountName is the admin specified service account which will be
+	// used to deploy operator(s) in this operator group.
+	ServiceAccountName string
 
 	// Static tells OLM not to update the OperatorGroup's providedAPIs annotation
 	// +optional
@@ -41,6 +42,9 @@ type OperatorGroupSpec struct {
 type OperatorGroupStatus struct {
 	// Namespaces is the set of target namespaces for the OperatorGroup.
 	Namespaces []string
+
+	// ServiceAccountRef references the service account object specified.
+	ServiceAccountRef *corev1.ObjectReference
 
 	// LastUpdated is a timestamp of the last time the OperatorGroup's status was Updated.
 	LastUpdated metav1.Time

--- a/pkg/api/apis/operators/v1/operatorgroup_types.go
+++ b/pkg/api/apis/operators/v1/operatorgroup_types.go
@@ -28,8 +28,9 @@ type OperatorGroupSpec struct {
 	// +optional
 	TargetNamespaces []string `json:"targetNamespaces,omitempty"`
 
-	// ServiceAccount to bind OperatorGroup roles to.
-	ServiceAccount corev1.ServiceAccount `json:"serviceAccount,omitempty"`
+	// ServiceAccountName is the admin specified service account which will be
+	// used to deploy operator(s) in this operator group.
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Static tells OLM not to update the OperatorGroup's providedAPIs annotation
 	// +optional
@@ -40,6 +41,9 @@ type OperatorGroupSpec struct {
 type OperatorGroupStatus struct {
 	// Namespaces is the set of target namespaces for the OperatorGroup.
 	Namespaces []string `json:"namespaces,omitempty"`
+
+	// ServiceAccountRef references the service account object specified.
+	ServiceAccountRef *corev1.ObjectReference `json:"serviceAccountRef,omitempty"`
 
 	// LastUpdated is a timestamp of the last time the OperatorGroup's status was Updated.
 	LastUpdated metav1.Time `json:"lastUpdated"`

--- a/pkg/api/apis/operators/v1/operatorgroup_types.go
+++ b/pkg/api/apis/operators/v1/operatorgroup_types.go
@@ -76,3 +76,21 @@ func (o *OperatorGroup) BuildTargetNamespaces() string {
 	sort.Strings(o.Status.Namespaces)
 	return strings.Join(o.Status.Namespaces, ",")
 }
+
+// IsServiceAccountSpecified returns true if the spec has a service account name specified.
+func (o *OperatorGroup) IsServiceAccountSpecified() bool {
+	if o.Spec.ServiceAccountName == "" {
+		return false
+	}
+
+	return true
+}
+
+// HasServiceAccountSynced returns true if the service account specified has been synced.
+func (o *OperatorGroup) HasServiceAccountSynced() bool {
+	if o.IsServiceAccountSpecified() && o.Status.ServiceAccountRef != nil {
+		return true
+	}
+
+	return false
+}

--- a/pkg/api/apis/operators/v1/zz_generated.conversion.go
+++ b/pkg/api/apis/operators/v1/zz_generated.conversion.go
@@ -24,6 +24,7 @@ import (
 	unsafe "unsafe"
 
 	operators "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -136,7 +137,7 @@ func Convert_operators_OperatorGroupList_To_v1_OperatorGroupList(in *operators.O
 func autoConvert_v1_OperatorGroupSpec_To_operators_OperatorGroupSpec(in *OperatorGroupSpec, out *operators.OperatorGroupSpec, s conversion.Scope) error {
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.TargetNamespaces = *(*[]string)(unsafe.Pointer(&in.TargetNamespaces))
-	out.ServiceAccount = in.ServiceAccount
+	out.ServiceAccountName = in.ServiceAccountName
 	out.StaticProvidedAPIs = in.StaticProvidedAPIs
 	return nil
 }
@@ -149,7 +150,7 @@ func Convert_v1_OperatorGroupSpec_To_operators_OperatorGroupSpec(in *OperatorGro
 func autoConvert_operators_OperatorGroupSpec_To_v1_OperatorGroupSpec(in *operators.OperatorGroupSpec, out *OperatorGroupSpec, s conversion.Scope) error {
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.TargetNamespaces = *(*[]string)(unsafe.Pointer(&in.TargetNamespaces))
-	out.ServiceAccount = in.ServiceAccount
+	out.ServiceAccountName = in.ServiceAccountName
 	out.StaticProvidedAPIs = in.StaticProvidedAPIs
 	return nil
 }
@@ -161,6 +162,7 @@ func Convert_operators_OperatorGroupSpec_To_v1_OperatorGroupSpec(in *operators.O
 
 func autoConvert_v1_OperatorGroupStatus_To_operators_OperatorGroupStatus(in *OperatorGroupStatus, out *operators.OperatorGroupStatus, s conversion.Scope) error {
 	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	out.ServiceAccountRef = (*corev1.ObjectReference)(unsafe.Pointer(in.ServiceAccountRef))
 	out.LastUpdated = in.LastUpdated
 	return nil
 }
@@ -172,6 +174,7 @@ func Convert_v1_OperatorGroupStatus_To_operators_OperatorGroupStatus(in *Operato
 
 func autoConvert_operators_OperatorGroupStatus_To_v1_OperatorGroupStatus(in *operators.OperatorGroupStatus, out *OperatorGroupStatus, s conversion.Scope) error {
 	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	out.ServiceAccountRef = (*corev1.ObjectReference)(unsafe.Pointer(in.ServiceAccountRef))
 	out.LastUpdated = in.LastUpdated
 	return nil
 }

--- a/pkg/api/apis/operators/v1/zz_generated.deepcopy.go
+++ b/pkg/api/apis/operators/v1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -99,7 +100,6 @@ func (in *OperatorGroupSpec) DeepCopyInto(out *OperatorGroupSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	in.ServiceAccount.DeepCopyInto(&out.ServiceAccount)
 	return
 }
 
@@ -120,6 +120,11 @@ func (in *OperatorGroupStatus) DeepCopyInto(out *OperatorGroupStatus) {
 		in, out := &in.Namespaces, &out.Namespaces
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ServiceAccountRef != nil {
+		in, out := &in.ServiceAccountRef, &out.ServiceAccountRef
+		*out = new(corev1.ObjectReference)
+		**out = **in
 	}
 	in.LastUpdated.DeepCopyInto(&out.LastUpdated)
 	return

--- a/pkg/api/apis/operators/zz_generated.deepcopy.go
+++ b/pkg/api/apis/operators/zz_generated.deepcopy.go
@@ -879,7 +879,6 @@ func (in *OperatorGroupSpec) DeepCopyInto(out *OperatorGroupSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	in.ServiceAccount.DeepCopyInto(&out.ServiceAccount)
 	return
 }
 
@@ -900,6 +899,11 @@ func (in *OperatorGroupStatus) DeepCopyInto(out *OperatorGroupStatus) {
 		in, out := &in.Namespaces, &out.Namespaces
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ServiceAccountRef != nil {
+		in, out := &in.ServiceAccountRef, &out.ServiceAccountRef
+		*out = new(corev1.ObjectReference)
+		**out = **in
 	}
 	in.LastUpdated.DeepCopyInto(&out.LastUpdated)
 	return

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -23,11 +23,11 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/reference"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions"
 	olmerrors "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors"
@@ -39,6 +39,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
 )
 
@@ -75,6 +76,8 @@ type Operator struct {
 	resolver               resolver.Resolver
 	reconciler             reconciler.RegistryReconcilerFactory
 	csvProvidedAPIsIndexer map[string]cache.Indexer
+	clientAttenuator       *scoped.ClientAttenuator
+	serviceAccountQuerier  *scoped.UserDefinedServiceAccountQuerier
 }
 
 // NewOperator creates a new Catalog Operator.
@@ -84,8 +87,13 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		watchedNamespaces = []string{metav1.NamespaceAll}
 	}
 
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create a new client for OLM types (CRs)
-	crClient, err := client.NewClient(kubeconfigPath)
+	crClient, err := versioned.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
@@ -114,6 +122,8 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		catsrcQueueSet:         queueinformer.NewEmptyResourceQueueSet(),
 		subQueueSet:            queueinformer.NewEmptyResourceQueueSet(),
 		csvProvidedAPIsIndexer: map[string]cache.Indexer{},
+		serviceAccountQuerier:  scoped.NewUserDefinedServiceAccountQuerier(logger, crClient),
+		clientAttenuator:       scoped.NewClientAttenuator(logger, config, opClient, crClient),
 	}
 	op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, opClient, configmapRegistryImage, op.now)
 
@@ -1037,6 +1047,18 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 		return err
 	}
 
+	// Does the namespace have an operator group that specifies a user defined
+	// service account? If so, then we should use a scoped client for plan
+	// execution.
+	getter := o.serviceAccountQuerier.NamespaceQuerier(namespace)
+	kubeclient, crclient, err := o.clientAttenuator.AttenuateClient(getter)
+	if err != nil {
+		o.logger.Errorf("failed to get a client for plan execution- %v", err)
+		return err
+	}
+
+	ensurer := newStepEnsurer(kubeclient, crclient)
+
 	for i, step := range plan.Status.Plan {
 		switch step.Status {
 		case v1alpha1.StepStatusPresent, v1alpha1.StepStatusCreated:
@@ -1112,16 +1134,14 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 
 				// Attempt to create the CSV.
 				csv.SetNamespace(namespace)
-				_, err = o.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Create(&csv)
-				if k8serrors.IsAlreadyExists(err) {
-					// If it already existed, mark the step as Present.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error creating csv %s", csv.GetName())
-				} else {
-					// If no error occurred, mark the step as Created.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
+
+				status, err := ensurer.EnsureClusterServiceVersion(&csv)
+				if err != nil {
+					return err
 				}
+
+				plan.Status.Plan[i].Status = status
+
 			case v1alpha1.SubscriptionKind:
 				// Marshal the manifest into a subscription instance.
 				var sub v1alpha1.Subscription
@@ -1139,46 +1159,21 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 
 				// Attempt to create the Subscription
 				sub.SetNamespace(namespace)
-				_, err = o.client.OperatorsV1alpha1().Subscriptions(sub.GetNamespace()).Create(&sub)
-				if k8serrors.IsAlreadyExists(err) {
-					// If it already existed, mark the step as Present.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error creating subscription %s", sub.GetName())
-				} else {
-					// If no error occurred, mark the step as Created.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
-				}
-			case secretKind:
-				// TODO: this will confuse bundle users that include secrets in their bundles - this only handles pull secrets
-				// Get the pre-existing secret.
-				secret, err := o.opClient.KubernetesInterface().CoreV1().Secrets(o.namespace).Get(step.Resource.Name, metav1.GetOptions{})
-				if k8serrors.IsNotFound(err) {
-					return fmt.Errorf("secret %s does not exist", step.Resource.Name)
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error getting pull secret from olm namespace %s", secret.GetName())
+
+				status, err := ensurer.EnsureSubscription(&sub)
+				if err != nil {
+					return err
 				}
 
-				// Set the namespace to the InstallPlan's namespace and attempt to
-				// create a new secret.
-				secret.SetNamespace(namespace)
-				_, err = o.opClient.KubernetesInterface().CoreV1().Secrets(plan.Namespace).Create(&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      secret.Name,
-						Namespace: plan.Namespace,
-					},
-					Data: secret.Data,
-					Type: secret.Type,
-				})
-				if k8serrors.IsAlreadyExists(err) {
-					// If it already existed, mark the step as Present.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
+				plan.Status.Plan[i].Status = status
+
+			case secretKind:
+				status, err := ensurer.EnsureSecret(o.namespace, plan.GetNamespace(), step.Resource.Name)
+				if err != nil {
 					return err
-				} else {
-					// If no error occured, mark the step as Created.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
 				}
+
+				plan.Status.Plan[i].Status = status
 
 			case clusterRoleKind:
 				// Marshal the manifest into a ClusterRole instance.
@@ -1188,23 +1183,13 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
 
-				// Attempt to create the ClusterRole.
-				_, err = o.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(&cr)
-				if k8serrors.IsAlreadyExists(err) {
-					// if we're updating, point owner to the newest csv
-					cr.Labels[ownerutil.OwnerKey] = step.Resolving
-					_, err = o.opClient.UpdateClusterRole(&cr)
-					if err != nil {
-						return errorwrap.Wrapf(err, "error updating clusterrole %s", cr.GetName())
-					}
-					// If it already existed, mark the step as Present.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error creating clusterrole %s", cr.GetName())
-				} else {
-					// If no error occurred, mark the step as Created.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
+				status, err := ensurer.EnsureClusterRole(&cr, step)
+				if err != nil {
+					return err
 				}
+
+				plan.Status.Plan[i].Status = status
+
 			case clusterRoleBindingKind:
 				// Marshal the manifest into a RoleBinding instance.
 				var rb rbacv1.ClusterRoleBinding
@@ -1213,24 +1198,12 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
 
-				// Attempt to create the ClusterRoleBinding.
-				_, err = o.opClient.KubernetesInterface().RbacV1().ClusterRoleBindings().Create(&rb)
-				if k8serrors.IsAlreadyExists(err) {
-					// if we're updating, point owner to the newest csv
-					rb.Labels[ownerutil.OwnerKey] = step.Resolving
-					_, err = o.opClient.UpdateClusterRoleBinding(&rb)
-					if err != nil {
-						return errorwrap.Wrapf(err, "error updating clusterrolebinding %s", rb.GetName())
-					}
-
-					// If it already existed, mark the step as Present.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error creating clusterrolebinding %s", rb.GetName())
-				} else {
-					// If no error occurred, mark the step as Created.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
+				status, err := ensurer.EnsureClusterRoleBinding(&rb, step)
+				if err != nil {
+					return err
 				}
+
+				plan.Status.Plan[i].Status = status
 
 			case roleKind:
 				// Marshal the manifest into a Role instance.
@@ -1248,23 +1221,12 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 				r.SetOwnerReferences(updated)
 				r.SetNamespace(namespace)
 
-				// Attempt to create the Role.
-				_, err = o.opClient.KubernetesInterface().RbacV1().Roles(plan.Namespace).Create(&r)
-				if k8serrors.IsAlreadyExists(err) {
-					// If it already existed, mark the step as Present.
-					r.SetNamespace(plan.Namespace)
-					_, err = o.opClient.UpdateRole(&r)
-					if err != nil {
-						return errorwrap.Wrapf(err, "error updating role %s", r.GetName())
-					}
-
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error creating role %s", r.GetName())
-				} else {
-					// If no error occurred, mark the step as Created.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
+				status, err := ensurer.EnsureRole(plan.Namespace, &r)
+				if err != nil {
+					return err
 				}
+
+				plan.Status.Plan[i].Status = status
 
 			case roleBindingKind:
 				// Marshal the manifest into a RoleBinding instance.
@@ -1282,23 +1244,12 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 				rb.SetOwnerReferences(updated)
 				rb.SetNamespace(namespace)
 
-				// Attempt to create the RoleBinding.
-				_, err = o.opClient.KubernetesInterface().RbacV1().RoleBindings(plan.Namespace).Create(&rb)
-				if k8serrors.IsAlreadyExists(err) {
-					rb.SetNamespace(plan.Namespace)
-					_, err = o.opClient.UpdateRoleBinding(&rb)
-					if err != nil {
-						return errorwrap.Wrapf(err, "error updating rolebinding %s", rb.GetName())
-					}
-
-					// If it already existed, mark the step as Present.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error creating rolebinding %s", rb.GetName())
-				} else {
-					// If no error occurred, mark the step as Created.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
+				status, err := ensurer.EnsureRoleBinding(plan.Namespace, &rb)
+				if err != nil {
+					return err
 				}
+
+				plan.Status.Plan[i].Status = status
 
 			case serviceAccountKind:
 				// Marshal the manifest into a ServiceAccount instance.
@@ -1316,24 +1267,12 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 				sa.SetOwnerReferences(updated)
 				sa.SetNamespace(namespace)
 
-				// Attempt to create the ServiceAccount.
-				_, err = o.opClient.KubernetesInterface().CoreV1().ServiceAccounts(plan.Namespace).Create(&sa)
-				if k8serrors.IsAlreadyExists(err) {
-					// If it already exists we need to patch the existing SA with the new OwnerReferences
-					sa.SetNamespace(plan.Namespace)
-					_, err = o.opClient.UpdateServiceAccount(&sa)
-					if err != nil {
-						return errorwrap.Wrapf(err, "error updating service account: %s", sa.GetName())
-					}
-
-					// Mark as present
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error creating service account: %s", sa.GetName())
-				} else {
-					// If no error occurred, mark the step as Created.
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
+				status, err := ensurer.EnsureServiceAccount(namespace, &sa)
+				if err != nil {
+					return err
 				}
+
+				plan.Status.Plan[i].Status = status
 
 			case serviceKind:
 				// Marshal the manifest into a Service instance
@@ -1351,24 +1290,12 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 				s.SetOwnerReferences(updated)
 				s.SetNamespace(namespace)
 
-				// Attempt to create the Service
-				_, err = o.opClient.KubernetesInterface().CoreV1().Services(plan.Namespace).Create(&s)
-				if k8serrors.IsAlreadyExists(err) {
-					// If it already exists we need to patch the existing SA with the new OwnerReferences
-					s.SetNamespace(plan.Namespace)
-					_, err = o.opClient.UpdateService(&s)
-					if err != nil {
-						return errorwrap.Wrapf(err, "error updating service: %s", s.GetName())
-					}
-
-					// Mark as present
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusPresent
-				} else if err != nil {
-					return errorwrap.Wrapf(err, "error creating service: %s", s.GetName())
-				} else {
-					// If no error occurred, mark the step as Created
-					plan.Status.Plan[i].Status = v1alpha1.StepStatusCreated
+				status, err := ensurer.EnsureService(namespace, &s)
+				if err != nil {
+					return err
 				}
+
+				plan.Status.Plan[i].Status = status
 
 			default:
 				return v1alpha1.ErrInvalidInstallPlan

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped"
 )
 
 type mockTransitioner struct {
@@ -663,6 +665,8 @@ func NewFakeOperator(ctx context.Context, namespace string, watchedNamespaces []
 
 	}
 
+	logger := logrus.New()
+
 	// Create the new operator
 	queueOperator, err := queueinformer.NewOperator(opClientFake.KubernetesInterface().Discovery())
 	for _, informer := range sharedInformers {
@@ -685,6 +689,8 @@ func NewFakeOperator(ctx context.Context, namespace string, watchedNamespaces []
 			), "resolver"),
 		sources:  make(map[resolver.CatalogKey]resolver.SourceRef),
 		resolver: &fakes.FakeResolver{},
+		clientAttenuator: scoped.NewClientAttenuator(logger, &rest.Config{}, opClientFake, clientFake),
+		serviceAccountQuerier:  scoped.NewUserDefinedServiceAccountQuerier(logger, clientFake),
 	}
 	op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, op.opClient, "test:pod", op.now)
 

--- a/pkg/controller/operators/catalog/step_ensurer.go
+++ b/pkg/controller/operators/catalog/step_ensurer.go
@@ -1,0 +1,245 @@
+package catalog
+
+import (
+	"fmt"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
+	errorwrap "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newStepEnsurer(kubeClient operatorclient.ClientInterface, crClient versioned.Interface) *StepEnsurer {
+	return &StepEnsurer{
+		kubeClient: kubeClient,
+		crClient:   crClient,
+	}
+}
+
+// StepEnsurer ensures that resource(s) specified in install plan exist in cluster.
+type StepEnsurer struct {
+	kubeClient operatorclient.ClientInterface
+	crClient   versioned.Interface
+}
+
+// EnsureClusterServiceVersion writes the specified ClusterServiceVersion
+// object to the cluster.
+func (o *StepEnsurer) EnsureClusterServiceVersion(csv *v1alpha1.ClusterServiceVersion) (status v1alpha1.StepStatus, err error) {
+	_, createErr := o.crClient.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Create(csv)
+	if createErr == nil {
+		status = v1alpha1.StepStatusCreated
+		return
+	}
+
+	if !k8serrors.IsAlreadyExists(createErr) {
+		err = errorwrap.Wrapf(createErr, "error creating csv %s", csv.GetName())
+		return
+	}
+
+	status = v1alpha1.StepStatusPresent
+	return
+}
+
+// EnsureSubscription writes the specified Subscription object to the cluster.
+func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (status v1alpha1.StepStatus, err error) {
+	_, createErr := o.crClient.OperatorsV1alpha1().Subscriptions(subscription.GetNamespace()).Create(subscription)
+	if createErr == nil {
+		status = v1alpha1.StepStatusCreated
+		return
+	}
+
+	if !k8serrors.IsAlreadyExists(createErr) {
+		err = errorwrap.Wrapf(createErr, "error creating subscription %s", subscription.GetName())
+		return
+	}
+
+	status = v1alpha1.StepStatusPresent
+	return
+}
+
+// EnsureSecret copies the secret from the OLM namespace and writes a new one
+// to the namespace requested.
+func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string) (status v1alpha1.StepStatus, err error) {
+	secret, getError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(operatorNamespace).Get(name, metav1.GetOptions{})
+	if getError != nil {
+		if k8serrors.IsNotFound(getError) {
+			err = fmt.Errorf("secret %s does not exist - %v", name, getError)
+			return
+		}
+
+		err = errorwrap.Wrapf(getError, "error getting pull secret from olm namespace %s", secret.GetName())
+		return
+	}
+
+	// Set the namespace to the InstallPlan's namespace and attempt to
+	// create a new secret.
+	secret.SetNamespace(planNamespace)
+
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret.Name,
+			Namespace: planNamespace,
+		},
+		Data: secret.Data,
+		Type: secret.Type,
+	}
+
+	if _, createError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(planNamespace).Create(newSecret); createError != nil {
+		if k8serrors.IsAlreadyExists(createError) {
+			status = v1alpha1.StepStatusPresent
+			return
+		}
+
+		err = fmt.Errorf("error creating secret %s - %v", secret.Name, createError)
+		return
+	}
+
+	status = v1alpha1.StepStatusCreated
+	return
+}
+
+// EnsureServiceAccount writes the specified ServiceAccount object to the cluster.
+func (o *StepEnsurer) EnsureServiceAccount(namespace string, sa *corev1.ServiceAccount) (status v1alpha1.StepStatus, err error) {
+	_, createErr := o.kubeClient.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Create(sa)
+	if createErr == nil {
+		status = v1alpha1.StepStatusCreated
+		return
+	}
+
+	if !k8serrors.IsAlreadyExists(createErr) {
+		err = errorwrap.Wrapf(createErr, "error creating service account: %s", sa.GetName())
+		return
+	}
+
+	sa.SetNamespace(namespace)
+	if _, updateErr := o.kubeClient.UpdateServiceAccount(sa); updateErr != nil {
+		err = errorwrap.Wrapf(updateErr, "error updating service account: %s", sa.GetName())
+		return
+	}
+
+	status = v1alpha1.StepStatusPresent
+	return
+}
+
+// EnsureService writes the specified Service object to the cluster.
+func (o *StepEnsurer) EnsureService(namespace string, service *corev1.Service) (status v1alpha1.StepStatus, err error) {
+	_, createErr := o.kubeClient.KubernetesInterface().CoreV1().Services(namespace).Create(service)
+	if createErr == nil {
+		status = v1alpha1.StepStatusCreated
+		return
+	}
+
+	if !k8serrors.IsAlreadyExists(createErr) {
+		err = errorwrap.Wrapf(createErr, "error updating service: %s", service.GetName())
+		return
+	}
+
+	service.SetNamespace(namespace)
+	if _, updateErr := o.kubeClient.UpdateService(service); updateErr != nil {
+		err = errorwrap.Wrapf(updateErr, "error updating service: %s", service.GetName())
+		return
+	}
+
+	status = v1alpha1.StepStatusPresent
+	return
+}
+
+// EnsureClusterRole writes the specified ClusterRole object to the cluster.
+func (o *StepEnsurer) EnsureClusterRole(cr *rbacv1.ClusterRole, step *v1alpha1.Step) (status v1alpha1.StepStatus, err error) {
+	_, createErr := o.kubeClient.KubernetesInterface().RbacV1().ClusterRoles().Create(cr)
+	if createErr == nil {
+		status = v1alpha1.StepStatusCreated
+		return
+	}
+
+	if !k8serrors.IsAlreadyExists(createErr) {
+		err = errorwrap.Wrapf(createErr, "error creating clusterrole %s", cr.GetName())
+		return
+	}
+
+	// We're updating, point owner to the newest csv
+	cr.Labels[ownerutil.OwnerKey] = step.Resolving
+	if _, updateErr := o.kubeClient.UpdateClusterRole(cr); updateErr != nil {
+		err = errorwrap.Wrapf(updateErr, "error updating clusterrole %s", cr.GetName())
+		return
+	}
+
+	status = v1alpha1.StepStatusPresent
+	return
+}
+
+// EnsureClusterRoleBinding writes the specified ClusterRoleBinding object to the cluster.
+func (o *StepEnsurer) EnsureClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, step *v1alpha1.Step) (status v1alpha1.StepStatus, err error) {
+	_, createErr := o.kubeClient.KubernetesInterface().RbacV1().ClusterRoleBindings().Create(crb)
+	if createErr == nil {
+		status = v1alpha1.StepStatusCreated
+		return
+	}
+
+	if !k8serrors.IsAlreadyExists(createErr) {
+		err = errorwrap.Wrapf(createErr, "error creating clusterrolebinding %s", crb.GetName())
+		return
+	}
+
+	// if we're updating, point owner to the newest csv
+	crb.Labels[ownerutil.OwnerKey] = step.Resolving
+	if _, updateErr := o.kubeClient.UpdateClusterRoleBinding(crb); updateErr != nil {
+		err = errorwrap.Wrapf(updateErr, "error updating clusterrolebinding %s", crb.GetName())
+		return
+	}
+
+	status = v1alpha1.StepStatusPresent
+	return
+}
+
+// EnsureRole writes the specified Role object to the cluster.
+func (o *StepEnsurer) EnsureRole(namespace string, role *rbacv1.Role) (status v1alpha1.StepStatus, err error) {
+	_, createErr := o.kubeClient.KubernetesInterface().RbacV1().Roles(namespace).Create(role)
+	if createErr == nil {
+		status = v1alpha1.StepStatusCreated
+		return
+	}
+
+	if !k8serrors.IsAlreadyExists(createErr) {
+		err = errorwrap.Wrapf(createErr, "error creating role %s", role.GetName())
+		return
+	}
+
+	// If it already existed, mark the step as Present.
+	role.SetNamespace(namespace)
+	if _, updateErr := o.kubeClient.UpdateRole(role); updateErr != nil {
+		err = errorwrap.Wrapf(updateErr, "error updating role %s", role.GetName())
+		return
+	}
+
+	status = v1alpha1.StepStatusPresent
+	return
+}
+
+// EnsureRoleBinding writes the specified RoleBinding object to the cluster.
+func (o *StepEnsurer) EnsureRoleBinding(namespace string, rb *rbacv1.RoleBinding) (status v1alpha1.StepStatus, err error) {
+	_, createErr := o.kubeClient.KubernetesInterface().RbacV1().RoleBindings(namespace).Create(rb)
+	if createErr == nil {
+		status = v1alpha1.StepStatusCreated
+		return
+	}
+
+	if !k8serrors.IsAlreadyExists(createErr) {
+		err = errorwrap.Wrapf(createErr, "error creating rolebinding %s", rb.GetName())
+		return
+	}
+
+	rb.SetNamespace(namespace)
+	if _, updateErr := o.kubeClient.UpdateRoleBinding(rb); updateErr != nil {
+		err = errorwrap.Wrapf(updateErr, "error updating rolebinding %s", rb.GetName())
+		return
+	}
+
+	status = v1alpha1.StepStatusPresent
+	return
+}

--- a/pkg/controller/operators/olm/config.go
+++ b/pkg/controller/operators/olm/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/client-go/rest"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/internalversion"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
@@ -30,6 +31,7 @@ type operatorConfig struct {
 	strategyResolver  install.StrategyResolverInterface
 	apiReconciler     resolver.APIIntersectionReconciler
 	apiLabeler        labeler.Labeler
+	restConfig        *rest.Config
 }
 
 func (o *operatorConfig) apply(options []OperatorOption) {
@@ -67,6 +69,8 @@ func (o *operatorConfig) validate() (err error) {
 		err = newInvalidConfigError("api reconciler", "must not be nil")
 	case o.apiLabeler == nil:
 		err = newInvalidConfigError("api labeler", "must not be nil")
+	case o.restConfig == nil:
+		err = newInvalidConfigError("rest config", "must not be nil")
 	}
 
 	return
@@ -148,5 +152,11 @@ func WithAPIReconciler(apiReconciler resolver.APIIntersectionReconciler) Operato
 func WithAPILabeler(apiLabeler labeler.Labeler) OperatorOption {
 	return func(config *operatorConfig) {
 		config.apiLabeler = apiLabeler
+	}
+}
+
+func WithRestConfig(restConfig *rest.Config) OperatorOption {
+	return func(config *operatorConfig) {
+		config.restConfig = restConfig
 	}
 }

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 
@@ -260,6 +261,7 @@ func NewFakeOperator(ctx context.Context, options ...fakeOperatorOption) (*Opera
 			strategyResolver:  &install.StrategyResolver{},
 			apiReconciler:     resolver.APIIntersectionReconcileFunc(resolver.ReconcileAPIIntersection),
 			apiLabeler:        labeler.Func(resolver.LabelSetsFor),
+			restConfig: 	   &rest.Config{},
 		},
 		recorder: &record.FakeRecorder{},
 		// default expected namespaces

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 
@@ -57,6 +58,8 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped"
+	csvutility "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/csv"
 )
 
 type TestStrategy struct{}
@@ -287,6 +290,15 @@ func NewFakeOperator(ctx context.Context, options ...fakeOperatorOption) (*Opera
 		return nil, err
 	}
 	op.recorder = config.recorder
+
+	scheme := runtime.NewScheme()
+	if err := k8sscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	op.csvSetGenerator = csvutility.NewSetGenerator(config.logger, op.lister)
+	op.csvReplaceFinder = csvutility.NewReplaceFinder(config.logger, config.externalClient)
+	op.serviceAccountSyncer = scoped.NewUserDefinedServiceAccountSyncer(config.logger, scheme, config.operatorClient, op.client)
 
 	// Only start the operator's informers (no reconciliation)
 	op.RunInformers(ctx)

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -18,7 +18,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"	
 )
 
 const (
@@ -52,6 +52,12 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		"operatorGroup": op.GetName(),
 		"namespace":     op.GetNamespace(),
 	})
+
+	op, err := a.serviceAccountSyncer.SyncOperatorGroup(op)
+	if err != nil {
+		logger.Errorf("error updating service account - %v", err)
+		return err
+	}
 
 	targetNamespaces, err := a.updateNamespaceList(op)
 	if err != nil {

--- a/pkg/lib/operatorclient/client.go
+++ b/pkg/lib/operatorclient/client.go
@@ -157,6 +157,31 @@ func NewClientFromConfig(kubeconfig string, logger *logrus.Logger) ClientInterfa
 	return &Client{kubernetes.NewForConfigOrDie(config), apiextensions.NewForConfigOrDie(config), apiregistration.NewForConfigOrDie(config)}
 }
 
+func NewClientFromRestConfig(config *rest.Config) (client ClientInterface, err error) {
+	kubernetes, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return
+	}
+
+	apiextensions, err := apiextensions.NewForConfig(config)
+	if err != nil {
+		return
+	}
+
+	apiregistration, err := apiregistration.NewForConfig(config)
+	if err != nil {
+		return
+	}
+
+	client = &Client{
+		kubernetes, 
+		apiextensions,
+		apiregistration,
+	}
+
+	return
+}
+
 // NewClient creates a kubernetes client
 func NewClient(k8sClient kubernetes.Interface, extclient apiextensions.Interface, regclient apiregistration.Interface) ClientInterface {
 	return &Client{k8sClient, extclient, regclient}

--- a/pkg/lib/scoped/attenuator.go
+++ b/pkg/lib/scoped/attenuator.go
@@ -1,0 +1,93 @@
+package scoped
+
+import (
+	"errors"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scopedclient"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	errQuerierNotSpecified = errors.New("no service account querier func specified")
+)
+
+// NewClientAttenuator returns a new instance of ClientAttenuator.
+func NewClientAttenuator(logger *logrus.Logger, config *rest.Config, kubeclient operatorclient.ClientInterface, crclient versioned.Interface) *ClientAttenuator {
+	return &ClientAttenuator{
+		logger:     logger,
+		kubeclient: kubeclient,
+		crclient:   crclient,
+		factory:    scopedclient.NewFactory(config),
+		retriever: &BearerTokenRetriever{
+			kubeclient: kubeclient,
+			logger:     logger,
+		},
+	}
+}
+
+// ServiceAccountQuerierFunc returns a reference to the service account from
+// which scope client(s) can be created.
+// This abstraction allows the attenuator to be agnostic of what the source of user
+// specified service accounts are. A user can specify service account(s) for an
+// operator group, subscription and CSV.
+type ServiceAccountQuerierFunc func() (reference *corev1.ObjectReference, err error)
+
+// ClientAttenuator returns appropriately scoped client(s) to be used for an
+// operator that is being installed.
+type ClientAttenuator struct {
+	// default operator client used by the operator.
+	kubeclient operatorclient.ClientInterface
+
+	// default CR client used by the operator.
+	crclient versioned.Interface
+
+	factory   *scopedclient.Factory
+	retriever *BearerTokenRetriever
+	logger    *logrus.Logger
+}
+
+// AttenuateClient returns appropriately scoped client(s) to the caller.
+//
+// client(s) that are bound to OLM cluster-admin role are returned if the querier
+// returns no error and reference to a service account is nil.
+// Otherwise an attempt is made to return attenuated client instance(s).
+func (s *ClientAttenuator) AttenuateClient(querier ServiceAccountQuerierFunc) (kubeclient operatorclient.ClientInterface, crclient versioned.Interface, err error) {
+	if querier == nil {
+		err = errQuerierNotSpecified
+		return
+	}
+
+	reference, err := querier()
+	if err != nil {
+		return
+	}
+
+	if reference == nil {
+		// No service account/token has been provided. Return the default client(s).
+		kubeclient = s.kubeclient
+		crclient = s.crclient
+		return
+	}
+
+	token, err := s.retriever.Retrieve(reference)
+	if err != nil {
+		return
+	}
+
+	// Create client(s) bound to the user defined service account.
+	crclient, err = s.factory.NewKubernetesClient(token)
+	if err != nil {
+		return
+	}
+
+	kubeclient, err = s.factory.NewOperatorClient(token)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/pkg/lib/scoped/querier.go
+++ b/pkg/lib/scoped/querier.go
@@ -1,0 +1,93 @@
+package scoped
+
+import (
+	"fmt"
+
+	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewUserDefinedServiceAccountQuerier returns a new instance of UserDefinedServiceAccountQuerier.
+func NewUserDefinedServiceAccountQuerier(logger *logrus.Logger, crclient versioned.Interface) *UserDefinedServiceAccountQuerier {
+	return &UserDefinedServiceAccountQuerier{
+		logger:   logger,
+		crclient: crclient,
+	}
+}
+
+// UserDefinedServiceAccountQuerier retrieves reference to user defined service account(s).
+type UserDefinedServiceAccountQuerier struct {
+	crclient versioned.Interface
+	logger   *logrus.Logger
+}
+
+// NamespaceQuerier returns an instance of ServiceAccountQuerierFunc that can be used by the
+// caller to get the reference to the service account associated with the namespace.
+func (f *UserDefinedServiceAccountQuerier) NamespaceQuerier(namespace string) ServiceAccountQuerierFunc {
+	querierFunc := func() (reference *corev1.ObjectReference, err error) {
+		logger := f.logger.WithFields(logrus.Fields{
+			"namespace":  namespace,
+			logFieldName: logFieldValue,
+		})
+
+		return QueryServiceAccountFromNamespace(logger, f.crclient, namespace)
+	}
+
+	return querierFunc
+}
+
+// QueryServiceAccountFromNamespace will return the reference to a service account
+// associated with the operator group for the given namespace.
+// - If no operator group is found in the namespace, both reference and err are set to nil.
+// - If an operator group found is not managing the namespace then it is ignored.
+// - If no operator group is managing this namespace then both reference and err are set to nil.
+// - If more than one operator group are managing this namespace then an error is thrown.
+func QueryServiceAccountFromNamespace(logger *logrus.Entry, crclient versioned.Interface, namespace string) (reference *corev1.ObjectReference, err error) {
+	// TODO: use a lister instead of a noncached client here.
+	list, err := crclient.OperatorsV1().OperatorGroups(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+
+	if len(list.Items) == 0 {
+		logger.Warnf("list query returned an empty list")
+		return
+	}
+
+	groups := make([]*v1.OperatorGroup, 0)
+	for _, og := range list.Items {
+		if len(og.Status.Namespaces) == 0 {
+			logger.Warnf("skipping operator group since it is not managing any namespace og=%s", og.GetName())
+			continue
+		}
+
+		groups = append(groups, &og)
+	}
+
+	if len(groups) == 0 {
+		logger.Warn("no operator group found that is managing this namespace")
+		return
+	}
+
+	if len(groups) > 1 {
+		err = fmt.Errorf("more than one operator group(s) are managing this namespace count=%d", len(groups))
+		return
+	}
+
+	group := groups[0]
+	if !group.IsServiceAccountSpecified() {
+		// No user defined service account is specified.
+		return
+	}
+
+	if !group.HasServiceAccountSynced() {
+		err = fmt.Errorf("please make sure the service account exists. sa=%s operatorgroup=%s/%s", group.Spec.ServiceAccountName, group.GetNamespace(), group.GetName())
+		return
+	}
+
+	reference = group.Status.ServiceAccountRef
+	return
+}

--- a/pkg/lib/scoped/syncer.go
+++ b/pkg/lib/scoped/syncer.go
@@ -1,0 +1,108 @@
+package scoped
+
+import (
+	"fmt"
+	"reflect"
+
+	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/client-go/tools/reference"
+)
+
+// NewUserDefinedServiceAccountSyncer returns a new instance of UserDefinedServiceAccountSyncer.
+func NewUserDefinedServiceAccountSyncer(logger *logrus.Logger, scheme *runtime.Scheme, client operatorclient.ClientInterface, versioned versioned.Interface) *UserDefinedServiceAccountSyncer {
+	return &UserDefinedServiceAccountSyncer{
+		logger:    logger,
+		versioned: versioned,
+		client:    client,
+		clock:     &clock.RealClock{},
+		scheme:    scheme,
+	}
+}
+
+// UserDefinedServiceAccountSyncer syncs an operator group appropriately when
+// a user defined service account is specified.
+type UserDefinedServiceAccountSyncer struct {
+	versioned versioned.Interface
+	client    operatorclient.ClientInterface
+	logger    *logrus.Logger
+	clock     clock.Clock
+	scheme    *runtime.Scheme
+}
+
+const (
+	// All logs should in this package should have the following field to make
+	// it easy to comb through logs.
+	logFieldName  = "mode"
+	logFieldValue = "scoped"
+)
+
+// SyncOperatorGroup takes appropriate actions when a user specifies a service account.
+func (s *UserDefinedServiceAccountSyncer) SyncOperatorGroup(in *v1.OperatorGroup) (out *v1.OperatorGroup, err error) {
+	out = in
+	namespace := in.GetNamespace()
+	serviceAccountName := in.Spec.ServiceAccountName
+
+	logger := s.logger.WithFields(logrus.Fields{
+		"operatorGroup": in.GetName(),
+		"namespace":     in.GetNamespace(),
+		logFieldName:    logFieldValue,
+	})
+
+	if serviceAccountName == "" {
+		if in.Status.ServiceAccountRef == nil {
+			return
+		}
+
+		// User must have removed ServiceAccount from the spec. We need to
+		// rest Status to a nil reference.
+		out, err = s.update(in, nil)
+		if err != nil {
+			err = fmt.Errorf("failed to reset status.serviceAccount, sa=%s %v", serviceAccountName, err)
+		}
+		return
+	}
+
+	// A service account has been specified, we need to update the status.
+	sa, err := s.client.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Get(serviceAccountName, metav1.GetOptions{})
+	if err != nil {
+		err = fmt.Errorf("failed to get service account, sa=%s %v", serviceAccountName, err)
+		return
+	}
+
+	ref, err := reference.GetReference(s.scheme, sa)
+	if err != nil {
+		return
+	}
+
+	if reflect.DeepEqual(in.Status.ServiceAccountRef, ref) {
+		logger.Debugf("status.serviceAccount is in sync with spec sa=%s", serviceAccountName)
+		return
+	}
+
+	out, err = s.update(in, ref)
+	if err != nil {
+		err = fmt.Errorf("failed to set status.serviceAccount, sa=%s %v", serviceAccountName, err)
+	}
+
+	return
+}
+
+func (s *UserDefinedServiceAccountSyncer) update(in *v1.OperatorGroup, ref *corev1.ObjectReference) (out *v1.OperatorGroup, err error) {
+	out = in
+
+	status := out.Status.DeepCopy()
+	status.ServiceAccountRef = ref
+	status.LastUpdated = metav1.NewTime(s.clock.Now())
+
+	out.Status = *status
+
+	out, err = s.versioned.OperatorsV1().OperatorGroups(out.GetNamespace()).UpdateStatus(out)
+	return
+}

--- a/pkg/lib/scoped/token_retriever.go
+++ b/pkg/lib/scoped/token_retriever.go
@@ -62,6 +62,12 @@ func getAPISecret(logger *logrus.Entry, kubeclient operatorclient.ClientInterfac
 			break
 		}
 
+		// Validate that this is a token for API access.
+		if !IsServiceAccountToken(secret, sa) {
+			logger.Warnf("skipping secret %s - %v", ref.Name, getErr)
+			continue
+		}
+
 		// The first eligible secret that has an API access token is returned.
 		APISecret = secret
 		break

--- a/pkg/lib/scoped/token_retriever.go
+++ b/pkg/lib/scoped/token_retriever.go
@@ -1,0 +1,71 @@
+package scoped
+
+import (
+	"fmt"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BearerTokenRetriever retrieves bearer token from a service account.
+type BearerTokenRetriever struct {
+	kubeclient operatorclient.ClientInterface
+	logger     *logrus.Logger
+}
+
+// Retrieve returns the bearer token for API access from a given service account reference.
+func (r *BearerTokenRetriever) Retrieve(reference *corev1.ObjectReference) (token string, err error) {
+	logger := r.logger.WithFields(logrus.Fields{
+		"sa":         reference.Name,
+		"namespace":  reference.Namespace,
+		logFieldName: logFieldValue,
+	})
+
+	sa, err := r.kubeclient.KubernetesInterface().CoreV1().ServiceAccounts(reference.Namespace).Get(reference.Name, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	secret, err := getAPISecret(logger, r.kubeclient, sa)
+	if err != nil {
+		err = fmt.Errorf("error occurred while retrieving API secret associated with the service account sa=%s/%s - %v", sa.GetNamespace(), sa.GetName(), err)
+		return
+	}
+
+	if secret == nil {
+		err = fmt.Errorf("the service account does not have any API secret sa=%s/%s", sa.GetNamespace(), sa.GetName())
+		return
+	}
+
+	token = string(secret.Data[corev1.ServiceAccountTokenKey])
+	if token == "" {
+		err = fmt.Errorf("the secret does not have any API token sa=%s/%s secret=%s", sa.GetNamespace(), sa.GetName(), secret.GetName())
+	}
+
+	return
+}
+
+func getAPISecret(logger *logrus.Entry, kubeclient operatorclient.ClientInterface, sa *corev1.ServiceAccount) (APISecret *corev1.Secret, err error) {
+	for _, ref := range sa.Secrets {
+		// corev1.ObjectReference only has Name populated.
+		secret, getErr := kubeclient.KubernetesInterface().CoreV1().Secrets(sa.GetNamespace()).Get(ref.Name, metav1.GetOptions{})
+		if getErr != nil {
+			if k8serrors.IsNotFound(getErr) {
+				logger.Warnf("skipping secret %s - %v", ref.Name, getErr)
+				continue
+			}
+
+			err = getErr
+			break
+		}
+
+		// The first eligible secret that has an API access token is returned.
+		APISecret = secret
+		break
+	}
+
+	return
+}

--- a/pkg/lib/scoped/util.go
+++ b/pkg/lib/scoped/util.go
@@ -1,0 +1,26 @@
+package scoped
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// IsServiceAccountToken returns true if the secret is a valid api token for the service account
+// This has been copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/serviceaccount/util.go
+func IsServiceAccountToken(secret *v1.Secret, sa *v1.ServiceAccount) bool {
+	if secret.Type != v1.SecretTypeServiceAccountToken {
+		return false
+	}
+
+	name := secret.Annotations[v1.ServiceAccountNameKey]
+	uid := secret.Annotations[v1.ServiceAccountUIDKey]
+	if name != sa.Name {
+		// Name must match
+		return false
+	}
+	if len(uid) > 0 && uid != string(sa.UID) {
+		// If UID is specified, it must match
+		return false
+	}
+
+	return true
+}

--- a/pkg/lib/scopedclient/clientfactory.go
+++ b/pkg/lib/scopedclient/clientfactory.go
@@ -1,0 +1,47 @@
+package scopedclient
+
+import (
+	"k8s.io/client-go/rest"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+)
+
+// NewFactory returns a new instance of Factory.
+func NewFactory(config *rest.Config) *Factory {
+	return &Factory{
+		config: config,
+	}
+}
+
+// Factory holds on to a default config and can create a new client instance(s)
+// bound to any bearer token specified.
+type Factory struct {
+	// default config object from which new client instance(s) will be created.
+	config *rest.Config
+}
+
+// NewOperatorClient return a new instance of operator client from the bearer
+// token specified.
+func (f *Factory) NewOperatorClient(token string) (client operatorclient.ClientInterface, err error) {
+	scoped := copy(f.config, token)
+	client, err = operatorclient.NewClientFromRestConfig(scoped)
+
+	return
+}
+
+// NewKubernetesClient return a new instance of CR client from the bearer
+// token specified.
+func (f *Factory) NewKubernetesClient(token string) (client versioned.Interface, err error) {
+	scoped := copy(f.config, token)
+	client, err = versioned.NewForConfig(scoped)
+
+	return
+}
+
+func copy(config *rest.Config, token string) *rest.Config {
+	copied := rest.AnonymousClientConfig(config)
+	copied.BearerToken = token
+
+	return copied
+}

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -65,11 +65,15 @@ func buildInstallPlanCleanupFunc(crc versioned.Interface, namespace string, inst
 }
 
 func fetchInstallPlan(t *testing.T, c versioned.Interface, name string, checkPhase checkInstallPlanFunc) (*v1alpha1.InstallPlan, error) {
+	return fetchInstallPlanWithNamespace(t, c, name, testNamespace, checkPhase)
+}
+
+func fetchInstallPlanWithNamespace(t *testing.T, c versioned.Interface, name string, namespace string, checkPhase checkInstallPlanFunc) (*v1alpha1.InstallPlan, error) {
 	var fetchedInstallPlan *v1alpha1.InstallPlan
 	var err error
 
 	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-		fetchedInstallPlan, err = c.OperatorsV1alpha1().InstallPlans(testNamespace).Get(name, metav1.GetOptions{})
+		fetchedInstallPlan, err = c.OperatorsV1alpha1().InstallPlans(namespace).Get(name, metav1.GetOptions{})
 		if err != nil || fetchedInstallPlan == nil {
 			return false, err
 		}

--- a/test/e2e/scoped_client_test.go
+++ b/test/e2e/scoped_client_test.go
@@ -1,0 +1,134 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped"
+)
+
+// TestScopedClient ensures that we we can create a scoped client bound to a
+// service account and then we can use the scoped client to make API calls.
+func TestScopedClient(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, false)
+
+	require.NotEmpty(t, kubeConfigPath)
+
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigPath)
+	require.NoError(t, err)
+
+	kubeclient := newKubeClient(t)
+	crclient := newCRClient(t)
+
+	logger := logrus.New()
+
+	tests := []struct {
+		name       string
+		grant      func(namespace, name string) (cleanup cleanupFunc)
+		assertFunc func(errGot error)
+	}{
+		// The parent test invokes 'Get' API on non existent objects. If the
+		// scoped client has enough permission, we expect a NotFound error code.
+		// Otherwise, we expect a 'Forbidden' error code due to lack of permission.
+		{
+			// The service account does not have any permission granted to it.
+			// We expect the get api call to return 'Forbidden' error due to
+			// lack of permission.
+			name: "ServiceAccountDoesNotHaveAnyPermission",
+			assertFunc: func(errGot error) {
+				require.True(t, k8serrors.IsForbidden(errGot))
+			},
+		},
+		{
+			// The service account does have permission granted to it.
+			// We expect the get api call to return 'NotFound' error.
+			name: "ServiceAccountHasPermission",
+			grant: func(namespace, name string) (cleanup cleanupFunc) {
+				cleanup = grantPermission(t, kubeclient, namespace, name)
+				return
+			},
+			assertFunc: func(errGot error) {
+				require.True(t, k8serrors.IsNotFound(errGot))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Steps:
+			// 1. Create a new namespace
+			// 2. Create a service account.
+			// 3. Grant permission(s) to the service account if specified.
+			// 4. Get scoped client instance(s)
+			// 5. Invoke Get API call on non existent object(s) to check if
+			//    the call can be made successfully.
+			namespace := genName("a")
+			_, cleanupNS := newNamespace(t, kubeclient, namespace)
+			defer cleanupNS()
+
+			saName := genName("user-defined-")
+			sa, cleanupSA := newServiceAccount(t, kubeclient, namespace, saName)
+			defer cleanupSA()
+
+			waitForServiceAccountSecretAvailable(t, kubeclient, sa.GetNamespace(), sa.GetName())
+
+			strategy := scoped.NewClientAttenuator(logger, config, kubeclient, crclient)
+			getter := func() (reference *corev1.ObjectReference, err error) {
+				reference = &corev1.ObjectReference{
+					Namespace: namespace,
+					Name:      saName,
+				}
+
+				return
+			}
+
+			if tt.grant != nil {
+				cleanupPerm := tt.grant(sa.GetNamespace(), sa.GetName())
+				defer cleanupPerm()
+			}
+
+			// We expect to get scoped client instance(s).
+			kubeclientGot, crclientGot, errGot := strategy.AttenuateClient(getter)
+			require.NoError(t, errGot)
+			require.NotNil(t, kubeclientGot)
+			require.NotNil(t, crclientGot)
+
+			_, errGot = kubeclientGot.KubernetesInterface().CoreV1().ConfigMaps(namespace).Get(genName("does-not-exist-"), metav1.GetOptions{})
+			require.Error(t, errGot)
+			tt.assertFunc(errGot)
+
+			_, errGot = crclientGot.OperatorsV1alpha1().CatalogSources(namespace).Get(genName("does-not-exist-"), metav1.GetOptions{})
+			require.Error(t, errGot)
+			tt.assertFunc(errGot)
+		})
+	}
+}
+
+func waitForServiceAccountSecretAvailable(t *testing.T, client operatorclient.ClientInterface, namespace, name string) *corev1.ServiceAccount {
+	var sa *corev1.ServiceAccount
+	err := wait.Poll(5*time.Second, time.Minute, func() (bool, error) {
+		sa, err := client.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(sa.Secrets) > 0 {
+			return true, nil
+		}
+
+		return false, nil
+
+	})
+
+	require.NoError(t, err)
+	return sa
+}

--- a/test/e2e/user_defined_sa_test.go
+++ b/test/e2e/user_defined_sa_test.go
@@ -1,0 +1,334 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+func TestUserDefinedServiceAccountWithNoPermission(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, false)
+
+	kubeclient := newKubeClient(t)
+	crclient := newCRClient(t)
+
+	namespace := genName("scoped-ns-")
+	_, cleanupNS := newNamespace(t, kubeclient, namespace)
+	defer cleanupNS()
+
+	// Create a service account, but add no permission to it.
+	saName := genName("scoped-sa-")
+	_, cleanupSA := newServiceAccount(t, kubeclient, namespace, saName)
+	defer cleanupSA()
+
+	// Add an OperatorGroup and specify the service account.
+	ogName := genName("scoped-og-")
+	_, cleanupOG := newOperatorGroupWithServiceAccount(t, crclient, namespace, ogName, saName)
+	defer cleanupOG()
+
+	catsrc, subSpec, catsrcCleanup := newCatalogSource(t, kubeclient, crclient, namespace)
+	defer catsrcCleanup()
+
+	// Ensure that the catalog source is resolved before we create a subscription.
+	_, err := fetchCatalogSource(t, crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
+	require.NoError(t, err)
+
+	subscriptionName := genName("scoped-sub-")
+	cleanupSubscription := createSubscriptionForCatalog(t, crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
+	defer cleanupSubscription()
+
+	// Wait until an install plan is created.
+	subscription, err := fetchSubscription(t, crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+
+	// We expect the InstallPlan to be in status: Failed.
+	ipName := subscription.Status.Install.Name
+	ipPhaseCheckerFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseFailed)
+	ipGot, err := fetchInstallPlanWithNamespace(t, crclient, ipName, namespace, ipPhaseCheckerFunc)
+	require.NoError(t, err)
+
+	conditionGot := mustHaveCondition(t, ipGot, v1alpha1.InstallPlanInstalled)
+	assert.Equal(t, corev1.ConditionFalse, conditionGot.Status)
+	assert.Equal(t, v1alpha1.InstallPlanReasonComponentFailed, conditionGot.Reason)
+	assert.Contains(t, conditionGot.Message, fmt.Sprintf("is forbidden: User \"system:serviceaccount:%s:%s\" cannot create resource", namespace, saName))
+
+	// Verify that all step resources are in Unknown state.
+	for _, step := range ipGot.Status.Plan {
+		assert.Equal(t, v1alpha1.StepStatusUnknown, step.Status)
+	}
+}
+
+func TestUserDefinedServiceAccountWithPermission(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, false)
+
+	// Create the CatalogSource
+	kubeclient := newKubeClient(t)
+	crclient := newCRClient(t)
+
+	namespace := genName("scoped-ns-")
+	_, cleanupNS := newNamespace(t, kubeclient, namespace)
+	defer cleanupNS()
+
+	// Create a service account, add enough permission to it so that operator install is successful.
+	saName := genName("scoped-sa")
+	_, cleanupSA := newServiceAccount(t, kubeclient, namespace, saName)
+	defer cleanupSA()
+	cleanupPerm := grantPermission(t, kubeclient, namespace, saName)
+	defer cleanupPerm()
+
+	// Add an OperatorGroup and specify the service account.
+	ogName := genName("scoped-og-")
+	_, cleanupOG := newOperatorGroupWithServiceAccount(t, crclient, namespace, ogName, saName)
+	defer cleanupOG()
+
+	catsrc, subSpec, catsrcCleanup := newCatalogSource(t, kubeclient, crclient, namespace)
+	defer catsrcCleanup()
+
+	// Ensure that the catalog source is resolved before we create a subscription.
+	_, err := fetchCatalogSource(t, crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
+	require.NoError(t, err)
+
+	subscriptionName := genName("scoped-sub-")
+	cleanupSubscription := createSubscriptionForCatalog(t, crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
+	defer cleanupSubscription()
+
+	// Wait until an install plan is created.
+	subscription, err := fetchSubscription(t, crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+
+	// We expect the InstallPlan to be in status: Complete.
+	ipName := subscription.Status.Install.Name
+	ipPhaseCheckerFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete)
+	ipGot, err := fetchInstallPlanWithNamespace(t, crclient, ipName, namespace, ipPhaseCheckerFunc)
+	require.NoError(t, err)
+
+	conditionGot := mustHaveCondition(t, ipGot, v1alpha1.InstallPlanInstalled)
+	assert.Equal(t, v1alpha1.InstallPlanConditionReason(""), conditionGot.Reason)
+	assert.Equal(t, corev1.ConditionTrue, conditionGot.Status)
+	assert.Equal(t, "", conditionGot.Message)
+
+	// Verify that all step resources are in Created state.
+	for _, step := range ipGot.Status.Plan {
+		assert.Equal(t, v1alpha1.StepStatusCreated, step.Status)
+	}
+}
+
+func newNamespace(t *testing.T, client operatorclient.ClientInterface, name string) (ns *corev1.Namespace, cleanup cleanupFunc) {
+	request := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	ns, err := client.KubernetesInterface().CoreV1().Namespaces().Create(request)
+	require.NoError(t, err)
+	require.NotNil(t, ns)
+
+	cleanup = func() {
+		err := client.KubernetesInterface().CoreV1().Namespaces().Delete(ns.GetName(), &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}
+
+	return
+}
+
+func newServiceAccount(t *testing.T, client operatorclient.ClientInterface, namespace, name string) (sa *corev1.ServiceAccount, cleanup cleanupFunc) {
+	request := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	sa, err := client.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Create(request)
+	require.NoError(t, err)
+	require.NotNil(t, sa)
+
+	cleanup = func() {
+		err := client.KubernetesInterface().CoreV1().ServiceAccounts(sa.GetNamespace()).Delete(sa.GetName(), &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}
+
+	return
+}
+
+func newOperatorGroupWithServiceAccount(t *testing.T, client versioned.Interface, namespace, name, serviceAccountName string) (og *v1.OperatorGroup, cleanup cleanupFunc) {
+	request := &v1.OperatorGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1.OperatorGroupSpec{
+			TargetNamespaces: []string{
+				namespace,
+			},
+			ServiceAccountName: serviceAccountName,
+		},
+	}
+
+	og, err := client.OperatorsV1().OperatorGroups(namespace).Create(request)
+	require.NoError(t, err)
+	require.NotNil(t, og)
+
+	cleanup = func() {
+		err := client.OperatorsV1().OperatorGroups(og.GetNamespace()).Delete(og.GetName(), &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}
+
+	return
+}
+
+func newCatalogSource(t *testing.T, kubeclient operatorclient.ClientInterface, crclient versioned.Interface, namespace string) (catsrc *v1alpha1.CatalogSource, subscriptionSpec *v1alpha1.SubscriptionSpec, cleanup cleanupFunc) {
+	crdPlural := genName("ins")
+	crdName := crdPlural + ".cluster.com"
+
+	crd := apiextensions.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensions.CustomResourceDefinitionSpec{
+			Group:   "cluster.com",
+			Version: "v1alpha1",
+			Names: apiextensions.CustomResourceDefinitionNames{
+				Plural:   crdPlural,
+				Singular: crdPlural,
+				Kind:     crdPlural,
+				ListKind: "list" + crdPlural,
+			},
+			Scope: "Namespaced",
+		},
+	}
+
+	// Create CSV
+	packageName := genName("nginx-")
+	stableChannel := "stable"
+
+	permissions := deploymentPermissions(t)
+	namedStrategy := newNginxInstallStrategy(genName("dep-"), permissions, nil)
+	csvA := newCSV("nginx-a", namespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, namedStrategy)
+	csvB := newCSV("nginx-b", namespace, "nginx-a", semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{crd}, nil, namedStrategy)
+
+	// Create PackageManifests
+	manifests := []registry.PackageManifest{
+		{
+			PackageName: packageName,
+			Channels: []registry.PackageChannel{
+				{Name: stableChannel, CurrentCSVName: csvB.GetName()},
+			},
+			DefaultChannelName: stableChannel,
+		},
+	}
+
+	catalogSourceName := genName("mock-nginx-")
+	catsrc, cleanup = createInternalCatalogSource(t, kubeclient, crclient, catalogSourceName, namespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
+	require.NotNil(t, catsrc)
+	require.NotNil(t, cleanup)
+
+	subscriptionSpec = &v1alpha1.SubscriptionSpec{
+		CatalogSource:          catsrc.GetName(),
+		CatalogSourceNamespace: catsrc.GetNamespace(),
+		Package:                packageName,
+		Channel:                stableChannel,
+		StartingCSV:            csvB.GetName(),
+		InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
+	}
+	return
+}
+
+func mustHaveCondition(t *testing.T, ip *v1alpha1.InstallPlan, conditionType v1alpha1.InstallPlanConditionType) (condition *v1alpha1.InstallPlanCondition) {
+	for i := range ip.Status.Conditions {
+		if ip.Status.Conditions[i].Type == conditionType {
+			condition = &ip.Status.Conditions[i]
+			break
+		}
+	}
+
+	require.NotNil(t, condition)
+	return
+}
+
+func deploymentPermissions(t *testing.T) []install.StrategyDeploymentPermissions {
+	// Generate permissions
+	serviceAccountName := genName("nginx-sa-")
+	permissions := []install.StrategyDeploymentPermissions{
+		{
+			ServiceAccountName: serviceAccountName,
+			Rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{rbac.VerbAll},
+					APIGroups: []string{rbac.APIGroupAll},
+					Resources: []string{rbac.ResourceAll}},
+			},
+		},
+	}
+
+	return permissions
+}
+
+func grantPermission(t *testing.T, client operatorclient.ClientInterface, namespace, serviceAccountName string) (cleanup cleanupFunc) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      genName("scoped-role-"),
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{rbac.VerbAll},
+				APIGroups: []string{rbac.APIGroupAll},
+				Resources: []string{rbac.ResourceAll},
+			},
+		},
+	}
+
+	role, err := client.KubernetesInterface().RbacV1().Roles(namespace).Create(role)
+	require.NoError(t, err)
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      genName("scoped-rolebinding-"),
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				APIGroup:  "",
+				Name:      serviceAccountName,
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.GetName(),
+		},
+	}
+
+	binding, err = client.KubernetesInterface().RbacV1().RoleBindings(namespace).Create(binding)
+	require.NoError(t, err)
+
+	cleanup = func() {
+		err := client.KubernetesInterface().RbacV1().Roles(role.GetNamespace()).Delete(role.GetName(), &metav1.DeleteOptions{})
+		require.NoError(t, err)
+
+		err = client.KubernetesInterface().RbacV1().RoleBindings(binding.GetNamespace()).Delete(binding.GetName(), &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}
+
+	return
+}


### PR DESCRIPTION
Add support for user defined ServiceAccount for OperatorGroup.

As a cluster administrator, I should be able to require that all operator installs and upgrades be and run under a ServiceAccount, so that I can ensure no user can install an operator with greater permissions than their own.

This is an implementation of phase 1 of the proposal- https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/contributors/design-proposals/user-defined-service-account.md