### PR TITLE
WIP: write error into sync channel always

### DIFF
--- a/pkg/lib/operatorstatus/status.go
+++ b/pkg/lib/operatorstatus/status.go
@@ -63,18 +63,22 @@ func MonitorClusterStatus(name, namespace string, syncCh <-chan error, stopCh <-
 			syncs++
 			if err == nil {
 				successfulSyncs++
+			} else {
+				log.Debugf("Got error from sync channel: %v", err)
 			}
 			// grab any other sync events that have accumulated
 			for len(syncCh) > 0 {
 				if err := <-syncCh; err == nil {
 					successfulSyncs++
+				} else {
+					log.Debugf("Got error from sync channel with length %v: %v", len(syncCh), err)
 				}
 				syncs++
 			}
 			// if we haven't yet accumulated enough syncs, wait longer
 			// TODO: replace these magic numbers with a better measure of syncs across all queueInformers
-			if successfulSyncs < 5 || syncs < 10 {
-				log.Printf("Waiting to observe more successful syncs")
+			if successfulSyncs < 5 && syncs < 50 {
+				log.Printf("Waiting to observe more successful syncs. Successful count: %v, total count: %v", successfulSyncs, syncs)
 				return
 			}
 		}

--- a/pkg/lib/queueinformer/queueinformer_operator.go
+++ b/pkg/lib/queueinformer/queueinformer_operator.go
@@ -286,7 +286,7 @@ func (o *operator) processNextWorkItem(ctx context.Context, loop *QueueInformer)
 	queue.Forget(item)
 
 	select {
-	case o.syncCh <- err:
+	case o.syncCh <- fmt.Errorf("failing always for event %v", event):
 	default:
 	}
 


### PR DESCRIPTION
This is just to test that the degraded message is reported.