### PR TITLE
Bug 1727800: Remove Icon from `PackageManifest` Resource

### DIFF
--- a/pkg/package-server/storage/reststorage.go
+++ b/pkg/package-server/storage/reststorage.go
@@ -85,6 +85,12 @@ func (m *PackageManifestStorage) List(ctx context.Context, options *metainternal
 			filtered = append(filtered, manifest)
 		}
 	}
+	// Strip logo icons
+	for i := range filtered {
+		for j := range filtered[i].Status.Channels {
+			filtered[i].Status.Channels[j].CurrentCSVDesc.Icon = []operators.Icon{}
+		}
+	}
 	res.Items = filtered
 
 	return res, nil
@@ -96,6 +102,10 @@ func (m *PackageManifestStorage) Get(ctx context.Context, name string, opts *met
 	manifest, err := m.prov.Get(namespace, name)
 	if err != nil || manifest == nil {
 		return nil, k8serrors.NewNotFound(m.groupResource, name)
+	}
+	// Strip logo icons
+	for i := range manifest.Status.Channels {
+		manifest.Status.Channels[i].CurrentCSVDesc.Icon = []operators.Icon{}
 	}
 
 	return manifest, nil


### PR DESCRIPTION
### Description

Reduces the large HTTP size of the `PackageManifest` resource by removing the base64-encoded icon data. Clients should use the [`packagemanifests/icon` subresource](https://github.com/operator-framework/operator-lifecycle-manager/pull/990) instead. This field is **optional**, so clients should have been checking for `nil` values and won't be broken by this change.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1727800
Addresses https://jira.coreos.com/browse/OLM-1211