### PR TITLE
Install a C compiler in the builder image used by the upstream Dockerfile.

### DIFF
--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12-alpine as builder
 LABEL stage=builder
 WORKDIR /build
 
-RUN apk update && apk add bash make git mercurial jq && apk upgrade
+RUN apk update && apk add bash make git mercurial jq build-base && apk upgrade
 
 # copy just enough of the git repo to parse HEAD, used to record version in OLM binaries
 COPY .git/HEAD .git/HEAD


### PR DESCRIPTION
Importing the package
github.com/operator-framework/operator-registry/pkg/configmap took on
a transitive dependency on github.com/mattn/go-sqlite3, which needs to
build with CGO. This commit installs gcc and libc-dev on the builder
image used for upstream image builds.
