### PR TITLE
Bug 1746159: Cleanup leftover cross-namespace OwnerReferences

### DIFF
--- a/cmd/olm/cleanup.go
+++ b/cmd/olm/cleanup.go
@@ -4,10 +4,14 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 )
@@ -19,6 +23,7 @@ const (
 
 type checkResourceFunc func() error
 type deleteResourceFunc func() error
+type mutateMeta func(obj metav1.Object) (mutated bool)
 
 func cleanup(logger *logrus.Logger, c operatorclient.ClientInterface, crc versioned.Interface) {
 	if err := waitForDelete(checkCatalogSource(crc, "olm-operators"), deleteCatalogSource(crc, "olm-operators")); err != nil {
@@ -44,6 +49,10 @@ func cleanup(logger *logrus.Logger, c operatorclient.ClientInterface, crc versio
 	if err := waitForDelete(checkClusterServiceVersion(crc, "packageserver.v0.9.0"), deleteClusterServiceVersion(crc, "packageserver.v0.9.0")); err != nil {
 		logger.WithError(err).Fatal("couldn't clean previous release")
 	}
+
+	if err := cleanupOwnerReferences(c, crc); err != nil {
+		logger.WithError(err).Fatal("couldn't cleanup cross-namespace ownerreferences")
+	}
 }
 
 func waitForDelete(checkResource checkResourceFunc, deleteResource deleteResourceFunc) error {
@@ -53,8 +62,7 @@ func waitForDelete(checkResource checkResourceFunc, deleteResource deleteResourc
 	if err := deleteResource(); err != nil {
 		return err
 	}
-	var err error
-	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+	err := wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		err := checkResource()
 		if errors.IsNotFound(err) {
 			return true, nil
@@ -117,5 +125,117 @@ func checkCatalogSource(crc versioned.Interface, name string) checkResourceFunc 
 func deleteCatalogSource(crc versioned.Interface, name string) deleteResourceFunc {
 	return func() error {
 		return crc.OperatorsV1alpha1().CatalogSources(*namespace).Delete(name, metav1.NewDeleteOptions(0))
+	}
+}
+
+// cleanupOwnerReferences cleans up inter-namespace and cluster-to-namespace scoped OwnerReferences to ClusterServiceVersions.
+//
+// Cross-namespace and cluster-to-namespace scoped OwnerReferences may cause sibling resources in the owner namespace to be
+// deleted sporadically (see CVE-2019-3884 https://access.redhat.com/security/cve/cve-2019-3884). Older versions of OLM use both types of
+// OwnerReference, and in cases where OLM is updated, they must be removed to prevent erroneous deletion of OLM's self-hosted components.
+func cleanupOwnerReferences(c operatorclient.ClientInterface, crc versioned.Interface) error {
+	listOpts := metav1.ListOptions{}
+	csvs, err := crc.OperatorsV1alpha1().ClusterServiceVersions(metav1.NamespaceAll).List(listOpts)
+	if err != nil {
+		return err
+	}
+
+	uidNamespaces := map[types.UID]string{}
+	for _, csv := range csvs.Items {
+		uidNamespaces[csv.GetUID()] = csv.GetNamespace()
+	}
+	removeBadRefs := crossNamespaceOwnerReferenceRemoval(v1alpha1.ClusterServiceVersionKind, uidNamespaces)
+
+	// Cleanup cross-namespace OwnerReferences on CSVs, ClusterRoles/Bindings, and Roles/Bindings
+	var objs []metav1.Object
+	for _, obj := range csvs.Items {
+		objs = append(objs, &obj)
+	}
+
+	clusterRoles, _ := c.KubernetesInterface().RbacV1().ClusterRoles().List(listOpts)
+	for _, obj := range clusterRoles.Items {
+		objs = append(objs, &obj)
+	}
+
+	clusterRoleBindings, _ := c.KubernetesInterface().RbacV1().ClusterRoleBindings().List(listOpts)
+	for _, obj := range clusterRoleBindings.Items {
+		objs = append(objs, &obj)
+	}
+
+	roles, _ := c.KubernetesInterface().RbacV1().Roles(metav1.NamespaceAll).List(listOpts)
+	for _, obj := range roles.Items {
+		objs = append(objs, &obj)
+	}
+	roleBindings, _ := c.KubernetesInterface().RbacV1().RoleBindings(metav1.NamespaceAll).List(listOpts)
+	for _, obj := range roleBindings.Items {
+		objs = append(objs, &obj)
+	}
+
+	for _, obj := range objs {
+		if !removeBadRefs(obj) {
+			continue
+		}
+
+		update := func() error {
+			// If this is not a type we care about, do nothing
+			return nil
+		}
+		switch v := obj.(type) {
+		case *v1alpha1.ClusterServiceVersion:
+			update = func() error {
+				_, err := crc.OperatorsV1alpha1().ClusterServiceVersions(v.GetNamespace()).Update(v)
+				return err
+			}
+		case *rbacv1.ClusterRole:
+			update = func() error {
+				_, err = c.KubernetesInterface().RbacV1().ClusterRoles().Update(v)
+				return err
+			}
+		case *rbacv1.ClusterRoleBinding:
+			update = func() error {
+				_, err = c.KubernetesInterface().RbacV1().ClusterRoleBindings().Update(v)
+				return err
+			}
+		case *rbacv1.Role:
+			update = func() error {
+				_, err = c.KubernetesInterface().RbacV1().Roles(v.GetNamespace()).Update(v)
+				return err
+			}
+		case *rbacv1.RoleBinding:
+			update = func() error {
+				_, err = c.KubernetesInterface().RbacV1().RoleBindings(v.GetNamespace()).Update(v)
+				return err
+			}
+		}
+
+		if err := retry.RetryOnConflict(retry.DefaultBackoff, update); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func crossNamespaceOwnerReferenceRemoval(kind string, uidNamespaces map[types.UID]string) mutateMeta {
+	return func(obj metav1.Object) (mutated bool) {
+		var cleanRefs []metav1.OwnerReference
+		objNamespace := obj.GetNamespace()
+		for _, ref := range obj.GetOwnerReferences() {
+			if ref.Kind == kind {
+				refNamespace, ok := uidNamespaces[ref.UID]
+				if !ok || (refNamespace != metav1.NamespaceAll && refNamespace != objNamespace) {
+					mutated = true
+					continue
+				}
+			}
+
+			cleanRefs = append(cleanRefs, ref)
+		}
+
+		if mutated {
+			obj.SetOwnerReferences(cleanRefs)
+		}
+
+		return
 	}
 }

--- a/cmd/olm/cleanup_test.go
+++ b/cmd/olm/cleanup_test.go
@@ -1,0 +1,542 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	operatorsfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+)
+
+func TestCrossOwnerReferenceRemoval(t *testing.T) {
+	clusterScopedKind := "ClusterScoped"
+
+	type fields struct {
+		kind          string
+		uidNamespaces map[types.UID]string
+	}
+	type args struct {
+		obj metav1.Object
+	}
+	type expected struct {
+		obj     metav1.Object
+		mutated bool
+	}
+	tests := []struct {
+		description string
+		fields      fields
+		args        args
+		expected    expected
+	}{
+		{
+			description: "OneRef/NoResources/Removed",
+			fields: fields{
+				kind:          v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: nil,
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace:       "ns-a",
+					OwnerReferences: nil,
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "OneRef/ResourceMissing/Removed",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a0-uid": "ns-a",
+					"csv-a1-uid": "ns-a",
+					"csv-b-uid":  "ns-b",
+					"csv-c0-uid": "ns-c",
+					"csv-c1-uid": "ns-c",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace:       "ns-a",
+					OwnerReferences: nil,
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "OneRef/NotOfKind/Ignored",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a0-uid": "ns-a",
+					"csv-a1-uid": "ns-a",
+					"csv-b-uid":  "ns-b",
+					"csv-c0-uid": "ns-c",
+					"csv-c1-uid": "ns-c",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "DefinitelyNotACSV",
+							UID:  "no-csv-here-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "DefinitelyNotACSV",
+							UID:  "no-csv-here-uid",
+						},
+					},
+				},
+				mutated: false,
+			},
+		},
+		{
+			description: "OneRef/Internamespace/Removed",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-b-uid": "ns-b",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-b-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace:       "ns-a",
+					OwnerReferences: nil,
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "ManyRefs/Internamespace/Removed",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a0-uid": "ns-a",
+					"csv-a1-uid": "ns-a",
+					"csv-b-uid":  "ns-b",
+					"csv-c0-uid": "ns-c",
+					"csv-c1-uid": "ns-c",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a0-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-c1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-b-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a0-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a1-uid",
+						},
+					},
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "OneRef/ClusterToNamespaced/Removed",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a-uid": "ns-a",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					OwnerReferences: nil,
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "ManyRefs/ClusterToNamespaced/Removed/NotOfKind/Ignored",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a0-uid": "ns-a",
+					"csv-a1-uid": "ns-a",
+					"csv-b-uid":  "ns-b",
+					"csv-c0-uid": "ns-c",
+					"csv-c1-uid": "ns-c",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a0-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a1-uid",
+						},
+						{
+							Kind: "DefinitelyNotACSV",
+							UID:  "no-csv-here-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "DefinitelyNotACSV",
+							UID:  "no-csv-here-uid",
+						},
+					},
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "ManyRefs/NamespacedToCluster/Kept/NotOfKind/Ignored",
+			fields: fields{
+				kind: clusterScopedKind,
+				uidNamespaces: map[types.UID]string{
+					"csk-0-uid": metav1.NamespaceAll,
+					"csk-1-uid": metav1.NamespaceAll,
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: clusterScopedKind,
+							UID:  "csk-0-uid",
+						},
+						{
+							Kind: clusterScopedKind,
+							UID:  "csk-1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-b-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: clusterScopedKind,
+							UID:  "csk-0-uid",
+						},
+						{
+							Kind: clusterScopedKind,
+							UID:  "csk-1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-b-uid",
+						},
+					},
+				},
+				mutated: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			removeBadRefs := crossNamespaceOwnerReferenceRemoval(tt.fields.kind, tt.fields.uidNamespaces)
+			obj := tt.args.obj
+			require.Equal(t, tt.expected.mutated, removeBadRefs(obj))
+			require.Equal(t, tt.expected.obj, obj)
+		})
+	}
+}
+
+func TestCleanupOwnerReferences(t *testing.T) {
+	clusterRoleKind := "ClusterRole"
+
+	type fields struct {
+		k8sObjs    []runtime.Object
+		clientObjs []runtime.Object
+	}
+	type expected struct {
+		err                 error
+		csvs                []v1alpha1.ClusterServiceVersion
+		clusterRoles        []rbacv1.ClusterRole
+		clusterRoleBindings []rbacv1.ClusterRoleBinding
+		roles               []rbacv1.Role
+		roleBindings        []rbacv1.RoleBinding
+	}
+	tests := []struct {
+		description string
+		fields      fields
+		expected    expected
+	}{
+		{
+			description: "CrossNamespace/Removed",
+			fields: fields{
+				k8sObjs: []runtime.Object{
+					newClusterRole("cr", "cr-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+					newClusterRoleBinding("crb", "crb-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+					newRoleBinding("ns-a", "rb", "rb-a-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+					newRole("ns-a", "r", "r-a-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+				},
+				clientObjs: []runtime.Object{
+					newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+					newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+				},
+			},
+			expected: expected{
+				csvs: []v1alpha1.ClusterServiceVersion{
+					*newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					*newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+				clusterRoles: []rbacv1.ClusterRole{
+					*newClusterRole("cr", "cr-uid"),
+				},
+				clusterRoleBindings: []rbacv1.ClusterRoleBinding{
+					*newClusterRoleBinding("crb", "crb-uid"),
+				},
+				roles: []rbacv1.Role{
+					*newRole("ns-a", "r", "r-a-uid"),
+				},
+				roleBindings: []rbacv1.RoleBinding{
+					*newRoleBinding("ns-a", "rb", "rb-a-uid"),
+				},
+			},
+		},
+		{
+			description: "CrossNamespace/Removed/InNamespace/Kept",
+			fields: fields{
+				k8sObjs: []runtime.Object{
+					newRoleBinding("ns-a", "rb", "rb-a-uid",
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-a-uid"),
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid"),
+					),
+				},
+				clientObjs: []runtime.Object{
+					newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+			},
+			expected: expected{
+				csvs: []v1alpha1.ClusterServiceVersion{
+					*newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					*newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+				roleBindings: []rbacv1.RoleBinding{
+					*newRoleBinding("ns-a", "rb", "rb-a-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-a-uid")),
+				},
+			},
+		},
+		{
+			description: "CrossNamespace/Removed/ToClusterScoped/Ignored",
+			fields: fields{
+				k8sObjs: []runtime.Object{
+					newClusterRole("cr", "cr-uid"),
+					newRoleBinding("ns-a", "rb", "rb-a-uid",
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-a-uid"),
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid"),
+						newOwnerReference(clusterRoleKind, "cr-uid"),
+					),
+				},
+				clientObjs: []runtime.Object{
+					newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+			},
+			expected: expected{
+				csvs: []v1alpha1.ClusterServiceVersion{
+					*newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					*newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+				clusterRoles: []rbacv1.ClusterRole{
+					*newClusterRole("cr", "cr-uid"),
+				},
+				roleBindings: []rbacv1.RoleBinding{
+					*newRoleBinding("ns-a", "rb", "rb-a-uid",
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-a-uid"),
+						newOwnerReference(clusterRoleKind, "cr-uid"),
+					),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			k8sClient := k8sfake.NewSimpleClientset(tt.fields.k8sObjs...)
+			c := operatorclient.NewClient(k8sClient, apiextensionsfake.NewSimpleClientset(), apiregistrationfake.NewSimpleClientset())
+			crc := operatorsfake.NewSimpleClientset(tt.fields.clientObjs...)
+			require.Equal(t, tt.expected.err, cleanupOwnerReferences(c, crc))
+
+			listOpts := metav1.ListOptions{}
+			csvs, err := crc.OperatorsV1alpha1().ClusterServiceVersions(metav1.NamespaceAll).List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.csvs, csvs.Items)
+
+			clusterRoles, err := c.KubernetesInterface().RbacV1().ClusterRoles().List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.clusterRoles, clusterRoles.Items)
+
+			clusterRoleBindings, err := c.KubernetesInterface().RbacV1().ClusterRoleBindings().List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.clusterRoleBindings, clusterRoleBindings.Items)
+
+			roles, err := c.KubernetesInterface().RbacV1().Roles(metav1.NamespaceAll).List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.roles, roles.Items)
+
+			roleBindings, err := c.KubernetesInterface().RbacV1().RoleBindings(metav1.NamespaceAll).List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.roleBindings, roleBindings.Items)
+		})
+	}
+}
+
+func newOwnerReference(kind string, uid types.UID) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		Kind: kind,
+		UID:  uid,
+	}
+}
+
+func newClusterServiceVersion(namespace, name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *v1alpha1.ClusterServiceVersion {
+	csv := &v1alpha1.ClusterServiceVersion{}
+	csv.SetUID(uid)
+	csv.SetNamespace(namespace)
+	csv.SetName(name)
+	csv.SetUID(uid)
+	csv.SetOwnerReferences(ownerRefs)
+	return csv
+}
+
+func newClusterRole(name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *rbacv1.ClusterRole {
+	clusterRole := &rbacv1.ClusterRole{}
+	clusterRole.SetUID(uid)
+	clusterRole.SetName(name)
+	clusterRole.SetOwnerReferences(ownerRefs)
+	return clusterRole
+}
+
+func newClusterRoleBinding(name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *rbacv1.ClusterRoleBinding {
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	clusterRoleBinding.SetUID(uid)
+	clusterRoleBinding.SetName(name)
+	clusterRoleBinding.SetOwnerReferences(ownerRefs)
+	return clusterRoleBinding
+}
+
+func newRole(namespace, name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *rbacv1.Role {
+	role := &rbacv1.Role{}
+	role.SetUID(uid)
+	role.SetNamespace(namespace)
+	role.SetName(name)
+	role.SetOwnerReferences(ownerRefs)
+	return role
+}
+
+func newRoleBinding(namespace, name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *rbacv1.RoleBinding {
+	roleBinding := &rbacv1.RoleBinding{}
+	roleBinding.SetUID(uid)
+	roleBinding.SetNamespace(namespace)
+	roleBinding.SetName(name)
+	roleBinding.SetOwnerReferences(ownerRefs)
+	return roleBinding
+}


### PR DESCRIPTION
Adds cross-namespace OwnerReference cleanup logic to OLM startup.

Cross-namespace and cluster-to-namespace scoped OwnerReferences may cause sibling resources in the owner namespace to be deleted sporadically (see [CVE-2019-3884]( https://access.redhat.com/security/cve/cve-2019-3884)). Older versions of OLM use both types of OwnerReference, and in cases where OLM is updated, they must be removed to prevent erroneous deletion of OLM's self-hosted components.