### PR TITLE
Fix kind detection for local builds.

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -5,16 +5,18 @@
 
 set -e
 
+docker build -f local.Dockerfile -t quay.io/operator-framework/olm:local -t quay.io/operator-framework/olm-e2e:local ./bin
+docker build -f test/e2e/hang.Dockerfile -t hang:10 ./bin
+
+if [ -x "$(command -v kind)" ] && [[ "$(kubectl config current-context)" =~ ^kind-? ]]; then
+  kind load docker-image quay.io/operator-framework/olm:local
+  kind load docker-image quay.io/operator-framework/olm-e2e:local
+  kind load docker-image hang:10
+  exit 0 # don't bother with minikube if kind is active
+fi
+
 if [ -z "$NO_MINIKUBE" ]; then
   pgrep -f "[m]inikube" >/dev/null || minikube start --kubernetes-version="v1.16.2" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
   eval "$(minikube docker-env)" || { echo 'Cannot switch to minikube docker'; exit 1; }
   kubectl config use-context minikube
-fi
-
-docker build -f local.Dockerfile -t quay.io/operator-framework/olm:local -t quay.io/operator-framework/olm-e2e:local ./bin
-docker build -f test/e2e/hang.Dockerfile -t hang:10 ./bin
-
-if [ -x "$(command -v kind)" ] && [ "$(kubectl config current-context)" = "kind" ]; then
-  kind load docker-image quay.io/operator-framework/olm:local
-  kind load docker-image quay.io/operator-framework/olm-e2e:local
 fi


### PR DESCRIPTION
By default, kind 0.7.0 context names are of the form
kind-* (e.g. kind-kind). Not sure when this changed -- presumably the
behavior here worked at the time it was written.

This also skips minikube setup if the current context is guessed to
point to a kind cluster, without requiring nonempty NO_MINIKUBE.
