### PR TITLE
[release-4.2] Bug 1805575: Remove run-level 1 from olm and openshift-operators namespaces

### DIFF
--- a/deploy/chart/templates/0000_50_olm_00-namespace.yaml
+++ b/deploy/chart/templates/0000_50_olm_00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "1"
+    openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
   {{ end }}
 ---
@@ -18,5 +18,5 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "1"
+    openshift.io/scc: "anyuid"
   {{ end }}

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -2,11 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
-  
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "1"
+    openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
   
 ---
@@ -14,9 +13,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operators
-  
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "1"
-  
+    openshift.io/scc: "anyuid"

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -2493,26 +2493,15 @@ func TestUpdateCSVInPlace(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, dep)
 
-	// Create "updated" CSV with a different image
+	// Create "updated" CSV
 	strategyNew := strategy
 	strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers = []corev1.Container{
 		{
-			Name:    genName("hat"),
-			Image:   "quay.io/coreos/mock-extension-apiserver:master",
-			Command: []string{"/bin/mock-extension-apiserver"},
-			Args: []string{
-				"-v=4",
-				"--mock-kinds",
-				"fedora",
-				"--mock-group-version",
-				"group.version",
-				"--secure-port",
-				"5443",
-				"--debug",
-			},
+			Name:  genName("nginx-"),
+			Image: *dummyImage,
 			Ports: []corev1.ContainerPort{
 				{
-					ContainerPort: 5443,
+					ContainerPort: 80,
 				},
 			},
 			ImagePullPolicy: corev1.PullIfNotPresent,


### PR DESCRIPTION
OLM and the operators that it deploys shouldn't have run-level 1
and should use SCC as "anyuid" or "restricted".

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
