### PR TITLE
[Release 4.1] Bug 1767846: Manual approval strategy ignored for subsequent releases

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -771,7 +771,8 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 			// phase
 			if installPlanApproval == v1alpha1.ApprovalAutomatic {
 				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
-			} else if installPlanApproval == v1alpha1.ApprovalManual {
+			} else {
+				logger.Info("Testing")
 				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
 			}
 			for _, step := range installPlan.Status.Plan {

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -767,7 +767,13 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 				}
 			}
 
-			installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+			// Use provided `installPlanApproval` to determine the appropreciate
+			// phase
+			if installPlanApproval == v1alpha1.ApprovalAutomatic {
+				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+			} else if installPlanApproval == v1alpha1.ApprovalManual {
+				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
+			}
 			for _, step := range installPlan.Status.Plan {
 				step.Status = v1alpha1.StepStatusUnknown
 			}

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -760,8 +760,10 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 			for _, sub := range subs {
 				ownerWasAdded = ownerWasAdded || !ownerutil.EnsureOwner(installPlan, sub)
 			}
+
+			out := installPlan.DeepCopy()
 			if ownerWasAdded {
-				_, err := o.client.OperatorsV1alpha1().InstallPlans(installPlan.GetNamespace()).Update(installPlan)
+				out, err = o.client.OperatorsV1alpha1().InstallPlans(installPlan.GetNamespace()).Update(installPlan)
 				if err != nil {
 					return nil, err
 				}
@@ -770,19 +772,18 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 			// Use provided `installPlanApproval` to determine the appropreciate
 			// phase
 			if installPlanApproval == v1alpha1.ApprovalAutomatic {
-				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+				out.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
 			} else {
-				logger.Info("Testing")
-				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
+				out.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
 			}
-			for _, step := range installPlan.Status.Plan {
+			for _, step := range out.Status.Plan {
 				step.Status = v1alpha1.StepStatusUnknown
 			}
-			_, err = o.client.OperatorsV1alpha1().InstallPlans(namespace).UpdateStatus(installPlan)
+			res, err := o.client.OperatorsV1alpha1().InstallPlans(namespace).UpdateStatus(out)
 			if err != nil {
 				return nil, err
 			}
-			return operators.GetReference(installPlan)
+			return operators.GetReference(res)
 		}
 	}
 	logger.Warn("no installplan found with matching manifests, creating new one")

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -842,6 +842,122 @@ func TestSubscriptionUpdatesMultipleIntermediates(t *testing.T) {
 	// TODO: check installplans, subscription status, etc
 }
 
+// TestSubscriptionUpdatesExistingInstallPlan ensures that an existing InstallPlan
+//  has the appropriate approval requirement from Subscription.
+func TestSubscriptionUpdatesExistingInstallPlan(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
+	// Create CSV
+	packageName := genName("nginx-")
+	stableChannel := "stable"
+
+	namedStrategy := newNginxInstallStrategy(genName("dep-"), nil, nil)
+	csvA := newCSV("nginx-a", testNamespace, "", semver.MustParse("0.1.0"), nil, nil, namedStrategy)
+	csvB := newCSV("nginx-b", testNamespace, "nginx-a", semver.MustParse("0.2.0"), nil, nil, namedStrategy)
+
+	// Create PackageManifests
+	manifests := []registry.PackageManifest{
+		{
+			PackageName: packageName,
+			Channels: []registry.PackageChannel{
+				{Name: stableChannel, CurrentCSVName: csvB.GetName()},
+			},
+			DefaultChannelName: stableChannel,
+		},
+	}
+
+	// Create the CatalogSource with just one version
+	c := newKubeClient(t)
+	crc := newCRClient(t)
+	catalogSourceName := genName("mock-nginx-")
+	_, cleanupCatalogSource := createInternalCatalogSource(t, c, crc, catalogSourceName, testNamespace, manifests, nil, []v1alpha1.ClusterServiceVersion{csvA, csvB})
+	defer cleanupCatalogSource()
+
+	// Attempt to get the catalog source before creating install plan
+	_, err := fetchCatalogSource(t, crc, catalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
+	require.NoError(t, err)
+
+	// Create a subscription to just get an InstallPlan for csvB
+	subscriptionName := genName("sub-nginx-")
+	createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, catalogSourceName, packageName, stableChannel, csvB.GetName(), v1alpha1.ApprovalAutomatic)
+
+	// Wait for csvB to be installed
+	_, err = awaitCSV(t, crc, testNamespace, csvB.GetName(), csvSucceededChecker)
+	require.NoError(t, err)
+
+	subscription, err := fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+	fetchedInstallPlan, err := fetchInstallPlan(t, crc, subscription.Status.InstallPlanRef.Name, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+
+	// Delete this subscription
+	err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	// Create an InstallPlan for csvB
+	ip := &v1alpha1.InstallPlan{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "install-",
+			Namespace:    testNamespace,
+		},
+		Spec: v1alpha1.InstallPlanSpec{
+			ClusterServiceVersionNames: []string{csvB.GetName()},
+			Approval:                   v1alpha1.ApprovalAutomatic,
+			Approved:                   false,
+		},
+	}
+	ip2, err := crc.OperatorsV1alpha1().InstallPlans(testNamespace).Create(ip)
+	require.NoError(t, err)
+
+	ip2.Status = v1alpha1.InstallPlanStatus{
+		Plan:           fetchedInstallPlan.Status.Plan,
+		CatalogSources: []string{catalogSourceName},
+	}
+
+	_, err = crc.OperatorsV1alpha1().InstallPlans(testNamespace).UpdateStatus(ip2)
+	require.NoError(t, err)
+
+	subscriptionName = genName("sub-nginx-")
+	cleanupSubscription := createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, catalogSourceName, packageName, stableChannel, csvA.GetName(), v1alpha1.ApprovalManual)
+	defer cleanupSubscription()
+
+	subscription, err = fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+
+	installPlanName := subscription.Status.Install.Name
+
+	// Wait for InstallPlan to be status: Complete before checking resource presence
+	requiresApprovalChecker := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseRequiresApproval)
+	fetchedInstallPlan, err = fetchInstallPlan(t, crc, installPlanName, requiresApprovalChecker)
+	require.NoError(t, err)
+
+	// Approve the installplan and wait for csvA to be installed
+	fetchedInstallPlan.Spec.Approved = true
+	_, err = crc.OperatorsV1alpha1().InstallPlans(testNamespace).Update(fetchedInstallPlan)
+	require.NoError(t, err)
+
+	// Wait for csvA to be installed
+	_, err = awaitCSV(t, crc, testNamespace, csvA.GetName(), csvSucceededChecker)
+	require.NoError(t, err)
+
+	// Wait for the subscription to begin upgrading to csvB
+	subscription, err = fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionStateUpgradePendingChecker)
+	require.NoError(t, err)
+
+	// Fetch existing csvB installPlan
+	fetchedInstallPlan, err = fetchInstallPlan(t, crc, subscription.Status.InstallPlanRef.Name, requiresApprovalChecker)
+	require.NoError(t, err)
+	require.Equal(t, ip2.GetName(), subscription.Status.InstallPlanRef.Name, "expected new installplan is the same with pre-exising one")
+
+	// Approve the installplan and wait for csvB to be installed
+	fetchedInstallPlan.Spec.Approved = true
+	_, err = crc.OperatorsV1alpha1().InstallPlans(testNamespace).Update(fetchedInstallPlan)
+	require.NoError(t, err)
+
+	// Wait for csvB to be installed
+	_, err = awaitCSV(t, crc, testNamespace, csvB.GetName(), csvSucceededChecker)
+	require.NoError(t, err)
+}
+
 func updateInternalCatalog(t *testing.T, c operatorclient.ClientInterface, crc versioned.Interface, catalogSourceName, namespace string, crds []apiextensions.CustomResourceDefinition, csvs []v1alpha1.ClusterServiceVersion, packages []registry.PackageManifest) {
 	fetchedInitialCatalog, err := fetchCatalogSource(t, crc, catalogSourceName, namespace, catalogSourceRegistryPodSynced)
 	require.NoError(t, err)

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -891,6 +891,8 @@ func TestSubscriptionUpdatesExistingInstallPlan(t *testing.T) {
 	// Delete this subscription
 	err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
 	require.NoError(t, err)
+	// Delete orphaned csvB
+	require.NoError(t, crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(csvB.GetName(), &metav1.DeleteOptions{}))
 
 	// Create an InstallPlan for csvB
 	ip := &v1alpha1.InstallPlan{

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	pollInterval = 1 * time.Second
-	pollDuration = 5 * time.Minute
+	pollDuration = 2 * time.Minute
 
 	olmConfigMap = "olm-operators"
 	// sync name with scripts/install_local.sh

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	pollInterval = 1 * time.Second
-	pollDuration = 2 * time.Minute
+	pollDuration = 5 * time.Minute
 
 	olmConfigMap = "olm-operators"
 	// sync name with scripts/install_local.sh


### PR DESCRIPTION
For an subscription with manual approval, only the initial installplan
respects the approval requires. Subsequent installplans ignore the
fact the approval status is still false and install the operator
regardless. This issue is due to catalog incorrectly transitions
the installplan into install phase without checking for approval
condition.

Signed-off-by: Vu Dinh <vdinh@redhat.com>
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**
Cherry-pick to 4.1
**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
