### PR TITLE
fix: update existing robot credentials

### DIFF
--- a/test/e2e/skopeo.go
+++ b/test/e2e/skopeo.go
@@ -10,9 +10,9 @@ import (
 const (
 	// robot credentials to access the catsrc-update-test quay repository
 	// these are write-only and checks are made to ensure only the intended images are allowed to run
-	creds       = "--screds=olmtest+e2etest:3GIQMPN3CKT49LRBL2IP9Q2OTLHP4RHZQ6QYCEYDJQIW8KO8LYZQ38BHNR4FD2TA"
-	dcreds      = "--dcreds=olmtest+e2etest:3GIQMPN3CKT49LRBL2IP9Q2OTLHP4RHZQ6QYCEYDJQIW8KO8LYZQ38BHNR4FD2TA"
-	deletecreds = "--creds=olmtest+e2etest:3GIQMPN3CKT49LRBL2IP9Q2OTLHP4RHZQ6QYCEYDJQIW8KO8LYZQ38BHNR4FD2TA"
+	creds       = "--screds=olmtest+e2etest:V1YASVAXKBCMX6FFKRXJ74T0XMWUEVLF8YYOX3V4BLXSR0LFZI5NDL2V16MNI813"
+	dcreds      = "--dcreds=olmtest+e2etest:V1YASVAXKBCMX6FFKRXJ74T0XMWUEVLF8YYOX3V4BLXSR0LFZI5NDL2V16MNI813"
+	deletecreds = "--creds=olmtest+e2etest:V1YASVAXKBCMX6FFKRXJ74T0XMWUEVLF8YYOX3V4BLXSR0LFZI5NDL2V16MNI813"
 	insecure    = "--insecure-policy=true"
 	skopeo      = "skopeo"
 	debug       = "--debug"


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updates robot credentials that were accidentally deleted. 

These credentials will be removed once #1257 lands. 

**Motivation for the change:**
This anticipates and fixes the issue where e2e olm tests will fail on CI due to the fact that the previous credentials were deleted. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
