### PR TITLE
[CatalogSource] Set Global Catalog NS with EnvVar

### DIFF
--- a/Documentation/install/install.md
+++ b/Documentation/install/install.md
@@ -87,6 +87,10 @@ To configure a release of OLM for installation in a cluster:
 
 The above steps are automated for official releases with `make ver=0.3.0 release`, which will output new versions of manifests in `deploy/tectonic-alm-operator/manifests/$(ver)`.
 
+## Overriding the Global Catalog Namespace
+
+It is possible to override the Global Catalog Namespace by setting the `GLOBAL_CATALOG_NAMESPACE` environment variable in the catalog operator deployment.
+
 ## Subscribe to a Package and Channel
 
 Cloud Services can be installed from the catalog by subscribing to a channel in the corresponding package.

--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -26,6 +26,7 @@ import (
 )
 
 const (
+	catalogNamespaceEnvVarName  = "GLOBAL_CATALOG_NAMESPACE"
 	defaultWakeupInterval       = 15 * time.Minute
 	defaultCatalogNamespace     = "openshift-operator-lifecycle-manager"
 	defaultConfigMapServerImage = "quay.io/operatorframework/configmap-operator-registry:latest"
@@ -102,6 +103,12 @@ func main() {
 		logger.SetLevel(log.DebugLevel)
 	}
 	logger.Infof("log level %s", logger.Level)
+
+	// If the catalogNamespaceEnvVarName environment variable is set, then  update the value of catalogNamespace.
+	if catalogNamespaceEnvVarValue := os.Getenv(catalogNamespaceEnvVarName); catalogNamespaceEnvVarValue != "" {
+		logger.Infof("%s environment variable is set. Updating Global Catalog Namespace to %s", catalogNamespaceEnvVarName, catalogNamespaceEnvVarValue)
+		*catalogNamespace = catalogNamespaceEnvVarValue
+	}
 
 	var useTLS bool
 	if *tlsCertPath != "" && *tlsKeyPath == "" || *tlsCertPath == "" && *tlsKeyPath != "" {


### PR DESCRIPTION
This commit introduces a change that makes it possible to configure the
Global Catalog Namespace by adding the CATALOG_NAMESPACE environment
variable to the catalog-operator deployment.