### PR TITLE
Bug 1732613: Follow up for pod configuration

### DIFF
--- a/pkg/controller/install/deployment.go
+++ b/pkg/controller/install/deployment.go
@@ -80,7 +80,9 @@ func (c DeploymentInitializerFuncChain) Apply(deployment *appsv1.Deployment) (er
 	return
 }
 
-type DeploymentInitializerFuncBuilder func(owner ownerutil.Owner) DeploymentInitializerFunc
+// DeploymentInitializerBuilderFunc returns a DeploymentInitializerFunc based on
+// the given context.
+type DeploymentInitializerBuilderFunc func(owner ownerutil.Owner) DeploymentInitializerFunc
 
 func NewStrategyDeploymentInstaller(strategyClient wrappers.InstallStrategyDeploymentInterface, templateAnnotations map[string]string, owner ownerutil.Owner, previousStrategy Strategy, initializers DeploymentInitializerFuncChain) StrategyInstaller {
 	return &StrategyDeploymentInstaller{

--- a/pkg/controller/install/resolver.go
+++ b/pkg/controller/install/resolver.go
@@ -29,7 +29,7 @@ type StrategyResolverInterface interface {
 }
 
 type StrategyResolver struct {
-	ProxyInjectorBuilder DeploymentInitializerFuncBuilder
+	ProxyInjectorBuilderFunc DeploymentInitializerBuilderFunc
 }
 
 func (r *StrategyResolver) UnmarshalStrategy(s v1alpha1.NamedInstallStrategy) (strategy Strategy, err error) {
@@ -51,8 +51,8 @@ func (r *StrategyResolver) InstallerForStrategy(strategyName string, opClient op
 		strategyClient := wrappers.NewInstallStrategyDeploymentClient(opClient, opLister, owner.GetNamespace())
 
 		initializers := []DeploymentInitializerFunc{}
-		if r.ProxyInjectorBuilder != nil {
-			initializers = append(initializers, r.ProxyInjectorBuilder(owner))
+		if r.ProxyInjectorBuilderFunc != nil {
+			initializers = append(initializers, r.ProxyInjectorBuilderFunc(owner))
 		}
 
 		return NewStrategyDeploymentInstaller(strategyClient, annotations, owner, previousStrategy, initializers)

--- a/pkg/controller/operators/olm/envvar/initializer.go
+++ b/pkg/controller/operators/olm/envvar/initializer.go
@@ -63,7 +63,7 @@ func (d *DeploymentInitializer) initialize(ownerCSV ownerutil.Owner, deployment 
 	merged = append(podConfigEnvVar, proxyEnvVar...)
 
 	if len(merged) == 0 {
-		d.logger.Debugf("no env var to inject into csv=%s", ownerCSV.GetName())
+		d.logger.WithField("csv", ownerCSV.GetName()).Debug("no env var to inject into csv")
 	}
 
 	podSpec := deployment.Spec.Template.Spec

--- a/pkg/controller/operators/olm/envvar/initializer.go
+++ b/pkg/controller/operators/olm/envvar/initializer.go
@@ -56,6 +56,8 @@ func (d *DeploymentInitializer) initialize(ownerCSV ownerutil.Owner, deployment 
 			err = fmt.Errorf("failed to query cluster proxy configuration - %v", err)
 			return err
 		}
+
+		proxyEnvVar = dropEmptyProxyEnv(proxyEnvVar)
 	}
 
 	merged = append(podConfigEnvVar, proxyEnvVar...)
@@ -70,4 +72,17 @@ func (d *DeploymentInitializer) initialize(ownerCSV ownerutil.Owner, deployment 
 	}
 
 	return nil
+}
+
+func dropEmptyProxyEnv(in []corev1.EnvVar) (out []corev1.EnvVar) {
+	out = make([]corev1.EnvVar, 0)
+	for i := range in {
+		if in[i].Value == "" {
+			continue
+		}
+
+		out = append(out, in[i])
+	}
+
+	return
 }

--- a/pkg/controller/operators/olm/envvar/inject.go
+++ b/pkg/controller/operators/olm/envvar/inject.go
@@ -29,18 +29,15 @@ func merge(containerEnvVars []corev1.EnvVar, newEnvVars []corev1.EnvVar) (merged
 
 	for _, newEnvVar := range newEnvVars {
 		existing, found := find(containerEnvVars, newEnvVar.Name)
-		if !found {
-			if newEnvVar.Value != "" {
-				merged = append(merged, corev1.EnvVar{
-					Name:  newEnvVar.Name,
-					Value: newEnvVar.Value,
-				})
-			}
-
+		if found {
+			existing.Value = newEnvVar.Value
 			continue
 		}
 
-		existing.Value = newEnvVar.Value
+		merged = append(merged, corev1.EnvVar{
+			Name:  newEnvVar.Name,
+			Value: newEnvVar.Value,
+		})
 	}
 
 	return

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -407,7 +407,6 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		return nil, err
 	}
 
-
 	// setup proxy env var injection policies
 	discovery := config.operatorClient.KubernetesInterface().Discovery()
 	proxyAPIExists, err := proxy.IsAPIAvailable(discovery)
@@ -416,7 +415,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		return nil, err
 	}
 
-	proxyQuerierInUse := proxy.DefaultQuerier()
+	proxyQuerierInUse := proxy.NoopQuerier()
 	if proxyAPIExists {
 		op.logger.Info("OpenShift Proxy API  available - setting up watch for Proxy type")
 
@@ -443,7 +442,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 
 	proxyEnvInjector := envvar.NewDeploymentInitializer(op.logger, proxyQuerierInUse, op.lister)
 	op.resolver = &install.StrategyResolver{
-		ProxyInjectorBuilder: proxyEnvInjector.GetDeploymentInitializer,
+		ProxyInjectorBuilderFunc: proxyEnvInjector.GetDeploymentInitializer,
 	}
 	
 	return op, nil

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -453,10 +453,19 @@ func (a *Operator) now() metav1.Time {
 }
 
 func (a *Operator) syncSubscription(obj interface{}) error {
-	_, ok := obj.(*v1alpha1.Subscription)
+	sub, ok := obj.(*v1alpha1.Subscription)
 	if !ok {
 		a.logger.Debugf("wrong type: %#v\n", obj)
 		return fmt.Errorf("casting Subscription failed")
+	}
+
+	installedCSV := sub.Status.InstalledCSV
+	if installedCSV != "" {
+		a.logger.WithField("csv", installedCSV).Debug("subscription has changed, requeuing installed csv")
+		if err := a.csvQueueSet.Requeue(sub.GetNamespace(), installedCSV); err != nil {
+			a.logger.WithField("csv", installedCSV).Debug("failed to requeue installed csv")
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/lib/proxy/querier.go
+++ b/pkg/lib/proxy/querier.go
@@ -4,9 +4,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// DefaultQuerier does...
-func DefaultQuerier() Querier {
-	return &defaultQuerier{}
+// NoopQuerier returns an instance of noopQuerier. It's used for upstream where
+// we don't have any cluster proxy configuration.
+func NoopQuerier() Querier {
+	return &noopQuerier{}
 }
 
 // Querier is an interface that wraps the QueryProxyConfig method.
@@ -16,11 +17,11 @@ type Querier interface {
 	QueryProxyConfig() (proxy []corev1.EnvVar, err error)
 }
 
-type defaultQuerier struct {
+type noopQuerier struct {
 }
 
 // QueryProxyConfig returns no env variable(s), err is set to nil to indicate
 // that the cluster has no global proxy configuration.
-func (*defaultQuerier) QueryProxyConfig() (proxy []corev1.EnvVar, err error) {
+func (*noopQuerier) QueryProxyConfig() (proxy []corev1.EnvVar, err error) {
 	return
 }

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -1141,19 +1141,27 @@ func TestCreateNewSubscriptionWithPodConfig(t *testing.T) {
 		}
 
 		require.NotNil(t, proxy)
-		proxyEnv := []corev1.EnvVar{
-			corev1.EnvVar{
+		proxyEnv := []corev1.EnvVar{}
+
+		if proxy.Status.HTTPProxy !="" {
+			proxyEnv = append(proxyEnv, corev1.EnvVar{
 				Name:  "HTTP_PROXY",
 				Value: proxy.Status.HTTPProxy,
-			},
-			corev1.EnvVar{
+			})
+		}
+
+		if proxy.Status.HTTPSProxy !="" {
+			proxyEnv = append(proxyEnv, corev1.EnvVar{
 				Name:  "HTTPS_PROXY",
 				Value: proxy.Status.HTTPSProxy,
-			},
-			corev1.EnvVar{
+			})
+		}
+
+		if proxy.Status.NoProxy !="" {
+			proxyEnv = append(proxyEnv, corev1.EnvVar{
 				Name:  "NO_PROXY",
 				Value: proxy.Status.NoProxy,
-			},
+			})
 		}
 
 		return proxyEnv

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -1120,11 +1120,9 @@ func TestCreateNewSubscriptionWithPodConfig(t *testing.T) {
 
 	newConfigClient := func(t *testing.T) configv1client.ConfigV1Interface {
 		config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigPath)
-		// require.NoErrorf(t, err, "could not create rest config: %s", err.Error())
 		require.NoError(t, err,)
 
 		client, err := configv1client.NewForConfig(config)
-		// require.NoErrorf(t, err, "error creating OpenShift Config client: %s", err.Error())
 		require.NoError(t, err)
 
 		return client


### PR DESCRIPTION
* When a subscription changes, if it has an installed CSV then requeue
it so that any changes in pod configuration can take effect
immediately.

* Empty proxy env var should result in unset  …
*  If an env variable specified in pod configuration is empty, it will
  override the target PodSpec. For example, if 'foo=""' in pod
  configuration, olm will reset the 'foo' env variable in the target
  PodSpec to 'foo=""'
*  However, proxy env var is an exception to the above. An empty proxy
  env var means that it should not be set or it should be unset if it
  is already set in the target PodSpec.

* Rename and remove commented code

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1732613