### PR TITLE
Bug 1740332: OLM should resume operator install

### DIFF
--- a/pkg/api/apis/operators/installplan_types.go
+++ b/pkg/api/apis/operators/installplan_types.go
@@ -78,10 +78,11 @@ var ErrInvalidInstallPlan = errors.New("the InstallPlan contains invalid data")
 //
 // Status may trail the actual state of a system.
 type InstallPlanStatus struct {
-	Phase          InstallPlanPhase
-	Conditions     []InstallPlanCondition
-	CatalogSources []string
-	Plan           []*Step
+	Phase                       InstallPlanPhase
+	Conditions                  []InstallPlanCondition
+	CatalogSources              []string
+	Plan                        []*Step
+	AttenuatedServiceAccountRef *corev1.ObjectReference
 }
 
 // InstallPlanCondition represents the overall status of the execution of

--- a/pkg/api/apis/operators/v1alpha1/installplan_types.go
+++ b/pkg/api/apis/operators/v1alpha1/installplan_types.go
@@ -84,6 +84,10 @@ type InstallPlanStatus struct {
 	Conditions     []InstallPlanCondition `json:"conditions,omitempty"`
 	CatalogSources []string               `json:"catalogSources"`
 	Plan           []*Step                `json:"plan,omitempty"`
+
+	// AttenuatedServiceAccountRef references the service account that is used
+	// to do scoped operator install.
+	AttenuatedServiceAccountRef *corev1.ObjectReference `json:"attenuatedServiceAccountRef,omitempty"`
 }
 
 // InstallPlanCondition represents the overall status of the execution of
@@ -131,23 +135,22 @@ func (s *InstallPlanStatus) SetCondition(cond InstallPlanCondition) InstallPlanC
 	return cond
 }
 
-
 func ConditionFailed(cond InstallPlanConditionType, reason InstallPlanConditionReason, message string, now *metav1.Time) InstallPlanCondition {
 	return InstallPlanCondition{
-		Type:    cond,
-		Status:  corev1.ConditionFalse,
-		Reason:  reason,
-		Message: message,
-		LastUpdateTime: *now,
+		Type:               cond,
+		Status:             corev1.ConditionFalse,
+		Reason:             reason,
+		Message:            message,
+		LastUpdateTime:     *now,
 		LastTransitionTime: *now,
 	}
 }
 
 func ConditionMet(cond InstallPlanConditionType, now *metav1.Time) InstallPlanCondition {
 	return InstallPlanCondition{
-		Type:   cond,
-		Status: corev1.ConditionTrue,
-		LastUpdateTime: *now,
+		Type:               cond,
+		Status:             corev1.ConditionTrue,
+		LastUpdateTime:     *now,
 		LastTransitionTime: *now,
 	}
 }

--- a/pkg/api/apis/operators/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/apis/operators/v1alpha1/zz_generated.conversion.go
@@ -1239,6 +1239,7 @@ func autoConvert_v1alpha1_InstallPlanStatus_To_operators_InstallPlanStatus(in *I
 	out.Conditions = *(*[]operators.InstallPlanCondition)(unsafe.Pointer(&in.Conditions))
 	out.CatalogSources = *(*[]string)(unsafe.Pointer(&in.CatalogSources))
 	out.Plan = *(*[]*operators.Step)(unsafe.Pointer(&in.Plan))
+	out.AttenuatedServiceAccountRef = (*corev1.ObjectReference)(unsafe.Pointer(in.AttenuatedServiceAccountRef))
 	return nil
 }
 
@@ -1252,6 +1253,7 @@ func autoConvert_operators_InstallPlanStatus_To_v1alpha1_InstallPlanStatus(in *o
 	out.Conditions = *(*[]InstallPlanCondition)(unsafe.Pointer(&in.Conditions))
 	out.CatalogSources = *(*[]string)(unsafe.Pointer(&in.CatalogSources))
 	out.Plan = *(*[]*Step)(unsafe.Pointer(&in.Plan))
+	out.AttenuatedServiceAccountRef = (*corev1.ObjectReference)(unsafe.Pointer(in.AttenuatedServiceAccountRef))
 	return nil
 }
 

--- a/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/apis/operators/v1alpha1/zz_generated.deepcopy.go
@@ -777,6 +777,11 @@ func (in *InstallPlanStatus) DeepCopyInto(out *InstallPlanStatus) {
 			}
 		}
 	}
+	if in.AttenuatedServiceAccountRef != nil {
+		in, out := &in.AttenuatedServiceAccountRef, &out.AttenuatedServiceAccountRef
+		*out = new(corev1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/apis/operators/zz_generated.deepcopy.go
+++ b/pkg/api/apis/operators/zz_generated.deepcopy.go
@@ -777,6 +777,11 @@ func (in *InstallPlanStatus) DeepCopyInto(out *InstallPlanStatus) {
 			}
 		}
 	}
+	if in.AttenuatedServiceAccountRef != nil {
+		in, out := &in.AttenuatedServiceAccountRef, &out.AttenuatedServiceAccountRef
+		*out = new(corev1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/operators/catalog/installplan_sync.go
+++ b/pkg/controller/operators/catalog/installplan_sync.go
@@ -1,0 +1,100 @@
+package catalog
+
+import (
+	"errors"
+
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
+)
+
+// When a user adds permission to a ServiceAccount by creating or updating
+// Role/RoleBinding then we expect the InstallPlan that refers to the
+// ServiceAccount to be retried if it has failed to install before due to
+// permission issue(s).
+func (o *Operator) triggerInstallPlanRetry(obj interface{}) (syncError error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		syncError = errors.New("casting to metav1 object failed")
+		o.logger.Warn(syncError.Error())
+		return
+	}
+
+	related, _ := isObjectRBACRelated(obj)
+	if !related {
+		return
+	}
+
+	ips, err := o.lister.OperatorsV1alpha1().InstallPlanLister().InstallPlans(metaObj.GetNamespace()).List(labels.Everything())
+	if err != nil {
+		syncError = err
+		return
+	}
+
+	isTarget := func(ip *v1alpha1.InstallPlan) bool {
+		// Only an InstallPlan that has failed to install before and only if it
+		// has a reference to a ServiceAccount then
+		return ip.Status.Phase == v1alpha1.InstallPlanPhaseFailed && ip.Status.AttenuatedServiceAccountRef != nil
+	}
+
+	update := func(ip *v1alpha1.InstallPlan) error {
+		out := ip.DeepCopy()
+		out.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+		_, err := o.client.OperatorsV1alpha1().InstallPlans(ip.GetNamespace()).UpdateStatus(out)
+
+		return err
+	}
+
+	var errs []error
+	for _, ip := range ips {
+		if !isTarget(ip) {
+			continue
+		}
+
+		logger := o.logger.WithFields(logrus.Fields{
+			"ip":        ip.GetName(),
+			"namespace": ip.GetNamespace(),
+			"phase":     ip.Status.Phase,
+		})
+
+		if updateErr := update(ip); updateErr != nil {
+			errs = append(errs, updateErr)
+			logger.WithError(updateErr).Warn("failed to kick off InstallPlan retry")
+			continue
+		}
+
+		logger.Info("InstallPlan status set to 'Installing' for retry")
+	}
+
+	syncError = utilerrors.NewAggregate(errs)
+	return
+}
+
+func isObjectRBACRelated(obj interface{}) (related bool, object runtime.Object) {
+	object, ok := obj.(runtime.Object)
+	if !ok {
+		return
+	}
+
+	if err := ownerutil.InferGroupVersionKind(object); err != nil {
+		return
+	}
+
+	kind := object.GetObjectKind().GroupVersionKind().Kind
+	switch kind {
+	case roleKind:
+		fallthrough
+	case roleBindingKind:
+		fallthrough
+	case serviceAccountKind:
+		related = true
+	}
+
+	return
+}

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -388,7 +388,7 @@ func (o *Operator) syncObject(obj interface{}) (syncError error) {
 
 	o.requeueOwners(metaObj)
 
-	return
+	return o.triggerInstallPlanRetry(obj)
 }
 
 func (o *Operator) handleDeletion(obj interface{}) {
@@ -1027,6 +1027,28 @@ func (o *Operator) syncInstallPlans(obj interface{}) (syncError error) {
 		return
 	}
 
+	querier := o.serviceAccountQuerier.NamespaceQuerier(plan.GetNamespace())
+	reference, err := querier()
+	if err != nil {
+		syncError = fmt.Errorf("attenuated service account query failed - %v", err)
+		return
+	}
+
+	if reference != nil {
+		out := plan.DeepCopy()
+		out.Status.AttenuatedServiceAccountRef = reference
+
+		if !reflect.DeepEqual(plan, out) {
+			if _, updateErr := o.client.OperatorsV1alpha1().InstallPlans(out.GetNamespace()).UpdateStatus(out); err != nil {
+				syncError = fmt.Errorf("failed to attach attenuated ServiceAccount to status - %v", updateErr)
+				return
+			}
+						
+			logger.WithField("attenuated-sa", reference.Name).Info("successfully attached attenuated ServiceAccount to status")
+			return
+		}
+	}
+
 	outInstallPlan, syncError := transitionInstallPlanState(logger.Logger, o, *plan, o.now())
 
 	if syncError != nil {
@@ -1190,8 +1212,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 	// Does the namespace have an operator group that specifies a user defined
 	// service account? If so, then we should use a scoped client for plan
 	// execution.
-	getter := o.serviceAccountQuerier.NamespaceQuerier(namespace)
-	kubeclient, crclient, err := o.clientAttenuator.AttenuateClient(getter)
+	kubeclient, crclient, err := o.clientAttenuator.AttenuateClientWithServiceAccount(plan.Status.AttenuatedServiceAccountRef)
 	if err != nil {
 		o.logger.Errorf("failed to get a client for plan execution- %v", err)
 		return err


### PR DESCRIPTION
OLM should automatically resume operator install when a user grants
proper permission(s).

Currently, a user has to manually delete the subscription and recreate
it in order to trigger a reinstall of the operator.

Do the following to trigger reinstall:
- Add a new field 'AttenuatedServiceAccountRef' to status of
  InstallPlan. We use this to refer to the ServiceAccount that will be
  used to do attenuated scoped install of the operator.
- Watch on Role(Binding), ServiceAccount resources. When these RBAC
  resources are added/updated find the target InstallPlan object.
- Update the status.phase of the InstallPlan object to Installing.
  This will trigger a sync of the InstallPlan.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1740332
Jira: https://jira.coreos.com/browse/OLM-1244
