### PR TITLE
Bug 1799463: Duplicate packages in packageserver APIService response 

### DIFF
--- a/pkg/package-server/provider/registry.go
+++ b/pkg/package-server/provider/registry.go
@@ -412,7 +412,7 @@ func (p *RegistryProvider) Get(namespace, name string) (*operators.PackageManife
 func (p *RegistryProvider) List(namespace string, selector labels.Selector) (*operators.PackageManifestList, error) {
 	var pkgs []*operators.PackageManifest
 	if namespace == metav1.NamespaceAll {
-		all, err := p.pkgLister.List(labels.Everything())
+		all, err := p.pkgLister.List(selector)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Bug report of duplicate packages being returned by the default packageserver APIService shipped with OLM. See BZ for details.  

**Motivation for the change:**
It looks like OLM ignores the packagemanifest label selector when listing in all namespaces:

`$ oc get packagemanifests -l '!opsrc-owner-name' -n openshift-marketplace
No resources found.`

`$ oc get packagemanifests -l '!opsrc-owner-name' --all-namespaces | grep openshift-marketplace | wc -l
     198`

This is causing console to have duplicate items returned.


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
