### PR TITLE
Bug 1797747: Make provided API ClusterRoles be owned by the corresponding API.

### DIFF
--- a/pkg/api/apis/operators/operatorgroup_types.go
+++ b/pkg/api/apis/operators/operatorgroup_types.go
@@ -74,6 +74,8 @@ type OperatorGroupList struct {
 }
 
 func (o *OperatorGroup) BuildTargetNamespaces() string {
-	sort.Strings(o.Status.Namespaces)
-	return strings.Join(o.Status.Namespaces, ",")
+	ns := make([]string, len(o.Status.Namespaces))
+	copy(ns, o.Status.Namespaces)
+	sort.Strings(ns)
+	return strings.Join(ns, ",")
 }

--- a/pkg/api/apis/operators/v1/operatorgroup_types.go
+++ b/pkg/api/apis/operators/v1/operatorgroup_types.go
@@ -74,8 +74,10 @@ type OperatorGroupList struct {
 }
 
 func (o *OperatorGroup) BuildTargetNamespaces() string {
-	sort.Strings(o.Status.Namespaces)
-	return strings.Join(o.Status.Namespaces, ",")
+	ns := make([]string, len(o.Status.Namespaces))
+	copy(ns, o.Status.Namespaces)
+	sort.Strings(ns)
+	return strings.Join(ns, ",")
 }
 
 // IsServiceAccountSpecified returns true if the spec has a service account name specified.

--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -9,10 +9,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
 const (
@@ -364,6 +367,24 @@ func InferGroupVersionKind(obj runtime.Object) error {
 			Group:   v1.GroupName,
 			Version: v1.GroupVersion,
 			Kind:    "OperatorGroup",
+		})
+	case *apiregistrationv1.APIService:
+		objectKind.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   apiregistrationv1.GroupName,
+			Version: apiregistrationv1.SchemeGroupVersion.Version,
+			Kind:    "APIService",
+		})
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		objectKind.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   apiextensionsv1beta1.GroupName,
+			Version: apiextensionsv1beta1.SchemeGroupVersion.Version,
+			Kind:    "CustomResourceDefinition",
+		})
+	case *apiextensionsv1.CustomResourceDefinition:
+		objectKind.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   apiextensionsv1.GroupName,
+			Version: apiextensionsv1.SchemeGroupVersion.Version,
+			Kind:    "CustomResourceDefinition",
 		})
 	default:
 		return fmt.Errorf("could not infer GVK for object: %#v, %#v", obj, objectKind)


### PR DESCRIPTION
The existing CSV owner labels lead to a neverending battle for
ownership in clusters with more than one CSV providing the same
API. The amount of additional work generated by the owner label
conflict manifested (not exclusively) as excessive operator
installation latency in affected clusters.

This conflict is resolved by abandoning CSV owner labels in favor of
OwnerReferences to the providing APIService or
CustomResourceDefinition.

Aggregation of API ClusterRoles to the providing OperatorGroup
ClusterRoles is also changed. Instead of labeling API ClusterRoles
based on the names of OperatorGroups providing the associated API,
each API ClusterRole is labeled based on the name of the API
itself. OperatorGroup ClusterRoles accumulate one label selector per
provided API.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
