### PR TITLE
Enable vendoring on Go 1.1x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 SHELL := /bin/bash
 PKG   := github.com/operator-framework/operator-lifecycle-manager
-MOD_FLAGS := $(shell (go version | grep -q -E "1\.(11|12)") && echo -mod=vendor)
+MOD_FLAGS := $(shell (go version | grep -q -E "1\.1[1-9]") && echo -mod=vendor)
 CMDS  := $(shell go list $(MOD_FLAGS) ./cmd/...)
 TCMDS := $(shell go list $(MOD_FLAGS) ./test/e2e/...)
 CODEGEN_INTERNAL := ./vendor/k8s.io/code-generator/generate_internal_groups.sh


### PR DESCRIPTION
This handles Go 1.13-1.19, in addition to the existing 1.11 and 1.12.

Closes: #1032

Signed-off-by: Stephen Kitt <skitt@redhat.com>