### PR TITLE
Bug 1808113: Fix OwnerReferences for bundled CRs

### DIFF
--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -1093,7 +1093,6 @@ func NewFakeOperator(ctx context.Context, namespace string, namespaces []string,
 	k8sClientFake.Resources = apiResourcesForObjects(append(config.extObjs, config.regObjs...))
 	opClientFake := operatorclient.NewClient(k8sClientFake, apiextensionsfake.NewSimpleClientset(config.extObjs...), apiregistrationfake.NewSimpleClientset(config.regObjs...))
 	dynamicClientFake := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme())
-	// dynamicClientFake.Resources = k8sClientFake.Resources
 
 	// Create operator namespace
 	_, err := opClientFake.KubernetesInterface().CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})

--- a/pkg/controller/operators/catalog/testdata/prometheusrule.cr.yaml
+++ b/pkg/controller/operators/catalog/testdata/prometheusrule.cr.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: rule 
-  # namespace: placeholder
   labels:
     prometheus: alert-rules
     role: alert-rules

--- a/pkg/controller/operators/catalog/testdata/prometheusrule.cr.yaml
+++ b/pkg/controller/operators/catalog/testdata/prometheusrule.cr.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rule 
+  # namespace: placeholder
+  labels:
+    prometheus: alert-rules
+    role: alert-rules
+spec:
+  groups:
+    - name: olm.failing_operators.rules
+      rules:
+        - alert: SeriousAlert 
+          annotations:
+            message: A serious alert! 
+          expr: alert_status{prioirity="Serious"}
+          labels:
+            severity: warn 

--- a/pkg/controller/operators/catalog/testdata/prometheusrule.crd.yaml
+++ b/pkg/controller/operators/catalog/testdata/prometheusrule.crd.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: PrometheusRule
+    listKind: PrometheusRuleList
+    plural: prometheusrules
+    singular: prometheusrule
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Fix InstallPlan execution to generate OwnerReferences on CRs applied to the respective CSV rather than the InstallPlan itself.

**Motivation for the change:**

Currently, bundled CRs are given OwnerReferences to the InstallPlan they were applied from, which is incorrect.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
