### PR TITLE
add -l option to $POD_MANAGER attach

### DIFF
--- a/scripts/run_console_local.sh
+++ b/scripts/run_console_local.sh
@@ -44,7 +44,7 @@ run_ocp_console_image (){
 verify_ocp_console_image (){
     if [ "$($POD_MANAGER ps -q -f label=io.openshift.build.source-location=https://github.com/openshift/console)" ];
     then
-      container_id="$($POD_MANAGER ps -q -f label=io.openshift.build.source-location=https://github.com/openshift/console)"
+      container_id="$($POD_MANAGER ps -q -l -f label=io.openshift.build.source-location=https://github.com/openshift/console)"
       echo -e "${GREEN}The OLM is accessible via web console at:${RESET}"
       echo -e "${GREEN}http://localhost:9000/${RESET}"
       echo -e "${GREEN}Press Ctrl-C to quit${RESET}";


### PR DESCRIPTION
this script can fail to attach to container if it is executed on a host that is running another openshift console image. only attempt to attach to the latest.