### PR TITLE
Add note for version field

### DIFF
--- a/doc/design/dependency-resolution.md
+++ b/doc/design/dependency-resolution.md
@@ -35,6 +35,19 @@ versions:
     storage: true
 ```
 
+Note: In `apiextensions.k8s.io/v1beta1`, there was a version field instead of versions. The version field is deprecated and optional, but if it is not empty, it must match the first item in the versions field.
+
+```
+version: v1beta1
+versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+```
+
 2. Ensure the referencing version of CRD in CSV is updated if CSV intends to use the new version in `owned` section:
 
 ```


### PR DESCRIPTION
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change is to add a note if you have `version` field defined, then it must match the first item of `versions`. `operator-sdk olm-catalog gen-csv --csv-version 0.10.0 --update-crds` generates a `version` field. it is error-prone without a note here.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
