### PR TITLE
fix(build): don't use helm in src image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ RUN yum install -y make git
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-# install helm for templating - used in verification tests
-RUN curl -LO https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-linux-amd64.tar.gz && \
-    tar -zxvf helm-v2.13.1-linux-amd64.tar.gz && \
-    mv linux-amd64/helm /usr/local/bin/helm
-
 WORKDIR /go/src/github.com/operator-framework/operator-lifecycle-manager
 
 # copy just enough of the git repo to parse HEAD, used to record version in OLM binaries

--- a/Makefile
+++ b/Makefile
@@ -162,8 +162,11 @@ verify-codegen: codegen
 # this is here for backwards compatibility with the ci job that calls verify-catalog
 verify-catalog:
 
-verify-manifests: ver=$(shell cat OLM_VERSION)
+# this is here for backwards compatibility with the ci job that calls verify-manifests
 verify-manifests:
+
+verify-release: ver=$(shell cat OLM_VERSION)
+verify-release:
 	rm -rf manifests
 	mkdir manifests
 	./scripts/package_release.sh $(ver) manifests deploy/ocp/values.yaml


### PR DESCRIPTION
We lose our manifest validation with this change, but it's currently an issue for the build pipeline.