### PR TITLE
[release-4.2] Bug 1767848: Manual approval strategy ignored for subsequent release

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -927,8 +927,10 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 			for _, sub := range subs {
 				ownerWasAdded = ownerWasAdded || !ownerutil.EnsureOwner(installPlan, sub)
 			}
+
+			out := installPlan.DeepCopy()
 			if ownerWasAdded {
-				_, err := o.client.OperatorsV1alpha1().InstallPlans(installPlan.GetNamespace()).Update(installPlan)
+				out, err = o.client.OperatorsV1alpha1().InstallPlans(installPlan.GetNamespace()).Update(installPlan)
 				if err != nil {
 					return nil, err
 				}
@@ -937,19 +939,18 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 			// Use provided `installPlanApproval` to determine the appropreciate
 			// phase
 			if installPlanApproval == v1alpha1.ApprovalAutomatic {
-				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+				out.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
 			} else {
-				logger.Info("Testing")
-				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
+				out.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
 			}
-			for _, step := range installPlan.Status.Plan {
+			for _, step := range out.Status.Plan {
 				step.Status = v1alpha1.StepStatusUnknown
 			}
-			_, err = o.client.OperatorsV1alpha1().InstallPlans(namespace).UpdateStatus(installPlan)
+			res, err := o.client.OperatorsV1alpha1().InstallPlans(namespace).UpdateStatus(out)
 			if err != nil {
 				return nil, err
 			}
-			return reference.GetReference(installPlan)
+			return reference.GetReference(res)
 		}
 	}
 	logger.Warn("no installplan found with matching manifests, creating new one")

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -934,7 +934,13 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 				}
 			}
 
-			installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+			// Use provided `installPlanApproval` to determine the appropreciate
+			// phase
+			if installPlanApproval == v1alpha1.ApprovalAutomatic {
+				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
+			} else if installPlanApproval == v1alpha1.ApprovalManual {
+				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
+			}
 			for _, step := range installPlan.Status.Plan {
 				step.Status = v1alpha1.StepStatusUnknown
 			}

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -938,7 +938,8 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, sub
 			// phase
 			if installPlanApproval == v1alpha1.ApprovalAutomatic {
 				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseInstalling
-			} else if installPlanApproval == v1alpha1.ApprovalManual {
+			} else {
+				logger.Info("Testing")
 				installPlan.Status.Phase = v1alpha1.InstallPlanPhaseRequiresApproval
 			}
 			for _, step := range installPlan.Status.Plan {

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -659,6 +659,8 @@ func TestCreateInstallPlanWithPreExistingCRDOwners(t *testing.T) {
 		// Update the subscription resource to point to the beta CSV
 		err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
 		require.NoError(t, err)
+		// Delete orphaned csv
+		require.NoError(t, crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(mainStableCSV.GetName(), &metav1.DeleteOptions{}))
 
 		// existing cleanup should remove this
 		createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, mainCatalogSourceName, mainPackageName, betaChannel, "", v1alpha1.ApprovalAutomatic)
@@ -1192,6 +1194,8 @@ func TestInstallPlanWithDeprecatedVersionCRD(t *testing.T) {
 			// Update the subscription resource to point to the beta CSV
 			err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
 			require.NoError(t, err)
+			// Delete orphaned csv
+			require.NoError(t, crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(mainStableCSV.GetName(), &metav1.DeleteOptions{}))
 
 			// existing cleanup should remove this
 			createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, mainCatalogSourceName, mainPackageName, betaChannel, "", v1alpha1.ApprovalAutomatic)
@@ -1241,6 +1245,8 @@ func TestInstallPlanWithDeprecatedVersionCRD(t *testing.T) {
 			// Update the subscription resource to point to the beta CSV
 			err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
 			require.NoError(t, err)
+			// Delete orphaned csv
+			require.NoError(t, crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(mainBetaCSV.GetName(), &metav1.DeleteOptions{}))
 
 			// existing cleanup should remove this
 			createSubscriptionForCatalog(t, crc, testNamespace, subscriptionName, mainCatalogSourceName, mainPackageName, deltaChannel, "", v1alpha1.ApprovalAutomatic)

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -920,6 +920,8 @@ func TestSubscriptionUpdatesExistingInstallPlan(t *testing.T) {
 	// Delete this subscription
 	err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{})
 	require.NoError(t, err)
+	// Delete orphaned csvB
+	require.NoError(t, crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(csvB.GetName(), &metav1.DeleteOptions{}))
 
 	// Create an InstallPlan for csvB
 	ip := &v1alpha1.InstallPlan{

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	pollInterval = 1 * time.Second
-	pollDuration = 5 * time.Minute
+	pollDuration = 2 * time.Minute
 
 	olmConfigMap = "olm-operators"
 	// sync name with scripts/install_local.sh

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	pollInterval = 1 * time.Second
-	pollDuration = 2 * time.Minute
+	pollDuration = 5 * time.Minute
 
 	olmConfigMap = "olm-operators"
 	// sync name with scripts/install_local.sh


### PR DESCRIPTION
For an subscription with manual approval, only the initial installplan
respects the approval requires. Subsequent installplans ignore the
fact the approval status is still false and install the operator
regardless. This issue is due to catalog incorrectly transitions
the installplan into install phase without checking for approval
condition.

Signed-off-by: Vu Dinh <vdinh@redhat.com>
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**
Cherry-pick to 4.2 release
**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
