### PR TITLE
bug(install) Fix packageserver name in install.sh

### DIFF
--- a/deploy/upstream/quickstart/install.sh
+++ b/deploy/upstream/quickstart/install.sh
@@ -24,7 +24,7 @@ kubectl rollout status -w deployment/catalog-operator --namespace="${namespace}"
 
 retries=50
 until [[ $retries == 0 || $new_csv_phase == "Succeeded" ]]; do
-    new_csv_phase=$(kubectl get csv -n "${namespace}" packageserver.v${release} -o jsonpath='{.status.phase}' 2>/dev/null || echo "Waiting for CSV to appear")
+    new_csv_phase=$(kubectl get csv -n "${namespace}" packageserver -o jsonpath='{.status.phase}' 2>/dev/null || echo "Waiting for CSV to appear")
     if [[ $new_csv_phase != "$csv_phase" ]]; then
         csv_phase=$new_csv_phase
         echo "Package server phase: $csv_phase"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ kubectl rollout status -w deployment/catalog-operator --namespace="${namespace}"
 
 retries=50
 until [[ $retries == 0 || $new_csv_phase == "Succeeded" ]]; do
-    new_csv_phase=$(kubectl get csv -n "${namespace}" packageserver.v${release} -o jsonpath='{.status.phase}' 2>/dev/null || echo "Waiting for CSV to appear")
+    new_csv_phase=$(kubectl get csv -n "${namespace}" packageserver -o jsonpath='{.status.phase}' 2>/dev/null || echo "Waiting for CSV to appear")
     if [[ $new_csv_phase != "$csv_phase" ]]; then
         csv_phase=$new_csv_phase
         echo "Package server phase: $csv_phase"


### PR DESCRIPTION
The install.sh script is searching for a csv named packageserver.v{release}, which no longer matches the name of the csv deployed by OLM. This commit fixes this bug in the install scripts.