### PR TITLE
[WIP] Test if changes in this PR fixes 983

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -19,7 +19,6 @@ import (
 	extinf "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -915,7 +914,7 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 	}
 
 	// Check if any existing installplans are creating the same resources
-	installPlans, err := o.lister.OperatorsV1alpha1().InstallPlanLister().InstallPlans(namespace).List(labels.Everything())
+	installPlans, err := o.listInstallPlans(namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1597,6 +1596,20 @@ func (o *Operator) listSubscriptions(namespace string) (subs []*v1alpha1.Subscri
 	subs = make([]*v1alpha1.Subscription, 0)
 	for i := range list.Items {
 		subs = append(subs, &list.Items[i])
+	}
+
+	return
+}
+
+func (o *Operator) listInstallPlans(namespace string) (ips []*v1alpha1.InstallPlan, err error) {
+	list, err := o.client.OperatorsV1alpha1().InstallPlans(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+
+	ips = make([]*v1alpha1.InstallPlan, 0)
+	for i := range list.Items {
+		ips = append(ips, &list.Items[i])
 	}
 
 	return

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -25,11 +25,31 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	opver "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/version"
 )
 
 type checkInstallPlanFunc func(fip *v1alpha1.InstallPlan) bool
+
+func validateCRDVersions(t *testing.T, c operatorclient.ClientInterface, name string, expectedVersions map[string]struct{}) {
+	// Retrieve CRD information
+	crd, err := c.ApiextensionsV1beta1Interface().ApiextensionsV1beta1().CustomResourceDefinitions().Get(name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, len(expectedVersions), len(crd.Spec.Versions), "number of CRD versions don't not match installed")
+
+	for _, version := range crd.Spec.Versions {
+		_, ok := expectedVersions[version.Name]
+		require.True(t, ok, "couldn't find %v in expected versions: %#v", version.Name, expectedVersions)
+
+		// Remove the entry from the expected steps set (to ensure no duplicates in resolved plan)
+		delete(expectedVersions, version.Name)
+	}
+
+	// Should have removed every matching version
+	require.Equal(t, 0, len(expectedVersions), "Actual CRD versions do not match expected")
+}
 
 func buildInstallPlanPhaseCheckFunc(phases ...v1alpha1.InstallPlanPhase) checkInstallPlanFunc {
 	return func(fip *v1alpha1.InstallPlan) bool {
@@ -190,9 +210,20 @@ func newCSV(name, namespace, replaces string, version semver.Version, owned []ap
 
 	// Populate owned and required
 	for _, crd := range owned {
+		crdVersion := "v1alpha1"
+		if crd.Spec.Version != "" {
+			crdVersion = crd.Spec.Version
+		} else {
+			for _, v := range crd.Spec.Versions {
+				if v.Served && v.Storage {
+					crdVersion = v.Name
+					break
+				}
+			}
+		}
 		desc := v1alpha1.CRDDescription{
 			Name:        crd.GetName(),
-			Version:     "v1alpha1",
+			Version:     crdVersion,
 			Kind:        crd.Spec.Names.Plural,
 			DisplayName: crd.GetName(),
 			Description: crd.GetName(),
@@ -201,9 +232,20 @@ func newCSV(name, namespace, replaces string, version semver.Version, owned []ap
 	}
 
 	for _, crd := range required {
+		crdVersion := "v1alpha1"
+		if crd.Spec.Version != "" {
+			crdVersion = crd.Spec.Version
+		} else {
+			for _, v := range crd.Spec.Versions {
+				if v.Served && v.Storage {
+					crdVersion = v.Name
+					break
+				}
+			}
+		}
 		desc := v1alpha1.CRDDescription{
 			Name:        crd.GetName(),
-			Version:     "v1alpha1",
+			Version:     crdVersion,
 			Kind:        crd.Spec.Names.Plural,
 			DisplayName: crd.GetName(),
 			Description: crd.GetName(),
@@ -991,6 +1033,230 @@ func TestInstallPlanWithCRDSchemaChange(t *testing.T) {
 			// Ensure correct in-cluster resource(s)
 			fetchedCSV, err := fetchCSV(t, crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
 			require.NoError(t, err)
+
+			t.Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
+		})
+	}
+}
+
+func TestInstallPlanWithDeprecatedVersionCRD(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
+	// generated outside of the test table so that the same naming can be used for both old and new CSVs
+	mainCRDPlural := genName("ins")
+
+	// excluded: new CRD, same version, same schema - won't trigger a CRD update
+	tests := []struct {
+		name            string
+		expectedPhase   v1alpha1.InstallPlanPhase
+		oldCRD          *apiextensions.CustomResourceDefinition
+		intermediateCRD *apiextensions.CustomResourceDefinition
+		newCRD          *apiextensions.CustomResourceDefinition
+	}{
+		{
+			name:          "upgrade CRD with deprecated version",
+			expectedPhase: v1alpha1.InstallPlanPhaseComplete,
+			oldCRD: func() *apiextensions.CustomResourceDefinition {
+				oldCRD := newCRD(mainCRDPlural)
+				oldCRD.Spec.Version = "v1alpha1"
+				oldCRD.Spec.Versions = []apiextensions.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+					},
+				}
+				return &oldCRD
+			}(),
+			intermediateCRD: func() *apiextensions.CustomResourceDefinition {
+				intermediateCRD := newCRD(mainCRDPlural)
+				intermediateCRD.Spec.Version = "v1alpha1"
+				intermediateCRD.Spec.Versions = []apiextensions.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1alpha1",
+						Served:  false,
+						Storage: false,
+					},
+					{
+						Name:    "v1alpha2",
+						Served:  true,
+						Storage: true,
+					},
+				}
+				return &intermediateCRD
+			}(),
+			newCRD: func() *apiextensions.CustomResourceDefinition {
+				newCRD := newCRD(mainCRDPlural)
+				newCRD.Spec.Version = "v1alpha2"
+				newCRD.Spec.Versions = []apiextensions.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1alpha2",
+						Served:  true,
+						Storage: true,
+					},
+					{
+						Name:    "v1beta1",
+						Served:  true,
+						Storage: false,
+					},
+				}
+				return &newCRD
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer cleaner.NotifyTestComplete(t, true)
+
+			mainPackageName := genName("nginx-")
+			mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
+			mainPackageBeta := fmt.Sprintf("%s-beta", mainPackageName)
+			mainPackageDelta := fmt.Sprintf("%s-delta", mainPackageName)
+
+			stableChannel := "stable"
+			betaChannel := "beta"
+			deltaChannel := "delta"
+
+			// Create manifests
+			mainManifests := []registry.PackageManifest{
+				{
+					PackageName: mainPackageName,
+					Channels: []registry.PackageChannel{
+						{Name: stableChannel, CurrentCSVName: mainPackageStable},
+						{Name: betaChannel, CurrentCSVName: mainPackageBeta},
+						//	{Name: deltaChannel, CurrentCSVName: mainPackageDelta},
+					},
+					DefaultChannelName: stableChannel,
+				},
+			}
+
+			// Create a new named install strategy
+			mainNamedStrategy := newNginxInstallStrategy(genName("dep-"), nil, nil)
+
+			// Create new CSVs
+			mainStableCSV := newCSV(mainPackageStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, mainNamedStrategy)
+			mainBetaCSV := newCSV(mainPackageBeta, testNamespace, mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, nil, mainNamedStrategy)
+			mainDeltaCSV := newCSV(mainPackageDelta, testNamespace, mainPackageBeta, semver.MustParse("0.3.0"), []apiextensions.CustomResourceDefinition{*tt.newCRD}, nil, mainNamedStrategy)
+
+			c := newKubeClient(t)
+			crc := newCRClient(t)
+
+			// Create the catalog source
+			mainCatalogSourceName := genName("mock-ocs-main-")
+			_, cleanupCatalogSource := createInternalCatalogSource(t, c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []v1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV, mainDeltaCSV})
+			defer cleanupCatalogSource()
+
+			// Attempt to get the catalog source before creating install plan(s)
+			_, err := fetchCatalogSource(t, crc, mainCatalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
+			require.NoError(t, err)
+
+			subscriptionName := genName("sub-nginx-")
+			// this subscription will be cleaned up below without the clean up function
+			createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", v1alpha1.ApprovalAutomatic)
+
+			subscription, err := fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+			require.NoError(t, err)
+			require.NotNil(t, subscription)
+
+			installPlanName := subscription.Status.Install.Name
+
+			// Wait for InstallPlan to be status: Complete or failed before checking resource presence
+			completeOrFailedFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete, v1alpha1.InstallPlanPhaseFailed)
+			fetchedInstallPlan, err := fetchInstallPlan(t, crc, installPlanName, completeOrFailedFunc)
+			require.NoError(t, err)
+			t.Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
+			require.Equal(t, v1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
+
+			// Ensure CRD versions are accurate
+			expectedVersions := map[string]struct{}{
+				"v1alpha1": {},
+			}
+
+			validateCRDVersions(t, c, tt.oldCRD.GetName(), expectedVersions)
+
+			updateInternalCatalog(t, c, crc, mainCatalogSourceName, testNamespace, []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, []v1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV, mainDeltaCSV}, mainManifests)
+			// Attempt to get the catalog source before creating install plan(s)
+			_, err = fetchCatalogSource(t, crc, mainCatalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
+			require.NoError(t, err)
+			// Update the subscription resource to point to the beta CSV
+			err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			// existing cleanup should remove this
+			createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, mainCatalogSourceName, mainPackageName, betaChannel, "", v1alpha1.ApprovalAutomatic)
+
+			subscription, err = fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+			require.NoError(t, err)
+			require.NotNil(t, subscription)
+
+			installPlanName = subscription.Status.Install.Name
+
+			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
+			fetchedInstallPlan, err = fetchInstallPlan(t, crc, installPlanName, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete, v1alpha1.InstallPlanPhaseFailed))
+			require.NoError(t, err)
+			t.Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
+
+			require.Equal(t, tt.expectedPhase, fetchedInstallPlan.Status.Phase)
+
+			// Ensure correct in-cluster resource(s)
+			fetchedCSV, err := fetchCSV(t, crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
+			require.NoError(t, err)
+
+			// Ensure CRD versions are accurate
+			expectedVersions = map[string]struct{}{
+				"v1alpha1": {},
+				"v1alpha2": {},
+			}
+
+			validateCRDVersions(t, c, tt.oldCRD.GetName(), expectedVersions)
+
+			mainManifests = []registry.PackageManifest{
+				{
+					PackageName: mainPackageName,
+					Channels: []registry.PackageChannel{
+						{Name: betaChannel, CurrentCSVName: mainPackageBeta},
+						{Name: deltaChannel, CurrentCSVName: mainPackageDelta},
+					},
+					DefaultChannelName: deltaChannel,
+				},
+			}
+
+			updateInternalCatalog(t, c, crc, mainCatalogSourceName, testNamespace, []apiextensions.CustomResourceDefinition{*tt.newCRD}, []v1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV, mainDeltaCSV}, mainManifests)
+			// Attempt to get the catalog source before creating install plan(s)
+			_, err = fetchCatalogSource(t, crc, mainCatalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
+			require.NoError(t, err)
+			// Update the subscription resource to point to the beta CSV
+			err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			// existing cleanup should remove this
+			createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, mainCatalogSourceName, mainPackageName, deltaChannel, "", v1alpha1.ApprovalAutomatic)
+
+			subscription, err = fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+			require.NoError(t, err)
+			require.NotNil(t, subscription)
+
+			installPlanName = subscription.Status.Install.Name
+
+			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
+			fetchedInstallPlan, err = fetchInstallPlan(t, crc, installPlanName, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete, v1alpha1.InstallPlanPhaseFailed))
+			require.NoError(t, err)
+			t.Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
+
+			require.Equal(t, tt.expectedPhase, fetchedInstallPlan.Status.Phase)
+
+			// Ensure correct in-cluster resource(s)
+			fetchedCSV, err = fetchCSV(t, crc, mainDeltaCSV.GetName(), testNamespace, csvSucceededChecker)
+			require.NoError(t, err)
+
+			// Ensure CRD versions are accurate
+			expectedVersions = map[string]struct{}{
+				"v1alpha2": {},
+				"v1beta1":  {},
+			}
+
+			validateCRDVersions(t, c, tt.oldCRD.GetName(), expectedVersions)
 
 			t.Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
 		})

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -1148,7 +1148,7 @@ func TestInstallPlanWithDeprecatedVersionCRD(t *testing.T) {
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err := fetchCatalogSource(t, crc, mainCatalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSource(t, crc, mainCatalogSourceName, testNamespace, catalogSourceIsConnectedToRegistryPod)
 			require.NoError(t, err)
 
 			subscriptionName := genName("sub-nginx-")

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -321,6 +321,17 @@ func catalogSourceRegistryPodSynced(catalog *v1alpha1.CatalogSource) bool {
 	return false
 }
 
+func catalogSourceIsConnectedToRegistryPod(catalog *v1alpha1.CatalogSource) bool {
+	registry := catalog.Status.RegistryServiceStatus
+	connState := catalog.Status.GRPCConnectionState
+	if registry != nil && connState != nil && connState.LastObservedState == "READY" {
+		fmt.Printf("catalog %s pod with address %s\n", catalog.GetName(), registry.Address())
+		return registryPodHealthy(registry.Address())
+	}
+	fmt.Printf("waiting for catalog pod %v to be available (for sync)\n", catalog.GetName())
+	return false
+}
+
 func fetchCatalogSource(t *testing.T, crc versioned.Interface, name, namespace string, check catalogSourceCheckFunc) (*v1alpha1.CatalogSource, error) {
 	var fetched *v1alpha1.CatalogSource
 	var err error


### PR DESCRIPTION
Bugzilla 1744245: Subscription should not point to old ip  …
Delete and recreate of a subscription object without any delay causes
operator install to fail.

How to reproduce:

1. Create a CatalogSource object, wait for it to become healthy.
2. Create a Subscription that refers to the CatalogSource above.
3. Wait for the operator to install successfully.
4. Update the CatalogSource
5. Wait for the updated CatalogSource to become healthy.
6. Delete the Subscription object ( created above ).
7. Recreate the Subscription object ( no time delay between delete
and create ). Delete and Create can be done one after another, there
is no need to make them concurrent.