### PR TITLE
Bug 1798645: fix(bundles): execute opm from tooling container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,12 @@ COPY OLM_VERSION OLM_VERSION
 COPY pkg pkg
 COPY vendor vendor
 COPY cmd cmd
+COPY util util
 COPY test test
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN CGO_ENABLED=1 make build
+RUN make build-util
 
 FROM openshift/origin-base
 
@@ -32,6 +34,7 @@ LABEL io.openshift.release.operator=true
 COPY --from=builder /build/bin/olm /bin/olm
 COPY --from=builder /build/bin/catalog /bin/catalog
 COPY --from=builder /build/bin/package-server /bin/package-server
+COPY --from=builder /build/bin/cpb /bin/cpb
 
 # This image doesn't need to run as root user.
 USER 1001

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,14 @@ build-wait: clean bin/wait
 bin/wait:
 	GOOS=linux GOARCH=386 go build -o $@ $(PKG)/test/e2e/wait
 
+build-util-linux: arch_flags=GOOS=linux GOARCH=386
+build-util-linux: build-util
+
+build-util: bin/cpb
+
+bin/cpb:
+	CGO_ENABLED=0 $(arch_flags) go build $(MOD_FLAGS) -ldflags '-extldflags "-static"' -o $@ ./util/cpb
+
 $(CMDS): version_flags=-ldflags "-X $(PKG)/pkg/version.GitCommit=$(GIT_COMMIT) -X $(PKG)/pkg/version.OLMVersion=`cat OLM_VERSION`"
 $(CMDS):
 	$(arch_flags) go $(build_cmd) $(MOD_FLAGS) $(version_flags) -o bin/$(shell basename $@) $@
@@ -84,7 +92,7 @@ build: clean $(CMDS)
 $(TCMDS):
 	go test -c $(BUILD_TAGS) $(MOD_FLAGS) -o bin/$(shell basename $@) $@
 
-run-local: build-linux build-wait
+run-local: build-linux build-wait build-util-linux
 	rm -rf build
 	. ./scripts/build_local.sh
 	mkdir -p build/resources

--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -31,6 +31,7 @@ const (
 	defaultWakeupInterval       = 15 * time.Minute
 	defaultCatalogNamespace     = "openshift-operator-lifecycle-manager"
 	defaultConfigMapServerImage = "quay.io/operatorframework/configmap-operator-registry:latest"
+	defaultUtilImage            = "quay.io/operator-framework/olm:latest"
 	defaultOperatorName         = ""
 )
 
@@ -47,6 +48,9 @@ var (
 
 	configmapServerImage = flag.String(
 		"configmapServerImage", defaultConfigMapServerImage, "the image to use for serving the operator registry api for a configmap")
+
+	utilImage = flag.String(
+		"util-image", defaultUtilImage, "an image containing custom olm utilities")
 
 	writeStatusName = flag.String(
 		"writeStatusName", defaultOperatorName, "ClusterOperator name in which to write status, set to \"\" to disable.")
@@ -168,7 +172,7 @@ func main() {
 	}
 
 	// Create a new instance of the operator.
-	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *catalogNamespace)
+	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *utilImage, *catalogNamespace)
 	if err != nil {
 		log.Panicf("error configuring operator: %s", err.Error())
 	}

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -34,6 +34,8 @@ spec:
           {{- if .Values.catalog.commandArgs }}
           - {{ .Values.catalog.commandArgs }}
           {{- end }}
+          - -util-image
+          -  {{ .Values.catalog.image.ref }}
           {{- if .Values.writeStatusNameCatalog }}
           - -writeStatusName
           - {{ .Values.writeStatusNameCatalog }}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b
 	github.com/operator-framework/operator-registry v1.5.8
+	github.com/otiai10/copy v1.0.1
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/sirupsen/logrus v1.4.2
@@ -23,6 +24,7 @@ require (
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/grpc v1.24.0
+	gopkg.in/yaml.v2 v2.2.4
 	helm.sh/helm/v3 v3.0.1
 	k8s.io/api v0.17.1
 	k8s.io/apiextensions-apiserver v0.17.1

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /
 COPY olm /bin/olm
 COPY catalog /bin/catalog
 COPY package-server /bin/package-server
+COPY cpb /bin/cpb
 EXPOSE 8080
 EXPOSE 5443
 CMD ["/bin/olm"]

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -27,6 +27,8 @@ spec:
           - '-namespace'
           - openshift-marketplace
           - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
+          - -util-image
+          -  quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
           - -writeStatusName
           - operator-lifecycle-manager-catalog
           - -tls-cert

--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -54,9 +54,9 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 					RestartPolicy: corev1.RestartPolicyOnFailure,
 					Containers: []corev1.Container{
 						{
-							Name:    cmRef.Name,
-							Image:   bundlePath,
-							Command: []string{"/injected/opm", "alpha", "bundle", "extract", "-n", cmRef.Namespace, "-c", cmRef.Name},
+							Name:    "extract",
+							Image:   c.opmImage,
+							Command: []string{"opm", "alpha", "bundle", "extract", "-m", "/bundle/", "-n", cmRef.Namespace, "-c", cmRef.Name},
 							Env: []corev1.EnvVar{
 								{
 									Name:  configmap.EnvContainerImage,
@@ -65,28 +65,49 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "copydir",
-									MountPath: "/injected",
+									Name:      "bundle", // Expected bundle content mount
+									MountPath: "/bundle",
 								},
 							},
 						},
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:    "copy-binary",
-							Image:   c.copyImage,
-							Command: []string{"/bin/cp", "/bin/opm", "/copy-dest"},
+							Name:    "tools",
+							Image:   "busybox",
+							Command: []string{"/bin/cp", "-Rv", "/bin/cp", "/tools/cp"}, // Copy tooling for the bundle container to use
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "copydir",
-									MountPath: "/copy-dest",
+									Name:      "tools",
+									MountPath: "/tools",
+								},
+							},
+						},
+						{
+							Name:    "pull",
+							Image:   bundlePath,
+							Command: []string{"/tools/cp", "-Rv", "/manifests", "/metadata", "/bundle"}, // Copy bundle content to its mount
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "bundle",
+									MountPath: "/bundle",
+								},
+								{
+									Name:      "tools",
+									MountPath: "/tools",
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "copydir",
+							Name: "bundle", // Used to share bundle content
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "tools", // Used to share tool
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -110,7 +131,7 @@ type Unpacker interface {
 }
 
 type ConfigMapUnpacker struct {
-	copyImage  string
+	opmImage   string
 	client     kubernetes.Interface
 	csLister   listersoperatorsv1alpha1.CatalogSourceLister
 	cmLister   listerscorev1.ConfigMapLister
@@ -136,9 +157,9 @@ func NewConfigmapUnpacker(options ...ConfigMapUnpackerOption) (*ConfigMapUnpacke
 	return unpacker, nil
 }
 
-func WithCopyImage(copyImage string) ConfigMapUnpackerOption {
+func WithOPMImage(opmImage string) ConfigMapUnpackerOption {
 	return func(unpacker *ConfigMapUnpacker) {
-		unpacker.copyImage = copyImage
+		unpacker.opmImage = opmImage
 	}
 }
 
@@ -192,7 +213,7 @@ func (c *ConfigMapUnpacker) apply(options ...ConfigMapUnpackerOption) {
 
 func (c *ConfigMapUnpacker) validate() (err error) {
 	switch {
-	case c.copyImage == "":
+	case c.opmImage == "":
 		err = fmt.Errorf("no copy image given")
 	case c.client == nil:
 		err = fmt.Errorf("client is nil")

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -27,6 +27,7 @@ const (
 	etcdCluster = "{\"apiVersion\":\"apiextensions.k8s.io/v1beta1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"name\":\"etcdclusters.etcd.database.coreos.com\"},\"spec\":{\"group\":\"etcd.database.coreos.com\",\"names\":{\"kind\":\"EtcdCluster\",\"listKind\":\"EtcdClusterList\",\"plural\":\"etcdclusters\",\"shortNames\":[\"etcdclus\",\"etcd\"],\"singular\":\"etcdcluster\"},\"scope\":\"Namespaced\",\"version\":\"v1beta2\"}}"
 	etcdRestore = "{\"apiVersion\":\"apiextensions.k8s.io/v1beta1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"name\":\"etcdrestores.etcd.database.coreos.com\"},\"spec\":{\"group\":\"etcd.database.coreos.com\",\"names\":{\"kind\":\"EtcdRestore\",\"listKind\":\"EtcdRestoreList\",\"plural\":\"etcdrestores\",\"singular\":\"etcdrestore\"},\"scope\":\"Namespaced\",\"version\":\"v1beta2\"}}"
 	opmImage    = "opm-image"
+	utilImage   = "util-image"
 	bundlePath  = "bundle-path"
 )
 
@@ -198,28 +199,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									},
 									InitContainers: []corev1.Container{
 										{
-											Name:    "tools",
-											Image:   "busybox",
-											Command: []string{"/bin/cp", "-Rv", "/bin/cp", "/tools/cp"},
+											Name:    "util",
+											Image:   utilImage,
+											Command: []string{"/bin/cp", "-Rv", "/bin/cpb", "/util/cpb"}, // Copy tooling for the bundle container to use
 											VolumeMounts: []corev1.VolumeMount{
 												{
-													Name:      "tools",
-													MountPath: "/tools",
+													Name:      "util",
+													MountPath: "/util",
 												},
 											},
 										},
 										{
 											Name:    "pull",
 											Image:   bundlePath,
-											Command: []string{"/tools/cp", "-Rv", "/manifests", "/metadata", "/bundle"},
+											Command: []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 											VolumeMounts: []corev1.VolumeMount{
 												{
 													Name:      "bundle",
 													MountPath: "/bundle",
 												},
 												{
-													Name:      "tools",
-													MountPath: "/tools",
+													Name:      "util",
+													MountPath: "/util",
 												},
 											},
 										},
@@ -232,7 +233,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 										{
-											Name: "tools",
+											Name: "util",
 											VolumeSource: corev1.VolumeSource{
 												EmptyDir: &corev1.EmptyDirVolumeSource{},
 											},
@@ -354,28 +355,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									},
 									InitContainers: []corev1.Container{
 										{
-											Name:    "tools",
-											Image:   "busybox",
-											Command: []string{"/bin/cp", "-Rv", "/bin/cp", "/tools/cp"},
+											Name:    "util",
+											Image:   utilImage,
+											Command: []string{"/bin/cp", "-Rv", "/bin/cpb", "/util/cpb"}, // Copy tooling for the bundle container to use
 											VolumeMounts: []corev1.VolumeMount{
 												{
-													Name:      "tools",
-													MountPath: "/tools",
+													Name:      "util",
+													MountPath: "/util",
 												},
 											},
 										},
 										{
 											Name:    "pull",
 											Image:   bundlePath,
-											Command: []string{"/tools/cp", "-Rv", "/manifests", "/metadata", "/bundle"},
+											Command: []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 											VolumeMounts: []corev1.VolumeMount{
 												{
 													Name:      "bundle",
 													MountPath: "/bundle",
 												},
 												{
-													Name:      "tools",
-													MountPath: "/tools",
+													Name:      "util",
+													MountPath: "/util",
 												},
 											},
 										},
@@ -388,7 +389,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 										{
-											Name: "tools",
+											Name: "util",
 											VolumeSource: corev1.VolumeSource{
 												EmptyDir: &corev1.EmptyDirVolumeSource{},
 											},
@@ -549,28 +550,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									},
 									InitContainers: []corev1.Container{
 										{
-											Name:    "tools",
-											Image:   "busybox",
-											Command: []string{"/bin/cp", "-Rv", "/bin/cp", "/tools/cp"},
+											Name:    "util",
+											Image:   utilImage,
+											Command: []string{"/bin/cp", "-Rv", "/bin/cpb", "/util/cpb"}, // Copy tooling for the bundle container to use
 											VolumeMounts: []corev1.VolumeMount{
 												{
-													Name:      "tools",
-													MountPath: "/tools",
+													Name:      "util",
+													MountPath: "/util",
 												},
 											},
 										},
 										{
 											Name:    "pull",
 											Image:   bundlePath,
-											Command: []string{"/tools/cp", "-Rv", "/manifests", "/metadata", "/bundle"},
+											Command: []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 											VolumeMounts: []corev1.VolumeMount{
 												{
 													Name:      "bundle",
 													MountPath: "/bundle",
 												},
 												{
-													Name:      "tools",
-													MountPath: "/tools",
+													Name:      "util",
+													MountPath: "/util",
 												},
 											},
 										},
@@ -583,7 +584,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 										{
-											Name: "tools",
+											Name: "util",
 											VolumeSource: corev1.VolumeSource{
 												EmptyDir: &corev1.EmptyDirVolumeSource{},
 											},
@@ -705,6 +706,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 				WithRoleLister(roleLister),
 				WithRoleBindingLister(rbLister),
 				WithOPMImage(opmImage),
+				WithUtilImage(utilImage),
 				WithNow(now),
 			)
 			require.NoError(t, err)

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -313,7 +313,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		bundle.WithJobLister(jobInformer.Lister()),
 		bundle.WithRoleLister(roleInformer.Lister()),
 		bundle.WithRoleBindingLister(roleBindingInformer.Lister()),
-		bundle.WithCopyImage(op.bundleUnpackerImage),
+		bundle.WithOPMImage(op.bundleUnpackerImage),
 		bundle.WithNow(op.now),
 	)
 	if err != nil {

--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -17,6 +17,7 @@ COPY go.sum go.sum
 COPY cmd cmd
 COPY test test
 RUN make build
+RUN make build-util
 
 FROM alpine:latest
 LABEL stage=olm
@@ -24,6 +25,7 @@ WORKDIR /
 COPY --from=builder /build/bin/olm /bin/olm
 COPY --from=builder /build/bin/catalog /bin/catalog
 COPY --from=builder /build/bin/package-server /bin/package-server
+COPY --from=builder /build/bin/cpb /bin/cpb
 EXPOSE 8080
 EXPOSE 5443
 CMD ["/bin/olm"]

--- a/util/cpb/main.go
+++ b/util/cpb/main.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
+	"github.com/otiai10/copy"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "cpb [output directory]",
+	Short: "Copy bundle content",
+	Long: `Copy bundle metadata and manifests into an output directory.
+Copy traverses the filesystem from the current directory down
+until it finds an annotations.yaml representing the bundle's metadata.
+From there, it copies the annotations.yaml file and manifests into the
+specified output directory`,
+	Run: func(cmd *cobra.Command, args []string) {
+		dest := "./bundle"
+		if len(args) > 1 {
+			// Get the destination position argument
+			dest = args[0]
+		}
+
+		if err := copyBundle(dest); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	},
+}
+
+func copyBundle(dest string) error {
+	// Find the manifest directory
+	m, err := getMetadata()
+	if err != nil {
+		return fmt.Errorf("error finding metadata directory: %s", err)
+	}
+
+	fmt.Printf("%v\n", m)
+
+	return m.copy(dest)
+}
+
+type metadata struct {
+	annotationsFile string
+	manifestDir     string
+}
+
+func (m *metadata) copy(dest string) error {
+	// Copy the annotations file
+	path := filepath.Join(dest, "metadata/annotations.yaml")
+	if err := copy.Copy(m.annotationsFile, path); err != nil {
+		return err
+	}
+
+	// Copy manifest dir
+	path = filepath.Join(dest, "manifests")
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return err
+	}
+	if err := copy.Copy(m.manifestDir, path); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getMetadata() (m *metadata, err error) {
+	// Create default metadata
+	m = &metadata{
+		annotationsFile: "/metadata/annotations.yaml",
+		manifestDir:     "/manifests",
+	}
+
+	// Traverse the filesystem looking for metadata
+	err = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
+			return nil
+		}
+		if info.IsDir() {
+			fmt.Printf("skipping a dir without errors: %+v \n", info.Name())
+			return nil
+		}
+		if info.Name() != bundle.AnnotationsFile {
+			return nil
+		}
+		m.annotationsFile = path
+
+		// Unmarshal metadata
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("couldn't get content of annotations.yaml file: %s", path)
+		}
+
+		annotations := bundle.AnnotationMetadata{}
+		if err := yaml.Unmarshal(content, &annotations); err != nil {
+			return err
+		}
+
+		if annotations.Annotations == nil {
+			return fmt.Errorf("annotations.yaml file unmarshalling failed: %s", path)
+		}
+
+		if manifestDir, ok := annotations.Annotations[bundle.ManifestsLabel]; ok {
+			m.manifestDir = manifestDir
+		}
+
+		// Skip the remainder of files in the directory
+		return filepath.SkipDir
+	})
+
+	if err != nil {
+		m = nil
+	}
+
+	return
+}

--- a/util/cpb/main_test.go
+++ b/util/cpb/main_test.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"testing"
+)
+
+// Test started when the test binary is started. Only calls main.
+func TestMain(t *testing.T) {
+	main()
+}


### PR DESCRIPTION
**Description of the change:**

Execute the `opm` command in a container of the image it was packaged with.

**Motivation for the change:**

To prevent dynamic linking issues caused by running in a `FROM scratch` bundle container.
