### PR TITLE
Lock down package server runtime environment

### DIFF
--- a/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -60,5 +60,15 @@ spec:
         {{- if .Values.package.resources }}
         resources:
 {{ toYaml .Values.package.resources | indent 10 }}
-        {{- end}}
+        {{- end }}
+        {{- if .Values.package.securityContext }}
+        securityContext:
+          runAsUser: {{ .Values.package.securityContext.runAsUser }}
+        {{- end }}
+        volumeMounts:
+        - name: tmpfs
+          mountPath: /tmp
+      volumes:
+      - name: tmpfs
+        emptyDir: {}
 {{- end -}}

--- a/deploy/upstream/values.yaml
+++ b/deploy/upstream/values.yaml
@@ -27,5 +27,7 @@ package:
     pullPolicy: Always
   service:
     internalPort: 5443
+  securityContext:
+    runAsUser: 1000
 catalog_sources:
 - rh-operators

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -123,6 +123,12 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 50Mi
+                volumeMounts:
+                - name: tmpfs
+                  mountPath: /tmp
+              volumes:
+              - name: tmpfs
+                emptyDir: {}
   maturity: alpha
   version: 0.14.1
   apiservicedefinitions:


### PR DESCRIPTION
**Description of the change:**
This PR modifes the package server component's deployment manifest's pods to:

* Run as non-root (uid 1000) by default
* Mount a emptyDir volume to /tmp so that the root filesystem can be read-only


**Motivation for the change:**
At Indeed we're using restrictive pod security policies that among other things prevent pods running as root and marks them to have read-only root filesystems.


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

