### PR TITLE
 reduce GRPC transient failures

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -143,7 +143,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		bundleUnpackerImage:      configmapRegistryImage, // Assume the configmapRegistryImage contains the unpacker for now.
 	}
 	op.sources = grpc.NewSourceStore(logger, 10*time.Second, 10*time.Minute, op.syncSourceState)
-	op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, opClient, configmapRegistryImage, op.now)
+	op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, opClient, configmapRegistryImage, op.now, op.logger)
 
 	// Wire OLM CR sharedIndexInformers
 	crInformerFactory := externalversions.NewSharedInformerFactoryWithOptions(op.client, resyncPeriod)

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -1011,7 +1011,7 @@ func NewFakeOperator(ctx context.Context, namespace string, namespaces []string,
 	}
 	op.sources = grpc.NewSourceStore(config.logger, 1*time.Second, 5*time.Second, op.syncSourceState)
 	if op.reconciler == nil {
-		op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, op.opClient, "test:pod", op.now)
+		op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, op.opClient, "test:pod", op.now, op.logger)
 	}
 
 	op.RunInformers(ctx)
@@ -1125,7 +1125,7 @@ func toManifest(obj runtime.Object) string {
 }
 
 func pod(s v1alpha1.CatalogSource) *corev1.Pod {
-	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetLabels(), 5, 10)
+	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetLabels(), 5, 10, false)
 	ownerutil.AddOwner(pod, &s, false, false)
 	return pod
 }

--- a/pkg/controller/registry/grpc/source.go
+++ b/pkg/controller/registry/grpc/source.go
@@ -64,7 +64,7 @@ func (s *SourceStore) Start(ctx context.Context) {
 					s.logger.Debug("closing source manager")
 					return
 				case e := <-s.notify:
-					s.logger.Debugf("Got source event: %#v", e)
+					s.logger.Debugf("Got source event: %#v, (state: %s)", e, e.State)
 					s.syncFn(e)
 				}
 			}

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -48,9 +48,7 @@ const (
 )
 
 func (s *configMapCatalogSourceDecorator) Labels() map[string]string {
-	labels := map[string]string{
-		CatalogSourceLabelKey: s.GetName(),
-	}
+	labels := CatalogSourceLabelForPod(s.GetName())
 	if s.Spec.SourceType == v1alpha1.SourceTypeInternal || s.Spec.SourceType == v1alpha1.SourceTypeConfigmap {
 		labels[ConfigMapRVLabelKey] = s.Status.ConfigMapResource.ResourceVersion
 	}
@@ -405,7 +403,6 @@ func (c *ConfigMapRegistryReconciler) CheckRegistryServer(catalogSource *v1alpha
 
 	// Check on registry resources
 	// TODO: more complex checks for resources
-	// TODO: add gRPC health check
 	if c.currentServiceAccount(source) == nil ||
 		c.currentRole(source) == nil ||
 		c.currentRoleBinding(source) == nil ||

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -36,9 +36,7 @@ func (s *grpcCatalogSourceDecorator) SelectorForUpdate() labels.Selector {
 }
 
 func (s *grpcCatalogSourceDecorator) Labels() map[string]string {
-	return map[string]string{
-		CatalogSourceLabelKey: s.GetName(),
-	}
+	return CatalogSourceLabelForPod(s.GetName())
 }
 
 func (s *grpcCatalogSourceDecorator) Service() *v1.Service {

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -187,7 +187,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 
 			// Check for resource existence
 			decorated := grpcCatalogSourceDecorator{tt.in.catsrc}
-			pod := decorated.Pod()
+			pod := decorated.Pod(false)
 			service := decorated.Service()
 			listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{CatalogSourceLabelKey: tt.in.catsrc.GetName()}).String()}
 			outPods, podErr := client.KubernetesInterface().CoreV1().Pods(pod.GetNamespace()).List(listOptions)

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -152,3 +152,9 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 	}
 	return pod
 }
+
+func CatalogSourceLabelForPod(sourceName string) map[string]string {
+	return map[string]string{
+		CatalogSourceLabelKey: sourceName,
+	}
+}

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -18,7 +18,7 @@ func TestPodNodeSelector(t *testing.T) {
 	key := "beta.kubernetes.io/os"
 	value := "linux"
 
-	gotCatSrcPod := Pod(catsrc, "hello", "busybox", map[string]string{}, int32(0), int32(0))
+	gotCatSrcPod := Pod(catsrc, "hello", "busybox", map[string]string{}, int32(0), int32(0), false)
 	gotCatSrcPodSelector := gotCatSrcPod.Spec.NodeSelector
 
 	if gotCatSrcPodSelector[key] != value {

--- a/pkg/lib/queueinformer/resourcequeue.go
+++ b/pkg/lib/queueinformer/resourcequeue.go
@@ -69,8 +69,6 @@ func (r *ResourceQueueSet) Requeue(namespace, name string) error {
 	return fmt.Errorf("couldn't find queue for resource")
 }
 
-// TODO: this may not actually be required if the requeue is done on the namespace rather than the installplan
-// RequeueAfter requeues the resource in the set with the given name and namespace (just like Requeue), but only does so after duration has passed
 func (r *ResourceQueueSet) RequeueAfter(namespace, name string, duration time.Duration) error {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()

--- a/test/e2e/setup_bare_test.go
+++ b/test/e2e/setup_bare_test.go
@@ -57,9 +57,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	if err := flag.Set("logtostderr", "true"); err != nil {
-		panic(err)
-	}
 	flag.Parse()
 
 	testNamespace = *namespace


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This adds an additional function in the syncCatalogSource sync chain to ensure the GRPC readiness probes are reporting as ready before attempting any GPRC operations.

**Motivation for the change:**
The idea is to reduce transient errors as reported on the catalog source status. Unfortunately, I've only been able to reliably improve the catalog sources that are of type grpc and not the ones that are backed by configmaps (which is what the reported bug is specifically about).

There's also some work done to make debugging easier in the future.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
