### PR TITLE
docs(release): add additional clarifying details

### DIFF
--- a/Documentation/design/release.md
+++ b/Documentation/design/release.md
@@ -12,14 +12,16 @@
 
 Changelogs for OLM are generated using [GitHub Changelog Generator](https://github.com/github-changelog-generator/github-changelog-generator).
 
-If the gem command is available, one can install via `gem install github_changelog_generator`. Afterward installing it may be worth modifying the MAX_THREAD_NUMBER to something lower similar to what is done here: <https://github.com/github-changelog-generator/github-changelog-generator/pull/661>. Now the changelog can be generated:
+If the gem command is available, one can install via `gem install github_changelog_generator`. Afterward installing it may be worth modifying the MAX_THREAD_NUMBER to something lower similar to what is done here: <https://github.com/github-changelog-generator/github-changelog-generator/pull/661>. Note that the referenced PR has been merged, but the number is still too high. Although 1 is a very low value, it does seem to work more reliably. (On Fedora, the install location for the gem is ~/.gem/ruby/gems/github_changelog_generator-1.14.3/lib/github_changelog_generator/octo_fetcher.rb.)
+
+Now the changelog can be generated:
 
 ```bash
 github_changelog_generator -u operator-framework -p operator-lifecycle-manager --since-tag=<start-semver> \
     --token=<github-api-token> --future-release=<end-semver> --pr-label="**Other changes:**"
 ```
 
-The resulting CHANGELOG.md file can be copied into a new release created via <https://github.com/operator-framework/operator-lifecycle-manager/releases/new>.
+The resulting CHANGELOG.md file can be copied into a new release created via <https://github.com/operator-framework/operator-lifecycle-manager/releases/new>. Also, make sure to commit the new changes to CHANGELOG.md as well.
 
 ## QuickStart
 


### PR DESCRIPTION
This covers details that were discovered missing while having a conversation with @dinhxuanvu. The two changes are: including the gem install location and noting that CHANGELOG.md needs to be committed too.