### PR TITLE
feat(deploy): add resource requests to all pods

### DIFF
--- a/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -57,4 +57,8 @@ spec:
             path: /healthz
             port: {{ .Values.package.service.internalPort }}
         terminationMessagePolicy: FallbackToLogsOnError
+        {{- if .Values.package.resources }}
+        resources:
+{{ toYaml .Values.package.resources | indent 10 }}
+        {{- end}}
 {{- end -}}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -17,6 +17,10 @@ olm:
     internalPort: 8080
   nodeSelector:
     beta.kubernetes.io/os: linux
+  resources:
+    requests:
+     cpu: 10m
+     memory: 160Mi
 
 catalog:
   replicaCount: 1
@@ -28,6 +32,10 @@ catalog:
     internalPort: 8080
   nodeSelector:
     beta.kubernetes.io/os: linux
+  resources:
+    requests:
+     cpu: 10m
+     memory: 80Mi
 
 package:
   replicaCount: 2
@@ -38,3 +46,7 @@ package:
     internalPort: 5443
   nodeSelector:
     beta.kubernetes.io/os: linux
+  resources:
+    requests:
+     cpu: 10m
+     memory: 50Mi

--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -31,6 +31,10 @@ olm:
     tolerationSeconds: 120
   tlsCertPath: /var/run/secrets/serving-cert/tls.crt
   tlsKeyPath: /var/run/secrets/serving-cert/tls.key
+  resources:
+    requests:
+      cpu: 10m
+      memory: 160Mi
 catalog:
   replicaCount: 1
   image:
@@ -53,6 +57,10 @@ catalog:
     operator: Exists
     effect: NoExecute
     tolerationSeconds: 120
+  resources:
+    requests:
+      cpu: 10m
+      memory: 80Mi
 package:
   replicaCount: 2
   image:
@@ -75,3 +83,7 @@ package:
     operator: Exists
     effect: NoExecute
     tolerationSeconds: 120
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -61,6 +61,11 @@ spec:
                 fieldPath: metadata.namespace
           - name: OPERATOR_NAME
             value: olm-operator
+          resources:
+            requests:
+              cpu: 10m
+              memory: 160Mi
+            
           
           volumeMounts:
           - mountPath: /var/run/secrets/serving-cert

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -54,6 +54,11 @@ spec:
           - name: RELEASE_VERSION
             value: "0.0.1-snapshot"
           
+          resources:
+            requests:
+              cpu: 10m
+              memory: 80Mi
+            
           
           volumeMounts:
           - mountPath: /var/run/secrets/serving-cert

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -121,6 +121,11 @@ spec:
                     path: /healthz
                     port: 5443
                 terminationMessagePolicy: FallbackToLogsOnError
+                resources:
+                  requests:
+                    cpu: 10m
+                    memory: 50Mi
+                  
   maturity: alpha
   version: 0.10.1
   apiservicedefinitions:

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -241,11 +241,11 @@ func TestExecutePlan(t *testing.T) {
 						Resource: v1alpha1.StepResource{
 							CatalogSource:          "catalog",
 							CatalogSourceNamespace: namespace,
-							Group:    "",
-							Version:  "v1",
-							Kind:     "Service",
-							Name:     "service",
-							Manifest: toManifest(service("service", namespace)),
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "Service",
+							Name:                   "service",
+							Manifest:               toManifest(service("service", namespace)),
 						},
 						Status: v1alpha1.StepStatusUnknown,
 					},
@@ -253,11 +253,11 @@ func TestExecutePlan(t *testing.T) {
 						Resource: v1alpha1.StepResource{
 							CatalogSource:          "catalog",
 							CatalogSourceNamespace: namespace,
-							Group:    "operators.coreos.com",
-							Version:  "v1alpha1",
-							Kind:     "ClusterServiceVersion",
-							Name:     "csv",
-							Manifest: toManifest(csv("csv", namespace, nil, nil)),
+							Group:                  "operators.coreos.com",
+							Version:                "v1alpha1",
+							Kind:                   "ClusterServiceVersion",
+							Name:                   "csv",
+							Manifest:               toManifest(csv("csv", namespace, nil, nil)),
 						},
 						Status: v1alpha1.StepStatusUnknown,
 					},
@@ -330,6 +330,7 @@ func TestSyncCatalogSources(t *testing.T) {
 			Name:      "cool-catalog",
 			Namespace: "cool-namespace",
 			UID:       types.UID("catalog-uid"),
+			Labels:    map[string]string{"olm.catalogSource": "cool-catalog"},
 		},
 		Spec: v1alpha1.CatalogSourceSpec{
 			Image:      "catalog-image",
@@ -493,6 +494,7 @@ func TestSyncCatalogSources(t *testing.T) {
 						Name:      "cool-catalog",
 						Namespace: "cool-namespace",
 						UID:       types.UID("catalog-uid"),
+						Labels:    map[string]string{"olm.catalogSource": "cool-catalog"},
 					},
 					Spec: v1alpha1.CatalogSourceSpec{
 						Image:      "old-image",
@@ -898,50 +900,7 @@ func toManifest(obj runtime.Object) string {
 }
 
 func pod(s v1alpha1.CatalogSource) *corev1.Pod {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: s.GetName() + "-",
-			Namespace:    s.GetNamespace(),
-			Labels: map[string]string{
-				"olm.catalogSource": s.GetName(),
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "registry-server",
-					Image: s.Spec.Image,
-					Ports: []corev1.ContainerPort{
-						{
-							Name:          "grpc",
-							ContainerPort: 50051,
-						},
-					},
-					ReadinessProbe: &corev1.Probe{
-						Handler: corev1.Handler{
-							Exec: &corev1.ExecAction{
-								Command: []string{"grpc_health_probe", "-addr=localhost:50051"},
-							},
-						},
-						InitialDelaySeconds: 5,
-					},
-					LivenessProbe: &corev1.Probe{
-						Handler: corev1.Handler{
-							Exec: &corev1.ExecAction{
-								Command: []string{"grpc_health_probe", "-addr=localhost:50051"},
-							},
-						},
-						InitialDelaySeconds: 10,
-					},
-				},
-			},
-			Tolerations: []corev1.Toleration{
-				{
-					Operator: corev1.TolerationOpExists,
-				},
-			},
-		},
-	}
+	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetLabels(), 5, 10)
 	ownerutil.AddOwner(pod, &s, false, false)
 	return pod
 }

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -90,56 +89,9 @@ func (s *configMapCatalogSourceDecorator) Service() *v1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: s.GetName() + "-",
-			Namespace:    s.GetNamespace(),
-			Labels:       s.Labels(),
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:    "configmap-registry-server",
-					Image:   image,
-					Command: []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()},
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "grpc",
-							ContainerPort: 50051,
-						},
-					},
-					ReadinessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
-								Command: []string{"grpc_health_probe", "-addr=localhost:50051"},
-							},
-						},
-						InitialDelaySeconds: 1,
-					},
-					LivenessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
-								Command: []string{"grpc_health_probe", "-addr=localhost:50051"},
-							},
-						},
-						InitialDelaySeconds: 2,
-					},
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("10m"),
-							v1.ResourceMemory: resource.MustParse("50Mi"),
-						},
-					},
-				},
-			},
-			Tolerations: []v1.Toleration{
-				{
-					Operator: v1.TolerationOpExists,
-				},
-			},
-			ServiceAccountName: s.GetName() + ConfigMapServerPostfix,
-		},
-	}
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, s.Labels(), 1, 2)
+	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
+	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)
 	return pod
 }

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -122,6 +123,12 @@ func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
 							},
 						},
 						InitialDelaySeconds: 2,
+					},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("10m"),
+							v1.ResourceMemory: resource.MustParse("50Mi"),
+						},
 					},
 				},
 			},

--- a/pkg/controller/registry/reconciler/configmap_test.go
+++ b/pkg/controller/registry/reconciler/configmap_test.go
@@ -170,6 +170,7 @@ func validConfigMapCatalogSource(configMap *corev1.ConfigMap) *v1alpha1.CatalogS
 			Name:      "cool-catalog",
 			Namespace: testNamespace,
 			UID:       types.UID("catalog-uid"),
+			Labels: map[string]string{"olm.catalogSource": "cool-catalog"},
 		},
 		Spec: v1alpha1.CatalogSourceSpec{
 			ConfigMap:  "cool-configmap",

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -87,6 +88,12 @@ func (s *grpcCatalogSourceDecorator) Pod() *v1.Pod {
 							},
 						},
 						InitialDelaySeconds: 10,
+					},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("10m"),
+							v1.ResourceMemory: resource.MustParse("50Mi"),
+						},
 					},
 				},
 			},

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -22,6 +22,7 @@ func validGrpcCatalogSource(image, address string) *v1alpha1.CatalogSource {
 			Name:      "img-catalog",
 			Namespace: testNamespace,
 			UID:       types.UID("catalog-uid"),
+			Labels:    map[string]string{"olm.catalogSource": "img-catalog"},
 		},
 		Spec: v1alpha1.CatalogSourceSpec{
 			Image:      image,


### PR DESCRIPTION
CPU has been set to 10m for all pods. The following are the memory requests:
olm-operator     160Mi
catalog-operator 80Mi
packageserver    50Mi
catalog sources  50Mi

This is for https://bugzilla.redhat.com/show_bug.cgi?id=1711070 (OLM-1130).