### PR TITLE
feat(csv): detect changes to a deployment and persist them

### DIFF
--- a/pkg/controller/install/deployment.go
+++ b/pkg/controller/install/deployment.go
@@ -6,6 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/diff"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/wrappers"
@@ -61,30 +63,32 @@ func NewStrategyDeploymentInstaller(strategyClient wrappers.InstallStrategyDeplo
 
 func (i *StrategyDeploymentInstaller) installDeployments(deps []StrategyDeploymentSpec) error {
 	for _, d := range deps {
-		dep := &appsv1.Deployment{Spec: d.Spec}
-		dep.SetName(d.Name)
-		dep.SetNamespace(i.owner.GetNamespace())
-
-		// Merge annotations (to avoid losing info from pod template)
-		annotations := map[string]string{}
-		for k, v := range i.templateAnnotations {
-			annotations[k] = v
-		}
-		for k, v := range dep.Spec.Template.GetAnnotations() {
-			annotations[k] = v
-		}
-		dep.Spec.Template.SetAnnotations(annotations)
-
-		ownerutil.AddNonBlockingOwner(dep, i.owner)
-		if err := ownerutil.AddOwnerLabels(dep, i.owner); err != nil {
-			return err
-		}
-		if _, err := i.strategyClient.CreateOrUpdateDeployment(dep); err != nil {
+		if _, err := i.strategyClient.CreateOrUpdateDeployment(i.deploymentForSpec(d.Name, d.Spec)); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (i *StrategyDeploymentInstaller) deploymentForSpec(name string, spec appsv1.DeploymentSpec) *appsv1.Deployment {
+	dep := &appsv1.Deployment{Spec: spec}
+	dep.SetName(name)
+	dep.SetNamespace(i.owner.GetNamespace())
+
+	// Merge annotations (to avoid losing info from pod template)
+	annotations := map[string]string{}
+	for k, v := range i.templateAnnotations {
+		annotations[k] = v
+	}
+	for k, v := range dep.Spec.Template.GetAnnotations() {
+		annotations[k] = v
+	}
+	dep.Spec.Template.SetAnnotations(annotations)
+
+	ownerutil.AddNonBlockingOwner(dep, i.owner)
+	ownerutil.AddOwnerLabelsForKind(dep, i.owner, v1alpha1.ClusterServiceVersionKind)
+	return dep
 }
 
 func (i *StrategyDeploymentInstaller) cleanupPrevious(current *StrategyDetailsDeployment, previous *StrategyDetailsDeployment) error {
@@ -179,8 +183,42 @@ func (i *StrategyDeploymentInstaller) checkForDeployments(deploymentSpecs []Stra
 				return StrategyError{Reason: StrategyErrReasonAnnotationsMissing, Message: fmt.Sprintf("annotations on deployment don't match. couldn't find %s: %s", key, value)}
 			}
 		}
+
+		// check equality
+		calculated := i.deploymentForSpec(spec.Name, spec.Spec)
+		if !i.equalDeployments(&calculated.Spec, &dep.Spec) {
+			return StrategyError{Reason: StrategyErrDeploymentUpdated, Message: fmt.Sprintf("deployment changed, rolling update with patch: %s\n%#v\n%#v", diff.ObjectDiff(dep.Spec.Template.Spec, calculated.Spec.Template.Spec), calculated.Spec.Template.Spec, dep.Spec.Template.Spec)}
+		}
 	}
 	return nil
+}
+
+func (i *StrategyDeploymentInstaller) equalDeployments(calculated, onCluster *appsv1.DeploymentSpec) bool {
+	// ignore template annotations, OLM injects these elsewhere
+	calculated.Template.Annotations = nil
+
+	// DeepDerivative doesn't treat `0` ints as unset. Stripping them here means we miss changes to these values,
+	// but we don't end up getting bitten by the defaulter for deployments.
+	for i, c := range onCluster.Template.Spec.Containers {
+		o := calculated.Template.Spec.Containers[i]
+		if o.ReadinessProbe != nil {
+			o.ReadinessProbe.InitialDelaySeconds = c.ReadinessProbe.InitialDelaySeconds
+			o.ReadinessProbe.TimeoutSeconds = c.ReadinessProbe.TimeoutSeconds
+			o.ReadinessProbe.PeriodSeconds = c.ReadinessProbe.PeriodSeconds
+			o.ReadinessProbe.SuccessThreshold = c.ReadinessProbe.SuccessThreshold
+			o.ReadinessProbe.FailureThreshold = c.ReadinessProbe.FailureThreshold
+		}
+		if o.LivenessProbe != nil {
+			o.LivenessProbe.InitialDelaySeconds = c.LivenessProbe.InitialDelaySeconds
+			o.LivenessProbe.TimeoutSeconds = c.LivenessProbe.TimeoutSeconds
+			o.LivenessProbe.PeriodSeconds = c.LivenessProbe.PeriodSeconds
+			o.LivenessProbe.SuccessThreshold = c.LivenessProbe.SuccessThreshold
+			o.LivenessProbe.FailureThreshold = c.LivenessProbe.FailureThreshold
+		}
+	}
+
+	// DeepDerivative ensures that, for any non-nil, non-empty value in A, the corresponding value is set in B
+	return equality.Semantic.DeepDerivative(calculated, onCluster)
 }
 
 // Clean up orphaned deployments after reinstalling deployments process

--- a/pkg/controller/install/errors.go
+++ b/pkg/controller/install/errors.go
@@ -9,12 +9,15 @@ const (
 	StrategyErrReasonInvalidStrategy    = "InvalidStrategy"
 	StrategyErrReasonTimeout            = "Timeout"
 	StrategyErrReasonUnknown            = "Unknown"
+	StrategyErrBadPatch                 = "PatchUnsuccessful"
+	StrategyErrDeploymentUpdated        = "DeploymentUpdated"
 )
 
 // unrecoverableErrors are the set of errors that mean we can't recover an install strategy
 var unrecoverableErrors = map[string]struct{}{
 	StrategyErrReasonInvalidStrategy: {},
 	StrategyErrReasonTimeout:         {},
+	StrategyErrBadPatch:              {},
 }
 
 // StrategyError is used to represent error types for install strategies

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1271,6 +1271,10 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 	strategyInstalled, strategyErr := installer.CheckInstalled(strategy)
 	now := a.now()
 
+	if strategyErr != nil {
+		a.logger.WithError(strategyErr).Debug("operator not installed")
+	}
+
 	if strategyInstalled && apiServicesInstalled {
 		// if there's no error, we're successfully running
 		csv.SetPhaseWithEventIfChanged(v1alpha1.CSVPhaseSucceeded, v1alpha1.CSVReasonInstallSuccessful, "install strategy completed with no errors", now, a.recorder)

--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -195,21 +195,26 @@ func OwnerLabel(owner Owner, kind string) map[string]string {
 	}
 }
 
-// AddOwnerLabels adds ownerref-like labels to an object
+// AddOwnerLabels adds ownerref-like labels to an object by inferring the owner kind
 func AddOwnerLabels(object metav1.Object, owner Owner) error {
 	err := InferGroupVersionKind(owner)
 	if err != nil {
 		return err
 	}
+	AddOwnerLabelsForKind(object, owner, owner.GetObjectKind().GroupVersionKind().Kind)
+	return nil
+}
+
+// AddOwnerLabels adds ownerref-like labels to an object, with no inference
+func AddOwnerLabelsForKind(object metav1.Object, owner Owner, kind string) {
 	labels := object.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	for key, val := range OwnerLabel(owner, owner.GetObjectKind().GroupVersionKind().Kind) {
+	for key, val := range OwnerLabel(owner, kind) {
 		labels[key] = val
 	}
 	object.SetLabels(labels)
-	return nil
 }
 
 // IsOwnedByKindLabel returns whether or not a label exists on the object pointing to an owner of a particular kind

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -13,7 +13,7 @@ fi
 
 docker build -f local.Dockerfile -t quay.io/operator-framework/olm:local -t quay.io/operator-framework/olm-e2e:local ./bin
 
-if [ -x "$(command -v kind)" ] && [ "kubectl config current-context" -eq "kind" ]; then
+if [ -x "$(command -v kind)" ] && [ "$(kubectl config current-context)" = "kind" ]; then
   kind load docker-image quay.io/operator-framework/olm:local
   kind load docker-image quay.io/operator-framework/olm-e2e:local
 fi

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -101,7 +101,7 @@ func newNginxInstallStrategy(name string, permissions []install.StrategyDeployme
 						Spec: corev1.PodSpec{Containers: []corev1.Container{
 							{
 								Name:            genName("nginx"),
-								Image:           "bitnami/nginx:latest",
+								Image:           "redis",
 								Ports:           []corev1.ContainerPort{{ContainerPort: 80}},
 								ImagePullPolicy: corev1.PullIfNotPresent,
 							},

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -210,7 +210,7 @@ var (
 						Spec: corev1.PodSpec{Containers: []corev1.Container{
 							{
 								Name:            genName("nginx"),
-								Image:           "bitnami/nginx:latest",
+								Image:           "redis",
 								Ports:           []corev1.ContainerPort{{ContainerPort: 80}},
 								ImagePullPolicy: corev1.PullIfNotPresent,
 							},


### PR DESCRIPTION
Prior to this PR, changes made to a CSV's deployment specs would not affect the running deployments. Instead, you would need to delete and recreate the CSV, or create a new one that replaces the existing one, to test changes to a deployment.

This is obviously a UX improvement for developing CSVs, but this also has an advantage for simplifying our deployment. We are looking at switching to kustomize instead of helm, which means we need to limit the templating we do, and specifically the lack of partials in kustomize means that it's difficult to support our current deployment model. With this change we can just include the packageserver CSV (instead of CSV + Deployment + CatalogSource + ConfigMap) in our release artifacts.