### PR TITLE
Bug 1779313: Enable multiple namespaces sync if catsrc is updated in global ns

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -348,11 +348,11 @@ func (o *Operator) syncSourceState(state grpc.SourceState) {
 	switch state.State {
 	case connectivity.Ready:
 		if o.namespace == state.Key.Namespace {
-			subs, err := index.CatalogSubscriberNamespaces(o.catalogSubscriberIndexer,
+			namespaces, err := index.CatalogSubscriberNamespaces(o.catalogSubscriberIndexer,
 				state.Key.Name, state.Key.Namespace)
 
 			if err == nil {
-				for _, ns := range subs {
+				for ns := range namespaces {
 					o.nsResolveQueue.Add(ns)
 				}
 			}

--- a/pkg/lib/index/catalog.go
+++ b/pkg/lib/index/catalog.go
@@ -1,0 +1,55 @@
+package indexer
+
+import (
+	"fmt"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// PresentCatalogIndexFuncKey is the recommended key to use for registering
+	// the index func with an indexer.
+	PresentCatalogIndexFuncKey string = "presentcatalogindexfunc"
+)
+
+// PresentCatalogIndexFunc returns index from CatalogSource/CatalogSourceNamespace
+// of the given object (Subscription)
+func PresentCatalogIndexFunc(obj interface{}) ([]string, error) {
+	indicies := []string{}
+
+	sub, ok := obj.(*v1alpha1.Subscription)
+	if !ok {
+		return indicies, fmt.Errorf("invalid object of type: %T", obj)
+	}
+
+	indicies = append(indicies, fmt.Sprintf("%s/%s", sub.Spec.CatalogSource,
+		sub.Spec.CatalogSourceNamespace))
+
+	return indicies, nil
+}
+
+// CatalogSubscriberNamespaces returns the list of Suscriptions' name and namespace
+// (name/namespace as key and namespace as value) that uses the given CatalogSource (name/namespace)
+func CatalogSubscriberNamespaces(indexers map[string]cache.Indexer, name, namespace string) (map[string]string, error) {
+	nsSet := map[string]string{}
+	index := fmt.Sprintf("%s/%s", name, namespace)
+
+	for _, indexer := range indexers {
+		subs, err := indexer.ByIndex(PresentCatalogIndexFuncKey, index)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range subs {
+			s, ok := item.(*v1alpha1.Subscription)
+			if !ok {
+				continue
+			}
+			// Add to set
+			key := fmt.Sprintf("%s/%s", s.GetName(), s.GetNamespace())
+			nsSet[key] = s.GetNamespace()
+		}
+	}
+
+	return nsSet, nil
+}

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -81,6 +81,114 @@ func TestCatalogLoadingBetweenRestarts(t *testing.T) {
 	t.Logf("Catalog source sucessfully loaded after rescale")
 }
 
+func TestGlobalCatalogUpdateTriggersSubscriptionSync(t *testing.T) {
+	defer cleaner.NotifyTestComplete(t, true)
+
+	globalNS := operatorNamespace
+	c := newKubeClient(t)
+	crc := newCRClient(t)
+
+	// Determine which namespace is global. Should be `openshift-marketplace` for OCP 4.2+.
+	// Locally it is `olm`
+	namespaces, _ := c.KubernetesInterface().CoreV1().Namespaces().List(metav1.ListOptions{})
+	for _, ns := range namespaces.Items {
+		if ns.GetName() == "openshift-marketplace" {
+			globalNS = "openshift-marketplace"
+		}
+	}
+
+	mainPackageName := genName("nginx-")
+
+	mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
+	mainPackageReplacement := fmt.Sprintf("%s-replacement", mainPackageStable)
+
+	stableChannel := "stable"
+
+	mainNamedStrategy := newNginxInstallStrategy(genName("dep-"), nil, nil)
+
+	crdPlural := genName("ins-")
+
+	mainCRD := newCRD(crdPlural)
+	mainCSV := newCSV(mainPackageStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, mainNamedStrategy)
+	replacementCSV := newCSV(mainPackageReplacement, testNamespace, mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, mainNamedStrategy)
+
+	mainCatalogName := genName("mock-ocs-main-")
+
+	// Create separate manifests for each CatalogSource
+	mainManifests := []registry.PackageManifest{
+		{
+			PackageName: mainPackageName,
+			Channels: []registry.PackageChannel{
+				{Name: stableChannel, CurrentCSVName: mainPackageStable},
+			},
+			DefaultChannelName: stableChannel,
+		},
+	}
+
+	// Create the initial catalogsource
+	createInternalCatalogSource(t, c, crc, mainCatalogName, globalNS, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []v1alpha1.ClusterServiceVersion{mainCSV})
+
+	// Attempt to get the catalog source before creating install plan
+	_, err := fetchCatalogSource(t, crc, mainCatalogName, globalNS, catalogSourceRegistryPodSynced)
+	require.NoError(t, err)
+
+	subscriptionSpec := &v1alpha1.SubscriptionSpec{
+		CatalogSource:          mainCatalogName,
+		CatalogSourceNamespace: globalNS,
+		Package:                mainPackageName,
+		Channel:                stableChannel,
+		StartingCSV:            mainCSV.GetName(),
+		InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
+	}
+
+	// Create Subscription
+	subscriptionName := genName("sub-")
+	createSubscriptionForCatalogWithSpec(t, crc, testNamespace, subscriptionName, subscriptionSpec)
+
+	subscription, err := fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionStateAtLatestChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	_, err = fetchCSV(t, crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+	require.NoError(t, err)
+
+	// Update manifest
+	mainManifests = []registry.PackageManifest{
+		{
+			PackageName: mainPackageName,
+			Channels: []registry.PackageChannel{
+				{Name: stableChannel, CurrentCSVName: replacementCSV.GetName()},
+			},
+			DefaultChannelName: stableChannel,
+		},
+	}
+
+	// Update catalog configmap
+	updateInternalCatalog(t, c, crc, mainCatalogName, globalNS, []apiextensions.CustomResourceDefinition{mainCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, replacementCSV}, mainManifests)
+
+	// Get updated catalogsource
+	fetchedUpdatedCatalog, err := fetchCatalogSource(t, crc, mainCatalogName, globalNS, func(catalog *v1alpha1.CatalogSource) bool {
+		registry := catalog.Status.RegistryServiceStatus
+		connState := catalog.Status.GRPCConnectionState
+		if registry != nil && connState != nil && connState.LastObservedState == "READY" && !connState.LastConnectTime.IsZero() {
+			fmt.Printf("catalog %s pod with address %s\n", catalog.GetName(), registry.Address())
+			return registryPodHealthy(registry.Address())
+		}
+		fmt.Printf("waiting for catalog pod %v to be available (for sync)\n", catalog.GetName())
+		return false
+	})
+	require.NoError(t, err)
+
+	subscription, err = fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionStateUpgradeAvailableChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+
+	// Ensure the timing
+	catalogConnState := fetchedUpdatedCatalog.Status.GRPCConnectionState
+	subUpdatedTime := subscription.Status.LastUpdated
+	timeLapse := subUpdatedTime.Sub(catalogConnState.LastConnectTime.Time).Seconds()
+	require.True(t, timeLapse < 60)
+}
+
 func TestConfigMapUpdateTriggersRegistryPodRollout(t *testing.T) {
 	defer cleaner.NotifyTestComplete(t, true)
 
@@ -153,8 +261,8 @@ func TestConfigMapUpdateTriggersRegistryPodRollout(t *testing.T) {
 	fetchedUpdatedCatalog, err := fetchCatalogSource(t, crc, mainCatalogName, testNamespace, func(catalog *v1alpha1.CatalogSource) bool {
 		before := fetchedInitialCatalog.Status.ConfigMapResource
 		after := catalog.Status.ConfigMapResource
-		if after != nil && before.LastUpdateTime.Before(&after.LastUpdateTime) && 
-		   after.ResourceVersion != before.ResourceVersion {
+		if after != nil && before.LastUpdateTime.Before(&after.LastUpdateTime) &&
+			after.ResourceVersion != before.ResourceVersion {
 			fmt.Println("catalog updated")
 			return true
 		}

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -1491,7 +1491,7 @@ func updateInternalCatalog(t *testing.T, c operatorclient.ClientInterface, crc v
 	require.NoError(t, err)
 
 	// Get initial configmap
-	configMap, err := c.KubernetesInterface().CoreV1().ConfigMaps(testNamespace).Get(fetchedInitialCatalog.Spec.ConfigMap, metav1.GetOptions{})
+	configMap, err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Get(fetchedInitialCatalog.Spec.ConfigMap, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// Update package to point to new csv
@@ -1515,11 +1515,11 @@ func updateInternalCatalog(t *testing.T, c operatorclient.ClientInterface, crc v
 	configMap.Data[registry.ConfigMapCSVName] = string(csvsRaw)
 
 	// Update configmap
-	_, err = c.KubernetesInterface().CoreV1().ConfigMaps(testNamespace).Update(configMap)
+	_, err = c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Update(configMap)
 	require.NoError(t, err)
 
 	// wait for catalog to update
-	_, err = fetchCatalogSource(t, crc, catalogSourceName, testNamespace, func(catalog *v1alpha1.CatalogSource) bool {
+	_, err = fetchCatalogSource(t, crc, catalogSourceName, namespace, func(catalog *v1alpha1.CatalogSource) bool {
 		before := fetchedInitialCatalog.Status.ConfigMapResource
 		after := catalog.Status.ConfigMapResource
 		if after != nil && after.LastUpdateTime.After(before.LastUpdateTime.Time) && after.ResourceVersion != before.ResourceVersion {


### PR DESCRIPTION
Currently, if CatalogSource is updated and connection is Ready,
only the namespace where CatalogSource resides gets resynced. Now, a list
of namespaces that contain Subscriptions that use updated CatalogSource
will get resynced instead.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
