### PR TITLE
Allow CRD updates with multiple owners

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1021,6 +1021,44 @@ func (o *Operator) ResolvePlan(plan *v1alpha1.InstallPlan) error {
 	return nil
 }
 
+// TODO: in the future this will be extended to verify more than just whether or not the schema changed
+func checkCRDSchemas(oldCRD *v1beta1ext.CustomResourceDefinition, newCRD *v1beta1ext.CustomResourceDefinition) bool {
+	if reflect.DeepEqual(oldCRD.Spec.Validation, newCRD.Spec.Validation) {
+		return true
+	}
+
+	return false
+}
+
+func safeToUpdate(oldCRD *v1beta1ext.CustomResourceDefinition, newCRD *v1beta1ext.CustomResourceDefinition) error {
+	shouldCheckSchema := len(oldCRD.Spec.Versions) == len(newCRD.Spec.Versions) // no version bump
+
+	// 1) if there's no version change, verify that schemas match 2) ensure all old versions are present
+	for _, oldVersion := range oldCRD.Spec.Versions {
+		var versionPresent bool
+		for _, newVersion := range newCRD.Spec.Versions {
+			if oldVersion.Name == newVersion.Name {
+				if shouldCheckSchema && !checkCRDSchemas(oldCRD, newCRD) {
+					return fmt.Errorf("not allowing CRD (%v) update with multiple owners with schema change on version %v", newCRD.GetName(), oldVersion)
+				}
+				versionPresent = true
+			}
+		}
+		if !versionPresent {
+			return fmt.Errorf("not allowing CRD (%v) update with unincluded version %v", newCRD.GetName(), oldVersion)
+		}
+	}
+
+	// ensure a CRD with multiple versions isn't checked
+	if newCRD.Spec.Version != "" {
+		if !checkCRDSchemas(oldCRD, newCRD) {
+			return fmt.Errorf("not allowing CRD (%v) update with multiple owners with schema change on (single) version %v", newCRD.GetName(), newCRD.Spec.Version)
+		}
+	}
+	return nil
+
+}
+
 // ExecutePlan applies a planned InstallPlan to a namespace.
 func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 	if plan.Status.Phase != v1alpha1.InstallPlanPhaseInstalling {
@@ -1067,9 +1105,19 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 						if err != nil {
 							return errorwrap.Wrapf(err, "error find matched CSV: %s", step.Resource.Name)
 						}
+						crd.SetResourceVersion(currentCRD.GetResourceVersion())
 						if len(matchedCSV) == 1 {
-							// Attempt to update CRD
-							crd.SetResourceVersion(currentCRD.GetResourceVersion())
+							o.logger.Debugf("Found one owner for CRD %v", crd)
+							_, err = o.opClient.ApiextensionsV1beta1Interface().ApiextensionsV1beta1().CustomResourceDefinitions().Update(&crd)
+							if err != nil {
+								return errorwrap.Wrapf(err, "error updating CRD: %s", step.Resource.Name)
+							}
+						} else if len(matchedCSV) > 1 {
+							o.logger.Debugf("Found multiple owners for CRD %v", crd)
+							if err := safeToUpdate(currentCRD, &crd); err != nil {
+								return err
+							}
+
 							_, err = o.opClient.ApiextensionsV1beta1Interface().ApiextensionsV1beta1().CustomResourceDefinitions().Update(&crd)
 							if err != nil {
 								return errorwrap.Wrapf(err, "error update CRD: %s", step.Resource.Name)

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -121,6 +121,99 @@ func TestTransitionInstallPlan(t *testing.T) {
 	}
 }
 
+func TestSafeToUpdate(t *testing.T) {
+	mainCRDPlural := "ins-main-abcde"
+	differentSchema := &v1beta1.CustomResourceValidation{
+		OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
+			Properties: map[string]v1beta1.JSONSchemaProps{
+				"spec": {
+					Type:        "object",
+					Description: "Spec of a test object.",
+					Properties: map[string]v1beta1.JSONSchemaProps{
+						"scalar": {
+							Type:        "number",
+							Description: "Scalar value that should have a min and max.",
+							Minimum: func() *float64 {
+								var min float64 = 2
+								return &min
+							}(),
+							Maximum: func() *float64 {
+								var max float64 = 256
+								return &max
+							}(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	differentVersions := []v1beta1.CustomResourceDefinitionVersion{
+		{
+			Name:    "v1alpha1",
+			Served:  true,
+			Storage: false,
+		},
+		{
+			Name:    "v1alpha2",
+			Served:  true,
+			Storage: true,
+		},
+	}
+
+	tests := []struct {
+		name            string
+		oldCRD          v1beta1.CustomResourceDefinition
+		newCRD          v1beta1.CustomResourceDefinition
+		expectedFailure bool
+	}{
+		{
+			// in reality this would never happen within ExecutePlan, but fully exercises function
+			name:   "same version, same schema",
+			oldCRD: crd(mainCRDPlural),
+			newCRD: crd(mainCRDPlural),
+		},
+		{
+			name:   "same version, different schema",
+			oldCRD: crd(mainCRDPlural),
+			newCRD: func() v1beta1.CustomResourceDefinition {
+				newCRD := crd(mainCRDPlural)
+				newCRD.Spec.Validation = differentSchema
+				return newCRD
+			}(),
+			expectedFailure: true,
+		},
+		{
+			name:   "different version, different schema",
+			oldCRD: crd(mainCRDPlural),
+			newCRD: func() v1beta1.CustomResourceDefinition {
+				newCRD := crd(mainCRDPlural)
+				newCRD.Spec.Version = ""
+				newCRD.Spec.Versions = differentVersions
+				newCRD.Spec.Validation = differentSchema
+				return newCRD
+			}(),
+		},
+		{
+			name:   "different version, same schema",
+			oldCRD: crd(mainCRDPlural),
+			newCRD: func() v1beta1.CustomResourceDefinition {
+				newCRD := crd(mainCRDPlural)
+				newCRD.Spec.Version = ""
+				newCRD.Spec.Versions = differentVersions
+				return newCRD
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		err := safeToUpdate(&tt.oldCRD, &tt.newCRD)
+		if tt.expectedFailure {
+			require.Error(t, err)
+		}
+	}
+}
+
 func TestExecutePlan(t *testing.T) {
 	namespace := "ns"
 

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1576,7 +1576,7 @@ func (a *Operator) ensureLabels(in *v1alpha1.ClusterServiceVersion, labelSets ..
 		return in, nil
 	}
 
-	a.logger.WithField("labels", merged).Error("Labels updated!")
+	a.logger.WithField("labels", merged).Info("Labels updated!")
 
 	out := in.DeepCopy()
 	out.SetLabels(merged)

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -642,6 +642,233 @@ func TestCreateInstallPlanWithPreExistingCRDOwners(t *testing.T) {
 	})
 }
 
+func TestInstallPlanWithCRDSchemaChange(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
+	var min float64 = 2
+	var max float64 = 256
+	// generated outside of the test table so that the same naming can be used for both old and new CSVs
+	mainCRDPlural := genName("ins-main-")
+
+	// excluded: new CRD, same version, same schema - won't trigger a CRD update
+	tests := []struct {
+		name          string
+		expectedPhase v1alpha1.InstallPlanPhase
+		oldCRDName    string
+		oldCRD        apiextensions.CustomResourceDefinition
+		newCRD        *apiextensions.CustomResourceDefinition
+	}{
+		{
+			name:          "same version, different schema",
+			expectedPhase: v1alpha1.InstallPlanPhaseFailed,
+			oldCRD:        newCRD(mainCRDPlural + "0"),
+			newCRD: func() *apiextensions.CustomResourceDefinition {
+				crd := newCRD(mainCRDPlural + "0")
+				crd.Spec.Version = "v1alpha1"
+				crd.Spec.Validation = &apiextensions.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+						Properties: map[string]apiextensions.JSONSchemaProps{
+							"spec": {
+								Type:        "object",
+								Description: "Spec of a test object.",
+								Properties: map[string]apiextensions.JSONSchemaProps{
+									"scalar": {
+										Type:        "number",
+										Description: "Scalar value that should have a min and max.",
+										Minimum:     &min,
+										Maximum:     &max,
+									},
+								},
+							},
+						},
+					},
+				}
+
+				return &crd
+			}(),
+		},
+		{
+			name:          "different version, different schema",
+			expectedPhase: v1alpha1.InstallPlanPhaseComplete,
+			oldCRD:        newCRD(mainCRDPlural + "1"),
+			newCRD: func() *apiextensions.CustomResourceDefinition {
+				crd := newCRD(mainCRDPlural + "1")
+				crd.Spec.Version = ""
+				crd.Spec.Versions = []apiextensions.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: false,
+					},
+					{
+						Name:    "v1alpha2",
+						Served:  true,
+						Storage: true,
+					},
+				}
+				crd.Spec.Validation = &apiextensions.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+						Properties: map[string]apiextensions.JSONSchemaProps{
+							"spec": {
+								Type:        "object",
+								Description: "Spec of a test object.",
+								Properties: map[string]apiextensions.JSONSchemaProps{
+									"scalar": {
+										Type:        "number",
+										Description: "Scalar value that should have a min and max.",
+										Minimum:     &min,
+										Maximum:     &max,
+									},
+								},
+							},
+						},
+					},
+				}
+
+				return &crd
+			}(),
+		},
+		{
+			name:          "different version, same schema",
+			expectedPhase: v1alpha1.InstallPlanPhaseComplete,
+			oldCRD:        newCRD(mainCRDPlural + "2"),
+			newCRD: func() *apiextensions.CustomResourceDefinition {
+				crd := newCRD(mainCRDPlural + "2")
+				crd.Spec.Version = ""
+				crd.Spec.Versions = []apiextensions.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: false,
+					},
+					{
+						Name:    "v1alpha2",
+						Served:  true,
+						Storage: true,
+					},
+				}
+				return &crd
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer cleaner.NotifyTestComplete(t, true)
+
+			mainPackageName := genName("nginx-")
+			mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
+			mainPackageBeta := fmt.Sprintf("%s-beta", mainPackageName)
+
+			stableChannel := "stable"
+			betaChannel := "beta"
+
+			// Create manifests
+			mainManifests := []registry.PackageManifest{
+				{
+					PackageName: mainPackageName,
+					Channels: []registry.PackageChannel{
+						{Name: stableChannel, CurrentCSVName: mainPackageStable},
+						{Name: betaChannel, CurrentCSVName: mainPackageBeta},
+					},
+					DefaultChannelName: stableChannel,
+				},
+			}
+
+			// Create a new named install strategy
+			mainNamedStrategy := newNginxInstallStrategy(genName("dep-"), nil, nil)
+
+			// Create new CSVs
+			mainStableCSV := newCSV(mainPackageStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{tt.oldCRD}, nil, mainNamedStrategy)
+			mainBetaCSV := newCSV(mainPackageBeta, testNamespace, mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{tt.oldCRD}, nil, mainNamedStrategy)
+
+			c := newKubeClient(t)
+			crc := newCRClient(t)
+
+			// Create the catalog source
+			mainCatalogSourceName := genName("mock-ocs-main-")
+			_, cleanupCatalogSource := createInternalCatalogSource(t, c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{tt.oldCRD}, []v1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV})
+			defer cleanupCatalogSource()
+
+			// Attempt to get the catalog source before creating install plan(s)
+			_, err := fetchCatalogSource(t, crc, mainCatalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
+			require.NoError(t, err)
+
+			subscriptionName := genName("sub-nginx-")
+			// this subscription will be cleaned up below without the clean up function
+			createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", v1alpha1.ApprovalAutomatic)
+
+			subscription, err := fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+			require.NoError(t, err)
+			require.NotNil(t, subscription)
+
+			installPlanName := subscription.Status.Install.Name
+
+			// Wait for InstallPlan to be status: Complete or failed before checking resource presence
+			completeOrFailedFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete, v1alpha1.InstallPlanPhaseFailed)
+			fetchedInstallPlan, err := fetchInstallPlan(t, crc, installPlanName, completeOrFailedFunc)
+			require.NoError(t, err)
+			t.Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
+			require.Equal(t, v1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
+
+			// Ensure that the desired resources have been created
+			expectedSteps := map[registry.ResourceKey]struct{}{
+				registry.ResourceKey{Name: tt.oldCRD.Name, Kind: "CustomResourceDefinition"}:            {},
+				registry.ResourceKey{Name: mainPackageStable, Kind: v1alpha1.ClusterServiceVersionKind}: {},
+			}
+
+			require.Equal(t, len(expectedSteps), len(fetchedInstallPlan.Status.Plan), "number of expected steps does not match installed")
+
+			for _, step := range fetchedInstallPlan.Status.Plan {
+				key := registry.ResourceKey{
+					Name: step.Resource.Name,
+					Kind: step.Resource.Kind,
+				}
+				_, ok := expectedSteps[key]
+				require.True(t, ok, "couldn't find %v in expected steps: %#v", key, expectedSteps)
+
+				// Remove the entry from the expected steps set (to ensure no duplicates in resolved plan)
+				delete(expectedSteps, key)
+			}
+
+			// Should have removed every matching step
+			require.Equal(t, 0, len(expectedSteps), "Actual resource steps do not match expected")
+
+			updateInternalCatalog(t, c, crc, mainCatalogSourceName, testNamespace, []apiextensions.CustomResourceDefinition{*tt.newCRD}, []v1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
+			// Attempt to get the catalog source before creating install plan(s)
+			_, err = fetchCatalogSource(t, crc, mainCatalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
+			require.NoError(t, err)
+
+			// Update the subscription resource to point to the beta CSV
+			err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			// existing cleanup should remove this
+			createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, mainCatalogSourceName, mainPackageName, betaChannel, "", v1alpha1.ApprovalAutomatic)
+
+			subscription, err = fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+			require.NoError(t, err)
+			require.NotNil(t, subscription)
+
+			installPlanName = subscription.Status.Install.Name
+
+			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
+			fetchedInstallPlan, err = fetchInstallPlan(t, crc, installPlanName, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete, v1alpha1.InstallPlanPhaseFailed))
+			require.NoError(t, err)
+			fmt.Printf("Phase = %v", fetchedInstallPlan.Status.Phase)
+			t.Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
+
+			require.Equal(t, tt.expectedPhase, fetchedInstallPlan.Status.Phase)
+
+			// Ensure correct in-cluster resource(s)
+			fetchedCSV, err := fetchCSV(t, crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
+			require.NoError(t, err)
+
+			t.Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
+		})
+	}
+}
+
 func TestUpdateInstallPlan(t *testing.T) {
 	defer cleaner.NotifyTestComplete(t, true)
 	t.Run("UpdateSingleExistingCRDOwner", func(t *testing.T) {

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -935,7 +935,7 @@ func updateInternalCatalog(t *testing.T, c operatorclient.ClientInterface, crc v
 			fmt.Println("catalog updated")
 			return true
 		}
-		fmt.Println("waiting for catalog pod to be available")
+		fmt.Printf("waiting for catalog pod %v to be available (after catalog update)\n", catalog.GetName())
 		return false
 	})
 	require.NoError(t, err)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -314,7 +314,7 @@ func catalogSourceRegistryPodSynced(catalog *v1alpha1.CatalogSource) bool {
 		fmt.Printf("catalog %s pod with address %s\n", catalog.GetName(), catalog.Status.RegistryServiceStatus.Address())
 		return registryPodHealthy(catalog.Status.RegistryServiceStatus.Address())
 	}
-	fmt.Println("waiting for catalog pod to be available")
+	fmt.Printf("waiting for catalog pod %v to be available (for sync)\n", catalog.GetName())
 	return false
 }
 


### PR DESCRIPTION
The purpose of this PR is to allow CRD updates for existing CRDs, which isn't currently done. This enables that functionality in the cases of:
- New CRD is a different non-existing version
- CRD is the same version without an openapi schema change

~This is rebased on top of https://github.com/operator-framework/operator-lifecycle-manager/pull/878, so that should merge first.~