### PR TITLE
fix(chart): add missing descriptions to operator group

### DIFF
--- a/deploy/chart/templates/0000_50_olm_10-operatorgroup.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_10-operatorgroup.crd.yaml
@@ -30,6 +30,8 @@ spec:
       description: A grouping of namespaces for usage with an operator.
       properties:
         spec:
+          type: object
+          description: Spec for an OperatorGroup.
           properties:
             selector:
               type: object
@@ -80,8 +82,9 @@ spec:
             staticProvidedAPIs:
               type: boolean
               description: If true, OLM will not modify the OperatorGroup's providedAPIs annotation.
-          type: object
         status:
+          type: object
+          description: The status of the OperatorGroup.
           properties:
             lastUpdated:
               format: date-time
@@ -92,6 +95,5 @@ spec:
               type: array
           required:
           - lastUpdated
-          type: object
       required:
       - metadata

--- a/deploy/upstream/quickstart/crds.yaml
+++ b/deploy/upstream/quickstart/crds.yaml
@@ -1075,6 +1075,8 @@ spec:
       description: A grouping of namespaces for usage with an operator.
       properties:
         spec:
+          type: object
+          description: Spec for an OperatorGroup.
           properties:
             selector:
               type: object
@@ -1125,8 +1127,9 @@ spec:
             staticProvidedAPIs:
               type: boolean
               description: If true, OLM will not modify the OperatorGroup's providedAPIs annotation.
-          type: object
         status:
+          type: object
+          description: The status of the OperatorGroup.
           properties:
             lastUpdated:
               format: date-time
@@ -1137,6 +1140,5 @@ spec:
               type: array
           required:
           - lastUpdated
-          type: object
       required:
       - metadata

--- a/manifests/0000_50_olm_10-operatorgroup.crd.yaml
+++ b/manifests/0000_50_olm_10-operatorgroup.crd.yaml
@@ -30,6 +30,8 @@ spec:
       description: A grouping of namespaces for usage with an operator.
       properties:
         spec:
+          type: object
+          description: Spec for an OperatorGroup.
           properties:
             selector:
               type: object
@@ -80,8 +82,9 @@ spec:
             staticProvidedAPIs:
               type: boolean
               description: If true, OLM will not modify the OperatorGroup's providedAPIs annotation.
-          type: object
         status:
+          type: object
+          description: The status of the OperatorGroup.
           properties:
             lastUpdated:
               format: date-time
@@ -92,6 +95,5 @@ spec:
               type: array
           required:
           - lastUpdated
-          type: object
       required:
       - metadata


### PR DESCRIPTION
This is to close out https://bugzilla.redhat.com/show_bug.cgi?id=1705746. Just adds descriptions for the spec and status of an operator group (queried from kubectl explain <crd>).