### PR TITLE
[release-4.1] Bug 1769562: Replacing (updating) operator creates dupl…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/go-openapi/runtime v0.17.2 // indirect
 	github.com/go-openapi/spec v0.19.0
 	github.com/go-openapi/swag v0.17.2 // indirect
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.2.1-0.20190329180013-73dc87cad333
 	github.com/google/btree v1.0.0 // indirect

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -143,11 +143,11 @@ func TestExecutePlan(t *testing.T) {
 						Resource: v1alpha1.StepResource{
 							CatalogSource:          "catalog",
 							CatalogSourceNamespace: namespace,
-							Group:    "",
-							Version:  "v1",
-							Kind:     "Service",
-							Name:     "service",
-							Manifest: toManifest(service("service", namespace)),
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "Service",
+							Name:                   "service",
+							Manifest:               toManifest(service("service", namespace)),
 						},
 						Status: v1alpha1.StepStatusUnknown,
 					},
@@ -155,17 +155,107 @@ func TestExecutePlan(t *testing.T) {
 						Resource: v1alpha1.StepResource{
 							CatalogSource:          "catalog",
 							CatalogSourceNamespace: namespace,
-							Group:    "operators.coreos.com",
-							Version:  "v1alpha1",
-							Kind:     "ClusterServiceVersion",
-							Name:     "csv",
-							Manifest: toManifest(csv("csv", namespace, nil, nil)),
+							Group:                  "operators.coreos.com",
+							Version:                "v1alpha1",
+							Kind:                   "ClusterServiceVersion",
+							Name:                   "csv",
+							Manifest:               toManifest(csv("csv", namespace, nil, nil)),
 						},
 						Status: v1alpha1.StepStatusUnknown,
 					},
 				},
 			),
 			want: []runtime.Object{service("service", namespace), csv("csv", namespace, nil, nil)},
+			err:  nil,
+		},
+		{
+			testName: "CreateServiceAccount",
+			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+				[]*v1alpha1.Step{
+					{
+						Resource: v1alpha1.StepResource{
+							CatalogSource:          "catalog",
+							CatalogSourceNamespace: namespace,
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "ServiceAccount",
+							Name:                   "sa",
+							Manifest: toManifest(serviceAccount("sa", namespace, "",
+								objectReference("init secret"))),
+						},
+						Status: v1alpha1.StepStatusUnknown,
+					},
+				},
+			),
+			want: []runtime.Object{serviceAccount("sa", namespace, "", objectReference("init secret"))},
+			err:  nil,
+		},
+		{
+			testName: "UpdateServiceAccountWithSameFields",
+			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+				[]*v1alpha1.Step{
+					{
+						Resource: v1alpha1.StepResource{
+							CatalogSource:          "catalog",
+							CatalogSourceNamespace: namespace,
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "ServiceAccount",
+							Name:                   "sa",
+							Manifest: toManifest(serviceAccount("sa", namespace, "name",
+								objectReference("init secret"))),
+						},
+						Status: v1alpha1.StepStatusUnknown,
+					},
+					{
+						Resource: v1alpha1.StepResource{
+							CatalogSource:          "catalog",
+							CatalogSourceNamespace: namespace,
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "ServiceAccount",
+							Name:                   "sa",
+							Manifest:               toManifest(serviceAccount("sa", namespace, "name", nil)),
+						},
+						Status: v1alpha1.StepStatusUnknown,
+					},
+				},
+			),
+			want: []runtime.Object{serviceAccount("sa", namespace, "name", objectReference("init secret"))},
+			err:  nil,
+		},
+		{
+			testName: "UpdateServiceAccountWithDiffFields",
+			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+				[]*v1alpha1.Step{
+					{
+						Resource: v1alpha1.StepResource{
+							CatalogSource:          "catalog",
+							CatalogSourceNamespace: namespace,
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "ServiceAccount",
+							Name:                   "sa",
+							Manifest: toManifest(serviceAccount("sa", namespace, "old_name",
+								objectReference("init secret"))),
+						},
+						Status: v1alpha1.StepStatusUnknown,
+					},
+					{
+						Resource: v1alpha1.StepResource{
+							CatalogSource:          "catalog",
+							CatalogSourceNamespace: namespace,
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "ServiceAccount",
+							Name:                   "sa",
+							Manifest:               toManifest(serviceAccount("sa", namespace, "new_name", nil)),
+						},
+						Status: v1alpha1.StepStatusUnknown,
+					},
+				},
+			),
+			want: []runtime.Object{serviceAccount("sa", namespace, "new_name", objectReference("init secret"))},
 			err:  nil,
 		},
 	}
@@ -196,6 +286,8 @@ func TestExecutePlan(t *testing.T) {
 					fetched, err = op.OpClient.GetRoleBinding(namespace, o.GetName())
 				case *corev1.ServiceAccount:
 					fetched, err = op.OpClient.GetServiceAccount(namespace, o.GetName())
+				case *corev1.Secret:
+					fetched, err = op.OpClient.GetSecret(namespace, o.GetName())
 				case *corev1.Service:
 					fetched, err = op.OpClient.GetService(namespace, o.GetName())
 				case *v1alpha1.ClusterServiceVersion:
@@ -764,6 +856,25 @@ func service(name, namespace string) *corev1.Service {
 			Namespace: namespace,
 		},
 	}
+}
+
+func serviceAccount(name, namespace, generateName string, secretRef *corev1.ObjectReference) *corev1.ServiceAccount {
+	if secretRef == nil {
+		return &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, GenerateName: generateName},
+		}
+	}
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, GenerateName: generateName},
+		Secrets:    []corev1.ObjectReference{*secretRef},
+	}
+}
+
+func objectReference(name string) *corev1.ObjectReference {
+	if name == "" {
+		return &corev1.ObjectReference{}
+	}
+	return &corev1.ObjectReference{Name: name}
 }
 
 func toManifest(obj runtime.Object) string {


### PR DESCRIPTION
…icate secrets for the operator's ServiceAccount

Cause:
OLM catalog ensurer EnsureServiceAccount makes sure the service account
is updated when a new version of an operator is present. This
happens during ExecutePlan applying InstallPlan to a namespace.
If it is an update, fields of service account are updated but the
references to older secrets are dropped.

Consequence:
This process of dereferencing secret fails to clean up the older
secrets and result in the secrets pilling up as the operator upgrades.
Eventually, there will be too many old secrets laying around and only
getting cleaned up when the operator is uninstalled.

Fix:
We carry over older secrets through updating the service account.
We also compare the update using DeepDerivative to see if the
update changes any existing fields. If not, we skip the update API call
since it will not change anything.

Result:
Older secretes are again referred in the updated SA and no new secrets
are created.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
