### PR TITLE
Add tests for GC assumptions.

### DIFF
--- a/test/e2e/convert_suite_test.go
+++ b/test/e2e/convert_suite_test.go
@@ -2,14 +2,15 @@ package e2e
 
 import (
 	"flag"
-	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client"
 )
 
 var (
@@ -39,6 +40,8 @@ var (
 
 func TestConvert(t *testing.T) {
 	RegisterFailHandler(Fail)
+	SetDefaultEventuallyTimeout(1 * time.Minute)
+	SetDefaultEventuallyPollingInterval(1 * time.Second)
 	RunSpecs(t, "Convert Suite")
 }
 

--- a/test/e2e/dsl/dsl.go
+++ b/test/e2e/dsl/dsl.go
@@ -1,0 +1,30 @@
+package dsl
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+)
+
+// IgnoreError acknowledges that an error value is being intentionally
+// disregarded.
+//
+// In general, errors should not be ignored, however, errors may be
+// unimportant in certain test scenarios. IgnoreError accepts a
+// variable-length argument list, like Expect(), as a convenience for
+// functions returning values and an error, e.g. `func DoSomething()
+// (string, error)`. IgnoreError will fail the current test if the
+// last argument is neither nil nor a non-nil error.
+func IgnoreError(vals ...interface{}) {
+	if len(vals) == 0 {
+		return
+	}
+	err := vals[len(vals)-1]
+	if err == nil {
+		return
+	}
+	if _, ok := err.(error); ok {
+		return
+	}
+	Fail(fmt.Sprintf("the last argument to IgnoreError must be an error, but it was %T", err))
+}

--- a/vendor/github.com/onsi/gomega/go.mod
+++ b/vendor/github.com/onsi/gomega/go.mod
@@ -1,5 +1,7 @@
 module github.com/onsi/gomega
 
+go 1.14
+
 require (
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/golang/protobuf v1.2.0


### PR DESCRIPTION
The ClusterRoles that OLM creates per provided API now have owner
references to their respective CRD or APIService instead of owner
labels to a providing OperatorGroup. These tests verify that the
Kubernetes garbage collector behaves as expected.
