### PR TITLE
Alerts for failing OLM operators

### DIFF
--- a/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
+++ b/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
@@ -1,0 +1,20 @@
+{{ if and .Values.installType (eq .Values.installType "ocp") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: olm-alert-rules
+  namespace: {{ .Values.namespace }}
+  labels:
+    prometheus: alert-rules
+    role: alert-rules
+spec:
+  groups:
+    - name: olm.failing_operators.rules
+      rules:
+        - alert: FailingOperator
+          annotations:
+            message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Reason-{{ printf "{{ $labels.reason }}" }}
+          expr: csv_abnormal{phase="Failed"}
+          labels:
+            severity: info
+{{ end }}

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: olm-alert-rules
+  namespace: openshift-operator-lifecycle-manager
+  labels:
+    prometheus: alert-rules
+    role: alert-rules
+spec:
+  groups:
+    - name: olm.failing_operators.rules
+      rules:
+        - alert: FailingOperator
+          annotations:
+            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Reason-{{ $labels.reason }}
+          expr: csv_abnormal{phase="Failed"}
+          labels:
+            severity: info


### PR DESCRIPTION
**Description of the change:**

- Add prometheus rule for firing an alert when csv_abnormal metric
  is emitted with phase=failed
- Alert message contains name and version of operator.

**Motivation for the change:**

As a OpenShift administrator, I want to be able to receive a notification when an operator is consistently reaching a failed state so that I can immediately address known issues.

[Enhancement proposal](https://github.com/openshift/enhancements/pull/12)

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
