### PR TITLE
Bug 1773661: schedule catalogsource pods to linux nodes only

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -133,6 +133,9 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 					Operator: v1.TolerationOpExists,
 				},
 			},
+			NodeSelector: map[string]string{
+				"beta.kubernetes.io/os": "linux",
+			},
 		},
 	}
 	return pod

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -15,10 +15,8 @@ func TestPodNodeSelector(t *testing.T) {
 		},
 	}
 
-	expectedCatSrcPodSelector := make(map[string]string)
 	key := "beta.kubernetes.io/os"
 	value := "linux"
-	expectedCatSrcPodSelector[key] = value
 
 	gotCatSrcPod := Pod(catsrc, "hello", "busybox", map[string]string{}, int32(0), int32(0))
 	gotCatSrcPodSelector := gotCatSrcPod.Spec.NodeSelector

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -1,0 +1,30 @@
+package reconciler
+
+import (
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"testing"
+)
+
+func TestPodNodeSelector(t *testing.T) {
+	catsrc := &v1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "testns",
+		},
+	}
+
+	expectedCatSrcPodSelector := make(map[string]string)
+	key := "beta.kubernetes.io/os"
+	value := "linux"
+	expectedCatSrcPodSelector[key] = value
+
+	gotCatSrcPod := Pod(catsrc, "hello", "busybox", map[string]string{}, int32(0), int32(0))
+	gotCatSrcPodSelector := gotCatSrcPod.Spec.NodeSelector
+
+	if gotCatSrcPodSelector[key] != value {
+		t.Errorf("expected %s value for node selector key %s, received %s value instead", value, key,
+			gotCatSrcPodSelector[key])
+	}
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Ensures catalog source pods are only scheduled onto linux nodes via a Node Selector. The same Node Selector is being used in OLM deployments. 

**Motivation for the change:**
See #1119 - a bug that is caused by this issue. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
