### PR TITLE
[release-4.1] Bug 1775180: schedule catalogsource pods to linux nodes only

### DIFF
--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -134,6 +134,9 @@ func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
 				},
 			},
 			ServiceAccountName: s.GetName() + ConfigMapServerPostfix,
+			NodeSelector: map[string]string{
+				"beta.kubernetes.io/os": "linux",
+			},
 		},
 	}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)

--- a/pkg/controller/registry/reconciler/configmap_test.go
+++ b/pkg/controller/registry/reconciler/configmap_test.go
@@ -462,3 +462,19 @@ func TestConfigMapRegistryReconciler(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigMapRegistryNodeSelector(t *testing.T) {
+	catsrc := &configMapCatalogSourceDecorator{
+		CatalogSource: &v1alpha1.CatalogSource{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "testns", Labels: nil},
+			Spec:       v1alpha1.CatalogSourceSpec{},
+			Status:     v1alpha1.CatalogSourceStatus{},
+		},
+	}
+
+	catsrcPod := catsrc.Pod("test")
+	if catsrcPod.Spec.NodeSelector["beta.kubernetes.io/os"] != "linux" {
+		t.Error("linux node selector not present on catalog source pod")
+	}
+}

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -95,6 +95,9 @@ func (s *grpcCatalogSourceDecorator) Pod() *v1.Pod {
 					Operator: v1.TolerationOpExists,
 				},
 			},
+			NodeSelector: map[string]string{
+				"beta.kubernetes.io/os": "linux",
+			},
 		},
 	}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -369,3 +369,19 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		})
 	}
 }
+
+func TestGrpcRegistryNodeSelector(t *testing.T) {
+	catsrc := &grpcCatalogSourceDecorator{
+		CatalogSource: &v1alpha1.CatalogSource{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "testns", Labels: nil},
+			Spec:       v1alpha1.CatalogSourceSpec{},
+			Status:     v1alpha1.CatalogSourceStatus{},
+		},
+	}
+
+	catsrcPod := catsrc.Pod()
+	if catsrcPod.Spec.NodeSelector["beta.kubernetes.io/os"] != "linux" {
+		t.Error("linux node selector not present on catalog source pod")
+	}
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Cherry pick of #1132 to 4.1.x release branch

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
