### PR TITLE
Bug 1767004: defer provided api update in operator groups

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1252,6 +1252,12 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		if unionedAnnotations == nil {
 			unionedAnnotations = make(map[string]string)
 		}
+		if unionedAnnotations[v1.OperatorGroupProvidedAPIsAnnotationKey] == union.String() {
+			// resolver may think apis need adding with invalid input, so continue when there's no work
+			// to be done so that the CSV can progress far enough to get requirements checked
+			a.logger.Debug("operator group annotations up to date, continuing")
+			break
+		}
 		unionedAnnotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = union.String()
 		operatorGroup.SetAnnotations(unionedAnnotations)
 		if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(operatorGroup); err != nil && !k8serrors.IsNotFound(err) {

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -4264,7 +4264,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 			require.NoError(t, err)
 
 			// Sync csvs enough to get them back to succeeded state
-			for i := 0; i < 8; i++ {
+			for i := 0; i < 16; i++ {
 				opGroupCSVs, err := op.client.OperatorsV1alpha1().ClusterServiceVersions(operatorNamespace).List(metav1.ListOptions{})
 				require.NoError(t, err)
 
@@ -4292,7 +4292,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						require.NoError(t, err)
 					}
 
-					if i == 8 {
+					if i == 16 {
 						err = wait.PollImmediate(1*time.Millisecond, 10*time.Second, func() (bool, error) {
 							for namespace, objects := range tt.final.objects {
 								if err := RequireObjectsInCache(t, op.lister, namespace, objects, true); err != nil {


### PR DESCRIPTION
This is the case of a bug where the CSV status wasn't updated due to an
invalid CSV. The cause for this was twofold:

1) The CSV and OperatorGroup reconcile loops were undoing each others
changes continously, giving no chance for the CSV to get synced beyond
provided api conflict detection.

2) Due to the way the provided APIs are produced differently for
operator groups (uses GVKSTringToProvidedAPISet) and OLM (uses
NewOperatorFromV1Alpha1CSV) when an invalid CSV is in use, the resolver
attempts to continue to instruct that an operator group annotation
update is needed beyond the point of that being true.

The changes are to ensure that OLM does not get stuck attempting to
update the operator group annotations when they are no longer needed
combined with ensuring that the operator group sync loop does not try to
prematurely dismiss a provided api before the CSV has a chance to check
the requirements and produce status.

In order to accomplish "premature detection", providedAPIsFromCSVs was
modified to not only return the APIs but also the CSV that provides a
given API.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
