### PR TITLE
Bug 1732302: Fix panic when binding already exists

### DIFF
--- a/pkg/controller/operators/catalog/step_ensurer.go
+++ b/pkg/controller/operators/catalog/step_ensurer.go
@@ -163,7 +163,10 @@ func (o *StepEnsurer) EnsureClusterRole(cr *rbacv1.ClusterRole, step *v1alpha1.S
 	}
 
 	// We're updating, point owner to the newest csv
-	cr.Labels[ownerutil.OwnerKey] = step.Resolving
+	if cr.ObjectMeta.Labels == nil {
+		cr.ObjectMeta.Labels = map[string]string{}
+	}
+	cr.ObjectMeta.Labels[ownerutil.OwnerKey] = step.Resolving
 	if _, updateErr := o.kubeClient.UpdateClusterRole(cr); updateErr != nil {
 		err = errorwrap.Wrapf(updateErr, "error updating clusterrole %s", cr.GetName())
 		return
@@ -187,7 +190,10 @@ func (o *StepEnsurer) EnsureClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, s
 	}
 
 	// if we're updating, point owner to the newest csv
-	crb.Labels[ownerutil.OwnerKey] = step.Resolving
+	if crb.ObjectMeta.Labels == nil {
+		crb.ObjectMeta.Labels = map[string]string{}
+	}
+	crb.ObjectMeta.Labels[ownerutil.OwnerKey] = step.Resolving
 	if _, updateErr := o.kubeClient.UpdateClusterRoleBinding(crb); updateErr != nil {
 		err = errorwrap.Wrapf(updateErr, "error updating clusterrolebinding %s", crb.GetName())
 		return


### PR DESCRIPTION
Fix the following panic when the RoleBinding/ClusterRoleBinding already exists.

Note this will need to be backported, as it exists in the release-4.x branches as well.

```
panic: assignment to entry in nil map

goroutine 183 [running]:
github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog.(*Operator).ExecutePlan(0xc4204bec00, 0xc421924000, 0x1, 0x1)
        /go/src/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go:1187 +0x4243
```