### PR TITLE
feat(metrics) record CSV failures

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -930,6 +930,8 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 	})
 	logger.Debug("syncing CSV")
 
+	metrics.EmitCSVMetric(clusterServiceVersion)
+
 	if a.csvNotification != nil {
 		a.csvNotification.OnAddOrUpdate(clusterServiceVersion)
 	}


### PR DESCRIPTION
This commit introduces a change so OLM will exposed metrics about a CSV
whenever either of the following conditions are met:
- The CSV enters the failed phase.
- The CSV is already in the failed phase, but the reason has changed.

The metrics are recorded with name, version, and reason labels.