### PR TITLE
Wait for successful deployment before proceeding

### DIFF
--- a/pkg/api/wrappers/wrappersfakes/fake_install_strategy_deployment_interface.go
+++ b/pkg/api/wrappers/wrappersfakes/fake_install_strategy_deployment_interface.go
@@ -151,6 +151,20 @@ type FakeInstallStrategyDeploymentInterface struct {
 		result1 *v1b.ServiceAccount
 		result2 error
 	}
+	IsDeploymentReadyStub        func(string, string) (bool, error)
+	isDeploymentReadyMutex       sync.RWMutex
+	isDeploymentReadyArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	isDeploymentReadyReturns struct {
+		result1 bool
+		result2 error
+	}
+	isDeploymentReadyReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -829,6 +843,70 @@ func (fake *FakeInstallStrategyDeploymentInterface) GetServiceAccountByNameRetur
 	}{result1, result2}
 }
 
+func (fake *FakeInstallStrategyDeploymentInterface) IsDeploymentReady(arg1 string, arg2 string) (bool, error) {
+	fake.isDeploymentReadyMutex.Lock()
+	ret, specificReturn := fake.isDeploymentReadyReturnsOnCall[len(fake.isDeploymentReadyArgsForCall)]
+	fake.isDeploymentReadyArgsForCall = append(fake.isDeploymentReadyArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("IsDeploymentReady", []interface{}{arg1, arg2})
+	fake.isDeploymentReadyMutex.Unlock()
+	if fake.IsDeploymentReadyStub != nil {
+		return fake.IsDeploymentReadyStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.isDeploymentReadyReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeInstallStrategyDeploymentInterface) IsDeploymentReadyCallCount() int {
+	fake.isDeploymentReadyMutex.RLock()
+	defer fake.isDeploymentReadyMutex.RUnlock()
+	return len(fake.isDeploymentReadyArgsForCall)
+}
+
+func (fake *FakeInstallStrategyDeploymentInterface) IsDeploymentReadyCalls(stub func(string, string) (bool, error)) {
+	fake.isDeploymentReadyMutex.Lock()
+	defer fake.isDeploymentReadyMutex.Unlock()
+	fake.IsDeploymentReadyStub = stub
+}
+
+func (fake *FakeInstallStrategyDeploymentInterface) IsDeploymentReadyArgsForCall(i int) (string, string) {
+	fake.isDeploymentReadyMutex.RLock()
+	defer fake.isDeploymentReadyMutex.RUnlock()
+	argsForCall := fake.isDeploymentReadyArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeInstallStrategyDeploymentInterface) IsDeploymentReadyReturns(result1 bool, result2 error) {
+	fake.isDeploymentReadyMutex.Lock()
+	defer fake.isDeploymentReadyMutex.Unlock()
+	fake.IsDeploymentReadyStub = nil
+	fake.isDeploymentReadyReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeInstallStrategyDeploymentInterface) IsDeploymentReadyReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.isDeploymentReadyMutex.Lock()
+	defer fake.isDeploymentReadyMutex.Unlock()
+	fake.IsDeploymentReadyStub = nil
+	if fake.isDeploymentReadyReturnsOnCall == nil {
+		fake.isDeploymentReadyReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isDeploymentReadyReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeInstallStrategyDeploymentInterface) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -854,6 +932,8 @@ func (fake *FakeInstallStrategyDeploymentInterface) Invocations() map[string][][
 	defer fake.getOpListerMutex.RUnlock()
 	fake.getServiceAccountByNameMutex.RLock()
 	defer fake.getServiceAccountByNameMutex.RUnlock()
+	fake.isDeploymentReadyMutex.RLock()
+	defer fake.isDeploymentReadyMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/controller/install/deployment_test.go
+++ b/pkg/controller/install/deployment_test.go
@@ -230,6 +230,7 @@ func TestInstallStrategyDeploymentInstallDeployments(t *testing.T) {
 
 			for i, m := range tt.createOrUpdateMocks {
 				fakeClient.CreateDeploymentReturns(nil, m.returnError)
+				fakeClient.IsDeploymentReadyReturns(true, nil)
 				defer func(i int, expectedDeployment appsv1.Deployment) {
 					dep := fakeClient.CreateOrUpdateDeploymentArgsForCall(i)
 					expectedDeployment.Spec.Template.Annotations = map[string]string{}

--- a/pkg/controller/install/status/status_viewer.go
+++ b/pkg/controller/install/status/status_viewer.go
@@ -1,4 +1,4 @@
-package install
+package status
 
 // See kubernetes/pkg/kubectl/rollout_status.go
 
@@ -12,6 +12,9 @@ const TimedOutReason = "ProgressDeadlineExceeded"
 
 // Status returns a message describing deployment status, and a bool value indicating if the status is considered done.
 func DeploymentStatus(deployment *appsv1.Deployment) (string, bool, error) {
+	if deployment == nil {
+		return "Deployment pointer cannot be nil", false, fmt.Errorf("nil pointer")
+	}
 	if deployment.Generation <= deployment.Status.ObservedGeneration {
 		// check if deployment has timed out
 		cond := getDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)

--- a/pkg/controller/install/status/status_viewer_test.go
+++ b/pkg/controller/install/status/status_viewer_test.go
@@ -1,8 +1,9 @@
-package install
+package status
 
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -116,4 +117,11 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			)
 		}
 	}
+}
+
+func TestNilDeployment(t *testing.T) {
+	msg, done, err := DeploymentStatus(nil)
+	require.Equal(t, "Deployment pointer cannot be nil", msg)
+	require.False(t, done)
+	require.Error(t, err)
 }

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -3126,7 +3126,7 @@ func TestUpdates(t *testing.T) {
 		[]*apiextensionsv1.CustomResourceDefinition{},
 		v1alpha1.CSVPhaseNone)
 
-	simulateSuccessfulRollout := func(csv *v1alpha1.ClusterServiceVersion, client operatorclient.ClientInterface) {
+	simulateSuccessfulRollout := func(client operatorclient.ClientInterface) {
 		// get the deployment, which should exist
 		dep, err := client.GetDeployment(namespace, deploymentName)
 		require.NoError(t, err)
@@ -3325,7 +3325,7 @@ func TestUpdates(t *testing.T) {
 				current := csvsToSync[e.whenIn.name]
 
 				if current.Status.Phase == v1alpha1.CSVPhaseInstalling {
-					simulateSuccessfulRollout(current, op.opClient)
+					simulateSuccessfulRollout(op.opClient)
 				}
 				for current.Status.Phase != e.whenIn.phase {
 					fmt.Printf("waiting for (when) %s to be %s\n", e.whenIn.name, e.whenIn.phase)


### PR DESCRIPTION
This commit introduces a change that updates OLM so it waits for a
deployment to reach a ready state prior to proceeding to the next
deployment when installing a CSV.
