### PR TITLE
fix(manifest): fix env var projection in command

### DIFF
--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -27,7 +27,7 @@ spec:
           - /bin/olm
           args:
           - -namespace
-          - ${OPERATOR_NAMESPACE}
+          - $(OPERATOR_NAMESPACE)
           {{- if .Values.watchedNamespaces }}
           - -watchedNamespaces
           - {{ .Values.watchedNamespaces }}

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -25,7 +25,7 @@ spec:
           - /bin/olm
           args:
           - -namespace
-          - ${OPERATOR_NAMESPACE}
+          - $(OPERATOR_NAMESPACE)
           - -writeStatusName
           - operator-lifecycle-manager
           - -writePackageServerStatusName


### PR DESCRIPTION
the wrong brackets was causing the "cleanup" namespace to be set to ""
instead of the namespace where olm is deployed. this caused upgrade
failures when old artifacts weren't properly cleaned on startup.