### PR TITLE
[release-4.1] Bug 1805576: Remove run-level 1 from olm and openshift-operators namespaces

### DIFF
--- a/deploy/chart/templates/0000_50_olm_00-namespace.yaml
+++ b/deploy/chart/templates/0000_50_olm_00-namespace.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "1"
+    openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
   {{ end }}
 ---
@@ -18,5 +18,5 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "1"
+    openshift.io/scc: "anyuid"
   {{ end }}

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     openshift.io/node-selector: ""  
   labels:
-    openshift.io/run-level: "1"
+    openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
   
 ---
@@ -16,5 +16,4 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "1"
-  
+    openshift.io/scc: "anyuid"


### PR DESCRIPTION
OLM and the operators that it deploys shouldn't have run-level 1
and should use SCC as "anyuid" or "restricted".

Signed-off-by: Vu Dinh <vdinh@redhat.com>
