### PR TITLE
Bug 1798135: Fix cases where an operator's ready channel may never close.

### DIFF
--- a/pkg/lib/queueinformer/config.go
+++ b/pkg/lib/queueinformer/config.go
@@ -161,7 +161,7 @@ func WithSyncer(syncer kubestate.Syncer) Option {
 }
 
 type operatorConfig struct {
-	discovery      discovery.DiscoveryInterface
+	serverVersion  discovery.ServerVersionInterface
 	queueInformers []*QueueInformer
 	informers      []cache.SharedIndexInformer
 	logger         *logrus.Logger
@@ -217,7 +217,7 @@ func WithNumWorkers(numWorkers int) OperatorOption {
 // validate returns an error if the config isn't valid.
 func (c *operatorConfig) validate() (err error) {
 	switch config := c; {
-	case config.discovery == nil:
+	case config.serverVersion == nil:
 		err = newInvalidOperatorConfigError("discovery client nil")
 	case config.numWorkers < 1:
 		err = newInvalidOperatorConfigError("must specify at least one worker per queue")

--- a/pkg/lib/queueinformer/queueinformer_operator_test.go
+++ b/pkg/lib/queueinformer/queueinformer_operator_test.go
@@ -1,0 +1,88 @@
+package queueinformer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+type versionFunc func() (*version.Info, error)
+
+func (f versionFunc) ServerVersion() (*version.Info, error) {
+	if f == nil {
+		return &version.Info{}, nil
+	}
+	return (func() (*version.Info, error))(f)()
+}
+
+func TestOperatorRunReadyChannelClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// set up the operator under test and return a cleanup func to be invoked when the test completes
+		of func(cancel context.CancelFunc, o *operator) func()
+	}{
+		{
+			name: "error getting server version",
+			of: func(cancel context.CancelFunc, o *operator) func() {
+				o.serverVersion = versionFunc(func() (*version.Info, error) {
+					return nil, errors.New("test error")
+				})
+				return func() {}
+			},
+		},
+		{
+			name: "context cancelled while getting server version",
+			of: func(cancel context.CancelFunc, o *operator) func() {
+				done := make(chan struct{})
+				o.serverVersion = versionFunc(func() (*version.Info, error) {
+					defer func() {
+						<-done
+					}()
+					cancel()
+					return nil, errors.New("test error")
+				})
+				return func() {
+					close(done)
+				}
+			},
+		},
+		{
+			name: "context cancelled before cache sync",
+			of: func(cancel context.CancelFunc, o *operator) func() {
+				o.hasSynced = func() bool {
+					cancel()
+					return false
+				}
+				return func() {}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			o, err := newOperatorFromConfig(defaultOperatorConfig())
+			if err != nil {
+				t.Fatalf("could not create operator from default config: %s", err)
+			}
+			o.serverVersion = versionFunc(nil)
+			o.hasSynced = func() bool { return true }
+
+			done := func() {}
+			if tc.of != nil {
+				done = tc.of(cancel, o)
+			}
+			defer done()
+
+			o.Run(ctx)
+
+			select {
+			case <-o.Ready():
+			case <-time.After(time.Second):
+				t.Error("timed out before ready channel closed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
In at least three error/cancellation scenarios, an operator would
finish running without closing its ready channel. Users (i.e. olm,
catalog, and package-server) block first on <-o.Ready() and then on
<-o.Done(), so if the operator terminates without closing its ready
channel, they will block indefinitely, which prevents recovery via
automatic restarts.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
