### PR TITLE
Bug 1760608: add resource limits to all OLM pods and the 0.13.0 release for OCP

### DIFF
--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -91,8 +91,8 @@ package:
     tolerationSeconds: 120
   resources:
     limits:
-      cpu: 100m
-      memory: 100Mi
+      cpu: 200m
+      memory: 200Mi
     requests:
       cpu: 10m
       memory: 50Mi

--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -91,8 +91,8 @@ package:
     tolerationSeconds: 120
   resources:
     limits:
-      cpu: 200m
-      memory: 200Mi
+      cpu: 400m
+      memory: 400Mi
     requests:
       cpu: 10m
       memory: 50Mi

--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -32,6 +32,9 @@ olm:
   tlsCertPath: /var/run/secrets/serving-cert/tls.crt
   tlsKeyPath: /var/run/secrets/serving-cert/tls.key
   resources:
+    limits:
+      cpu: 400m
+      memory: 400Mi
     requests:
       cpu: 10m
       memory: 160Mi
@@ -58,6 +61,9 @@ catalog:
     effect: NoExecute
     tolerationSeconds: 120
   resources:
+    limits:
+      cpu: 200m
+      memory: 300Mi
     requests:
       cpu: 10m
       memory: 80Mi
@@ -84,6 +90,9 @@ package:
     effect: NoExecute
     tolerationSeconds: 120
   resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
     requests:
       cpu: 10m
       memory: 50Mi

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -62,6 +62,9 @@ spec:
           - name: OPERATOR_NAME
             value: olm-operator
           resources:
+            limits:
+              cpu: 400m
+              memory: 400Mi
             requests:
               cpu: 10m
               memory: 160Mi

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -55,6 +55,9 @@ spec:
             value: "0.0.1-snapshot"
           
           resources:
+            limits:
+              cpu: 200m
+              memory: 300Mi
             requests:
               cpu: 10m
               memory: 80Mi

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -123,8 +123,8 @@ spec:
                 terminationMessagePolicy: FallbackToLogsOnError
                 resources:
                   limits:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 200m
+                    memory: 200Mi
                   requests:
                     cpu: 10m
                     memory: 50Mi

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -123,8 +123,8 @@ spec:
                 terminationMessagePolicy: FallbackToLogsOnError
                 resources:
                   limits:
-                    cpu: 200m
-                    memory: 200Mi
+                    cpu: 400m
+                    memory: 400Mi
                   requests:
                     cpu: 10m
                     memory: 50Mi

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -122,6 +122,9 @@ spec:
                     port: 5443
                 terminationMessagePolicy: FallbackToLogsOnError
                 resources:
+                  limits:
+                    cpu: 100m
+                    memory: 100Mi
                   requests:
                     cpu: 10m
                     memory: 50Mi

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -121,6 +121,10 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 						InitialDelaySeconds: livenessDelay,
 					},
 					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
 						Requests: v1.ResourceList{
 							v1.ResourceCPU:    resource.MustParse("10m"),
 							v1.ResourceMemory: resource.MustParse("50Mi"),


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add resource limits to all OLM pods. Dupe of #1075 with limits found from doing some tests on a live OCP CI cluster (see https://github.com/operator-framework/operator-lifecycle-manager/pull/1075#issuecomment-554465931 for rationale and additional details). 

Note: limits apply to OCP releases only and are not applied to upstream deployments.  

**Motivation for the change:**
Bugs reporting memory overflows that resulted from not having resource limits set for OLM pods. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
