### PR TITLE
[wip] adding metric cardinality tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ setup-bare: clean e2e.namespace
 
 # e2e test exculding the rh-operators directory which tests rh-operators and their metric cardinality.
 e2e:
-	./test/rh-operators/e2e-origin-prometheus.sh
+	. ./test/rh-operators/e2e-origin-prometheus.sh
 
 e2e-local: build-linux build-wait build-util-linux
 	. ./scripts/build_local.sh

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ setup-bare: clean e2e.namespace
 
 # e2e test exculding the rh-operators directory which tests rh-operators and their metric cardinality.
 e2e:
-	go test -v $(MOD_FLAGS) -failfast -timeout 70m ./test/e2e/... -namespace=openshift-operators -kubeconfig=${KUBECONFIG} -olmNamespace=openshift-operator-lifecycle-manager -dummyImage=bitnami/nginx:latest
+	go test -v $(MOD_FLAGS) -failfast -timeout 70m ./test/rh-operators/...
+	./test/rh-operators/e2e-origin-prometheus.sh
 
 e2e-local: build-linux build-wait build-util-linux
 	. ./scripts/build_local.sh

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ setup-bare: clean e2e.namespace
 
 # e2e test exculding the rh-operators directory which tests rh-operators and their metric cardinality.
 e2e:
-	go test -v $(MOD_FLAGS) -failfast -timeout 70m ./test/rh-operators/...
 	./test/rh-operators/e2e-origin-prometheus.sh
 
 e2e-local: build-linux build-wait build-util-linux

--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,7 @@ e2e-local-docker:
 	. ./scripts/run_e2e_docker.sh $(TEST)
 
 e2e-operator-metrics:
-	go test -v $(MOD_FLAGS) -failfast -timeout 70m ./test/rh-operators/...
-	./test/rh-operators/e2e-origin-prometheus.sh
+	go test -v $(MOD_FLAGS) -failfast -timeout 70m ./test/rh-operators/... || ./test/rh-operators/e2e-origin-prometheus.sh
 
 vendor:
 	go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ e2e-local-docker:
 
 e2e-operator-metrics:
 	go test -v $(MOD_FLAGS) -failfast -timeout 70m ./test/rh-operators/...
+	./test/rh-operators/e2e-origin-prometheus.sh
 
 vendor:
 	go mod tidy

--- a/test/rh-operators/e2e-origin-prometheus.sh
+++ b/test/rh-operators/e2e-origin-prometheus.sh
@@ -16,5 +16,5 @@ mv ./kubectl /tmp/shared/kubectl
 make WHAT=cmd/openshift-tests
 DIR="./_output/local/bin/$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 
-${DIR}/openshift-tests run all --dry-run | grep "\[sig-instrumentation\].*Prometheus\|\[sig-instrumentation\].*Alerts" | ${DIR}/openshift-tests run --junit-dir=./ -o ./junit_e2e.xml -f -
-export JUNIT_REPORT_OUTPUT=$(pwd)/junit_e2e.xml
+${DIR}/openshift-tests run all --dry-run | grep "\[sig-instrumentation\].*Prometheus\|\[sig-instrumentation\].*Alerts" | ${DIR}/openshift-tests run --junit-dir=./ -o ./junit.e2e.xml -f -
+export JUNIT_REPORT_OUTPUT=$(pwd)/junit.e2e.xml

--- a/test/rh-operators/e2e-origin-prometheus.sh
+++ b/test/rh-operators/e2e-origin-prometheus.sh
@@ -1,72 +1,20 @@
 #!/bin/bash
 
-git clone https://github.com/openshift/origin.git
+git clone https://github.com/openshift/origin.git -b master
 cd origin
 
-# mirrored from openshift/origin/test/extended/conformance-k8s.sh
-source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+export GO111MODULE=off
 
-# Check inputs
-if [[ -z "${KUBECONFIG-}" ]]; then
-  os::log::fatal "KUBECONFIG must be set to a root account"
-fi
-test_report_dir="${ARTIFACT_DIR}"
-mkdir -p "${test_report_dir}"
+# install Kubectl required by the test.
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+mkdir -p /tmp/shared
+export PATH=$PATH:/tmp/shared
+mv ./kubectl /tmp/shared/kubectl
 
-# TODO: get version from input arg
-version="${KUBERNETES_VERSION:-release-1.17}"
-kubernetes="${KUBERNETES_ROOT:-${OS_ROOT}/../../../k8s.io/kubernetes}"
-if [[ -d "${kubernetes}" ]]; then
-  git fetch origin --tags
-else
-  if [[ -n "${KUBERNETES_ROOT-}" ]]; then
-    os::log::fatal "Cannot find Kubernetes source directory, set KUBERNETES_ROOT"
-  fi
-  kubernetes="${OS_ROOT}/_output/components/kubernetes"
-  if [[ ! -d "${kubernetes}" ]]; then
-    mkdir -p "$( dirname "${kubernetes}" )"
-    os::log::info "Cloning Kubernetes source"
-    git clone "https://github.com/kubernetes/kubernetes.git" -b "${version}" "${kubernetes}" # --depth=1 unfortunately we need history info as well
-  fi
-fi
+# make and run test
+make WHAT=cmd/openshift-tests
+DIR="./_output/local/bin/$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 
-os::log::info "Running Kubernetes conformance suite for ${version}"
-
-# Execute OpenShift prerequisites
-# Disable container security
-oc adm policy add-scc-to-group privileged system:authenticated system:serviceaccounts
-oc adm policy remove-scc-from-group restricted system:authenticated
-oc adm policy remove-scc-from-group anyuid system:cluster-admins
-# Mark the master nodes as unschedulable so tests ignore them
-oc get nodes -o name -l 'node-role.kubernetes.io/master' | xargs -L1 oc adm cordon
-unschedulable="$( ( oc get nodes -o name -l 'node-role.kubernetes.io/master'; ) | wc -l )"
-# TODO: undo these operations
-
-# Execute Kubernetes prerequisites
-pushd "${kubernetes}" > /dev/null
-git checkout "${version}"
-make WHAT=cmd/kubectl
-make WHAT=test/e2e/e2e.test
-make WHAT=vendor/github.com/onsi/ginkgo/ginkgo
-export PATH="${kubernetes}/_output/local/bin/$( os::build::host_platform ):${PATH}"
-
-kubectl version  > "${test_report_dir}/version.txt"
-echo "-----"    >> "${test_report_dir}/version.txt"
-oc version      >> "${test_report_dir}/version.txt"
-
-# Run the test, serial tests first, then parallel
-
-rc=0
-
-ginkgo \
-  -nodes 1 -noColor '-focus=(\[sig-instrumentation\].*Prometheus|\[sig-instrumentation\].*Alerts)' $( which e2e.test ) -- \
-  -report-dir "${test_report_dir}" \
-  -allowed-not-ready-nodes ${unschedulable} \
-  2>&1 | tee -a "${test_report_dir}/e2e.log" || rc=1
-
-rename -v junit_ junit_serial_ ${test_report_dir}/junit*.xml
-
-echo
-echo "Run complete, results in ${test_report_dir}"
-
-exit $rc
+${DIR}/openshift-tests run all --dry-run | grep "\[sig-instrumentation\].*Prometheus\|\[sig-instrumentation\].*Alerts" | ${DIR}/openshift-tests run --junit-dir=./ --output-file=junit_e2e.xml -f -
+export JUNIT_REPORT_OUTPUT=$(pwd)/junit_e2e.xml

--- a/test/rh-operators/e2e-origin-prometheus.sh
+++ b/test/rh-operators/e2e-origin-prometheus.sh
@@ -16,5 +16,5 @@ mv ./kubectl /tmp/shared/kubectl
 make WHAT=cmd/openshift-tests
 DIR="./_output/local/bin/$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 
-${DIR}/openshift-tests run all --dry-run | grep "\[sig-instrumentation\].*Prometheus\|\[sig-instrumentation\].*Alerts" | ${DIR}/openshift-tests run --junit-dir=./ --output-file=junit_e2e.xml -f -
+${DIR}/openshift-tests run all --dry-run | grep "\[sig-instrumentation\].*Prometheus\|\[sig-instrumentation\].*Alerts" | ${DIR}/openshift-tests run --junit-dir=./ -o ./junit_e2e.xml -f -
 export JUNIT_REPORT_OUTPUT=$(pwd)/junit_e2e.xml

--- a/test/rh-operators/e2e-origin-prometheus.sh
+++ b/test/rh-operators/e2e-origin-prometheus.sh
@@ -59,10 +59,12 @@ oc version      >> "${test_report_dir}/version.txt"
 rc=0
 
 ginkgo \
-  -nodes 1 -noColor '-focus=(\[[sig-instrumentation]\].*Prometheus|\[[sig-instrumentation]\].*Alerts)' $( which e2e.test ) -- \
+  -nodes 1 -noColor '-focus=(\[sig-instrumentation\].*Prometheus|\[sig-instrumentation\].*Alerts)' $( which e2e.test ) -- \
   -report-dir "${test_report_dir}" \
   -allowed-not-ready-nodes ${unschedulable} \
   2>&1 | tee -a "${test_report_dir}/e2e.log" || rc=1
+
+rename -v junit_ junit_serial_ ${test_report_dir}/junit*.xml
 
 echo
 echo "Run complete, results in ${test_report_dir}"

--- a/test/rh-operators/e2e-origin-prometheus.sh
+++ b/test/rh-operators/e2e-origin-prometheus.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+git clone https://github.com/openshift/origin.git
+cd origin
+
+# mirrored from openshift/origin/test/extended/conformance-k8s.sh
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+
+# Check inputs
+if [[ -z "${KUBECONFIG-}" ]]; then
+  os::log::fatal "KUBECONFIG must be set to a root account"
+fi
+test_report_dir="${ARTIFACT_DIR}"
+mkdir -p "${test_report_dir}"
+
+# TODO: get version from input arg
+version="${KUBERNETES_VERSION:-release-1.17}"
+kubernetes="${KUBERNETES_ROOT:-${OS_ROOT}/../../../k8s.io/kubernetes}"
+if [[ -d "${kubernetes}" ]]; then
+  git fetch origin --tags
+else
+  if [[ -n "${KUBERNETES_ROOT-}" ]]; then
+    os::log::fatal "Cannot find Kubernetes source directory, set KUBERNETES_ROOT"
+  fi
+  kubernetes="${OS_ROOT}/_output/components/kubernetes"
+  if [[ ! -d "${kubernetes}" ]]; then
+    mkdir -p "$( dirname "${kubernetes}" )"
+    os::log::info "Cloning Kubernetes source"
+    git clone "https://github.com/kubernetes/kubernetes.git" -b "${version}" "${kubernetes}" # --depth=1 unfortunately we need history info as well
+  fi
+fi
+
+os::log::info "Running Kubernetes conformance suite for ${version}"
+
+# Execute OpenShift prerequisites
+# Disable container security
+oc adm policy add-scc-to-group privileged system:authenticated system:serviceaccounts
+oc adm policy remove-scc-from-group restricted system:authenticated
+oc adm policy remove-scc-from-group anyuid system:cluster-admins
+# Mark the master nodes as unschedulable so tests ignore them
+oc get nodes -o name -l 'node-role.kubernetes.io/master' | xargs -L1 oc adm cordon
+unschedulable="$( ( oc get nodes -o name -l 'node-role.kubernetes.io/master'; ) | wc -l )"
+# TODO: undo these operations
+
+# Execute Kubernetes prerequisites
+pushd "${kubernetes}" > /dev/null
+git checkout "${version}"
+make WHAT=cmd/kubectl
+make WHAT=test/e2e/e2e.test
+make WHAT=vendor/github.com/onsi/ginkgo/ginkgo
+export PATH="${kubernetes}/_output/local/bin/$( os::build::host_platform ):${PATH}"
+
+kubectl version  > "${test_report_dir}/version.txt"
+echo "-----"    >> "${test_report_dir}/version.txt"
+oc version      >> "${test_report_dir}/version.txt"
+
+# Run the test, serial tests first, then parallel
+
+rc=0
+
+ginkgo \
+  -nodes 1 -noColor '-focus=(\[[sig-instrumentation]\].*Prometheus|\[[sig-instrumentation]\].*Alerts)' $( which e2e.test ) -- \
+  -report-dir "${test_report_dir}" \
+  -allowed-not-ready-nodes ${unschedulable} \
+  2>&1 | tee -a "${test_report_dir}/e2e.log" || rc=1
+
+echo
+echo "Run complete, results in ${test_report_dir}"
+
+exit $rc


### PR DESCRIPTION
This commits adds a script to run metric cardinality tests from origin/test/extended/Prometheus test package. The test package will remain effective with operators uninstalled from the cluster because alerts and messages fired to Prometheus on the cluster are not erased. 