### PR TITLE
Bug 1727042: Ensure status monitor always reports upgradeable

### DIFF
--- a/pkg/lib/operatorstatus/builder.go
+++ b/pkg/lib/operatorstatus/builder.go
@@ -71,6 +71,21 @@ func (b *Builder) WithAvailable(status configv1.ConditionStatus, message string)
 	return b
 }
 
+// WithUpgradeable sets an OperatorUpgradeable type condition.
+func (b *Builder) WithUpgradeable(status configv1.ConditionStatus, message string) *Builder {
+	b.init()
+	condition := &configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorUpgradeable,
+		Status:             status,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(b.clock.Now()),
+	}
+
+	b.setCondition(condition)
+
+	return b
+}
+
 // WithVersion adds the specific version into the status.
 func (b *Builder) WithVersion(name, version string) *Builder {
 	b.init()

--- a/pkg/lib/operatorstatus/csv_reporter.go
+++ b/pkg/lib/operatorstatus/csv_reporter.go
@@ -67,6 +67,9 @@ func (r *csvStatusReporter) GetNewStatus(existing *configv1.ClusterOperatorStatu
 	// We don't monitor whether the CSV backed operator is in degraded status.
 	builder.WithDegraded(configv1.ConditionFalse)
 
+	// Don't monitor this here. As long as degraded is false this should be true.
+	builder.WithUpgradeable(configv1.ConditionTrue, "")
+
 	// A CSV has been deleted.
 	if context.CurrentDeleted {
 		csv := context.Current

--- a/pkg/lib/operatorstatus/csv_reporter_test.go
+++ b/pkg/lib/operatorstatus/csv_reporter_test.go
@@ -56,6 +56,11 @@ func TestGetNewStatus(t *testing.T) {
 						LastTransitionTime: metav1.NewTime(fakeClock.Now()),
 					},
 					configv1.ClusterOperatorStatusCondition{
+						Type:               configv1.OperatorUpgradeable,
+						Status:             configv1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+					},
+					configv1.ClusterOperatorStatusCondition{
 						Type:               configv1.OperatorAvailable,
 						Status:             configv1.ConditionFalse,
 						LastTransitionTime: metav1.NewTime(fakeClock.Now()),
@@ -114,6 +119,11 @@ func TestGetNewStatus(t *testing.T) {
 					configv1.ClusterOperatorStatusCondition{
 						Type:               configv1.OperatorDegraded,
 						Status:             configv1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+					},
+					configv1.ClusterOperatorStatusCondition{
+						Type:               configv1.OperatorUpgradeable,
+						Status:             configv1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(fakeClock.Now()),
 					},
 					configv1.ClusterOperatorStatusCondition{

--- a/pkg/lib/operatorstatus/monitor.go
+++ b/pkg/lib/operatorstatus/monitor.go
@@ -202,6 +202,7 @@ func Waiting(clock clock.Clock, name string) *configv1.ClusterOperatorStatus {
 	}
 
 	status := builder.WithDegraded(configv1.ConditionFalse).
+		WithUpgradeable(configv1.ConditionTrue, "").
 		WithAvailable(configv1.ConditionFalse, "").
 		WithProgressing(configv1.ConditionTrue, fmt.Sprintf("waiting for events - source=%s", name)).
 		GetStatus()

--- a/pkg/lib/operatorstatus/monitor_test.go
+++ b/pkg/lib/operatorstatus/monitor_test.go
@@ -23,6 +23,11 @@ func TestMonitorWaiting(t *testing.T) {
 				LastTransitionTime: metav1.NewTime(fakeClock.Now()),
 			},
 			configv1.ClusterOperatorStatusCondition{
+				Type:               configv1.OperatorUpgradeable,
+				Status:             configv1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+			},
+			configv1.ClusterOperatorStatusCondition{
 				Type:               configv1.OperatorAvailable,
 				Status:             configv1.ConditionFalse,
 				LastTransitionTime: metav1.NewTime(fakeClock.Now()),


### PR DESCRIPTION
Currently on startup the initial status reporting sets the upgradeable
field. However, because of the way the status monitor builder recreates
the entire status block on every report, we also need to set upgradeable
every time that object is reported.

For now, report that upgradeable is always true as long as nothing is in
a degraded state.

Pertaining to these bugzillas:
https://bugzilla.redhat.com/show_bug.cgi?id=1727042
https://bugzilla.redhat.com/show_bug.cgi?id=1727032
