### PR TITLE
Bug 1815957: increase grpc_health_probe timeout

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -129,6 +129,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 							},
 						},
 						InitialDelaySeconds: livenessDelay,
+						TimeoutSeconds:      10,
 					},
 					Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -114,7 +114,8 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 					ReadinessProbe: &v1.Probe{
 						Handler: v1.Handler{
 							Exec: &v1.ExecAction{
-								Command: []string{"grpc_health_probe", "-addr=localhost:50051"},
+								Command: []string{"grpc_health_probe", "-addr=localhost:50051",
+								"-rpc-timeout=10s"},
 							},
 						},
 						InitialDelaySeconds: readinessDelay,
@@ -123,7 +124,8 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 					LivenessProbe: &v1.Probe{
 						Handler: v1.Handler{
 							Exec: &v1.ExecAction{
-								Command: []string{"grpc_health_probe", "-addr=localhost:50051"},
+								Command: []string{"grpc_health_probe", "-addr=localhost:50051",
+								"-rpc-timeout=10s"},
 							},
 						},
 						InitialDelaySeconds: livenessDelay,

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -119,7 +119,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 							},
 						},
 						InitialDelaySeconds: readinessDelay,
-						TimeoutSeconds:      5,
+						TimeoutSeconds:      10,
 					},
 					LivenessProbe: &v1.Probe{
 						Handler: v1.Handler{


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
increase grpc_health_probe timeout by adding -rpc-timeout=10s

**Motivation for the change:**
the community operator catalog source pod will continue to restart because the healthcheck failed, due to the timeout is too small.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
