### PR TITLE
Bug 1748914: Drop the hard-coded DNS suffix

### DIFF
--- a/pkg/api/apis/operators/catalogsource_types.go
+++ b/pkg/api/apis/operators/catalogsource_types.go
@@ -74,7 +74,7 @@ type GRPCConnectionState struct {
 }
 
 func (s *RegistryServiceStatus) Address() string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local:%s", s.ServiceName, s.ServiceNamespace, s.Port)
+	return fmt.Sprintf("%s.%s.svc:%s", s.ServiceName, s.ServiceNamespace, s.Port)
 }
 
 type CatalogSourceStatus struct {

--- a/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
+++ b/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
@@ -75,7 +75,7 @@ type RegistryServiceStatus struct {
 }
 
 func (s *RegistryServiceStatus) Address() string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local:%s", s.ServiceName, s.ServiceNamespace, s.Port)
+	return fmt.Sprintf("%s.%s.svc:%s", s.ServiceName, s.ServiceNamespace, s.Port)
 }
 
 type GRPCConnectionState struct {


### PR DESCRIPTION
Having the catalog source hard-code its cluster.local suffix makes it
impossible to deploy in environments which use different suffixes.
This patch drops it, relying on the default search which K8s setups
expect to be set correctly anyway.

(For context, we use multiple clusters with different suffixes in our Submariner multi-cluster end-to-end tests.)