### PR TITLE
Bug 1774720: catalogsource context cancel function leak

### DIFF
--- a/pkg/controller/registry/grpc/source.go
+++ b/pkg/controller/registry/grpc/source.go
@@ -193,6 +193,7 @@ func (s *SourceStore) Remove(key resolver.CatalogKey) error {
 func (s *SourceStore) AsClients(globalNamespace, localNamespace string) map[resolver.CatalogKey]client.Interface {
 	refs := map[resolver.CatalogKey]client.Interface{}
 	s.sourcesLock.RLock()
+	defer s.sourcesLock.RUnlock()
 	for key, source := range s.sources {
 		if !(key.Namespace == globalNamespace || key.Namespace == localNamespace) {
 			continue
@@ -202,7 +203,6 @@ func (s *SourceStore) AsClients(globalNamespace, localNamespace string) map[reso
 		}
 		refs[key] = client.NewClientFromConn(source.Conn)
 	}
-	s.sourcesLock.RUnlock()
 
 	// TODO : remove unhealthy
 	return refs


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Start handling the returned cancel func from `context.WithTimeout` on so as not to leak cancel functions. This was done via a defer which required moving the default cause into an anonymous function and calling it immediately to have introduce function scope. 

This was brought up originally by @hdonnay

**Motivation for the change:**
Improve memory utilization of the catalog operator 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
