### PR TITLE
Bug 1768819: Fix configmap registry server readiness probe timeouts

### DIFF
--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -89,7 +89,7 @@ func (s *configMapCatalogSourceDecorator) Service() *v1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
-	pod := Pod(s.CatalogSource, "configmap-registry-server", image, s.Labels(), 1, 2)
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, s.Labels(), 5, 2)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -118,6 +118,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 							},
 						},
 						InitialDelaySeconds: readinessDelay,
+						TimeoutSeconds: 5,
 					},
 					LivenessProbe: &v1.Probe{
 						Handler: v1.Handler{


### PR DESCRIPTION
Fixes #1238 

**Description of the change:**

The configmap registry server readiness probe was defaulting to 1 second timeout.
In cases where cluster/node is a bit slow, the pod goes into CrashBackOff.

Increasing the readiness probe initial delay and timeout for the probe itself.
The failureThreshold for readiness is 3, this gives it 15 seconds total to get going.

**Motivation for the change:**

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive

Closes #1238
