### PR TITLE
feat(metrics) Limit Cardinality of CSV metrics

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -930,8 +930,6 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 	})
 	logger.Debug("syncing CSV")
 
-	metrics.EmitCSVMetric(clusterServiceVersion)
-
 	if a.csvNotification != nil {
 		a.csvNotification.OnAddOrUpdate(clusterServiceVersion)
 	}
@@ -964,6 +962,8 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 			} else {
 				syncError = fmt.Errorf("error transitioning ClusterServiceVersion: %s and error updating CSV status: %s", syncError, updateErr)
 			}
+		} else {
+			metrics.EmitCSVMetric(clusterServiceVersion, outCSV)
 		}
 	}
 

--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -49,11 +49,13 @@ func TestMetricsEndpoint(t *testing.T) {
 	}
 
 	// Verify metrics have been emitted for packageserver csv
-	require.Contains(t, rawOutput, "csv_sync_total")
+	require.Contains(t, rawOutput, "csv_abnormal")
 	require.Contains(t, rawOutput, "name=\""+failingCSV.Name+"\"")
 	require.Contains(t, rawOutput, "phase=\"Failed\"")
 	require.Contains(t, rawOutput, "reason=\"UnsupportedOperatorGroup\"")
 	require.Contains(t, rawOutput, "version=\"0.0.0\"")
+
+	require.Contains(t, rawOutput, "csv_succeeded")
 	log.Info(rawOutput)
 }
 


### PR DESCRIPTION
This commit introduces a change that limits the number of metrics that
an OLM cluster reports at any given time for a CSV.

The first metric introduced is called csv_succeeded, which tracks CSVs that
have reached the succeeded phase. The following information is
provided about the CSV via labels: name, version. The value of this
metric will always be 0 or 1.

The second metric introduced is called csv_abnormal, which is reported
whenever the CSV is updated and has not reached the succeeded phase. The
following information is provided about the CSV via labels: name,
version, phase, reason. Whenever a CSV is updated, the existing
timeseries is deleted and replaced by an updated version.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive