### PR TITLE
Bug 1809294: Update subscription_sync_count to include the package name

### DIFF
--- a/pkg/controller/operators/catalog/subscription/syncer.go
+++ b/pkg/controller/operators/catalog/subscription/syncer.go
@@ -91,7 +91,7 @@ func (s *subscriptionSyncer) recordMetrics(sub *v1alpha1.Subscription) {
 		return
 	}
 
-	metrics.CounterForSubscription(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Channel).Inc()
+	metrics.CounterForSubscription(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Channel, sub.Spec.Package).Inc()
 }
 
 func (s *subscriptionSyncer) Notify(event kubestate.ResourceEvent) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -18,6 +18,7 @@ const (
 	VERSION_LABEL   = "version"
 	PHASE_LABEL     = "phase"
 	REASON_LABEL    = "reason"
+	PACKAGE_LABEL   = "package"
 )
 
 // TODO(alecmerdler): Can we use this to emit Kubernetes events?
@@ -149,7 +150,7 @@ var (
 			Name: "subscription_sync_total",
 			Help: "Monotonic count of subscription syncs",
 		},
-		[]string{NAME_LABEL, INSTALLED_LABEL, CHANNEL_LABEL},
+		[]string{NAME_LABEL, INSTALLED_LABEL, CHANNEL_LABEL, PACKAGE_LABEL},
 	)
 
 	csvSucceeded = prometheus.NewGaugeVec(
@@ -183,8 +184,8 @@ func RegisterCatalog() {
 	prometheus.MustRegister(SubscriptionSyncCount)
 }
 
-func CounterForSubscription(name, installedCSV, channelName string) prometheus.Counter {
-	return SubscriptionSyncCount.WithLabelValues(name, installedCSV, channelName)
+func CounterForSubscription(name, installedCSV, channelName, packageName string) prometheus.Counter {
+	return SubscriptionSyncCount.WithLabelValues(name, installedCSV, channelName, packageName)
 }
 
 func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha1.ClusterServiceVersion) {


### PR DESCRIPTION
**Description of the change:**
This PR updates the subscription_sync_count metric to include a packageName label.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive



