### PR TITLE
Reconcile manifests with templates.

### DIFF
--- a/deploy/chart/templates/0000_50_olm_03-clusterserviceversion.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_03-clusterserviceversion.crd.yaml
@@ -40,6 +40,7 @@ spec:
     served: true
     storage: true
   scope: Namespaced
+  preserveUnknownFields: false
   subresources:
     status: {}
   validation:

--- a/deploy/chart/templates/0000_50_olm_04-installplan.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_04-installplan.crd.yaml
@@ -35,6 +35,7 @@ spec:
   - name: Approved
     type: boolean
     JSONPath: .spec.approved
+  preserveUnknownFields: false
   subresources:
     # status enables the status subresource.
     status: {}

--- a/deploy/chart/templates/0000_50_olm_05-subscription.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_05-subscription.crd.yaml
@@ -37,6 +37,7 @@ spec:
     type: string
     description: The channel of updates to subscribe to
     JSONPath: .spec.channel
+  preserveUnknownFields: false
   subresources:
     # status enables the status subresource.
     status: {}

--- a/deploy/chart/templates/0000_50_olm_10-operatorgroup.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_10-operatorgroup.crd.yaml
@@ -19,6 +19,7 @@ spec:
     categories:
     - olm
   scope: Namespaced
+  preserveUnknownFields: false
   subresources:
     # status enables the status subresource.
     status: {}

--- a/manifests/0000_50_olm_04-installplan.crd.yaml
+++ b/manifests/0000_50_olm_04-installplan.crd.yaml
@@ -127,6 +127,87 @@ spec:
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
+            bundleLookups:
+              type: array
+              items:
+                type: object
+                required:
+                - catalogSourceRef
+                - path
+                - replaces
+                properties:
+                  catalogSourceRef:
+                    description: ObjectReference contains enough information to let
+                      you inspect or modify the referred object.
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                  conditions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - status
+                      - type
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transitioned from one
+                            status to another.
+                          type: string
+                          format: date-time
+                        lastUpdateTime:
+                          description: Last time the condition was probed
+                          type: string
+                          format: date-time
+                        message:
+                          description: A human readable message indicating details
+                            about the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False,
+                            Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+                  path:
+                    type: string
+                  replaces:
+                    type: string
             catalogSources:
               type: array
               items:


### PR DESCRIPTION
**Description of the change:** Unknown field pruning was not enabled in several CRD templates (it's disabled by default in v1beta1), and new `bundleLookups` status field was added to the template schema, but not the corresponding generated manifest.

**Motivation for the change:** Reconciling differences between manifests and templates in preparation for a new release per the instructions at https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/release.md.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
