### PR TITLE
Add `apk upgrade` to upstream builder

### DIFF
--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12-alpine as builder
 LABEL stage=builder
 WORKDIR /build
 
-RUN apk update && apk add bash make git mercurial jq
+RUN apk update && apk add bash make git mercurial jq && apk upgrade
 
 # copy just enough of the git repo to parse HEAD, used to record version in OLM binaries
 COPY .git/HEAD .git/HEAD


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This adds an `apk upgrade` to the build so that we always have the latest packages.

**Motivation for the change:**
Ensuring that our upstream builds have the latest packages on every build.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

Closes #1066
