### PR TITLE
docs - add a mention of bundles to the README to help users find bundle info…

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ spec:
 
 This will keep the etcd `ClusterServiceVersion` up to date as new versions become available in the catalog.
 
-Catalogs are served internally over a grpc interface to OLM from [operator-registry](https://github.com/operator-framework/operator-registry) pods.
+Catalogs are served internally over a grpc interface to OLM from [operator-registry](https://github.com/operator-framework/operator-registry) pods.  Catalog data such as `bundles` are documented [there](https://github.com/operator-framework/operator-registry#manifest-format) as well.
 
 ## Samples
 


### PR DESCRIPTION


**Description of the change:**
this adds a link from the README to the operator-registry page related to what a bundle is.

**Motivation for the change:**
there is no mention of a bundle in the operator-lifecycle-manager docs or README that I could find.  Users might find it useful to be able to search under the OLM project 1st to find where a bundle is defined or explained, this link serves as a breadcrumb for users wanting to understand what a bundle is and are unaware that they are included in the operator-registry repo/docs.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
