### PR TITLE
Bug 1814457: fix(catsrc): remove limits on catalogsource pods

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -129,10 +129,6 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 						InitialDelaySeconds: livenessDelay,
 					},
 					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("100m"),
-							v1.ResourceMemory: resource.MustParse("100Mi"),
-						},
 						Requests: v1.ResourceList{
 							v1.ResourceCPU:    resource.MustParse("10m"),
 							v1.ResourceMemory: resource.MustParse("50Mi"),


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Removes resource limits for catalogsource pods

**Motivation for the change:**
This will prevent larger catalogs from starting

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
