### PR TITLE
Tolerations & Resources Override using .Subscription.Config

### DIFF
--- a/doc/design/subscription-config.md
+++ b/doc/design/subscription-config.md
@@ -84,3 +84,52 @@ spec:
     - mountPath: /config
       name: config-volume
 ```
+
+### Tolerations
+
+The `tolerations` field defines a list of [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) for the Pod created by OLM.
+
+> Note: Tolerations defined here will be appended to existing Tolerations, if not already present.
+
+#### Example
+
+Inject toleration to tolerate all taints.
+
+```
+kind: Subscription
+metadata:
+  name: my-operator
+spec:
+  package: etcd
+  channel: alpha
+  config:
+    tolerations:
+    - operator: "Exists"
+```
+
+### Resources
+
+The `resources` field defines [Resource Constraints](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) for all the containers in the Pod created by OLM.
+
+> Note: Resource Constraints defined here will overwrite existing resource constraints.
+
+#### Example
+
+Inject a request of 0.25 cpu and 64 MiB of memory, and a limit of 0.5 cpu and 128MiB of memory in each container.
+
+```
+kind: Subscription
+metadata:
+  name: my-operator
+spec:
+  package: etcd
+  channel: alpha
+  config:
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```

--- a/pkg/controller/operators/olm/overrides/config.go
+++ b/pkg/controller/operators/olm/overrides/config.go
@@ -16,7 +16,7 @@ type operatorConfig struct {
 	logger *logrus.Logger
 }
 
-func (o *operatorConfig) GetConfigOverrides(ownerCSV ownerutil.Owner) (envVarOverrides []corev1.EnvVar, volumeOverrides []corev1.Volume, volumeMountOverrides []corev1.VolumeMount, err error) {
+func (o *operatorConfig) GetConfigOverrides(ownerCSV ownerutil.Owner) (envVarOverrides []corev1.EnvVar, volumeOverrides []corev1.Volume, volumeMountOverrides []corev1.VolumeMount, tolerationOverrides []corev1.Toleration, resourcesOverride corev1.ResourceRequirements, err error) {
 	list, listErr := o.lister.OperatorsV1alpha1().SubscriptionLister().Subscriptions(ownerCSV.GetNamespace()).List(labels.Everything())
 	if listErr != nil {
 		err = fmt.Errorf("failed to list subscription namespace=%s - %v", ownerCSV.GetNamespace(), listErr)
@@ -32,6 +32,8 @@ func (o *operatorConfig) GetConfigOverrides(ownerCSV ownerutil.Owner) (envVarOve
 	envVarOverrides = owner.Spec.Config.Env
 	volumeOverrides = owner.Spec.Config.Volumes
 	volumeMountOverrides = owner.Spec.Config.VolumeMounts
+	tolerationOverrides = owner.Spec.Config.Tolerations
+	resourcesOverride = owner.Spec.Config.Resources
 
 	return
 }

--- a/pkg/controller/operators/olm/overrides/initializer.go
+++ b/pkg/controller/operators/olm/overrides/initializer.go
@@ -2,6 +2,7 @@ package overrides
 
 import (
 	"fmt"
+
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
@@ -43,7 +44,7 @@ func (d *DeploymentInitializer) initialize(ownerCSV ownerutil.Owner, deployment 
 	var envVarOverrides, proxyEnvVar, merged []corev1.EnvVar
 	var err error
 
-	envVarOverrides, volumeOverrides, volumeMountOverrides, err := d.config.GetConfigOverrides(ownerCSV)
+	envVarOverrides, volumeOverrides, volumeMountOverrides, tolerationOverrides, resourcesOverride, err := d.config.GetConfigOverrides(ownerCSV)
 	if err != nil {
 		err = fmt.Errorf("failed to get subscription pod configuration - %v", err)
 		return err
@@ -76,6 +77,14 @@ func (d *DeploymentInitializer) initialize(ownerCSV ownerutil.Owner, deployment 
 
 	if err = InjectVolumeMountsIntoDeployment(podSpec, volumeMountOverrides); err != nil {
 		return fmt.Errorf("failed to inject volumeMounts(s) into deployment spec name=%s - %v", deployment.Name, err)
+	}
+
+	if err = InjectTolerationsIntoDeployment(podSpec, tolerationOverrides); err != nil {
+		return fmt.Errorf("failed to inject toleration(s) into deployment spec name=%s - %v", deployment.Name, err)
+	}
+
+	if err = InjectResourcesIntoDeployment(podSpec, resourcesOverride); err != nil {
+		return fmt.Errorf("failed to inject resources into deployment spec name=%s - %v", deployment.Name, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
(feat) inject 'Tolerations' & 'Resources' from config

Updated deployment initializer function to inject tolerations
and resources specified in pod configuration of subscription
into deployment object.

- Toleration will be appended if it does not exist
- Resources will be overwritten

(test) update e2e test

**Motivation for the change:**
#1298 

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
