### PR TITLE
Bug 1717638 fix(olm): report name and group for related objects

### DIFF
--- a/pkg/lib/operatorstatus/status.go
+++ b/pkg/lib/operatorstatus/status.go
@@ -9,6 +9,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -254,11 +255,13 @@ func relatedObjects(name, namespace string) []configv1.ObjectReference {
 				Group:     olmv1.GroupName,
 				Resource:  olmv1.OperatorGroupKind,
 				Namespace: namespace,
+				Name:      clusterOperatorOLM,
 			},
 			{
 				Group:     olmv1alpha1.GroupName,
 				Resource:  olmv1alpha1.ClusterServiceVersionKind,
 				Namespace: namespace,
+				Name:      clusterOperatorOLM,
 			},
 		}
 	case clusterOperatorCatalogSource:
@@ -267,15 +270,18 @@ func relatedObjects(name, namespace string) []configv1.ObjectReference {
 				Group:     olmv1alpha1.GroupName,
 				Resource:  olmv1alpha1.SubscriptionKind,
 				Namespace: namespace,
+				Name:      clusterOperatorCatalogSource,
 			},
 			{
 				Group:     olmv1alpha1.GroupName,
 				Resource:  olmv1alpha1.InstallPlanKind,
 				Namespace: namespace,
+				Name:      clusterOperatorCatalogSource,
 			},
 		}
 	}
 	namespaces := configv1.ObjectReference{
+		Group:    corev1.GroupName,
 		Resource: "namespaces",
 		Name:     namespace,
 	}


### PR DESCRIPTION
This builds off https://github.com/operator-framework/operator-lifecycle-manager/pull/960/commits/6bfe15f542100437c58a8ad0f0913ba109734d79.

This is what cluster operator output looks like for all three OLM resources. Note that the group for namespaces (and all core resources) is the empty string "".
```
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  creationTimestamp: 2019-08-27T22:17:05Z
  generation: 1
  name: operator-lifecycle-manager
  resourceVersion: "28943"
  selfLink: /apis/config.openshift.io/v1/clusteroperators/operator-lifecycle-manager
  uid: 671e451a-c918-11e9-908b-12dfa945673a
spec: {}
status:
  conditions:
  - lastTransitionTime: 2019-08-27T22:17:05Z
    status: "False"
    type: Degraded
  - lastTransitionTime: 2019-08-27T22:17:05Z
    message: Deployed 0.11.0
    status: "True"
    type: Progressing
  - lastTransitionTime: 2019-08-27T22:17:05Z
    status: "True"
    type: Available
  - lastTransitionTime: 2019-08-27T22:17:05Z
    status: "True"
    type: Upgradeable
  extension: null
  relatedObjects:
  - group: operators.coreos.com
    name: operator-lifecycle-manager
    namespace: openshift-operator-lifecycle-manager
    resource: OperatorGroup
  - group: operators.coreos.com
    name: operator-lifecycle-manager
    namespace: openshift-operator-lifecycle-manager
    resource: ClusterServiceVersion
  - group: ""
    name: openshift-operator-lifecycle-manager
    resource: namespaces
  versions:
  - name: operator
    version: 4.2.0-0.ci-2019-08-27-181227
  - name: operator-lifecycle-manager
    version: 0.11.0
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  creationTimestamp: 2019-08-27T22:17:06Z
  generation: 1
  name: operator-lifecycle-manager-catalog
  resourceVersion: "28963"
  selfLink: /apis/config.openshift.io/v1/clusteroperators/operator-lifecycle-manager-catalog
  uid: 673dd84c-c918-11e9-b880-0a40fa8dec70
spec: {}
status:
  conditions:
  - lastTransitionTime: 2019-08-27T22:17:06Z
    status: "False"
    type: Degraded
  - lastTransitionTime: 2019-08-27T22:17:06Z
    message: Deployed 0.11.0
    status: "True"
    type: Progressing
  - lastTransitionTime: 2019-08-27T22:17:06Z
    status: "True"
    type: Available
  - lastTransitionTime: 2019-08-27T22:17:06Z
    status: "True"
    type: Upgradeable
  extension: null
  relatedObjects:
  - group: operators.coreos.com
    name: operator-lifecycle-manager-catalog
    namespace: openshift-marketplace
    resource: Subscription
  - group: operators.coreos.com
    name: operator-lifecycle-manager-catalog
    namespace: openshift-marketplace
    resource: InstallPlan
  - group: ""
    name: openshift-marketplace
    resource: namespaces
  versions:
  - name: operator
    version: 4.2.0-0.ci-2019-08-27-181227
  - name: operator-lifecycle-manager
    version: 0.11.0
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  creationTimestamp: 2019-08-27T22:17:05Z
  generation: 1
  name: operator-lifecycle-manager-packageserver
  resourceVersion: "29203"
  selfLink: /apis/config.openshift.io/v1/clusteroperators/operator-lifecycle-manager-packageserver
  uid: 671e49ea-c918-11e9-908b-12dfa945673a
spec: {}
status:
  conditions:
  - lastTransitionTime: 2019-08-27T22:17:05Z
    status: "False"
    type: Degraded
  - lastTransitionTime: 2019-08-27T22:17:25Z
    status: "True"
    type: Available
  - lastTransitionTime: 2019-08-27T22:17:25Z
    message: Deployed version 0.11.0
    status: "False"
    type: Progressing
  - lastTransitionTime: 2019-08-27T22:17:05Z
    message: Safe to upgrade
    status: "True"
    type: Upgradeable
  extension: null
  relatedObjects:
  - group: ""
    name: openshift-operator-lifecycle-manager
    resource: namespaces
  - group: operators.coreos.com
    name: packageserver
    namespace: openshift-operator-lifecycle-manager
    resource: ClusterServiceVersion
  versions:
  - name: operator
    version: 4.2.0-0.ci-2019-08-27-181227
  - name: packageserver
    version: 0.11.0
```