### PR TITLE
WIP: use static linking with cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-coverage: build_cmd=test -c -covermode=count -coverpkg ./pkg/controller/..
 build-coverage: clean $(CMDS)
 
 build-linux: build_cmd=build
-build-linux: arch_flags=GOOS=linux GOARCH=386
+build-linux: arch_flags=GOOS=linux # GOARCH=386
 build-linux: clean $(CMDS)
 
 build-wait: clean bin/wait
@@ -75,9 +75,9 @@ build-wait: clean bin/wait
 bin/wait:
 	CGO_ENABLED=1 CGO_DEBUG=1 GOOS=linux GOARCH=386 go build -o $@ $(PKG)/test/e2e/wait
 
-$(CMDS): version_flags=-ldflags "-X $(PKG)/pkg/version.GitCommit=$(GIT_COMMIT) -X $(PKG)/pkg/version.OLMVersion=`cat OLM_VERSION`"
+$(CMDS): version_flags=-ldflags "-linkmode external -extldflags '-Wl,-Bstatic -lpthread -lc -static' -X $(PKG)/pkg/version.GitCommit=$(GIT_COMMIT) -X $(PKG)/pkg/version.OLMVersion=`cat OLM_VERSION`"
 $(CMDS):
-	CGO_ENABLED=1 CGO_DEBUG=1 $(arch_flags) go $(build_cmd) $(MOD_FLAGS) $(version_flags) -o bin/$(shell basename $@) $@
+	CGO_ENABLED=1 $(arch_flags) go $(build_cmd) $(MOD_FLAGS) $(version_flags) -o bin/$(shell basename $@) $@
 
 $(TCMDS):
 	CGO_ENABLED=0 go test -c $(BUILD_TAGS) $(MOD_FLAGS) -o bin/$(shell basename $@) $@


### PR DESCRIPTION
This is really to just serve as discussion. As far as I can tell, statically linking to glibc is at best fragile and not supported well.

With the recent change to turn on cgo, binaries started being linked dynamically instead of statically as before. This might not be a problem when using a glibc based container, but obviously increases compatibility concerns. However, in our alpine local test images, the binaries no longer run since it is musl based.

This PR enables static linking and works in alpine, but I don't think it's a good solution. Here's the build output with warnings:

```
CGO_ENABLED=1  go build -mod=vendor -ldflags "-linkmode external -extldflags '-Wl,-Bstatic -lpthread -lc -static' -X github.com/operator-framework/operator-lifecycle-manager/pkg/version.GitCommit=04b659c6850eb87eab461213e77a94079ea42114 -X github.com/operator-framework/operator-lifecycle-manager/pkg/version.OLMVersion=`cat OLM_VERSION`" -o bin/catalog github.com/operator-framework/operator-lifecycle-manager/cmd/catalog
# github.com/operator-framework/operator-lifecycle-manager/cmd/catalog
/usr/bin/ld: /tmp/go-link-274462539/000019.o: in function `mygetgrouplist':
/workdir/go/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-274462539/000018.o: in function `mygetgrgid_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-274462539/000018.o: in function `mygetgrnam_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-274462539/000018.o: in function `mygetpwnam_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-274462539/000018.o: in function `mygetpwuid_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-274462539/000004.o: in function `_cgo_26061493d47f_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
CGO_ENABLED=1  go build -mod=vendor -ldflags "-linkmode external -extldflags '-Wl,-Bstatic -lpthread -lc -static' -X github.com/operator-framework/operator-lifecycle-manager/pkg/version.GitCommit=04b659c6850eb87eab461213e77a94079ea42114 -X github.com/operator-framework/operator-lifecycle-manager/pkg/version.OLMVersion=`cat OLM_VERSION`" -o bin/olm github.com/operator-framework/operator-lifecycle-manager/cmd/olm
# github.com/operator-framework/operator-lifecycle-manager/cmd/olm
/usr/bin/ld: /tmp/go-link-425091651/000007.o: in function `mygetgrouplist':
/workdir/go/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-425091651/000006.o: in function `mygetgrgid_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-425091651/000006.o: in function `mygetgrnam_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-425091651/000006.o: in function `mygetpwnam_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-425091651/000006.o: in function `mygetpwuid_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-425091651/000004.o: in function `_cgo_26061493d47f_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
CGO_ENABLED=1  go build -mod=vendor -ldflags "-linkmode external -extldflags '-Wl,-Bstatic -lpthread -lc -static' -X github.com/operator-framework/operator-lifecycle-manager/pkg/version.GitCommit=04b659c6850eb87eab461213e77a94079ea42114 -X github.com/operator-framework/operator-lifecycle-manager/pkg/version.OLMVersion=`cat OLM_VERSION`" -o bin/package-server github.com/operator-framework/operator-lifecycle-manager/cmd/package-server
# github.com/operator-framework/operator-lifecycle-manager/cmd/package-server
/usr/bin/ld: /tmp/go-link-877205879/000007.o: in function `mygetgrouplist':
/workdir/go/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-877205879/000006.o: in function `mygetgrgid_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-877205879/000006.o: in function `mygetgrnam_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-877205879/000006.o: in function `mygetpwnam_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-877205879/000006.o: in function `mygetpwuid_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-877205879/000004.o: in function `_cgo_26061493d47f_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

