### PR TITLE
Fix installplan error when installing from bundles

### DIFF
--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
+  
   annotations:
     openshift.io/node-selector: ""
   labels:
@@ -12,6 +13,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operators
+  
   annotations:
     openshift.io/node-selector: ""
   labels:

--- a/manifests/0000_50_olm_03-clusterserviceversion.crd.yaml
+++ b/manifests/0000_50_olm_03-clusterserviceversion.crd.yaml
@@ -8431,3 +8431,4 @@ spec:
                     type: string
                   version:
                     type: string
+

--- a/manifests/0000_50_olm_04-installplan.crd.yaml
+++ b/manifests/0000_50_olm_04-installplan.crd.yaml
@@ -67,6 +67,7 @@ spec:
           - approval
           - approved
           - clusterServiceVersionNames
+          - generation
           properties:
             approval:
               description: Approval is the user approval policy for an InstallPlan.
@@ -77,6 +78,8 @@ spec:
               type: array
               items:
                 type: string
+            generation:
+              type: integer
             source:
               type: string
             sourceNamespace:
@@ -128,17 +131,22 @@ spec:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
             bundleLookups:
+              description: BundleLookups is the set of in-progress requests to pull
+                and unpackage bundle content to the cluster.
               type: array
               items:
+                description: BundleLookup is a request to pull and unpackage the content
+                  of a bundle to the cluster.
                 type: object
                 required:
                 - catalogSourceRef
+                - identifier
                 - path
                 - replaces
                 properties:
                   catalogSourceRef:
-                    description: ObjectReference contains enough information to let
-                      you inspect or modify the referred object.
+                    description: CatalogSourceRef is a reference to the CatalogSource
+                      the bundle path was resolved from.
                     type: object
                     properties:
                       apiVersion:
@@ -174,6 +182,7 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                   conditions:
+                    description: Conditions represents the overall state of a BundleLookup.
                     type: array
                     items:
                       type: object
@@ -187,7 +196,7 @@ spec:
                           type: string
                           format: date-time
                         lastUpdateTime:
-                          description: Last time the condition was probed
+                          description: Last time the condition was probed.
                           type: string
                           format: date-time
                         message:
@@ -204,9 +213,17 @@ spec:
                         type:
                           description: Type of condition.
                           type: string
+                  identifier:
+                    description: Identifier is the catalog-unique name of the operator
+                      (the name of the CSV for bundles that contain CSVs)
+                    type: string
                   path:
+                    description: Path refers to the location of a bundle to pull.
+                      It's typically an image reference.
                     type: string
                   replaces:
+                    description: Replaces is the name of the bundle to replace with
+                      the one found at Path.
                     type: string
             catalogSources:
               type: array
@@ -284,3 +301,4 @@ spec:
                     description: StepStatus is the current status of a particular
                       resource an in InstallPlan
                     type: string
+

--- a/manifests/0000_50_olm_05-subscription.crd.yaml
+++ b/manifests/0000_50_olm_05-subscription.crd.yaml
@@ -1702,6 +1702,10 @@ spec:
             currentCSV:
               description: CurrentCSV is the CSV the Subscription is progressing to.
               type: string
+            installPlanGeneration:
+              description: InstallPlanGeneration is the current generation of the
+                installplan
+              type: integer
             installPlanRef:
               description: InstallPlanRef is a reference to the latest InstallPlan
                 that contains the Subscription's current CSV.
@@ -1776,3 +1780,4 @@ spec:
             state:
               description: State represents the current state of the Subscription
               type: string
+

--- a/manifests/0000_50_olm_06-catalogsource.crd.yaml
+++ b/manifests/0000_50_olm_06-catalogsource.crd.yaml
@@ -188,3 +188,4 @@ spec:
                   type: string
                 serviceNamespace:
                   type: string
+

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -34,7 +34,7 @@ spec:
           - /var/run/secrets/serving-cert/tls.crt
           - -tls-key
           - /var/run/secrets/serving-cert/tls.key
-          image: quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
+          image: quay.io/operator-framework/olm@sha256:f6ce23402d5309872855a47116ada409155b15d3ef7f74940eb1bdca6ebbded3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -28,14 +28,14 @@ spec:
           - openshift-marketplace
           - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
           - -util-image
-          -  quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
+          -  quay.io/operator-framework/olm@sha256:f6ce23402d5309872855a47116ada409155b15d3ef7f74940eb1bdca6ebbded3
           - -writeStatusName
           - operator-lifecycle-manager-catalog
           - -tls-cert
           - /var/run/secrets/serving-cert/tls.crt
           - -tls-key
           - /var/run/secrets/serving-cert/tls.key
-          image: quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
+          image: quay.io/operator-framework/olm@sha256:f6ce23402d5309872855a47116ada409155b15d3ef7f74940eb1bdca6ebbded3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/0000_50_olm_10-operatorgroup.crd.yaml
+++ b/manifests/0000_50_olm_10-operatorgroup.crd.yaml
@@ -161,3 +161,4 @@ spec:
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
+

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   name: packageserver
   namespace: openshift-operator-lifecycle-manager
   labels:
-    olm.version: 0.14.1
+    olm.version: 0.14.2
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
 spec:
   displayName: Package Server
@@ -104,7 +104,7 @@ spec:
                 - "5443"
                 - --global-namespace
                 - openshift-marketplace
-                image: quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
+                image: quay.io/operator-framework/olm@sha256:f6ce23402d5309872855a47116ada409155b15d3ef7f74940eb1bdca6ebbded3
                 imagePullPolicy: IfNotPresent
                 ports:
                 - containerPort: 5443
@@ -130,7 +130,7 @@ spec:
               - name: tmpfs
                 emptyDir: {}
   maturity: alpha
-  version: 0.14.1
+  version: 0.14.2
   apiservicedefinitions:
     owned:
     - group: packages.operators.coreos.com

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,7 +5,7 @@ spec:
   - name: operator-lifecycle-manager
     from:
       kind: DockerImage
-      name: quay.io/operator-framework/olm@sha256:0d15ffb5d10a176ef6e831d7865f98d51255ea5b0d16403618c94a004d049373
+      name: quay.io/operator-framework/olm@sha256:f6ce23402d5309872855a47116ada409155b15d3ef7f74940eb1bdca6ebbded3
   - name: operator-registry
     from:
       kind: DockerImage

--- a/pkg/api/apis/operators/installplan_types.go
+++ b/pkg/api/apis/operators/installplan_types.go
@@ -199,6 +199,8 @@ type BundleLookup struct {
 	// Path refers to the location of a bundle to pull.
 	// It's typically an image reference.
 	Path string
+	// Identifier is the catalog-unique name of the operator (the name of the CSV for bundles that contain CSVs)
+	Identifier string
 	// Replaces is the name of the bundle to replace with the one found at Path.
 	Replaces string
 	// CatalogSourceRef is a reference to the CatalogSource the bundle path was resolved from.

--- a/pkg/api/apis/operators/v1alpha1/installplan_types.go
+++ b/pkg/api/apis/operators/v1alpha1/installplan_types.go
@@ -252,6 +252,8 @@ type BundleLookup struct {
 	// Path refers to the location of a bundle to pull.
 	// It's typically an image reference.
 	Path string `json:"path"`
+	// Identifier is the catalog-unique name of the operator (the name of the CSV for bundles that contain CSVs)
+	Identifier string `json:"identifier"`
 	// Replaces is the name of the bundle to replace with the one found at Path.
 	Replaces string `json:"replaces"`
 	// CatalogSourceRef is a reference to the CatalogSource the bundle path was resolved from.

--- a/pkg/api/apis/operators/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/apis/operators/v1alpha1/zz_generated.conversion.go
@@ -673,6 +673,7 @@ func Convert_operators_AppLink_To_v1alpha1_AppLink(in *operators.AppLink, out *A
 
 func autoConvert_v1alpha1_BundleLookup_To_operators_BundleLookup(in *BundleLookup, out *operators.BundleLookup, s conversion.Scope) error {
 	out.Path = in.Path
+	out.Identifier = in.Identifier
 	out.Replaces = in.Replaces
 	out.CatalogSourceRef = (*v1.ObjectReference)(unsafe.Pointer(in.CatalogSourceRef))
 	out.Conditions = *(*[]operators.BundleLookupCondition)(unsafe.Pointer(&in.Conditions))
@@ -686,6 +687,7 @@ func Convert_v1alpha1_BundleLookup_To_operators_BundleLookup(in *BundleLookup, o
 
 func autoConvert_operators_BundleLookup_To_v1alpha1_BundleLookup(in *operators.BundleLookup, out *BundleLookup, s conversion.Scope) error {
 	out.Path = in.Path
+	out.Identifier = in.Identifier
 	out.Replaces = in.Replaces
 	out.CatalogSourceRef = (*v1.ObjectReference)(unsafe.Pointer(in.CatalogSourceRef))
 	out.Conditions = *(*[]BundleLookupCondition)(unsafe.Pointer(&in.Conditions))

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1022,6 +1022,9 @@ func (o *Operator) createInstallPlan(namespace string, gen int, subs []*v1alpha1
 		}
 		catalogSourceMap[s.Resource.CatalogSource] = struct{}{}
 	}
+	for _, b := range bundleLookups {
+		csvNames = append(csvNames, b.Identifier)
+	}
 	catalogSources := []string{}
 	for s := range catalogSourceMap {
 		catalogSources = append(catalogSources, s)

--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -378,6 +378,7 @@ func TestSyncSubscriptions(t *testing.T) {
 				bundleLookups: []v1alpha1.BundleLookup{
 					{
 						Path: "bundle-path-a",
+						Identifier: "bundle-a",
 						CatalogSourceRef: &corev1.ObjectReference{
 							Namespace: testNamespace,
 							Name:      "src",
@@ -447,7 +448,7 @@ func TestSyncSubscriptions(t *testing.T) {
 			},
 			wantInstallPlan: &v1alpha1.InstallPlan{
 				Spec: v1alpha1.InstallPlanSpec{
-					ClusterServiceVersionNames: []string{},
+					ClusterServiceVersionNames: []string{"bundle-a"},
 					Approval:                   v1alpha1.ApprovalAutomatic,
 					Approved:                   true,
 					Generation:                 1,
@@ -458,6 +459,7 @@ func TestSyncSubscriptions(t *testing.T) {
 					BundleLookups: []v1alpha1.BundleLookup{
 						{
 							Path: "bundle-path-a",
+							Identifier: "bundle-a",
 							CatalogSourceRef: &corev1.ObjectReference{
 								Namespace: testNamespace,
 								Name:      "src",

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -109,8 +109,9 @@ func (r *OperatorsV1alpha1Resolver) ResolveSteps(namespace string, sourceQuerier
 				steps = append(steps, bundleSteps...)
 			} else {
 				bundleLookups = append(bundleLookups, v1alpha1.BundleLookup{
-					Path:     op.Bundle().GetBundlePath(),
-					Replaces: op.Replaces(),
+					Path:       op.Bundle().GetBundlePath(),
+					Identifier: op.Identifier(),
+					Replaces:   op.Replaces(),
 					CatalogSourceRef: &corev1.ObjectReference{
 						Namespace: op.SourceInfo().Catalog.Namespace,
 						Name:      op.SourceInfo().Catalog.Name,

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -121,6 +121,7 @@ func TestNamespaceResolver(t *testing.T) {
 				lookups: []v1alpha1.BundleLookup{
 					{
 						Path: "quay.io/test/bundle@sha256:abcd",
+						Identifier: "b.v1",
 						CatalogSourceRef: &corev1.ObjectReference{
 							Namespace: catalog.Namespace,
 							Name:      catalog.Name,
@@ -234,6 +235,7 @@ func TestNamespaceResolver(t *testing.T) {
 				lookups: []v1alpha1.BundleLookup{
 					{
 						Path:     "quay.io/test/bundle@sha256:abcd",
+						Identifier: "a.v2",
 						Replaces: "a.v1",
 						CatalogSourceRef: &corev1.ObjectReference{
 							Namespace: catalog.Namespace,


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
@fantapsody tracked down an issue where operators installed via bundle images are not properly unpacked into the installplan. 

**Motivation for the change:**

This addresses #1347 and replaces #1386 

Bundle images were not surfacing the CSV name to the installplan, so those bundles were missing from the `clusterServiceVersionNames` field. That is used when applying an installplan to decide whether to emit errors like `pre-existing CRD owners found for owned CRD(s) of dependent CSV`.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
