### PR TITLE
Remove pyjq and yq from the release documentation prereqs.

### DIFF
--- a/doc/design/release.md
+++ b/doc/design/release.md
@@ -8,12 +8,6 @@ Ensure you have `autoconf`, `automake`, and `libtool` installed. On Fedora, you 
 dnf install autoconf automake libtool
 ```
 
-Install [pyjq](https://pypi.org/project/pyjq/) using `pip`. Finally install [yq](https://github.com/mikefarah/yq) (using `snap` on Fedora):
-
-```
-snap install yq
-```
-
 ## Step 1: Verify Manifests
 We need to ensure that `./manifests` folder is in sync with the templates in `deploy/chart/templates`.
 * Make sure you have a clean workspace. `git status` should show no change(s) or untracked file.


### PR DESCRIPTION
The release now uses a vendored copy of yq, and pyjq is unused.
