### PR TITLE
Bug 1760608: remove resource limits from packageserver

### DIFF
--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -90,9 +90,6 @@ package:
     effect: NoExecute
     tolerationSeconds: 120
   resources:
-    limits:
-      cpu: 400m
-      memory: 400Mi
     requests:
       cpu: 10m
       memory: 50Mi

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -122,9 +122,6 @@ spec:
                     port: 5443
                 terminationMessagePolicy: FallbackToLogsOnError
                 resources:
-                  limits:
-                    cpu: 400m
-                    memory: 400Mi
                   requests:
                     cpu: 10m
                     memory: 50Mi


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
After merging #1142 there were some concerns about the response time of the packageserver when the console loads all the operators (specifically regarding loading the icons on the page). See 
https://github.com/operator-framework/operator-lifecycle-manager/pull/1142#issuecomment-557660043 for more info. This PR backs out the newly added limits for the packageserver only.
Note: the load time can be improved by making optimizations to the packageserver and potentially the console. 

**Motivation for the change:**
Discussion with the team and the console team regarding the proposed limits for the package server. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
