### PR TITLE
Bug 1749031: test for OLM takes a while to detect internal CatalogSource changes

### DIFF
--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"sync"
 	"testing"
@@ -528,7 +527,7 @@ func TestSubscriptionNewConfigMapCatalogSource(t *testing.T) {
 	subscription, err := fetchSubscription(t, crc, testNamespace, testSubscriptionName, subscriptionStateAtLatestChecker)
 	require.NoError(t, err)
 	require.NotNil(t, subscription)
-	oldCSV, err := fetchCSV(t, crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+	_, err = fetchCSV(t, crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 	require.NoError(t, err)
 
 	// at this point we have a successful CSV in the cluster from a configmap based catalog source
@@ -576,16 +575,14 @@ func TestSubscriptionNewConfigMapCatalogSource(t *testing.T) {
 	configMap.Data[registry.ConfigMapCSVName] = string(csvListRaw)
 
 	//POST new configmap
-	_, err = c.KubernetesInterface().CoreV1().ConfigMaps(testNamespace).Create(configMap)
+	_, err = c.KubernetesInterface().CoreV1().ConfigMaps(testNamespace).Update(configMap)
 	require.NoError(t, err)
 
 	_, err = fetchCatalogSource(t, crc, dummyCatalogSource.Name, testNamespace, catalogSourceRegistryPodSynced)
 	require.NoError(t, err)
 
-	newCSV, err := fetchCSV(t, crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+	_, err = fetchCSV(t, crc, alphaPlusCSV.Name, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 	require.NoError(t, err)
-
-	assert.Greater(t, newCSV.Spec.Version, oldCSV.Spec.Version)
 }
 
 func TestSubscriptionSkipRange(t *testing.T) {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR introduces an e2e test for updating a CSV via updating the configmap backing the catalogsource. The ultimate goal is to provide some meaningful timeouts for the different steps in the test and ensure in our CI that the configmap-based update time is satisfactory. For go tests there is a 5 minute default timeout so that is the timeout set initially. 

**Motivation for the change:**
Bugzilla report 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
