### PR TITLE
Update release script to require version 3 of helm.

### DIFF
--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -1,6 +1,16 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: openshift-operators
+  
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/run-level: "1"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: openshift-operator-lifecycle-manager
   
   annotations:
@@ -8,15 +18,3 @@ metadata:
   labels:
     openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
-  
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-operators
-  
-  annotations:
-    openshift.io/node-selector: ""
-  labels:
-    openshift.io/run-level: "1"
-  

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -1,3 +1,9 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: olm-operator-serviceaccount
+  namespace: openshift-operator-lifecycle-manager
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -8,12 +14,6 @@ rules:
   verbs: ["*"]
 - nonResourceURLs: ["*"]
   verbs: ["*"]
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: olm-operator-serviceaccount
-  namespace: openshift-operator-lifecycle-manager
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/0000_50_olm_02-services.yaml
+++ b/manifests/0000_50_olm_02-services.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -36,4 +35,3 @@ spec:
     targetPort: metrics
   selector:
     app: catalog-operator
-

--- a/manifests/0000_50_olm_03-clusterserviceversion.crd.yaml
+++ b/manifests/0000_50_olm_03-clusterserviceversion.crd.yaml
@@ -42,7 +42,6 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   subresources:
-    # status enables the status subresource.
     status: {}
   validation:
     openAPIV3Schema:
@@ -824,7 +823,6 @@ spec:
                                     description: 'Standard object''s metadata. More
                                       info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                     type: object
-                                    # TODO: Autogen this...
                                     x-kubernetes-preserve-unknown-fields: true
                                   spec:
                                     description: 'Specification of the desired behavior

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -65,7 +65,6 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
-            
           
           volumeMounts:
           - mountPath: /var/run/secrets/serving-cert
@@ -80,7 +79,6 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
-        
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -93,4 +91,3 @@ spec:
         key: node.kubernetes.io/not-ready
         operator: Exists
         tolerationSeconds: 120
-      

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -58,7 +58,6 @@ spec:
             requests:
               cpu: 10m
               memory: 80Mi
-            
           
           volumeMounts:
           - mountPath: /var/run/secrets/serving-cert
@@ -73,7 +72,6 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
-        
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -86,4 +84,3 @@ spec:
         key: node.kubernetes.io/not-ready
         operator: Exists
         tolerationSeconds: 120
-      

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -1,22 +1,6 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aggregate-olm-edit
-  labels:
-    # Add these permissions to the "admin" and "edit" default roles.
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-rules:
-- apiGroups: ["operators.coreos.com"]
-  resources: ["subscriptions"]
-  verbs: ["create", "update", "patch", "delete"]
-- apiGroups: ["operators.coreos.com"]
-  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions"]
-  verbs: ["delete"]
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
   name: aggregate-olm-view
   labels:
     # Add these permissions to the "admin", "edit" and "view" default roles
@@ -30,3 +14,19 @@ rules:
 - apiGroups: ["packages.operators.coreos.com"]
   resources: ["packagemanifests", "packagemanifests/icon"]
   verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-edit
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["subscriptions"]
+  verbs: ["create", "update", "patch", "delete"]
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions"]
+  verbs: ["delete"]

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -83,7 +83,6 @@ spec:
               nodeSelector:
                 beta.kubernetes.io/os: linux
                 node-role.kubernetes.io/master: ""
-                
               tolerations:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
@@ -96,7 +95,6 @@ spec:
                 key: node.kubernetes.io/not-ready
                 operator: Exists
                 tolerationSeconds: 120
-              
               containers:
               - name: packageserver
                 command:
@@ -125,7 +123,6 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 50Mi
-                  
   maturity: alpha
   version: 0.13.0
   apiservicedefinitions:

--- a/manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/manifests/0000_50_olm_99-operatorstatus.yaml
@@ -1,8 +1,7 @@
-
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
-  name: operator-lifecycle-manager
+  name: operator-lifecycle-manager-catalog
 status:
   versions:
     - name: operator
@@ -11,7 +10,7 @@ status:
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
-  name: operator-lifecycle-manager-catalog
+  name: operator-lifecycle-manager
 status:
   versions:
     - name: operator

--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -1,32 +1,33 @@
-
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  name: olm-operator
+  name: operator-lifecycle-manager-metrics
   namespace: openshift-operator-lifecycle-manager
-  labels:
-    app: olm-operator
-spec:
-  endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
-    metricRelabelings:
-    - action: drop
-      regex: etcd_(debugging|disk|request|server).*
-      sourceLabels:
-      - __name__
-    port: https-metrics
-    scheme: https
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: olm-operator-metrics.openshift-operator-lifecycle-manager.svc
-  jobLabel: component
-  namespaceSelector:
-    matchNames:
-    - openshift-operator-lifecycle-manager
-  selector:
-    matchLabels:
-      app: olm-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operator-lifecycle-manager-metrics
+  namespace: openshift-operator-lifecycle-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-lifecycle-manager-metrics
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -58,34 +59,31 @@ spec:
     matchLabels:
       app: catalog-operator
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: operator-lifecycle-manager-metrics
+  name: olm-operator
   namespace: openshift-operator-lifecycle-manager
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: operator-lifecycle-manager-metrics
-subjects:
-- kind: ServiceAccount
-  name: prometheus-k8s
-  namespace: openshift-monitoring
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: operator-lifecycle-manager-metrics
-  namespace: openshift-operator-lifecycle-manager
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - endpoints
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-
+  labels:
+    app: olm-operator
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
+    port: https-metrics
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: olm-operator-metrics.openshift-operator-lifecycle-manager.svc
+  jobLabel: component
+  namespaceSelector:
+    matchNames:
+    - openshift-operator-lifecycle-manager
+  selector:
+    matchLabels:
+      app: olm-operator

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -17,4 +16,3 @@ spec:
           expr: csv_abnormal{phase="Failed"}
           labels:
             severity: info
-

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,4 +1,3 @@
-
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
-# requires helm to be installed
+# requires helm v3 to be installed
+# the output of "helm template" is not stable between versions 2 and 3
+if helm version 2>/dev/null | grep -v -q -E 'Version:"v3\.'; then
+    echo "error: helm version 3 is required"
+    exit 1
+fi
 
-if [[ ${#@} < 3 ]]; then
+if [[ ${#@} -lt 3 ]]; then
     echo "Usage: $0 semver chart values"
     echo "* semver: semver-formatted version for this package"
     echo "* chart: the directory to output the chart"


### PR DESCRIPTION
The output of "helm template" is not stable from version 2 to version
3, which resulted in the reordering of certain documents in
multi-document yaml files. The package_release script has been updated
to abort with an error message when the helm major version isn't
exactly 3, in order to reduce ambiguity and prevent meaningless
changes to manifest files.
