### PR TITLE
Bug 1758008: Manual approval strategy ignored for subsequent releases

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -939,7 +939,8 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 			// phase
 			if installPlanApproval == v1alpha1.ApprovalAutomatic {
 				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
-			} else if installPlanApproval == v1alpha1.ApprovalManual {
+			} else {
+				logger.Info("Testing")
 				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
 			}
 			for _, step := range installPlan.Status.Plan {

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -935,7 +935,13 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 				}
 			}
 
-			installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+			// Use provided `installPlanApproval` to determine the appropreciate
+			// phase
+			if installPlanApproval == v1alpha1.ApprovalAutomatic {
+				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+			} else if installPlanApproval == v1alpha1.ApprovalManual {
+				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
+			}
 			for _, step := range installPlan.Status.Plan {
 				step.Status = v1alpha1.StepStatusUnknown
 			}

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	pollInterval = 1 * time.Second
-	pollDuration = 5 * time.Minute
+	pollDuration = 2 * time.Minute
 
 	olmConfigMap = "olm-operators"
 	// sync name with scripts/install_local.sh

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	pollInterval = 1 * time.Second
-	pollDuration = 2 * time.Minute
+	pollDuration = 5 * time.Minute
 
 	olmConfigMap = "olm-operators"
 	// sync name with scripts/install_local.sh


### PR DESCRIPTION
For an subscription with manual approval, only the initial installplan
respects the approval requires. Subsequent installplans ignore the
fact the approval status is still false and install the operator
regardless. This issue is due to catalog incorrectly transitions
the installplan into install phase without checking for approval
condition.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
