### PR TITLE
1723818: package server 4.1 to 4.2 upgrade should not fail

### DIFF
--- a/manifests/0000_50_olm_11-olm-operators.configmap.yaml
+++ b/manifests/0000_50_olm_11-olm-operators.configmap.yaml
@@ -9,6 +9,127 @@ data:
     - apiVersion: operators.coreos.com/v1alpha1
       kind: ClusterServiceVersion
       metadata:
+        name: packageserver.v0.9.0
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        displayName: Package Server
+        description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
+        minKubeVersion: 1.11.0
+        keywords: ['packagemanifests', 'olm', 'packages']
+        maintainers:
+        - name: Red Hat
+          email: openshift-operators@redhat.com
+        provider:
+          name: Red Hat
+        links:
+        - name: Package Server
+          url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server
+        installModes:
+        - type: OwnNamespace
+          supported: true
+        - type: SingleNamespace
+          supported: true
+        - type: MultiNamespace
+          supported: true
+        - type: AllNamespaces
+          supported: true
+        install:
+          strategy: deployment
+          spec:
+            clusterPermissions:
+            - serviceAccountName: packageserver
+              rules:
+              - apiGroups:
+                  - authorization.k8s.io
+                resources:
+                  - subjectaccessreviews
+                verbs:
+                  - create
+                  - get
+              - apiGroups:
+                - ""
+                resources:
+                - configmaps
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - "operators.coreos.com"
+                resources:
+                - catalogsources
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - "packages.operators.coreos.com"
+                resources:
+                - packagemanifests
+                verbs:
+                - get
+                - list
+            deployments:
+            - name: packageserver
+              spec:
+                strategy:
+                  type: RollingUpdate
+                replicas: 2
+                selector:
+                  matchLabels:
+                    app: packageserver
+                template:
+                  metadata:
+                    labels:
+                      app: packageserver
+                  spec:
+                    serviceAccountName: packageserver
+                    nodeSelector:
+                      beta.kubernetes.io/os: linux
+                      node-role.kubernetes.io/master: ""
+                      
+                    tolerations:
+                      - operator: Exists
+                      
+                    containers:
+                    - name: packageserver
+                      command:
+                      - /bin/package-server
+                      - -v=4
+                      - --secure-port
+                      - "5443"
+                      - --global-namespace
+                      - openshift-operator-lifecycle-manager
+                      image: quay.io/operator-framework/olm@sha256:7e4b13b89b3d59876b228697bbd0c9e364fd73f946ab90308c34fd82053a5a76
+                      imagePullPolicy: IfNotPresent
+                      priorityClassName: "system-cluster-critical"
+                      ports:
+                      - containerPort: 5443
+                      livenessProbe:
+                        httpGet:
+                          scheme: HTTPS
+                          path: /healthz
+                          port: 5443
+                      readinessProbe:
+                        httpGet:
+                          scheme: HTTPS
+                          path: /healthz
+                          port: 5443
+        maturity: alpha
+        version: 0.9.0
+        apiservicedefinitions:
+          owned:
+          - group: packages.operators.coreos.com
+            version: v1
+            kind: PackageManifest
+            name: packagemanifests
+            displayName: PackageManifest
+            description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
+            deploymentName: packageserver
+            containerPort: 5443  
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
         name: packageserver.v0.10.1
         namespace: openshift-operator-lifecycle-manager
         labels:
@@ -17,6 +138,7 @@ data:
         displayName: Package Server
         description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
         minKubeVersion: 1.11.0
+        replaces: packageserver.v0.9.0
         keywords: ['packagemanifests', 'olm', 'packages']
         maintainers:
         - name: Red Hat

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -9,6 +9,7 @@ spec:
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
   minKubeVersion: 1.11.0
+  replaces: packageserver.v0.9.0
   keywords: ['packagemanifests', 'olm', 'packages']
   maintainers:
   - name: Red Hat


### PR DESCRIPTION
packageserver v0.10.1 `replaces` v0.9.0. This should kick off a
trigger that sets v0.9.0 to Replacing phase. The head CSV then
can take ownership of the APIService object.

TODO:
- I directly modified the manifests folder. In a follow up PR
  I will add the changes to the chart templates.