### PR TITLE
Bug 1769030: Replacing operator creates duplicate secrets

### DIFF
--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -1610,6 +1611,9 @@ func TestUpdateCatalogForSubscription(t *testing.T) {
 			},
 		}
 
+		oldSecrets, err := c.KubernetesInterface().CoreV1().Secrets(testNamespace).List(metav1.ListOptions{})
+		require.NoError(t, err, "error listing secrets")
+
 		// Create the catalog sources
 		updatedNamedStrategy := newNginxInstallStrategy(genName("dep-"), updatedPermissions, updatedClusterPermissions)
 		updatedCSV := newCSV(mainPackageStable+"-next", testNamespace, mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, updatedNamedStrategy)
@@ -1639,6 +1643,13 @@ func TestUpdateCatalogForSubscription(t *testing.T) {
 		// Wait for csv to update
 		_, err = awaitCSV(t, crc, testNamespace, updatedCSV.GetName(), csvSucceededChecker)
 		require.NoError(t, err)
+
+		newSecrets, err := c.KubernetesInterface().CoreV1().Secrets(testNamespace).List(metav1.ListOptions{})
+		require.NoError(t, err, "error listing secrets")
+		// Assert that the number of secrets is not increased from updating service account as part of the install plan,
+		assert.EqualValues(t, len(oldSecrets.Items), len(newSecrets.Items))
+		// And that the secret list is indeed updated.
+		assert.Equal(t, oldSecrets.Items, newSecrets.Items)
 
 		// Wait for ServiceAccount to not have access anymore
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {


### PR DESCRIPTION
Cause:
OLM catalog ensurer EnsureServiceAccount makes sure the service account
is updated when a new version of an operator is present. This
happens during ExecutePlan applying InstallPlan to a namespace.
If it is an update, fields of service account are updated but the
references to older secrets are dropped.

Consequence:
This process of dereferencing secret fails to clean up the older
secrets and result in the secrets pilling up as the operator upgrades.
Eventually, there will be too many old secrets laying around and only
getting cleaned up when the operator is uninstalled.

Fix:
We carry over older secrets through updating the service account.

Result:
Older secretes are again referred in the updated SA.

