### PR TITLE
Bug 1817833: Add spec validation and improved status for CatalogSources

### DIFF
--- a/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
+++ b/pkg/api/apis/operators/v1alpha1/catalogsource_types.go
@@ -29,7 +29,11 @@ const (
 )
 
 const (
-	CatalogSourceConfigMapError      ConditionReason = "ConfigMapError"
+	// CatalogSourceSpecInvalidError denotes when fields on the spec of the CatalogSource are not valid.
+	CatalogSourceSpecInvalidError ConditionReason = "SpecInvalidError"
+	// CatalogSourceConfigMapError denotes when there is an issue extracting manifests from the specified ConfigMap.
+	CatalogSourceConfigMapError ConditionReason = "ConfigMapError"
+	// CatalogSourceRegistryServerError denotes when there is an issue querying the specified registry server.
 	CatalogSourceRegistryServerError ConditionReason = "RegistryServerError"
 )
 
@@ -104,10 +108,10 @@ type GRPCConnectionState struct {
 }
 
 type CatalogSourceStatus struct {
-	// A human readable message indicating details about why the ClusterServiceVersion is in this condition.
+	// A human readable message indicating details about why the CatalogSource is in this condition.
 	// +optional
 	Message string `json:"message,omitempty"`
-	// Reason is the reason the Subscription was transitioned to its current state.
+	// Reason is the reason the CatalogSource was transitioned to its current state.
 	// +optional
 	Reason ConditionReason `json:"reason,omitempty"`
 
@@ -176,7 +180,6 @@ func (c *CatalogSource) Update() bool {
 	} else {
 		logrus.WithField("CatalogSource", c.Name).Debugf("latest poll %v", *c.Status.LatestImageRegistryPoll)
 	}
-
 
 	if c.Status.LatestImageRegistryPoll.IsZero() {
 		logrus.WithField("CatalogSource", c.Name).Debugf("creation timestamp plus interval before now %t", c.CreationTimestamp.Add(interval).Before(time.Now()))

--- a/pkg/controller/operators/catalog/subscription/reconciler.go
+++ b/pkg/controller/operators/catalog/subscription/reconciler.go
@@ -182,7 +182,12 @@ func (c *catalogHealthReconciler) health(now *metav1.Time, catalog *v1alpha1.Cat
 // healthy returns true if the given catalog is healthy, false otherwise, and any error encountered
 // while checking the catalog's registry server.
 func (c *catalogHealthReconciler) healthy(catalog *v1alpha1.CatalogSource) (bool, error) {
-	return c.registryReconcilerFactory.ReconcilerForSource(catalog).CheckRegistryServer(catalog)
+	rec := c.registryReconcilerFactory.ReconcilerForSource(catalog)
+	if rec == nil {
+		return false, fmt.Errorf("could not get reconciler for catalog: %#v", catalog)
+	}
+
+	return rec.CheckRegistryServer(catalog)
 }
 
 // installPlanReconciler reconciles InstallPlan status for Subscriptions.

--- a/pkg/controller/operators/catalog/subscription/reconciler.go
+++ b/pkg/controller/operators/catalog/subscription/reconciler.go
@@ -182,6 +182,12 @@ func (c *catalogHealthReconciler) health(now *metav1.Time, catalog *v1alpha1.Cat
 // healthy returns true if the given catalog is healthy, false otherwise, and any error encountered
 // while checking the catalog's registry server.
 func (c *catalogHealthReconciler) healthy(catalog *v1alpha1.CatalogSource) (bool, error) {
+	if catalog.Status.Reason == v1alpha1.CatalogSourceSpecInvalidError {
+		// The catalog's spec is bad, mark unhealthy
+		return false, nil
+	}
+
+	// Check connection health
 	rec := c.registryReconcilerFactory.ReconcilerForSource(catalog)
 	if rec == nil {
 		return false, fmt.Errorf("could not get reconciler for catalog: %#v", catalog)


### PR DESCRIPTION
- Add spec validation for CatalogSources that surfaces invalid empty sourceType/address/image/configmap field combinations as `status.reason: InvalidSpecError`
- Prevent a panic from a nil pointer access when checking the health of a CatalogSource for Subscription status updates.

Panic:

```
time="2020-03-27T14:02:04Z" level=info msg=syncing event=update reconciling="*v1alpha1.Subscription" selflink=/apis/operators.coreos.com/v1alpha1/namespaces/local-storage/subscriptions/local-storage-operator
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x15a4748]

goroutine 307 [running]:
github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription.(*catalogHealthReconciler).healthy(0xc000585540, 0xc000ffc3f0, 0xc000ffc1f8, 0xc00347a0e0, 0x0)
	/build/pkg/controller/operators/catalog/subscription/reconciler.go:185 +0x48
github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription.(*catalogHealthReconciler).health(0xc000585540, 0xc0002fc560, 0xc000ffc3f0, 0xc0002fc780, 0x0, 0x0)
	/build/pkg/controller/operators/catalog/subscription/reconciler.go:159 +0x39
github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription.(*catalogHealthReconciler).catalogHealth(0xc000585540, 0xc0000c5e50, 0xd, 0x1ca2fa0, 0xc00094d970, 0x1529800700c701, 0xc0033f70e8, 0xc0033f7060)
	/build/pkg/controller/operators/catalog/subscription/reconciler.go:137 +0x2ba
github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription.(*catalogHealthReconciler).Reconcile(0xc000585540, 0x1c729a0, 0xc00043c140, 0x7f5ee5367630, 0xc00094d950, 0x7f5ee5367630, 0xc00094d950, 0x0, 0x0)
	/build/pkg/controller/operators/catalog/subscription/reconciler.go:82 +0x21c
github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate.ReconcilerChain.Reconcile(0xc00052cfc0, 0x3, 0x4, 0x1c729a0, 0xc00043c140, 0x7f5ee5367250, 0xc00094d910, 0x0, 0x0, 0x70763750545a6742, ...)
	/build/pkg/lib/kubestate/kubestate.go:128 +0xa5
github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription.(*subscriptionSyncer).Sync(0xc0004518f0, 0x1c729a0, 0xc00043c140, 0x1c4e620, 0xc0004b6ba0, 0xc003811c01, 0x0)
	/build/pkg/controller/operators/catalog/subscription/syncer.go:75 +0x596
github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer.(*QueueInformer).Sync(...)
	/build/pkg/lib/queueinformer/queueinformer.go:36
github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer.(*operator).processNextWorkItem(0xc0000d73f0, 0x1c729a0, 0xc00043c140, 0xc00054bf20, 0x45c900)
	/build/pkg/lib/queueinformer/queueinformer_operator.go:287 +0x32b
github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer.(*operator).worker(0xc0000d73f0, 0x1c729a0, 0xc00043c140, 0xc00054bf20)
	/build/pkg/lib/queueinformer/queueinformer_operator.go:231 +0x49
created by github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer.(*operator).start
	/build/pkg/lib/queueinformer/queueinformer_operator.go:221 +0x455
```
