### PR TITLE
feat(metrics) Report subscription channel

### DIFF
--- a/pkg/controller/operators/catalog/subscription/syncer.go
+++ b/pkg/controller/operators/catalog/subscription/syncer.go
@@ -85,8 +85,13 @@ func (s *subscriptionSyncer) Sync(ctx context.Context, event kubestate.ResourceE
 	return nil
 }
 
-func (o *subscriptionSyncer) recordMetrics(sub *v1alpha1.Subscription) {
-	metrics.CounterForSubscription(sub.GetName(), sub.Status.InstalledCSV).Inc()
+func (s *subscriptionSyncer) recordMetrics(sub *v1alpha1.Subscription) {
+	// sub.Spec is not a required field.
+	if sub.Spec == nil {
+		return
+	}
+
+	metrics.CounterForSubscription(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Channel).Inc()
 }
 
 func (s *subscriptionSyncer) Notify(event kubestate.ResourceEvent) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -14,6 +14,7 @@ const (
 	NAME_LABEL      = "name"
 	INSTALLED_LABEL = "installed"
 	NAMESPACE_LABEL = "namespace"
+	CHANNEL_LABEL   = "channel"
 	VERSION_LABEL   = "version"
 	PHASE_LABEL     = "phase"
 	REASON_LABEL    = "reason"
@@ -148,7 +149,7 @@ var (
 			Name: "subscription_sync_total",
 			Help: "Monotonic count of subscription syncs",
 		},
-		[]string{NAME_LABEL, INSTALLED_LABEL},
+		[]string{NAME_LABEL, INSTALLED_LABEL, CHANNEL_LABEL},
 	)
 
 	csvSucceeded = prometheus.NewGaugeVec(
@@ -182,8 +183,8 @@ func RegisterCatalog() {
 	prometheus.MustRegister(SubscriptionSyncCount)
 }
 
-func CounterForSubscription(name, installedCSV string) prometheus.Counter {
-	return SubscriptionSyncCount.WithLabelValues(name, installedCSV)
+func CounterForSubscription(name, installedCSV, channelName string) prometheus.Counter {
+	return SubscriptionSyncCount.WithLabelValues(name, installedCSV, channelName)
 }
 
 func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha1.ClusterServiceVersion) {


### PR DESCRIPTION
This commit introduces a change that updates the sucription_sync_total
metric to include a channel 

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive
