### PR TITLE
Bug 1804812: fix(deployment): deployment spec hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,12 @@ all: test build
 test: clean cover.out
 
 unit:
-	go test $(MOD_FLAGS) $(SPECIFIC_UNIT_TEST) -v -race -tags=json1 -count=1 ./pkg/...
+	go test $(MOD_FLAGS) $(SPECIFIC_UNIT_TEST) -v -race -count=1 ./pkg/...
 
 schema-check:
 
 cover.out: schema-check
-	go test $(MOD_FLAGS) -v -race -tags=json1 -coverprofile=cover.out -covermode=atomic \
+	go test $(MOD_FLAGS) -v -race -coverprofile=cover.out -covermode=atomic \
 		-coverpkg ./pkg/controller/... ./pkg/...
 
 coverage: cover.out

--- a/pkg/controller/install/deployment.go
+++ b/pkg/controller/install/deployment.go
@@ -3,14 +3,13 @@ package install
 import (
 	"fmt"
 	"hash/fnv"
-	"k8s.io/apimachinery/pkg/util/rand"
 
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/rand"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 
-	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/wrappers"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
@@ -271,22 +270,6 @@ func (i *StrategyDeploymentInstaller) cleanupOrphanedDeployments(deploymentSpecs
 // HashDeploymentSpec calculates a hash given a copy of the deployment spec from a CSV, stripping any
 // operatorgroup annotations.
 func HashDeploymentSpec(spec appsv1.DeploymentSpec) string {
-	// TODO: the deployment installer should know about operatorgroups and ca hashes so that it can calculate these
-
-	// Remove operatorgroup annotations for deployment hashing - this simplifies calculation of the deployment hash
-	// because we don't need to worry about the current state of the operatorgroup
-	annotations := spec.Template.GetAnnotations()
-	if annotations != nil {
-		delete(annotations, v1.OperatorGroupAnnotationKey)
-		delete(annotations, v1.OperatorGroupNamespaceAnnotationKey)
-		delete(annotations, v1.OperatorGroupTargetsAnnotationKey)
-	}
-
-	if len(annotations) == 0 {
-		annotations = nil
-	}
-	spec.Template.SetAnnotations(annotations)
-
 	hasher := fnv.New32a()
 	hashutil.DeepHashObject(hasher, &spec)
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))

--- a/pkg/controller/install/deployment_test.go
+++ b/pkg/controller/install/deployment_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/util/labels"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	clientfakes "github.com/operator-framework/operator-lifecycle-manager/pkg/api/wrappers/wrappersfakes"
@@ -306,6 +307,7 @@ func TestInstallStrategyDeploymentCheckInstallErrors(t *testing.T) {
 
 			dep := testDeployment("olm-dep-1", namespace, &mockOwner)
 			dep.Spec.Template.SetAnnotations(map[string]string{"test": "annotation"})
+			dep.SetLabels(labels.CloneAndAddLabel(dep.ObjectMeta.GetLabels(), DeploymentSpecHashLabelKey, HashDeploymentSpec(dep.Spec)))
 			fakeClient.FindAnyDeploymentsMatchingLabelsReturns(
 				[]*appsv1.Deployment{
 					&dep,
@@ -321,6 +323,7 @@ func TestInstallStrategyDeploymentCheckInstallErrors(t *testing.T) {
 
 			deployment := testDeployment("olm-dep-1", namespace, &mockOwner)
 			deployment.Spec.Template.SetAnnotations(map[string]string{"test": "annotation"})
+			deployment.SetLabels(labels.CloneAndAddLabel(dep.ObjectMeta.GetLabels(), DeploymentSpecHashLabelKey, HashDeploymentSpec(deployment.Spec)))
 			fakeClient.CreateOrUpdateDeploymentReturns(&deployment, tt.createDeploymentErr)
 			defer func() {
 				require.Equal(t, &deployment, fakeClient.CreateOrUpdateDeploymentArgsForCall(0))

--- a/pkg/controller/install/errors.go
+++ b/pkg/controller/install/errors.go
@@ -1,7 +1,5 @@
 package install
 
-import "fmt"
-
 const (
 	StrategyErrReasonComponentMissing   = "ComponentMissing"
 	StrategyErrReasonAnnotationsMissing = "AnnotationsMissing"
@@ -32,7 +30,7 @@ var _ error = StrategyError{}
 
 // Error implements the Error interface.
 func (e StrategyError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Reason, e.Message)
+	return e.Message
 }
 
 // IsErrorUnrecoverable reports if a given strategy error is one of the predefined unrecoverable types

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1382,11 +1382,16 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			return
 		}
 
+		strategy, err := a.updateDeploymentSpecsWithApiServiceData(out, strategy)
+		if err != nil {
+			out.SetPhaseWithEvent(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsReinstall, "calculated deployment install is bad", now, a.recorder)
+			return
+		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhaseInstalling, v1alpha1.CSVReasonWaiting); installErr == nil {
 			logger.WithField("strategy", out.Spec.InstallStrategy.StrategyName).Infof("install strategy successful")
 		} else {
 			// Set phase to failed if it's been a long time since the last transition (5 minutes)
-			if metav1.Now().Sub(out.Status.LastTransitionTime.Time) >= 5*time.Minute {
+			if out.Status.LastTransitionTime != nil && metav1.Now().Sub(out.Status.LastTransitionTime.Time) >= 5*time.Minute {
 				out.SetPhaseWithEvent(v1alpha1.CSVPhaseFailed, v1alpha1.CSVReasonInstallCheckFailed, fmt.Sprintf("install timeout"), now, a.recorder)
 			}
 		}
@@ -1428,6 +1433,11 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 		// Check install status
+		strategy, err = a.updateDeploymentSpecsWithApiServiceData(out, strategy)
+		if err != nil {
+			out.SetPhaseWithEvent(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsReinstall, "calculated deployment install is bad", now, a.recorder)
+			return
+		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhaseFailed, v1alpha1.CSVReasonComponentUnhealthy); installErr != nil {
 			logger.WithField("strategy", out.Spec.InstallStrategy.StrategyName).Warnf("unhealthy component: %s", installErr)
 			return
@@ -1501,6 +1511,11 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 		// Check install status
+		strategy, err = a.updateDeploymentSpecsWithApiServiceData(out, strategy)
+		if err != nil {
+			out.SetPhaseWithEvent(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsReinstall, "calculated deployment install is bad", now, a.recorder)
+			return
+		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsReinstall); installErr != nil {
 			logger.WithField("strategy", out.Spec.InstallStrategy.StrategyName).Warnf("needs reinstall: %s", installErr)
 		}
@@ -1924,7 +1939,8 @@ func (a *Operator) ensureLabels(in *v1alpha1.ClusterServiceVersion, labelSets ..
 		return in, nil
 	}
 
-	a.logger.WithField("labels", merged).Info("Labels updated!")
+	logger := a.logger.WithFields(logrus.Fields{"labels": merged, "csv": in.GetName(), "ns": in.GetNamespace()})
+	logger.Info("updated labels")
 
 	out := in.DeepCopy()
 	out.SetLabels(merged)

--- a/pkg/controller/registry/grpc/source_test.go
+++ b/pkg/controller/registry/grpc/source_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func server(store registry.Query, port int) (func(), func()) {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {
 		logrus.Fatalf("failed to listen: %v", err)
 	}

--- a/pkg/lib/filemonitor/cert_updater_test.go
+++ b/pkg/lib/filemonitor/cert_updater_test.go
@@ -59,7 +59,7 @@ func TestOLMGetCertRotationFn(t *testing.T) {
 	require.NoError(t, err)
 
 	// find a free port to listen on and start server
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	freePort := listener.Addr().(*net.TCPAddr).Port
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/package-server/provider/registry_test.go
+++ b/pkg/package-server/provider/registry_test.go
@@ -41,7 +41,7 @@ const (
 
 func server() {
 	_ = os.Remove(dbName)
-	lis, err := net.Listen("tcp", ":"+port)
+	lis, err := net.Listen("tcp", "localhost:"+port)
 	if err != nil {
 		logrus.Fatalf("failed to listen: %v", err)
 	}

--- a/vendor/k8s.io/kubernetes/pkg/util/hash/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/hash/BUILD
@@ -1,0 +1,34 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hash.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/hash",
+    deps = ["//vendor/github.com/davecgh/go-spew/spew:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["hash_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/github.com/davecgh/go-spew/spew:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/util/hash/hash.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/hash/hash.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash
+
+import (
+	"hash"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1191,6 +1191,7 @@ k8s.io/kubernetes/pkg/apis/rbac/v1
 k8s.io/kubernetes/pkg/printers
 k8s.io/kubernetes/pkg/printers/storage
 k8s.io/kubernetes/pkg/registry/rbac/validation
+k8s.io/kubernetes/pkg/util/hash
 k8s.io/kubernetes/pkg/util/labels
 k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac
 # k8s.io/utils v0.0.0-20190801114015-581e00157fb1


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Use deployment spec hash for determining if change is needed on cluster

DeepDerivative will miss cases where values are removed, because an
empty value is treated as unchanged.

This adds some duplication to the apiservice handling, but I avoided doing any serious refactoring to ensure this cherry picks cleanly.

**Motivation for the change:**

We had been using deep derivative to compare the operator's view of what the deployment should be to the cluster's. But that has a lot of edge cases (zero values for ints, unsetting previously set values), so instead we just store a hash of the deployment spec on the resulting deployment and recalculate it when we need to compare.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
