### PR TITLE
Stop relying on pgrep -q

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -6,7 +6,7 @@
 set -e
 
 if [ -z "$NO_MINIKUBE" ]; then
-  pgrep -qf "[m]inikube" || minikube start --kubernetes-version="v1.14.2" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
+  pgrep -f "[m]inikube" >/dev/null || minikube start --kubernetes-version="v1.14.2" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
   eval "$(minikube docker-env)" || { echo 'Cannot switch to minikube docker'; exit 1; }
   kubectl config use-context minikube
 fi


### PR DESCRIPTION
Many distributions don't support pgrep -q, which causes build_local.sh
to behave incorrectly. This patch redirects to /dev/null instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>