### PR TITLE
Add config options to QueueInformer constructors

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -95,8 +95,7 @@ func main() {
 
 	logger := log.New()
 	if *debug {
-		// TODO: change back to debug level
-		logger.SetLevel(log.TraceLevel)
+		logger.SetLevel(log.DebugLevel)
 	}
 	logger.Infof("log level %s", logger.Level)
 

--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -91,8 +91,7 @@ func main() {
 	// Set log level to debug if `debug` flag set
 	logger := log.New()
 	if *debug {
-		// TODO: Switch back to debug level
-		logger.SetLevel(log.TraceLevel)
+		logger.SetLevel(log.DebugLevel)
 	}
 	logger.Infof("log level %s", logger.Level)
 

--- a/pkg/api/apis/operators/register.go
+++ b/pkg/api/apis/operators/register.go
@@ -48,7 +48,3 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
-
-func init() {
-
-}

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -664,7 +664,7 @@ func NewFakeOperator(ctx context.Context, namespace string, watchedNamespaces []
 	}
 
 	// Create the new operator
-	queueOperator, err := queueinformer.NewOperatorFromClient(opClientFake.KubernetesInterface().Discovery(), logrus.New())
+	queueOperator, err := queueinformer.NewOperator(opClientFake.KubernetesInterface().Discovery())
 	for _, informer := range sharedInformers {
 		queueOperator.RegisterInformer(informer)
 	}

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -83,18 +83,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		return nil, err
 	}
 
-	// // Create a new client for OLM types (CRs)
-	// crClient, err := client.NewClient(kubeconfigPath)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// internalClient, err := client.NewInternalClient(kubeconfigPath)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	queueOperator, err := queueinformer.NewOperatorFromClient(config.operatorClient.KubernetesInterface().Discovery(), config.logger)
+	queueOperator, err := queueinformer.NewOperator(config.operatorClient.KubernetesInterface().Discovery(), queueinformer.WithOperatorLogger(config.logger))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -331,7 +331,7 @@ func (a *Operator) permissionStatus(strategyDetailsDeployment *install.StrategyD
 
 	statuses := []v1alpha1.RequirementStatus{}
 	for key, status := range statusesSet {
-		a.logger.WithField("key", key).WithField("status", status).Debugf("appending permission status")
+		a.logger.WithField("key", key).WithField("status", status).Tracef("appending permission status")
 		statuses = append(statuses, status)
 	}
 

--- a/pkg/package-server/provider/registry_test.go
+++ b/pkg/package-server/provider/registry_test.go
@@ -83,7 +83,7 @@ func NewFakeRegistryProvider(ctx context.Context, clientObjs []runtime.Object, k
 	k8sClientFake := k8sfake.NewSimpleClientset(k8sObjs...)
 	opClientFake := operatorclient.NewClient(k8sClientFake, nil, nil)
 
-	op, err := queueinformer.NewOperatorFromClient(opClientFake.KubernetesInterface().Discovery(), logrus.StandardLogger())
+	op, err := queueinformer.NewOperator(opClientFake.KubernetesInterface().Discovery())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/package-server/server/server.go
+++ b/pkg/package-server/server/server.go
@@ -165,7 +165,7 @@ func (o *PackageServerOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	queueOperator, err := queueinformer.NewOperatorFromClient(crClient.Discovery(), log.New())
+	queueOperator, err := queueinformer.NewOperator(crClient.Discovery())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds config options to QueueInformers and follows up on some unresolved comments left in #881

- Add variadic config options to QueueInformer constructors
- Make number of queue workers configurable (default to 2)
- Ensure InstallPlan sync only triggers resolution *after* a change
- Remove empty `init()`
- Switch log level back to debug
- Change verbose permissions requirement to `Tracef(...)`