### PR TITLE
Reconcile Namespace OG Labels in Namespace Syncer

### DIFF
--- a/pkg/api/apis/operators/v1/operatorgroup_types.go
+++ b/pkg/api/apis/operators/v1/operatorgroup_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -15,6 +16,9 @@ const (
 	OperatorGroupProvidedAPIsAnnotationKey = "olm.providedAPIs"
 
 	OperatorGroupKind = "OperatorGroup"
+
+	operatorGroupLabelPrefix   = "olm.operatorgroup/"
+	operatorGroupLabelTemplate = operatorGroupLabelPrefix + "%s.%s"
 )
 
 // OperatorGroupSpec is the spec for an OperatorGroup resource.
@@ -96,4 +100,15 @@ func (o *OperatorGroup) HasServiceAccountSynced() bool {
 	}
 
 	return false
+}
+
+// getOperatorGroupLabel returns a label that is applied to Namespaces to signify that the
+// namespace is a part of the OperatorGroup using selectors.
+func (o *OperatorGroup) GetLabel() string {
+	return fmt.Sprintf(operatorGroupLabelTemplate, o.GetNamespace(), o.GetName())
+}
+
+// IsOperatorGroupLabel returns true if the label is an OperatorGroup label.
+func IsOperatorGroupLabel(label string) bool {
+	return strings.HasPrefix(label, operatorGroupLabelPrefix)
 }


### PR DESCRIPTION
This commit introduces a change so OLM will not attempt to update the
labels on all namespaces in an OperatorGroup while reconciling an
OperatorGroup.

Instead, OLM will trigger a sync on all namespaces in the OperatorGroup.
The sync will cause OLM to update the labels on each namespace in the
OperatorGroup separately.

This PR was born out of [this conversation](https://github.com/operator-framework/operator-lifecycle-manager/pull/1402#discussion_r396490845) .