### PR TITLE
Bug 1717636: Add proper name to related objects

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -171,7 +171,7 @@ func main() {
 	<-op.Ready()
 
 	if *writeStatusName != "" {
-		operatorstatus.MonitorClusterStatus(*writeStatusName, *catalogNamespace, op.AtLevel(), op.Done(), opClient, configClient, crClient)
+		operatorstatus.MonitorClusterStatus(*writeStatusName, op.AtLevel(), op.Done(), opClient, configClient, crClient)
 	}
 
 	<-op.Done()

--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -196,7 +196,7 @@ func main() {
 	<-op.Ready()
 
 	if *writeStatusName != "" {
-		operatorstatus.MonitorClusterStatus(*writeStatusName, *namespace, op.AtLevel(), ctx.Done(), opClient, configClient)
+		operatorstatus.MonitorClusterStatus(*writeStatusName, *namespace, op.AtLevel(), ctx.Done(), opClient, configClient, crClient)
 	}
 
 	if *writePackageServerStatusName != "" {

--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -196,7 +196,7 @@ func main() {
 	<-op.Ready()
 
 	if *writeStatusName != "" {
-		operatorstatus.MonitorClusterStatus(*writeStatusName, *namespace, op.AtLevel(), ctx.Done(), opClient, configClient, crClient)
+		operatorstatus.MonitorClusterStatus(*writeStatusName, op.AtLevel(), ctx.Done(), opClient, configClient, crClient)
 	}
 
 	if *writePackageServerStatusName != "" {


### PR DESCRIPTION
This is take 2. Would be nice to confirm that the related objects sections are totally correct. The catalog operator is not showing any subscriptions or installplans in the openshift-marketplace project because none have been created yet.

Also resolves https://bugzilla.redhat.com/show_bug.cgi?id=1717638.

```
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  creationTimestamp: 2019-08-30T21:18:05Z
  generation: 1
  name: operator-lifecycle-manager
  resourceVersion: "12313"
  selfLink: /apis/config.openshift.io/v1/clusteroperators/operator-lifecycle-manager
  uid: a8509a0e-cb6b-11e9-8b44-123338630872
spec: {}
status:
  conditions:
  - lastTransitionTime: 2019-08-30T21:18:05Z
    status: "False"
    type: Degraded
  - lastTransitionTime: 2019-08-30T21:23:10Z
    message: Deployed 0.11.0
    status: "False"
    type: Progressing
  - lastTransitionTime: 2019-08-30T21:18:05Z
    status: "True"
    type: Available
  - lastTransitionTime: 2019-08-30T21:18:05Z
    status: "True"
    type: Upgradeable
  extension: null
  relatedObjects:
  - group: ""
    name: operator-lifecycle-manager
    resource: namespaces
  versions:
  - name: operator
    version: 0.0.1-2019-08-30-210019
  - name: operator-lifecycle-manager
    version: 0.11.0
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  creationTimestamp: 2019-08-30T21:18:29Z
  generation: 1
  name: operator-lifecycle-manager-catalog
  resourceVersion: "12638"
  selfLink: /apis/config.openshift.io/v1/clusteroperators/operator-lifecycle-manager-catalog
  uid: b64fc99d-cb6b-11e9-8b44-123338630872
spec: {}
status:
  conditions:
  - lastTransitionTime: 2019-08-30T21:18:29Z
    status: "False"
    type: Degraded
  - lastTransitionTime: 2019-08-30T21:23:34Z
    message: Deployed 0.11.0
    status: "False"
    type: Progressing
  - lastTransitionTime: 2019-08-30T21:18:29Z
    status: "True"
    type: Available
  - lastTransitionTime: 2019-08-30T21:18:29Z
    status: "True"
    type: Upgradeable
  extension: null
  relatedObjects:
  - group: ""
    name: operator-lifecycle-manager
    resource: namespaces
  versions:
  - name: operator
    version: 0.0.1-2019-08-30-210019
  - name: operator-lifecycle-manager
    version: 0.11.0
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  creationTimestamp: 2019-08-30T21:18:05Z
  generation: 1
  name: operator-lifecycle-manager-packageserver
  resourceVersion: "8182"
  selfLink: /apis/config.openshift.io/v1/clusteroperators/operator-lifecycle-manager-packageserver
  uid: a84f41b8-cb6b-11e9-8b44-123338630872
spec: {}
status:
  conditions:
  - lastTransitionTime: 2019-08-30T21:18:05Z
    status: "False"
    type: Degraded
  - lastTransitionTime: 2019-08-30T21:20:45Z
    status: "True"
    type: Available
  - lastTransitionTime: 2019-08-30T21:20:45Z
    message: Deployed version 0.11.0
    status: "False"
    type: Progressing
  - lastTransitionTime: 2019-08-30T21:18:05Z
    message: Safe to upgrade
    status: "True"
    type: Upgradeable
  extension: null
  relatedObjects:
  - group: ""
    name: openshift-operator-lifecycle-manager
    resource: namespaces
  - group: operators.coreos.com
    name: packageserver
    namespace: openshift-operator-lifecycle-manager
    resource: ClusterServiceVersion
  versions:
  - name: operator
    version: 0.0.1-2019-08-30-210019
  - name: packageserver
    version: 0.11.0
```