### PR TITLE
Bug 1744490: Add RBAC for PackageManifest Icon Subresource

### DIFF
--- a/deploy/chart/templates/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/deploy/chart/templates/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -28,5 +28,5 @@ rules:
   resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["packages.operators.coreos.com"]
-  resources: ["packagemanifests"]
+  resources: ["packagemanifests", "packagemanifests/icon"]
   verbs: ["get", "list", "watch"]

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -28,5 +28,5 @@ rules:
   resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["packages.operators.coreos.com"]
-  resources: ["packagemanifests"]
+  resources: ["packagemanifests", "packagemanifests/icon"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
### Description

Ensures that users with the aggregated OLM roles can `GET packagemanifests/icon` resource added in https://github.com/operator-framework/operator-lifecycle-manager/pull/990.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1744490