### PR TITLE
Fixing doc typo

### DIFF
--- a/doc/design/subscription-config.md
+++ b/doc/design/subscription-config.md
@@ -10,7 +10,7 @@ Currently, the OLM supports the following configurations:
 
 The `Env` field defines a list of environment variables that must exist in all containers in the `pod` created by OLM.
 
-> Note: Values defined here will overwrite existing environment varaibles of the same name.
+> Note: Values defined here will overwrite existing environment variables of the same name.
 
 ### EnvFrom
 


### PR DESCRIPTION
**Description of the change:**
Correcting typo at Subscription Config documentation

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [X] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive



