### PR TITLE
Bug 1743345: clean up service account, cluster roles, and cluster role bindings after CSV deletion

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -18,7 +18,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"	
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 )
 
 const (
@@ -253,7 +253,7 @@ func (a *Operator) ensureProvidedAPIClusterRole(operatorGroup *v1.OperatorGroup,
 		},
 		Rules: []rbacv1.PolicyRule{{Verbs: verbs, APIGroups: []string{group}, Resources: []string{resource}, ResourceNames: resourceNames}},
 	}
-	err := ownerutil.AddOwnerLabels(clusterRole, operatorGroup)
+	err := ownerutil.AddOwnerLabels(clusterRole, csv)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/registry/resolver/rbac.go
+++ b/pkg/controller/registry/resolver/rbac.go
@@ -117,6 +117,7 @@ func RBACForClusterServiceVersion(csv *v1alpha1.ClusterServiceVersion) (map[stri
 		// Create ServiceAccount if necessary
 		if _, ok := permissions[permission.ServiceAccountName]; !ok {
 			serviceAccount := &corev1.ServiceAccount{}
+			ownerutil.AddOwner(serviceAccount, csv, false, false)
 			serviceAccount.SetName(permission.ServiceAccountName)
 
 			permissions[permission.ServiceAccountName] = NewOperatorPermissions(serviceAccount)

--- a/pkg/lib/queueinformer/config.go
+++ b/pkg/lib/queueinformer/config.go
@@ -197,7 +197,7 @@ func WithQueueInformers(queueInformers ...*QueueInformer) OperatorOption {
 	}
 }
 
-// WithQueueInformers registers a set of initial Informers with an Operator.
+// WithInformers registers a set of initial Informers with an Operator.
 func WithInformers(informers ...cache.SharedIndexInformer) OperatorOption {
 	return func(config *operatorConfig) {
 		config.informers = informers

--- a/pkg/lib/queueinformer/config.go
+++ b/pkg/lib/queueinformer/config.go
@@ -43,7 +43,7 @@ func (c *queueInformerConfig) complete() {
 }
 
 // validate returns an error if the config isn't valid.
-func (c *queueInformerConfig) validate() (err error) {
+func (c *queueInformerConfig) validateQueueInformer() (err error) {
 	switch config := c; {
 	case config.provider == nil:
 		err = newInvalidConfigError("nil metrics provider")
@@ -53,6 +53,24 @@ func (c *queueInformerConfig) validate() (err error) {
 		err = newInvalidConfigError("nil queue")
 	case config.indexer == nil && config.informer == nil:
 		err = newInvalidConfigError("nil indexer and informer")
+	case config.keyFunc == nil:
+		err = newInvalidConfigError("nil key function")
+	case config.syncer == nil:
+		err = newInvalidConfigError("nil syncer")
+	}
+
+	return
+}
+
+// difference from above is that this intentionally verifies without index/informer
+func (c *queueInformerConfig) validateQueue() (err error) {
+	switch config := c; {
+	case config.provider == nil:
+		err = newInvalidConfigError("nil metrics provider")
+	case config.logger == nil:
+		err = newInvalidConfigError("nil logger")
+	case config.queue == nil:
+		err = newInvalidConfigError("nil queue")
 	case config.keyFunc == nil:
 		err = newInvalidConfigError("nil key function")
 	case config.syncer == nil:

--- a/pkg/lib/queueinformer/queueinformer.go
+++ b/pkg/lib/queueinformer/queueinformer.go
@@ -105,6 +105,25 @@ func (q *QueueInformer) metricHandlers() *cache.ResourceEventHandlerFuncs {
 	}
 }
 
+func NewQueue(ctx context.Context, options ...Option) (*QueueInformer, error) {
+	config := defaultConfig()
+	config.apply(options)
+
+	if err := config.validateQueue(); err != nil {
+		return nil, err
+	}
+
+	queue := &QueueInformer{
+		MetricsProvider: config.provider,
+		logger:          config.logger,
+		queue:           config.queue,
+		keyFunc:         config.keyFunc,
+		syncer:          config.syncer,
+	}
+
+	return queue, nil
+}
+
 // NewQueueInformer returns a new QueueInformer configured with options.
 func NewQueueInformer(ctx context.Context, options ...Option) (*QueueInformer, error) {
 	// Get default config and apply given options
@@ -116,7 +135,7 @@ func NewQueueInformer(ctx context.Context, options ...Option) (*QueueInformer, e
 }
 
 func newQueueInformerFromConfig(ctx context.Context, config *queueInformerConfig) (*QueueInformer, error) {
-	if err := config.validate(); err != nil {
+	if err := config.validateQueueInformer(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/lib/queueinformer/queueinformer_operator.go
+++ b/pkg/lib/queueinformer/queueinformer_operator.go
@@ -247,17 +247,24 @@ func (o *operator) processNextWorkItem(ctx context.Context, loop *QueueInformer)
 
 		logger = logger.WithField("cache-key", key)
 
-		// Get the current cached version of the resource
-		resource, exists, err := loop.indexer.GetByKey(key)
-		if err != nil {
-			logger.WithError(err).Error("cache get failed")
-			queue.Forget(item)
-			return true
-		}
-		if !exists {
-			logger.WithField("existing-cache-keys", loop.indexer.ListKeys()).Debug("cache get failed, key not in cache")
-			queue.Forget(item)
-			return true
+		var resource interface{}
+		if loop.indexer == nil {
+			resource = event.Resource()
+		} else {
+			// Get the current cached version of the resource
+			var exists bool
+			var err error
+			resource, exists, err = loop.indexer.GetByKey(key)
+			if err != nil {
+				logger.WithError(err).Error("cache get failed")
+				queue.Forget(item)
+				return true
+			}
+			if !exists {
+				logger.WithField("existing-cache-keys", loop.indexer.ListKeys()).Debug("cache get failed, key not in cache")
+				queue.Forget(item)
+				return true
+			}
 		}
 
 		if !ok {

--- a/pkg/lib/queueinformer/resourcequeue.go
+++ b/pkg/lib/queueinformer/resourcequeue.go
@@ -34,6 +34,18 @@ func (r *ResourceQueueSet) Set(key string, queue workqueue.RateLimitingInterface
 	r.queueSet[key] = queue
 }
 
+func (r *ResourceQueueSet) RequeueEvent(namespace string, resourceEvent kubestate.ResourceEvent) error {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	if queue, ok := r.queueSet[namespace]; ok {
+		queue.AddRateLimited(resourceEvent)
+		return nil
+	}
+
+	return fmt.Errorf("couldn't find queue '%v' for event: %v", namespace, resourceEvent)
+}
+
 // Requeue requeues the resource in the set with the given name and namespace
 func (r *ResourceQueueSet) Requeue(namespace, name string) error {
 	r.mutex.RLock()

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -17,12 +17,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	opver "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/version"
 )
 
@@ -1449,6 +1451,96 @@ func TestCreateInstallPlanWithPermissions(t *testing.T) {
 
 	// Should have removed every matching step
 	require.Equal(t, 0, len(expectedSteps), "Actual resource steps do not match expected: %#v", expectedSteps)
+
+	// the test from here out verifies created RBAC is removed after CSV deletion
+	createdClusterRoles, err := c.KubernetesInterface().RbacV1().ClusterRoles().List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%v=%v", ownerutil.OwnerKey, stableCSVName)})
+	createdClusterRoleNames := map[string]struct{}{}
+	for _, role := range createdClusterRoles.Items {
+		createdClusterRoleNames[role.GetName()] = struct{}{}
+		t.Logf("Monitoring cluster role %v", role.GetName())
+	}
+
+	createdClusterRoleBindings, err := c.KubernetesInterface().RbacV1().ClusterRoleBindings().List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%v=%v", ownerutil.OwnerKey, stableCSVName)})
+	createdClusterRoleBindingNames := map[string]struct{}{}
+	for _, binding := range createdClusterRoleBindings.Items {
+		createdClusterRoleBindingNames[binding.GetName()] = struct{}{}
+		t.Logf("Monitoring cluster role binding %v", binding.GetName())
+	}
+
+	// can't query by owner reference, so just use the name we know is in the install plan
+	createdServiceAccountNames := map[string]struct{}{serviceAccountName: struct{}{}}
+	t.Logf("Monitoring service account %v", serviceAccountName)
+
+	crWatcher, err := c.KubernetesInterface().RbacV1().ClusterRoles().Watch(metav1.ListOptions{LabelSelector: fmt.Sprintf("%v=%v", ownerutil.OwnerKey, stableCSVName)})
+	require.NoError(t, err)
+	crbWatcher, err := c.KubernetesInterface().RbacV1().ClusterRoleBindings().Watch(metav1.ListOptions{LabelSelector: fmt.Sprintf("%v=%v", ownerutil.OwnerKey, stableCSVName)})
+	require.NoError(t, err)
+	saWatcher, err := c.KubernetesInterface().CoreV1().ServiceAccounts(testNamespace).Watch(metav1.ListOptions{})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	quit := make(chan struct{})
+	defer close(quit)
+	go func() {
+		for {
+			select {
+			case <-quit:
+				return
+			case evt, ok := <-crWatcher.ResultChan():
+				if !ok {
+					t.Fatal("cr watch channel closed unexpectedly")
+				}
+				if evt.Type == watch.Deleted {
+					cr, ok := evt.Object.(*rbacv1.ClusterRole)
+					if !ok {
+						continue
+					}
+					delete(createdClusterRoleNames, cr.GetName())
+					if len(createdClusterRoleNames) == 0 && len(createdClusterRoleBindingNames) == 0 && len(createdServiceAccountNames) == 0 {
+						done <- struct{}{}
+					}
+				}
+			case evt, ok := <-crbWatcher.ResultChan():
+				if !ok {
+					t.Fatal("crb watch channel closed unexpectedly")
+				}
+				if evt.Type == watch.Deleted {
+					crb, ok := evt.Object.(*rbacv1.ClusterRoleBinding)
+					if !ok {
+						continue
+					}
+					delete(createdClusterRoleBindingNames, crb.GetName())
+					if len(createdClusterRoleNames) == 0 && len(createdClusterRoleBindingNames) == 0 && len(createdServiceAccountNames) == 0 {
+						done <- struct{}{}
+					}
+				}
+			case evt, ok := <-saWatcher.ResultChan():
+				if !ok {
+					t.Fatal("sa watch channel closed unexpectedly")
+				}
+				if evt.Type == watch.Deleted {
+					sa, ok := evt.Object.(*corev1.ServiceAccount)
+					if !ok {
+						continue
+					}
+					delete(createdServiceAccountNames, sa.GetName())
+					if len(createdClusterRoleNames) == 0 && len(createdClusterRoleBindingNames) == 0 && len(createdServiceAccountNames) == 0 {
+						done <- struct{}{}
+					}
+				}
+			case <-time.After(pollDuration):
+				done <- struct{}{}
+			}
+		}
+	}()
+
+	t.Logf("Deleting CSV '%v' in namespace %v", stableCSVName, testNamespace)
+	require.NoError(t, crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{}))
+	<-done
+
+	require.Emptyf(t, createdClusterRoleNames, "unexpected cluster role remain: %v", createdClusterRoleNames)
+	require.Emptyf(t, createdClusterRoleBindingNames, "unexpected cluster role binding remain: %v", createdClusterRoleBindingNames)
+	require.Emptyf(t, createdServiceAccountNames, "unexpected service account remain: %v", createdServiceAccountNames)
 }
 
 func TestInstallPlanCRDValidation(t *testing.T) {


### PR DESCRIPTION
The approach I have here works, but takes a while as the resync interval has to pass. I was trying avoid creating a new queue for requeueing, though that may not have worked anyway since really it'd need to be requeued after CSV deletion. The commented out section did not work due to CSV requeueing and in progress CSV processing.

(The above is now outdated.)