### PR TITLE
Bug 1732214: Fix panic when binding already exists

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1160,6 +1160,9 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 				_, err = o.OpClient.KubernetesInterface().RbacV1().ClusterRoles().Create(&cr)
 				if k8serrors.IsAlreadyExists(err) {
 					// if we're updating, point owner to the newest csv
+					if cr.ObjectMeta.Labels == nil {
+						cr.ObjectMeta.Labels = map[string]string{}
+					}
 					cr.Labels[ownerutil.OwnerKey] = step.Resolving
 					_, err = o.OpClient.UpdateClusterRole(&cr)
 					if err != nil {
@@ -1184,6 +1187,9 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 				// Attempt to create the ClusterRoleBinding.
 				_, err = o.OpClient.KubernetesInterface().RbacV1().ClusterRoleBindings().Create(&rb)
 				if k8serrors.IsAlreadyExists(err) {
+					if rb.ObjectMeta.Labels == nil {
+						rb.ObjectMeta.Labels = map[string]string{}
+					}
 					rb.Labels[ownerutil.OwnerKey] = step.Resolving
 					_, err = o.OpClient.UpdateClusterRoleBinding(&rb)
 					if err != nil {

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1190,7 +1190,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 					if rb.ObjectMeta.Labels == nil {
 						rb.ObjectMeta.Labels = map[string]string{}
 					}
-					rb.Labels[ownerutil.OwnerKey] = step.Resolving
+					rb.ObjectMeta.Labels[ownerutil.OwnerKey] = step.Resolving
 					_, err = o.OpClient.UpdateClusterRoleBinding(&rb)
 					if err != nil {
 						return errorwrap.Wrapf(err, "error updating clusterrolebinding %s", rb.GetName())

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1163,7 +1163,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 					if cr.ObjectMeta.Labels == nil {
 						cr.ObjectMeta.Labels = map[string]string{}
 					}
-					cr.Labels[ownerutil.OwnerKey] = step.Resolving
+					cr.ObjectMeta.Labels[ownerutil.OwnerKey] = step.Resolving
 					_, err = o.OpClient.UpdateClusterRole(&cr)
 					if err != nil {
 						return errorwrap.Wrapf(err, "error updating clusterrole %s", cr.GetName())


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/operator-framework/operator-lifecycle-manager/pull/959

@cblecker 