### PR TITLE
Fix log message in resolver

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -96,7 +96,7 @@ func (r *OperatorsV1alpha1Resolver) ResolveSteps(namespace string, sourceQuerier
 		if op.Bundle() != nil {
 			bundleSteps, err := NewStepResourceFromBundle(op.Bundle(), namespace, op.Replaces(), op.SourceInfo().Catalog.Name, op.SourceInfo().Catalog.Namespace)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to turn bundle into steps %s", err.Error())
+				return nil, nil, fmt.Errorf("failed to turn bundle into steps: %s", err.Error())
 			}
 			for _, s := range bundleSteps {
 				steps = append(steps, &v1alpha1.Step{

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -96,7 +96,7 @@ func (r *OperatorsV1alpha1Resolver) ResolveSteps(namespace string, sourceQuerier
 		if op.Bundle() != nil {
 			bundleSteps, err := NewStepResourceFromBundle(op.Bundle(), namespace, op.Replaces(), op.SourceInfo().Catalog.Name, op.SourceInfo().Catalog.Namespace)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to turn bundle into steps")
+				return nil, nil, fmt.Errorf("failed to turn bundle into steps %s", err.Error())
 			}
 			for _, s := range bundleSteps {
 				steps = append(steps, &v1alpha1.Step{


### PR DESCRIPTION
This was masking the actual errors coming from the step generator

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Fixes an issue with the logs - actual errors were being masked instead of wrapped.


**Motivation for the change:**

Debugging a failing operator step generation.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
