### PR TITLE
fix(grpc): tiny bug fixes and logging improvement

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -591,6 +591,7 @@ func (o *Operator) syncConnection(logger *logrus.Entry, in *v1alpha1.CatalogSour
 
 		// Set connection status and return.
 		updateConnectionStateFunc(out, source)
+		return
 	}
 
 	// connection is already good, but we need to update the sync time

--- a/pkg/controller/registry/grpc/source.go
+++ b/pkg/controller/registry/grpc/source.go
@@ -64,7 +64,7 @@ func (s *SourceStore) Start(ctx context.Context) {
 					s.logger.Debug("closing source manager")
 					return
 				case e := <-s.notify:
-					s.logger.Debugf("Got source event: %#v", e)
+					s.logger.Debugf("Got source event: %#v, (state: %v)", e, e.State.String())
 					s.syncFn(e)
 				}
 			}
@@ -142,7 +142,8 @@ func (s *SourceStore) watch(ctx context.Context, key resolver.CatalogKey, source
 		case <-ctx.Done():
 			return
 		default:
-			timer, _ := context.WithTimeout(ctx, s.stateTimeout(state))
+			timer, cancel := context.WithTimeout(ctx, s.stateTimeout(state))
+			defer cancel()
 			if source.Conn.WaitForStateChange(timer, state) {
 				newState := source.Conn.GetState()
 				state = newState


### PR DESCRIPTION
This just adds a return that's added for readability, adds some logging to include the GRPC connection state text, and calls the cancel function for a context to not leak resources.