### PR TITLE
Bug 1781366: feat(resolver): fallback to csv parsing if grcp api does not contain info

### DIFF
--- a/pkg/controller/registry/resolver/operators_test.go
+++ b/pkg/controller/registry/resolver/operators_test.go
@@ -1019,6 +1019,14 @@ func TestNewOperatorFromBundle(t *testing.T) {
 		},
 	}
 
+	bundleWithAPIsUnextracted := &api.Bundle{
+		CsvName:     "testBundle",
+		PackageName: "testPackage",
+		ChannelName: "testChannel",
+		CsvJson:     string(csvJsonWithApis),
+		Object:      []string{string(csvJsonWithApis), string(crdJson)},
+	}
+
 	type args struct {
 		bundle    *api.Bundle
 		sourceKey CatalogKey
@@ -1112,6 +1120,53 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				bundle:       bundleNoAPIs,
 				replaces:     "replaced",
 				version:      &version.Version,
+				sourceInfo: &OperatorSourceInfo{
+					Package: "testPackage",
+					Channel: "testChannel",
+					Catalog: CatalogKey{"source", "testNamespace"},
+				},
+			},
+		},
+		{
+			name: "BundleCsvFallback",
+			args: args{
+				bundle:    bundleWithAPIsUnextracted,
+				sourceKey: CatalogKey{Name: "source", Namespace: "testNamespace"},
+				replaces:  "replaced",
+			},
+			want: &Operator{
+				name: "testCSV",
+				providedAPIs: APISet{
+					opregistry.APIKey{
+						Group:   "crd.group.com",
+						Version: "v1",
+						Kind:    "OwnedCRD",
+						Plural:  "owneds",
+					}: struct{}{},
+					opregistry.APIKey{
+						Group:   "apis.group.com",
+						Version: "v1",
+						Kind:    "OwnedAPI",
+						Plural:  "ownedapis",
+					}: struct{}{},
+				},
+				requiredAPIs: APISet{
+					opregistry.APIKey{
+						Group:   "crd.group.com",
+						Version: "v1",
+						Kind:    "RequiredCRD",
+						Plural:  "requireds",
+					}: struct{}{},
+					opregistry.APIKey{
+						Group:   "apis.group.com",
+						Version: "v1",
+						Kind:    "RequiredAPI",
+						Plural:  "requiredapis",
+					}: struct{}{},
+				},
+				bundle:   bundleWithAPIsUnextracted,
+				replaces: "replaced",
+				version:  &version.Version,
 				sourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Falls back to parsing the CSV in the grpc api response if expected fields are not present.

**Motivation for the change:**
Recent changes to the grpc api pulls out information from the CSV on load time via OPM and shares it. OLM is looking in those new fields to find it. If an older registry is used against a newer OLM, OLM will see packages that have no required/provided apis and will fail to resolve dependencies.

No official content was ever shipped with this combination, but users building their own custom catalogs will hit this. 

Note: this change is also included in #1105 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
