### PR TITLE
(status) update ClusterOperatorStatus builder

### DIFF
--- a/pkg/lib/operatorstatus/builder.go
+++ b/pkg/lib/operatorstatus/builder.go
@@ -43,12 +43,13 @@ func (b *Builder) WithProgressing(status configv1.ConditionStatus, message strin
 }
 
 // WithDegraded sets an OperatorDegraded type condition.
-func (b *Builder) WithDegraded(status configv1.ConditionStatus) *Builder {
+func (b *Builder) WithDegraded(status configv1.ConditionStatus, reason string) *Builder {
 	b.init()
 	condition := &configv1.ClusterOperatorStatusCondition{
 		Type:               configv1.OperatorDegraded,
 		Status:             status,
 		LastTransitionTime: metav1.NewTime(b.clock.Now()),
+		Reason:             reason,
 	}
 
 	b.setCondition(condition)
@@ -61,6 +62,21 @@ func (b *Builder) WithAvailable(status configv1.ConditionStatus, message string)
 	b.init()
 	condition := &configv1.ClusterOperatorStatusCondition{
 		Type:               configv1.OperatorAvailable,
+		Status:             status,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(b.clock.Now()),
+	}
+
+	b.setCondition(condition)
+
+	return b
+}
+
+// WithUpgradeable sets an OperatorUpgradeable type condition.
+func (b *Builder) WithUpgradeable(status configv1.ConditionStatus, message string) *Builder {
+	b.init()
+	condition := &configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorUpgradeable,
 		Status:             status,
 		Message:            message,
 		LastTransitionTime: metav1.NewTime(b.clock.Now()),

--- a/pkg/lib/operatorstatus/csv_reporter.go
+++ b/pkg/lib/operatorstatus/csv_reporter.go
@@ -65,7 +65,7 @@ func (r *csvStatusReporter) GetNewStatus(existing *configv1.ClusterOperatorStatu
 	}()
 
 	// We don't monitor whether the CSV backed operator is in degraded status.
-	builder.WithDegraded(configv1.ConditionFalse)
+	builder.WithDegraded(configv1.ConditionFalse, "")
 
 	// A CSV has been deleted.
 	if context.CurrentDeleted {

--- a/pkg/lib/operatorstatus/monitor.go
+++ b/pkg/lib/operatorstatus/monitor.go
@@ -201,7 +201,7 @@ func Waiting(clock clock.Clock, name string) *configv1.ClusterOperatorStatus {
 		clock: clock,
 	}
 
-	status := builder.WithDegraded(configv1.ConditionFalse).
+	status := builder.WithDegraded(configv1.ConditionFalse, "").
 		WithAvailable(configv1.ConditionFalse, "").
 		WithProgressing(configv1.ConditionTrue, fmt.Sprintf("waiting for events - source=%s", name)).
 		GetStatus()


### PR DESCRIPTION
Problem: The ClusterOperatorStatus builder does not provide a way to
report a reason when degraded. When an operator reports degraded,
OpenShift telemetry only provided the status (degraded == true) and
the reason. Also - the builder does not include the Upgradeable
condition.

Solution: Create and update the functions provided by the builder.