### PR TITLE
Clarify roles and adds info about Package Server

### DIFF
--- a/doc/design/architecture.md
+++ b/doc/design/architecture.md
@@ -11,11 +11,12 @@ Each of these Operators is responsible for managing the CRDs that are the basis 
 | CatalogSource         | catsrc         | Catalog | a repository of CSVs, CRDs, and packages that define an application                        |
 | Subscription          | sub        | Catalog | used to keep CSVs up to date by tracking a channel in a package                            |
 | OperatorGroup         | og     | OLM     | used to group multiple namespaces and prepare for use by an operator                     |
-| PackageManifest       |        | PackageServer | provides the user with an api presentation of the data a CatalogSource provides |
+
+In addition, a PackageManifest resource provides the user with an API presentation of the data a CatalogSource provides. This is not an actual CRD, but a simpler synthetic aggregated API resource. As a result, it cannot be managed in the same manner as a CRD.
 
 Each of these Operators are also responsible for creating resources:
 
-| Component | Creatable Resources        |
+| Component | Managed Resources          |
 |-----------|----------------------------|
 | OLM       | Deployment                 |
 | Catalog   | Service Account            |

--- a/doc/design/architecture.md
+++ b/doc/design/architecture.md
@@ -133,7 +133,7 @@ The Package Server provides a veneer API over the CatalogSource resources and th
 
 It is not neccessary to run this for OLM to function, but enhances the user experience by providing the information needed for Subscription generation to the user. In a Production scenario where no discovery work is needed and all Subscriptions are predefined, this may be removed.
 
-OpenShift/OKD GUIs will use this API extention to present operator package information such as CSVs, packages and CRDs found in the CatalogSource to users. Additionally, `kubectl` and `oc` users are able to issue commands like `kubectl get PackageManifests` to list out available Operators and then run `kubectl describe` on those resources to find the appropriate data to build a Subscription to it.
+Client GUI interfaces will use this API extention to present operator package information such as CSVs, packages and CRDs found in the CatalogSource to users. Additionally, CLI tools are able to examine the list of PackageManifests to list out available Operators and then examine the specific PackageManifests resources to find the appropriate data to build a Subscription to it.
 
 ## Catalog (Registry) Design
 


### PR DESCRIPTION
**Description of the change:**
Clarifies roles of the two Operators and adds info about Package Server's place in all of this, while making clear it is not a required component. Based on information that @ecordell provided in issue #1346 

**Motivation for the change:**
I found the current documentation to be confusing around these areas and lacking some details.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

Closes #1346