### PR TITLE
fix: make run_console_local.sh working on WSLv1

### DIFF
--- a/scripts/run_console_local.sh
+++ b/scripts/run_console_local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Colors definition
 readonly RED=$(tput setaf 1)
@@ -17,7 +17,7 @@ verify_podman_binary() {
 # Add port as 9000:9000 as arg when the SO is MacOS or Win
 add_host_port_arg (){
     args="--net=host"
-    if [[ "$OSTYPE" == "darwin"* ]] || uname -r | grep -q 'Microsoft'; then
+    if [ -z "${OSTYPE##*"darwin"*}" ] || uname -r | grep -q 'Microsoft'; then
       args="-p 9000:9000"
     fi
 }
@@ -30,30 +30,33 @@ run_ocp_console_image (){
     secretname=$(kubectl get serviceaccount default --namespace=kube-system -o jsonpath='{.secrets[0].name}')
     endpoint=$(kubectl config view -o json | jq '{myctx: .["current-context"], ctxs: .contexts[], clusters: .clusters[]}' | jq 'select(.myctx == .ctxs.name)' | jq 'select(.ctxs.context.cluster ==  .clusters.name)' | jq '.clusters.cluster.server' -r)
 
-    echo -e "Using $endpoint"
-    $POD_MANAGER run -dit --rm $args \
+    echo "Using $endpoint"
+    $POD_MANAGER run -d --rm $args \
       -e BRIDGE_USER_AUTH="disabled" \
       -e BRIDGE_K8S_MODE="off-cluster" \
       -e BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT="$endpoint" \
       -e BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true \
       -e BRIDGE_K8S_AUTH="bearer-token" \
       -e BRIDGE_K8S_AUTH_BEARER_TOKEN="$(kubectl get secret "$secretname" --namespace=kube-system -o template --template='{{.data.token}}' | base64 --decode)" \
-      quay.io/openshift/origin-console:latest &> /dev/null
+      quay.io/openshift/origin-console:latest > /dev/null 2>&1 &
 }
 
 verify_ocp_console_image (){
-    if [ "$($POD_MANAGER ps -q -f label=io.openshift.build.source-location=https://github.com/openshift/console)" ];
-    then
-      container_id="$($POD_MANAGER ps -q -l -f label=io.openshift.build.source-location=https://github.com/openshift/console)"
-      echo -e "${GREEN}The OLM is accessible via web console at:${RESET}"
-      echo -e "${GREEN}http://localhost:9000/${RESET}"
-      echo -e "${GREEN}Press Ctrl-C to quit${RESET}";
-      $POD_MANAGER attach "$container_id"
-    else
-      echo -e "${RED}Unable to run the console locally. May this port is in usage already.${RESET}"
-      echo -e "${RED}Check if the OLM is not accessible via web console at: http://localhost:9000/${RESET}"
-      exit 1
-    fi
+    # Try for 5 seconds to reach the image
+    for i in 1 2 3 4 5; do
+      if [ "$($POD_MANAGER ps -q -f label=io.openshift.build.source-location=https://github.com/openshift/console)" ]; then
+        container_id="$($POD_MANAGER ps -q -l -f label=io.openshift.build.source-location=https://github.com/openshift/console)"
+        echo "${GREEN}The OLM is accessible via web console at:${RESET}"
+        echo "${GREEN}http://localhost:9000/${RESET}"
+        echo "${GREEN}Press Ctrl-C to quit${RESET}";
+        $POD_MANAGER attach "$container_id"
+        exit 0
+      fi
+      sleep 1  # Wait one second to try again
+    done
+    echo "${RED}Unable to run the console locally. May this port is in usage already.${RESET}"
+    echo "${RED}Check if the OLM is not accessible via web console at: http://localhost:9000/${RESET}"
+    exit 1
 }
 
 # Calling the functions


### PR DESCRIPTION
**Description of the change:**

* Updates the if statement which check for WSL.
* Quoting of variables to mitigate [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086)
* Make sh compatible
* Removes -it from docker run, no need to start interactive when redirecting output

**Motivation for the change:**

The script wasn't working for me in WSlv1 because `[[ "$(< /proc/version)" == *"@(Microsoft|WSL)"* ]]` never evaluated to true. 
Simplified the statement by using `uname -r` (no need to grep for Microsoft or WSL) and by using `grep` 

The second commit is for making the script sh compatible to support more environments. I couldn't check it on MacOS but according to [the internet](https://kinoshita.eti.br/2016/11/05/checking-the-operating-system-type-in-shell-script.html) OSTYPE should be defined.
The for loop is needed since the script is much faster in sh and the if statement to check for running is sometimes run before the container has started.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive