### PR TITLE
Bug 1702552: Two "NAME" fields by command "oc get catalogsource"

### DIFF
--- a/deploy/chart/templates/0000_50_olm_06-catalogsource.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_06-catalogsource.crd.yaml
@@ -23,7 +23,7 @@ spec:
     categories:
     - olm
   additionalPrinterColumns:
-  - name: Name
+  - name: Display
     type: string
     description: The pretty name of the catalog
     JSONPath: .spec.displayName

--- a/manifests/0000_50_olm_06-catalogsource.crd.yaml
+++ b/manifests/0000_50_olm_06-catalogsource.crd.yaml
@@ -23,7 +23,7 @@ spec:
     categories:
     - olm
   additionalPrinterColumns:
-  - name: Name
+  - name: Display
     type: string
     description: The pretty name of the catalog
     JSONPath: .spec.displayName


### PR DESCRIPTION
The NAME field is now corrected as DISPLAY in catalogsource CRD manifest.

Signed-off-by: Vu Dinh <vdinh@redhat.com>