### PR TITLE
Bug 1741799: Remove InstallPlan Source, SourceNamespace from UX

### DIFF
--- a/deploy/chart/templates/0000_50_olm_04-installplan.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_04-installplan.crd.yaml
@@ -27,10 +27,6 @@ spec:
     type: string
     description: The first CSV in the list of clusterServiceVersionNames
     JSONPath: .spec.clusterServiceVersionNames[0]
-  - name: Source
-    type: string
-    description: The catalog source for the specified CSVs.
-    JSONPath: .spec.source
   - name: Approval
     type: string
     description: The approval mode

--- a/manifests/0000_50_olm_04-installplan.crd.yaml
+++ b/manifests/0000_50_olm_04-installplan.crd.yaml
@@ -27,10 +27,6 @@ spec:
     type: string
     description: The first CSV in the list of clusterServiceVersionNames
     JSONPath: .spec.clusterServiceVersionNames[0]
-  - name: Source
-    type: string
-    description: The catalog source for the specified CSVs.
-    JSONPath: .spec.source
   - name: Approval
     type: string
     description: The approval mode

--- a/pkg/api/apis/operators/v1alpha1/installplan_types.go
+++ b/pkg/api/apis/operators/v1alpha1/installplan_types.go
@@ -23,8 +23,8 @@ const (
 
 // InstallPlanSpec defines a set of Application resources to be installed
 type InstallPlanSpec struct {
-	CatalogSource              string   `json:"source"`
-	CatalogSourceNamespace     string   `json:"sourceNamespace"`
+	CatalogSource              string   `json:"source,omitempty"`
+	CatalogSourceNamespace     string   `json:"sourceNamespace,omitempty"`
 	ClusterServiceVersionNames []string `json:"clusterServiceVersionNames"`
 	Approval                   Approval `json:"approval"`
 	Approved                   bool     `json:"approved"`


### PR DESCRIPTION
InstallPlans no longer rely on a relationship to a single CatalogSource,
but calling `kubectl` to get installplans stills refers to the `source`
and `sourceNamespace` fields.

This pr marks those fields as `omitempty` and removes them as
display columns to remove them from the default user experience.

https://bugzilla.redhat.com/show_bug.cgi?id=1741799