### PR TITLE
fix(unit): Fix minor unit test bug and update local cluster to k8s 1.16

### DIFF
--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -512,7 +512,7 @@ func TestSyncCatalogSources(t *testing.T) {
 					Namespace:       "cool-namespace",
 					UID:             types.UID("configmap-uid"),
 					ResourceVersion: "resource-version",
-					LastUpdateTime: now,
+					LastUpdateTime:  now,
 				},
 				RegistryServiceStatus: nil,
 			},
@@ -854,7 +854,7 @@ func NewFakeOperator(ctx context.Context, namespace string, watchedNamespaces []
 	var sharedInformers []cache.SharedIndexInformer
 	for _, ns := range watchedNamespaces {
 		if ns != namespace {
-			_, err := opClientFake.KubernetesInterface().CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+			_, err := opClientFake.KubernetesInterface().CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 			if err != nil {
 				return nil, err
 			}
@@ -917,7 +917,7 @@ func NewFakeOperator(ctx context.Context, namespace string, watchedNamespaces []
 		reconciler:            config.reconciler,
 		clientAttenuator:      scoped.NewClientAttenuator(logger, &rest.Config{}, opClientFake, clientFake),
 		serviceAccountQuerier: scoped.NewUserDefinedServiceAccountQuerier(logger, clientFake),
-		catsrcQueueSet:         queueinformer.NewEmptyResourceQueueSet(),
+		catsrcQueueSet:        queueinformer.NewEmptyResourceQueueSet(),
 	}
 	op.sources = grpc.NewSourceStore(config.logger, 1*time.Second, 5*time.Second, op.syncSourceState)
 	if op.reconciler == nil {

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -6,7 +6,7 @@
 set -e
 
 if [ -z "$NO_MINIKUBE" ]; then
-  pgrep -f "[m]inikube" >/dev/null || minikube start --kubernetes-version="v1.14.2" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
+  pgrep -f "[m]inikube" >/dev/null || minikube start --kubernetes-version="v1.16.2" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
   eval "$(minikube docker-env)" || { echo 'Cannot switch to minikube docker'; exit 1; }
   kubectl config use-context minikube
 fi


### PR DESCRIPTION
1. Update k8s version for local cluster (1.16.2)
2. Fix minor namespace bug with NewFakeOperator

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
