### PR TITLE
[release-4.1] Bug 1755646: Cleanup leftover cross-namespace OwnerReferences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 SHELL := /bin/bash
 PKG   := github.com/operator-framework/operator-lifecycle-manager
-MOD_FLAGS := $(shell (go version | grep -q -E "1\.(11|12)") && echo -mod=vendor)
+MOD_FLAGS := $(shell (go version | grep -q -E "1\.(11|12|13)") && echo -mod=vendor)
 CMDS  := $(addprefix bin/, $(shell go list $(MOD_FLAGS) ./cmd/... | xargs -I{} basename {}))
 CODEGEN := ./vendor/k8s.io/code-generator/generate_groups.sh
 CODEGEN_INTERNAL := ./vendor/k8s.io/code-generator/generate_internal_groups.sh

--- a/cmd/olm/cleanup.go
+++ b/cmd/olm/cleanup.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+)
+
+const (
+	pollInterval = 1 * time.Second
+	pollDuration = 5 * time.Minute
+)
+
+type checkResourceFunc func() error
+type deleteResourceFunc func() error
+type mutateMeta func(obj metav1.Object) (mutated bool)
+
+func cleanup(logger *logrus.Logger, c operatorclient.ClientInterface, crc versioned.Interface) {
+	if err := cleanupOwnerReferences(c, crc); err != nil {
+		logger.WithError(err).Fatal("couldn't cleanup cross-namespace ownerreferences")
+	}
+
+	if err := waitForDelete(checkSubscription(crc, "packageserver"), deleteSubscription(crc, "packageserver")); err != nil {
+		logger.WithError(err).Fatal("couldn't clean previous release")
+	}
+}
+
+func waitForDelete(checkResource checkResourceFunc, deleteResource deleteResourceFunc) error {
+	if err := checkResource(); err != nil && errors.IsNotFound(err) {
+		return nil
+	}
+	if err := deleteResource(); err != nil {
+		return err
+	}
+	err := wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		err := checkResource()
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+
+	return err
+}
+
+func checkSubscription(crc versioned.Interface, name string) checkResourceFunc {
+	return func() error {
+		_, err := crc.OperatorsV1alpha1().Subscriptions(*namespace).Get(name, metav1.GetOptions{})
+		return err
+	}
+}
+
+func deleteSubscription(crc versioned.Interface, name string) deleteResourceFunc {
+	return func() error {
+		return crc.OperatorsV1alpha1().Subscriptions(*namespace).Delete(name, metav1.NewDeleteOptions(0))
+	}
+}
+
+// cleanupOwnerReferences cleans up inter-namespace and cluster-to-namespace scoped OwnerReferences to ClusterServiceVersions.
+//
+// Cross-namespace and cluster-to-namespace scoped OwnerReferences may cause sibling resources in the owner namespace to be
+// deleted sporadically (see CVE-2019-3884 https://access.redhat.com/security/cve/cve-2019-3884). Older versions of OLM use both types of
+// OwnerReference, and in cases where OLM is updated, they must be removed to prevent erroneous deletion of OLM's self-hosted components.
+func cleanupOwnerReferences(c operatorclient.ClientInterface, crc versioned.Interface) error {
+	listOpts := metav1.ListOptions{}
+	csvs, err := crc.OperatorsV1alpha1().ClusterServiceVersions(metav1.NamespaceAll).List(listOpts)
+	if err != nil {
+		return err
+	}
+
+	uidNamespaces := map[types.UID]string{}
+	for _, csv := range csvs.Items {
+		uidNamespaces[csv.GetUID()] = csv.GetNamespace()
+	}
+	removeBadRefs := crossNamespaceOwnerReferenceRemoval(v1alpha1.ClusterServiceVersionKind, uidNamespaces)
+
+	// Cleanup cross-namespace OwnerReferences on CSVs, ClusterRoles/Bindings, and Roles/Bindings
+	var objs []metav1.Object
+	for _, obj := range csvs.Items {
+		objs = append(objs, &obj)
+	}
+
+	clusterRoles, _ := c.KubernetesInterface().RbacV1().ClusterRoles().List(listOpts)
+	for _, obj := range clusterRoles.Items {
+		objs = append(objs, &obj)
+	}
+
+	clusterRoleBindings, _ := c.KubernetesInterface().RbacV1().ClusterRoleBindings().List(listOpts)
+	for _, obj := range clusterRoleBindings.Items {
+		objs = append(objs, &obj)
+	}
+
+	roles, _ := c.KubernetesInterface().RbacV1().Roles(metav1.NamespaceAll).List(listOpts)
+	for _, obj := range roles.Items {
+		objs = append(objs, &obj)
+	}
+	roleBindings, _ := c.KubernetesInterface().RbacV1().RoleBindings(metav1.NamespaceAll).List(listOpts)
+	for _, obj := range roleBindings.Items {
+		objs = append(objs, &obj)
+	}
+
+	for _, obj := range objs {
+		if !removeBadRefs(obj) {
+			continue
+		}
+
+		update := func() error {
+			// If this is not a type we care about, do nothing
+			return nil
+		}
+		switch v := obj.(type) {
+		case *v1alpha1.ClusterServiceVersion:
+			update = func() error {
+				_, err := crc.OperatorsV1alpha1().ClusterServiceVersions(v.GetNamespace()).Update(v)
+				return err
+			}
+		case *rbacv1.ClusterRole:
+			update = func() error {
+				_, err = c.KubernetesInterface().RbacV1().ClusterRoles().Update(v)
+				return err
+			}
+		case *rbacv1.ClusterRoleBinding:
+			update = func() error {
+				_, err = c.KubernetesInterface().RbacV1().ClusterRoleBindings().Update(v)
+				return err
+			}
+		case *rbacv1.Role:
+			update = func() error {
+				_, err = c.KubernetesInterface().RbacV1().Roles(v.GetNamespace()).Update(v)
+				return err
+			}
+		case *rbacv1.RoleBinding:
+			update = func() error {
+				_, err = c.KubernetesInterface().RbacV1().RoleBindings(v.GetNamespace()).Update(v)
+				return err
+			}
+		}
+
+		if err := retry.RetryOnConflict(retry.DefaultBackoff, update); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func crossNamespaceOwnerReferenceRemoval(kind string, uidNamespaces map[types.UID]string) mutateMeta {
+	return func(obj metav1.Object) (mutated bool) {
+		var cleanRefs []metav1.OwnerReference
+		objNamespace := obj.GetNamespace()
+		for _, ref := range obj.GetOwnerReferences() {
+			if ref.Kind == kind {
+				refNamespace, ok := uidNamespaces[ref.UID]
+				if !ok || (refNamespace != metav1.NamespaceAll && refNamespace != objNamespace) {
+					mutated = true
+					continue
+				}
+			}
+
+			cleanRefs = append(cleanRefs, ref)
+		}
+
+		if mutated {
+			obj.SetOwnerReferences(cleanRefs)
+		}
+
+		return
+	}
+}

--- a/cmd/olm/cleanup_test.go
+++ b/cmd/olm/cleanup_test.go
@@ -1,0 +1,542 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	operatorsfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+)
+
+func TestCrossOwnerReferenceRemoval(t *testing.T) {
+	clusterScopedKind := "ClusterScoped"
+
+	type fields struct {
+		kind          string
+		uidNamespaces map[types.UID]string
+	}
+	type args struct {
+		obj metav1.Object
+	}
+	type expected struct {
+		obj     metav1.Object
+		mutated bool
+	}
+	tests := []struct {
+		description string
+		fields      fields
+		args        args
+		expected    expected
+	}{
+		{
+			description: "OneRef/NoResources/Removed",
+			fields: fields{
+				kind:          v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: nil,
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace:       "ns-a",
+					OwnerReferences: nil,
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "OneRef/ResourceMissing/Removed",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a0-uid": "ns-a",
+					"csv-a1-uid": "ns-a",
+					"csv-b-uid":  "ns-b",
+					"csv-c0-uid": "ns-c",
+					"csv-c1-uid": "ns-c",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace:       "ns-a",
+					OwnerReferences: nil,
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "OneRef/NotOfKind/Ignored",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a0-uid": "ns-a",
+					"csv-a1-uid": "ns-a",
+					"csv-b-uid":  "ns-b",
+					"csv-c0-uid": "ns-c",
+					"csv-c1-uid": "ns-c",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "DefinitelyNotACSV",
+							UID:  "no-csv-here-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "DefinitelyNotACSV",
+							UID:  "no-csv-here-uid",
+						},
+					},
+				},
+				mutated: false,
+			},
+		},
+		{
+			description: "OneRef/Internamespace/Removed",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-b-uid": "ns-b",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-b-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace:       "ns-a",
+					OwnerReferences: nil,
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "ManyRefs/Internamespace/Removed",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a0-uid": "ns-a",
+					"csv-a1-uid": "ns-a",
+					"csv-b-uid":  "ns-b",
+					"csv-c0-uid": "ns-c",
+					"csv-c1-uid": "ns-c",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a0-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-c1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-b-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a0-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a1-uid",
+						},
+					},
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "OneRef/ClusterToNamespaced/Removed",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a-uid": "ns-a",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					OwnerReferences: nil,
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "ManyRefs/ClusterToNamespaced/Removed/NotOfKind/Ignored",
+			fields: fields{
+				kind: v1alpha1.ClusterServiceVersionKind,
+				uidNamespaces: map[types.UID]string{
+					"csv-a0-uid": "ns-a",
+					"csv-a1-uid": "ns-a",
+					"csv-b-uid":  "ns-b",
+					"csv-c0-uid": "ns-c",
+					"csv-c1-uid": "ns-c",
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a0-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a1-uid",
+						},
+						{
+							Kind: "DefinitelyNotACSV",
+							UID:  "no-csv-here-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "DefinitelyNotACSV",
+							UID:  "no-csv-here-uid",
+						},
+					},
+				},
+				mutated: true,
+			},
+		},
+		{
+			description: "ManyRefs/NamespacedToCluster/Kept/NotOfKind/Ignored",
+			fields: fields{
+				kind: clusterScopedKind,
+				uidNamespaces: map[types.UID]string{
+					"csk-0-uid": metav1.NamespaceAll,
+					"csk-1-uid": metav1.NamespaceAll,
+				},
+			},
+			args: args{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: clusterScopedKind,
+							UID:  "csk-0-uid",
+						},
+						{
+							Kind: clusterScopedKind,
+							UID:  "csk-1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-b-uid",
+						},
+					},
+				},
+			},
+			expected: expected{
+				obj: &metav1.ObjectMeta{
+					Namespace: "ns-a",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: clusterScopedKind,
+							UID:  "csk-0-uid",
+						},
+						{
+							Kind: clusterScopedKind,
+							UID:  "csk-1-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-a-uid",
+						},
+						{
+							Kind: v1alpha1.ClusterServiceVersionKind,
+							UID:  "csv-b-uid",
+						},
+					},
+				},
+				mutated: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			removeBadRefs := crossNamespaceOwnerReferenceRemoval(tt.fields.kind, tt.fields.uidNamespaces)
+			obj := tt.args.obj
+			require.Equal(t, tt.expected.mutated, removeBadRefs(obj))
+			require.Equal(t, tt.expected.obj, obj)
+		})
+	}
+}
+
+func TestCleanupOwnerReferences(t *testing.T) {
+	clusterRoleKind := "ClusterRole"
+
+	type fields struct {
+		k8sObjs    []runtime.Object
+		clientObjs []runtime.Object
+	}
+	type expected struct {
+		err                 error
+		csvs                []v1alpha1.ClusterServiceVersion
+		clusterRoles        []rbacv1.ClusterRole
+		clusterRoleBindings []rbacv1.ClusterRoleBinding
+		roles               []rbacv1.Role
+		roleBindings        []rbacv1.RoleBinding
+	}
+	tests := []struct {
+		description string
+		fields      fields
+		expected    expected
+	}{
+		{
+			description: "CrossNamespace/Removed",
+			fields: fields{
+				k8sObjs: []runtime.Object{
+					newClusterRole("cr", "cr-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+					newClusterRoleBinding("crb", "crb-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+					newRoleBinding("ns-a", "rb", "rb-a-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+					newRole("ns-a", "r", "r-a-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+				},
+				clientObjs: []runtime.Object{
+					newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+					newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid")),
+				},
+			},
+			expected: expected{
+				csvs: []v1alpha1.ClusterServiceVersion{
+					*newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					*newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+				clusterRoles: []rbacv1.ClusterRole{
+					*newClusterRole("cr", "cr-uid"),
+				},
+				clusterRoleBindings: []rbacv1.ClusterRoleBinding{
+					*newClusterRoleBinding("crb", "crb-uid"),
+				},
+				roles: []rbacv1.Role{
+					*newRole("ns-a", "r", "r-a-uid"),
+				},
+				roleBindings: []rbacv1.RoleBinding{
+					*newRoleBinding("ns-a", "rb", "rb-a-uid"),
+				},
+			},
+		},
+		{
+			description: "CrossNamespace/Removed/InNamespace/Kept",
+			fields: fields{
+				k8sObjs: []runtime.Object{
+					newRoleBinding("ns-a", "rb", "rb-a-uid",
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-a-uid"),
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid"),
+					),
+				},
+				clientObjs: []runtime.Object{
+					newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+			},
+			expected: expected{
+				csvs: []v1alpha1.ClusterServiceVersion{
+					*newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					*newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+				roleBindings: []rbacv1.RoleBinding{
+					*newRoleBinding("ns-a", "rb", "rb-a-uid", newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-a-uid")),
+				},
+			},
+		},
+		{
+			description: "CrossNamespace/Removed/ToClusterScoped/Ignored",
+			fields: fields{
+				k8sObjs: []runtime.Object{
+					newClusterRole("cr", "cr-uid"),
+					newRoleBinding("ns-a", "rb", "rb-a-uid",
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-a-uid"),
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-b-uid"),
+						newOwnerReference(clusterRoleKind, "cr-uid"),
+					),
+				},
+				clientObjs: []runtime.Object{
+					newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+			},
+			expected: expected{
+				csvs: []v1alpha1.ClusterServiceVersion{
+					*newClusterServiceVersion("ns-a", "csv-a", "csv-a-uid"),
+					*newClusterServiceVersion("ns-b", "csv-b", "csv-b-uid"),
+				},
+				clusterRoles: []rbacv1.ClusterRole{
+					*newClusterRole("cr", "cr-uid"),
+				},
+				roleBindings: []rbacv1.RoleBinding{
+					*newRoleBinding("ns-a", "rb", "rb-a-uid",
+						newOwnerReference(v1alpha1.ClusterServiceVersionKind, "csv-a-uid"),
+						newOwnerReference(clusterRoleKind, "cr-uid"),
+					),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			k8sClient := k8sfake.NewSimpleClientset(tt.fields.k8sObjs...)
+			c := operatorclient.NewClient(k8sClient, apiextensionsfake.NewSimpleClientset(), apiregistrationfake.NewSimpleClientset())
+			crc := operatorsfake.NewSimpleClientset(tt.fields.clientObjs...)
+			require.Equal(t, tt.expected.err, cleanupOwnerReferences(c, crc))
+
+			listOpts := metav1.ListOptions{}
+			csvs, err := crc.OperatorsV1alpha1().ClusterServiceVersions(metav1.NamespaceAll).List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.csvs, csvs.Items)
+
+			clusterRoles, err := c.KubernetesInterface().RbacV1().ClusterRoles().List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.clusterRoles, clusterRoles.Items)
+
+			clusterRoleBindings, err := c.KubernetesInterface().RbacV1().ClusterRoleBindings().List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.clusterRoleBindings, clusterRoleBindings.Items)
+
+			roles, err := c.KubernetesInterface().RbacV1().Roles(metav1.NamespaceAll).List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.roles, roles.Items)
+
+			roleBindings, err := c.KubernetesInterface().RbacV1().RoleBindings(metav1.NamespaceAll).List(listOpts)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected.roleBindings, roleBindings.Items)
+		})
+	}
+}
+
+func newOwnerReference(kind string, uid types.UID) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		Kind: kind,
+		UID:  uid,
+	}
+}
+
+func newClusterServiceVersion(namespace, name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *v1alpha1.ClusterServiceVersion {
+	csv := &v1alpha1.ClusterServiceVersion{}
+	csv.SetUID(uid)
+	csv.SetNamespace(namespace)
+	csv.SetName(name)
+	csv.SetUID(uid)
+	csv.SetOwnerReferences(ownerRefs)
+	return csv
+}
+
+func newClusterRole(name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *rbacv1.ClusterRole {
+	clusterRole := &rbacv1.ClusterRole{}
+	clusterRole.SetUID(uid)
+	clusterRole.SetName(name)
+	clusterRole.SetOwnerReferences(ownerRefs)
+	return clusterRole
+}
+
+func newClusterRoleBinding(name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *rbacv1.ClusterRoleBinding {
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	clusterRoleBinding.SetUID(uid)
+	clusterRoleBinding.SetName(name)
+	clusterRoleBinding.SetOwnerReferences(ownerRefs)
+	return clusterRoleBinding
+}
+
+func newRole(namespace, name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *rbacv1.Role {
+	role := &rbacv1.Role{}
+	role.SetUID(uid)
+	role.SetNamespace(namespace)
+	role.SetName(name)
+	role.SetOwnerReferences(ownerRefs)
+	return role
+}
+
+func newRoleBinding(namespace, name string, uid types.UID, ownerRefs ...metav1.OwnerReference) *rbacv1.RoleBinding {
+	roleBinding := &rbacv1.RoleBinding{}
+	roleBinding.SetUID(uid)
+	roleBinding.SetNamespace(namespace)
+	roleBinding.SetName(name)
+	roleBinding.SetOwnerReferences(ownerRefs)
+	return roleBinding
+}

--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -106,6 +106,9 @@ func main() {
 
 	opClient := operatorclient.NewClientFromConfig(*kubeConfigPath, logger)
 
+	// Perform resource cleanup before starting the operator
+	cleanup(logger, opClient, crClient)
+
 	// create a config client for operator status
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigPath)
 	if err != nil {

--- a/test/e2e/packagemanifest_e2e_test.go
+++ b/test/e2e/packagemanifest_e2e_test.go
@@ -1,15 +1,18 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	watch "k8s.io/apimachinery/pkg/watch"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
@@ -114,4 +117,40 @@ func TestPackageManifestLoading(t *testing.T) {
 	require.NoError(t, err, "could not access package manifests list meta")
 	require.NotNil(t, pmList.ListMeta, "package manifest list metadata empty")
 	require.NotNil(t, pmList.Items)
+}
+
+// TestPackageServerServiceAccountRegeneration ensures that when OLM is scaled down that the packageserver Subscription is deleted and when it's recreated, ensures that
+// OLM regenerates its `ServiceAccount`.
+func TestPackageServerServiceAccountRegeneration(t *testing.T) {
+	c := newKubeClient(t)
+	crc := newCRClient(t)
+
+	name := "packageserver"
+	getOpts := metav1.GetOptions{}
+	deleteOpts := &metav1.DeleteOptions{}
+
+	err := c.KubernetesInterface().CoreV1().ServiceAccounts(*olmNamespace).Delete(name, deleteOpts)
+	require.NoError(t, err)
+
+	// Start watching for the ServiceAccount
+	w, err := c.KubernetesInterface().CoreV1().ServiceAccounts(*olmNamespace).Watch(metav1.ListOptions{})
+	require.NoError(t, err)
+
+	// Delete and recreate the Subscription
+	sub, err := crc.OperatorsV1alpha1().Subscriptions(*olmNamespace).Get(name, getOpts)
+	require.NoError(t, err)
+	err = crc.OperatorsV1alpha1().Subscriptions(*olmNamespace).Delete(name, &metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	sub.ObjectMeta = metav1.ObjectMeta{
+		Namespace: sub.GetNamespace(),
+		Name:      sub.GetName(),
+	}
+	_, err = crc.OperatorsV1alpha1().Subscriptions(*olmNamespace).Create(sub)
+	require.NoError(t, err)
+
+	awaitCondition(context.Background(), t, w, conditionMetFunc(func(t *testing.T, event watch.Event) bool {
+		v, ok := event.Object.(*corev1.ServiceAccount)
+		return ok && v.GetName() == name
+	}))
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Backport #1025 to `release-4.1`

**Motivation for the change:**

#1025 ensures this cleanup occurs on upgrade between 4.1.z and 4.2.Z, but doesn't handle 4.1.z to 4.1.z'.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
