### PR TITLE
Bug 1798051: Reinstate v1alpha2 operatorgroup

### DIFF
--- a/deploy/chart/templates/0000_50_olm_10-operatorgroup.crd.yaml
+++ b/deploy/chart/templates/0000_50_olm_10-operatorgroup.crd.yaml
@@ -9,6 +9,9 @@ spec:
   - name: v1
     served: true
     storage: true
+  - name: v1alpha2
+    served: true
+    storage: false
   names:
     plural: operatorgroups
     singular: operatorgroup

--- a/manifests/0000_50_olm_10-operatorgroup.crd.yaml
+++ b/manifests/0000_50_olm_10-operatorgroup.crd.yaml
@@ -9,6 +9,9 @@ spec:
   - name: v1
     served: true
     storage: true
+  - name: v1alpha2
+    served: true
+    storage: false
   names:
     plural: operatorgroups
     singular: operatorgroup


### PR DESCRIPTION
We did not properly deprecate v1alpha2 version of operatorgroup crd in
the 4.4 OpenShift release. Adding back that version to the crd spec

In addition, this pr cuts a new upstream release to keep the manifests
in lockstep (along with fixing the 0.14.1 upstream release)

https://bugzilla.redhat.com/show_bug.cgi?id=1798051
