### PR TITLE
[release-4.1] Bug 1820339: Update subscription_sync_count to include the package label

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -621,7 +621,7 @@ func (o *Operator) syncSubscriptions(obj interface{}) error {
 }
 
 func (o *Operator) recordMetrics(sub *v1alpha1.Subscription) {
-	metrics.CounterForSubscription(sub.GetName(), sub.Status.InstalledCSV).Inc()
+	metrics.CounterForSubscription(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Package).Inc()
 }
 
 func (o *Operator) resolveNamespace(namespace string) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,6 +12,7 @@ import (
 const (
 	NAME_LABEL      = "name"
 	INSTALLED_LABEL = "installed"
+	PACKAGE_LABEL   = "package"
 )
 
 // TODO(alecmerdler): Can we use this to emit Kubernetes events?
@@ -143,7 +144,7 @@ var (
 			Name: "subscription_sync_total",
 			Help: "Monotonic count of subscription syncs",
 		},
-		[]string{NAME_LABEL, INSTALLED_LABEL},
+		[]string{NAME_LABEL, INSTALLED_LABEL, PACKAGE_LABEL},
 	)
 )
 
@@ -159,6 +160,6 @@ func RegisterCatalog() {
 	prometheus.MustRegister(SubscriptionSyncCount)
 }
 
-func CounterForSubscription(name, installedCSV string) prometheus.Counter {
-	return SubscriptionSyncCount.WithLabelValues(name, installedCSV)
+func CounterForSubscription(name, installedCSV, packageName string) prometheus.Counter {
+	return SubscriptionSyncCount.WithLabelValues(name, installedCSV, packageName)
 }


### PR DESCRIPTION
**Description of the change:**
This PR updates the subscription_sync_count metric to include a packageName label.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

