### PR TITLE
Bug 1800625: fix: add internal registry for catalog polling e2e test

### DIFF
--- a/pkg/package-server/client/client.go
+++ b/pkg/package-server/client/client.go
@@ -9,7 +9,7 @@ import (
 // NewClient creates a client that can interact with the ALM resources in k8s api
 func NewClient(kubeconfig string) (client versioned.Interface, err error) {
 	var config *rest.Config
-	config, err = getConfig(kubeconfig)
+	config, err = GetConfig(kubeconfig)
 	if err != nil {
 		return
 	}

--- a/pkg/package-server/client/util.go
+++ b/pkg/package-server/client/util.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// getConfig returns a kubernetes config for configuring a client from a kubeconfig string
-func getConfig(kubeconfig string) (*rest.Config, error) {
+// GetConfig returns a kubernetes config for configuring a client from a kubeconfig string
+func GetConfig(kubeconfig string) (*rest.Config, error) {
 	if len(kubeconfig) == 0 {
 		// Work around https://github.com/kubernetes/kubernetes/issues/40973
 		// See https://github.com/coreos/etcd-operator/issues/731#issuecomment-283804819

--- a/test/e2e/registry.go
+++ b/test/e2e/registry.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	"fmt"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os/exec"
+)
+
+// This module contains helper functions for copying images and creating image registries
+// Use for tests that require manipulating images or use of custom container registries
+
+const (
+	registryImage = "registry:2.7.1"
+	registryName  = "registry"
+	localFQDN     = "localhost:5000"
+)
+
+func createDockerRegistry(client operatorclient.ClientInterface, namespace string) (string, error) {
+	registry := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      registryName,
+			Namespace: namespace,
+			Labels:    map[string]string{"name": registryName},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  registryName,
+					Image: registryImage,
+					Ports: []corev1.ContainerPort{
+						{
+							HostPort:      int32(5000),
+							ContainerPort: int32(5000),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      registryName,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"name": registryName},
+			Ports: []corev1.ServicePort{
+				{
+					Port: int32(5000),
+				},
+			},
+		},
+	}
+
+	_, err := client.KubernetesInterface().CoreV1().Pods(namespace).Create(registry)
+	if err != nil {
+		return "", fmt.Errorf("creating test registry: %s", err)
+	}
+
+	_, err = client.KubernetesInterface().CoreV1().Services(namespace).Create(svc)
+	if err != nil {
+		return "", fmt.Errorf("creating test registry: %s", err)
+	}
+
+	return localFQDN, nil
+}
+
+func deleteDockerRegistry(client operatorclient.ClientInterface, namespace string) {
+	_ = client.KubernetesInterface().CoreV1().Pods(namespace).Delete(registryName, &metav1.DeleteOptions{})
+	_ = client.KubernetesInterface().CoreV1().Services(namespace).Delete(registryName, &metav1.DeleteOptions{})
+}
+
+// port-forward registry pod port 5000 for local test
+// port-forwarding ends when registry pod is deleted: no need for explicit port-forward stop
+func registryPortForward(namespace string) error {
+	cmd := exec.Command("kubectl", "-n", namespace, "port-forward", "registry", "5000:5000")
+	err := cmd.Start()
+	if err != nil {
+		return fmt.Errorf("failed to exec %#v: %v", cmd.Args, err)
+	}
+	return nil
+}

--- a/test/e2e/skopeo.Dockerfile
+++ b/test/e2e/skopeo.Dockerfile
@@ -1,0 +1,4 @@
+FROM fedora:31
+RUN yum install -y skopeo
+
+ENTRYPOINT ["skopeo"]


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updates e2e test to rely on an internal docker registry by creating/deleting one during the process of the test, or using the existing openshift registry. This removes the need for robot credentials to the quay registry that the test currently relies on. 

**Motivation for the change:**
Security. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
