### PR TITLE
fix(deploy): remove resource limits

### DIFF
--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,4 +1,3 @@
-installType: upstream
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: operator-lifecycle-manager
 catalog_namespace: operator-lifecycle-manager

--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -32,9 +32,6 @@ olm:
   tlsCertPath: /var/run/secrets/serving-cert/tls.crt
   tlsKeyPath: /var/run/secrets/serving-cert/tls.key
   resources:
-    limits:
-      cpu: 400m
-      memory: 400Mi
     requests:
       cpu: 10m
       memory: 160Mi
@@ -61,9 +58,6 @@ catalog:
     effect: NoExecute
     tolerationSeconds: 120
   resources:
-    limits:
-      cpu: 200m
-      memory: 300Mi
     requests:
       cpu: 10m
       memory: 80Mi
@@ -90,9 +84,6 @@ package:
     effect: NoExecute
     tolerationSeconds: 120
   resources:
-    limits:
-      cpu: 400m
-      memory: 400Mi
     requests:
       cpu: 10m
       memory: 50Mi

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -62,9 +62,6 @@ spec:
           - name: OPERATOR_NAME
             value: olm-operator
           resources:
-            limits:
-              cpu: 400m
-              memory: 400Mi
             requests:
               cpu: 10m
               memory: 160Mi

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -55,9 +55,6 @@ spec:
             value: "0.0.1-snapshot"
           
           resources:
-            limits:
-              cpu: 200m
-              memory: 300Mi
             requests:
               cpu: 10m
               memory: 80Mi

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -122,9 +122,6 @@ spec:
                     port: 5443
                 terminationMessagePolicy: FallbackToLogsOnError
                 resources:
-                  limits:
-                    cpu: 400m
-                    memory: 400Mi
                   requests:
                     cpu: 10m
                     memory: 50Mi


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Removes resource limits on OLM pods

**Motivation for the change:**

OLM resource usages scales with the size of a cluster. Having limits means that OLM can be killed by the scheduler on large clusters even though it is behaving normally.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
