### PR TITLE
Bug 1809661: Update subscription_sync_count to include the package name

### DIFF
--- a/pkg/controller/operators/catalog/subscription/syncer.go
+++ b/pkg/controller/operators/catalog/subscription/syncer.go
@@ -86,7 +86,7 @@ func (s *subscriptionSyncer) Sync(ctx context.Context, event kubestate.ResourceE
 }
 
 func (o *subscriptionSyncer) recordMetrics(sub *v1alpha1.Subscription) {
-	metrics.CounterForSubscription(sub.GetName(), sub.Status.InstalledCSV).Inc()
+	metrics.CounterForSubscription(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Package).Inc()
 }
 
 func (s *subscriptionSyncer) Notify(event kubestate.ResourceEvent) {

--- a/pkg/controller/operators/catalog/subscription/syncer_test.go
+++ b/pkg/controller/operators/catalog/subscription/syncer_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 )
@@ -40,7 +39,7 @@ func TestSync(t *testing.T) {
 			args: args{
 				event: kubestate.NewResourceEvent(
 					kubestate.ResourceAdded,
-					&v1alpha1.Subscription{},
+					&v1alpha1.Subscription{Spec:&v1alpha1.SubscriptionSpec{Package:"pkg"}},
 				),
 			},
 			want: want{
@@ -57,7 +56,7 @@ func TestSync(t *testing.T) {
 			args: args{
 				event: kubestate.NewResourceEvent(
 					kubestate.ResourceAdded,
-					&operators.Subscription{},
+					&v1alpha1.Subscription{Spec:&v1alpha1.SubscriptionSpec{Package:"pkg"}},
 				),
 			},
 			want: want{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,6 +12,7 @@ import (
 const (
 	NAME_LABEL      = "name"
 	INSTALLED_LABEL = "installed"
+	PACKAGE_LABEL   = "package"
 )
 
 // TODO(alecmerdler): Can we use this to emit Kubernetes events?
@@ -143,7 +144,7 @@ var (
 			Name: "subscription_sync_total",
 			Help: "Monotonic count of subscription syncs",
 		},
-		[]string{NAME_LABEL, INSTALLED_LABEL},
+		[]string{NAME_LABEL, INSTALLED_LABEL, PACKAGE_LABEL},
 	)
 )
 
@@ -159,6 +160,6 @@ func RegisterCatalog() {
 	prometheus.MustRegister(SubscriptionSyncCount)
 }
 
-func CounterForSubscription(name, installedCSV string) prometheus.Counter {
-	return SubscriptionSyncCount.WithLabelValues(name, installedCSV)
+func CounterForSubscription(name, installedCSV, packageName string) prometheus.Counter {
+	return SubscriptionSyncCount.WithLabelValues(name, installedCSV, packageName)
 }


### PR DESCRIPTION
**Description of the change:**
This PR updates the subscription_sync_count metric to include a packageName label.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
