### PR TITLE
Bug 1783284: fix(perf): remove periodic resync

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -28,7 +27,7 @@ import (
 
 const (
 	catalogNamespaceEnvVarName  = "GLOBAL_CATALOG_NAMESPACE"
-	defaultWakeupInterval       = 15 * time.Minute
+	defaultWakeupInterval       = 0
 	defaultCatalogNamespace     = "openshift-operator-lifecycle-manager"
 	defaultConfigMapServerImage = "quay.io/operatorframework/configmap-operator-registry:latest"
 	defaultOperatorName         = ""

--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -29,7 +28,7 @@ import (
 )
 
 const (
-	defaultWakeupInterval          = 5 * time.Minute
+	defaultWakeupInterval          = 0
 	defaultOperatorName            = ""
 	defaultPackageServerStatusName = ""
 )

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -188,7 +188,8 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 	}
 
 	// Wire CatalogSources
-	catsrcInformer := crInformerFactory.Operators().V1alpha1().CatalogSources()
+	// TODO: CatalogSources require a resync interval to periodically poll for updates to catalog images - remove this requirement
+	catsrcInformer := externalversions.NewSharedInformerFactoryWithOptions(op.client, 15*time.Minute).Operators().V1alpha1().CatalogSources()
 	op.lister.OperatorsV1alpha1().RegisterCatalogSourceLister(metav1.NamespaceAll, catsrcInformer.Lister())
 	catsrcQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "catsrcs")
 	op.catsrcQueueSet.Set(metav1.NamespaceAll, catsrcQueue)

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -200,7 +200,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		}
 
 		// Wire OperatorGroup reconciliation
-		operatorGroupInformer := extInformerFactory.Operators().V1().OperatorGroups()
+		operatorGroupInformer := externalversions.NewSharedInformerFactoryWithOptions(op.client, 5*time.Minute).Operators().V1().OperatorGroups()
 		op.lister.OperatorsV1().RegisterOperatorGroupLister(namespace, operatorGroupInformer.Lister())
 		ogQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), fmt.Sprintf("%s/og", namespace))
 		op.ogQueueSet.Set(namespace, ogQueue)


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Removes periodic resync to avoid spikes in CPU every few minutes.

CatalogSource still requires a resync to ensure polled updates are found, but that can be addressed later (and involves few resources).

**Motivation for the change:**
/hold 

holding to try this out in test clusters and make sure things look good.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
