### PR TITLE
Enable CGO and CGO_DEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,11 @@ build-linux: clean $(CMDS)
 build-wait: clean bin/wait
 
 bin/wait:
-	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -o $@ $(PKG)/test/e2e/wait
+	CGO_ENABLED=1 CGO_DEBUG=1 GOOS=linux GOARCH=386 go build -o $@ $(PKG)/test/e2e/wait
 
 $(CMDS): version_flags=-ldflags "-X $(PKG)/pkg/version.GitCommit=$(GIT_COMMIT) -X $(PKG)/pkg/version.OLMVersion=`cat OLM_VERSION`"
 $(CMDS):
-	CGO_ENABLED=0 $(arch_flags) go $(build_cmd) $(MOD_FLAGS) $(version_flags) -o bin/$(shell basename $@) $@
+	CGO_ENABLED=1 CGO_DEBUG=1 $(arch_flags) go $(build_cmd) $(MOD_FLAGS) $(version_flags) -o bin/$(shell basename $@) $@
 
 $(TCMDS):
 	CGO_ENABLED=0 go test -c $(BUILD_TAGS) $(MOD_FLAGS) -o bin/$(shell basename $@) $@


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
When using Kuryr SDN, Kuryr forces Pods to use TCP for DNS resolution. 
There is a problem for Pods running Go applications compiled with the CGO_DEBUG flag disabled. So, I just enable it. See bug for details: https://bugzilla.redhat.com/show_bug.cgi?id=1786217

**Motivation for the change:**
The OLM can run well in the OCP with Kuryr enabled.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
