### PR TITLE
Bug 1763750: Prioritize APIs from same CatSrc

### DIFF
--- a/pkg/controller/registry/resolver/evolver.go
+++ b/pkg/controller/registry/resolver/evolver.go
@@ -112,8 +112,15 @@ func (e *NamespaceGenerationEvolver) queryForRequiredAPIs() error {
 		}
 		e.gen.MarkAPIChecked(*api)
 
+		// identify the initialSource
+		initialSource := CatalogKey{}
+		for _, operator := range e.gen.MissingAPIs()[*api] {
+			initialSource = operator.SourceInfo().Catalog
+			break
+		}
+
 		// attempt to find a bundle that provides that api
-		if bundle, key, err := e.querier.FindProvider(*api); err == nil {
+		if bundle, key, err := e.querier.FindProvider(*api, initialSource); err == nil {
 			// add a bundle that provides the api to the generation
 			o, err := NewOperatorFromBundle(bundle, "", "", *key)
 			if err != nil {


### PR DESCRIPTION
Problem: When OLM installs an operator that requires dependencies that
are provided via multiple operators in different CatalogSources, the API
is pulled from any of the CatalogSources that provide the API.

Solution: This commit introduces a change so that OLM will generate a
list of operators that depend on the API, randomly select one of their
sources, and prioritize checking in that CatalogSource for the API prior
to checking the remaining CatalogSource for the API.

This commit is different than the 4.3 fix because of a method signature in the e2e test.

Reviewer Checklist

 Implementation matches the proposed design, or proposal is updated to match implementation
 Sufficient unit test coverage
 Sufficient end-to-end test coverage
 Docs updated or added to /docs
 Commit messages sensible and descriptive