### PR TITLE
Unbreak the minikube mode of build_local.sh.

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,30 @@
+name: test-scripts
+on:
+  pull_request:
+    paths:
+    - 'scripts/**'
+    - 'Makefile'
+  schedule:
+  - cron: '0 0 * * *' # daily to pick up releases
+jobs:
+  run-local-minikube:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
+        chmod +x minikube
+        sudo mv minikube /bin/
+        minikube config set vm-driver none
+        sudo make run-local # vm-driver=none requires root
+  run-local-kind:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        curl -sLo kind "$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '[.assets[] | select(.name == "kind-linux-amd64")] | first | .browser_download_url')"
+        chmod +x kind
+        sudo mv kind /bin/
+        kind create cluster
+        kind export kubeconfig
+        make run-local

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ tramp
 
 # cask packages
 .cask/
-dist/
+/dist/
 
 # Flycheck
 flycheck_*.el

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ build-linux: clean $(CMDS)
 build-wait: clean bin/wait
 
 bin/wait:
-	GOOS=linux GOARCH=386 go build -o $@ $(PKG)/test/e2e/wait
+	GOOS=linux GOARCH=386 go build $(MOD_FLAGS) -o $@ $(PKG)/test/e2e/wait
 
 build-util-linux: arch_flags=GOOS=linux GOARCH=386
 build-util-linux: build-util

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -5,18 +5,19 @@
 
 set -e
 
-docker build -f local.Dockerfile -t quay.io/operator-framework/olm:local -t quay.io/operator-framework/olm-e2e:local ./bin
-docker build -f test/e2e/hang.Dockerfile -t hang:10 ./bin
-
-if [ -x "$(command -v kind)" ] && [[ "$(kubectl config current-context)" =~ ^kind-? ]]; then
-  kind load docker-image quay.io/operator-framework/olm:local
-  kind load docker-image quay.io/operator-framework/olm-e2e:local
-  kind load docker-image hang:10
-  exit 0 # don't bother with minikube if kind is active
-fi
+[ -x "$(command -v kind)" ] && [[ "$(kubectl config current-context)" =~ ^kind-? ]] && KIND=1 NO_MINIKUBE=1
 
 if [ -z "$NO_MINIKUBE" ]; then
   pgrep -f "[m]inikube" >/dev/null || minikube start --kubernetes-version="v1.16.2" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
   eval "$(minikube docker-env)" || { echo 'Cannot switch to minikube docker'; exit 1; }
   kubectl config use-context minikube
+fi
+
+docker build -f local.Dockerfile -t quay.io/operator-framework/olm:local -t quay.io/operator-framework/olm-e2e:local ./bin
+docker build -f test/e2e/hang.Dockerfile -t hang:10 ./bin
+
+if [ -n "$KIND" ]; then
+  kind load docker-image quay.io/operator-framework/olm:local
+  kind load docker-image quay.io/operator-framework/olm-e2e:local
+  kind load docker-image hang:10
 fi


### PR DESCRIPTION
Fix the ordering of eval "$(minikube docker-env)" relative to local
image builds, which was broken in the process of fixing this script
for kind users.