### PR TITLE
fix: add err check before further operation

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -320,6 +320,9 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 			queueinformer.WithInformer(serviceAccountInformer.Informer()),
 			queueinformer.WithSyncer(k8sSyncer),
 		)
+		if err != nil {
+			return nil, err
+		}
 		if err := op.RegisterQueueInformer(serviceAccountQueueInformer); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Description of the change:**
After calling NewQueueInformer, it good to check the err first for further step. Other place in this project all follow this pattern, I think here shoud too.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
