### PR TITLE
Modify dynamic_resource_e2e_test to ginkgo

### DIFF
--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -24,8 +24,8 @@ var _ = Describe("CRD Versions", func() {
 		By("This test proves that OLM is able to handle v1beta1 CRDs successfully. Creating v1 CRDs has more " +
 			"restrictions around the schema. v1beta1 validation schemas are not necessarily valid in v1. " +
 			"OLM should support both v1beta1 and v1 CRDs")
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		mainPackageName := genName("nginx-update2-")
 		mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
@@ -80,14 +80,14 @@ var _ = Describe("CRD Versions", func() {
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err := fetchCatalogSource(GinkgoT(), crc, mainCatalogName, testNamespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, testNamespace, catalogSourceRegistryPodSynced)
 		Expect(err).ToNot(HaveOccurred())
 
 		subscriptionName := genName("sub-nginx-update2-")
-		subscriptionCleanup := createSubscriptionForCatalog(GinkgoT(), crc, testNamespace, subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, testNamespace, subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(GinkgoT(), crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(subscription).ToNot(Equal(nil))
 		Expect(subscription.Status.InstallPlanRef).ToNot(Equal(nil))
@@ -103,8 +103,8 @@ var _ = Describe("CRD Versions", func() {
 	})
 	It("creates v1 CRDs with a v1 schema successfully", func() {
 		By("v1 crds with a valid openapiv3 schema should be created successfully by OLM")
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		mainPackageName := genName("nginx-update2-")
 		mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
@@ -152,14 +152,14 @@ var _ = Describe("CRD Versions", func() {
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err := fetchCatalogSource(GinkgoT(), crc, mainCatalogName, testNamespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, testNamespace, catalogSourceRegistryPodSynced)
 		Expect(err).ToNot(HaveOccurred())
 
 		subscriptionName := genName("sub-nginx-update2-")
-		subscriptionCleanup := createSubscriptionForCatalog(GinkgoT(), crc, testNamespace, subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, testNamespace, subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(GinkgoT(), crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, testNamespace, subscriptionName, subscriptionHasInstallPlanChecker)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(subscription).ToNot(Equal(nil))
 		Expect(subscription.Status.InstallPlanRef).ToNot(Equal(nil))
@@ -173,7 +173,7 @@ var _ = Describe("CRD Versions", func() {
 		GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 		Expect(fetchedInstallPlan.Status.Phase).To(Equal(operatorsv1alpha1.InstallPlanPhaseComplete))
 	})
-	AfterEach(func() { cleaner.NotifyTestComplete(GinkgoT(), true) }, float64(10))
+	AfterEach(func() { cleaner.NotifyTestComplete(true) }, float64(10))
 })
 
 func checkCRD(v1crd *apiextensionsv1.CustomResourceDefinition) bool {

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -36,10 +36,10 @@ import (
 var _ = Describe("CSV", func() {
 	It("create with unmet requirements mini kube version", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		depName := genName("dep-")
 		csv := v1alpha1.ClusterServiceVersion{
@@ -88,10 +88,10 @@ var _ = Describe("CSV", func() {
 	// TODO: same test but missing serviceaccount instead
 	It("create with unmet requirements CRD", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		depName := genName("dep-")
 		csv := v1alpha1.ClusterServiceVersion{
@@ -150,10 +150,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("create with unmet permissions CRD", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		saName := genName("dep-")
 		permissions := []v1alpha1.StrategyDeploymentPermissions{
@@ -260,10 +260,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("create with unmet requirements API service", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		depName := genName("dep-")
 		csv := v1alpha1.ClusterServiceVersion{
@@ -322,10 +322,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("create with unmet permissions API service", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		saName := genName("dep-")
 		permissions := []v1alpha1.StrategyDeploymentPermissions{
@@ -412,10 +412,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("create with unmet requirements native API", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		depName := genName("dep-")
 		csv := v1alpha1.ClusterServiceVersion{
@@ -465,10 +465,10 @@ var _ = Describe("CSV", func() {
 	// TODO: same test but create serviceaccount instead
 	It("create requirements met CRD", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		sa := corev1.ServiceAccount{}
 		sa.SetName(genName("sa-"))
@@ -727,10 +727,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("create requirements met API service", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		sa := corev1.ServiceAccount{}
 		sa.SetName(genName("sa-"))
@@ -890,10 +890,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("create with owned API service", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -1079,10 +1079,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("update with owned API service", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -1282,10 +1282,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("create same CSV with owned API service multi namespace", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create new namespace in a new operator group
 		secondNamespaceName := genName(testNamespace + "-")
@@ -1487,9 +1487,9 @@ var _ = Describe("CSV", func() {
 	})
 	It("orphaned API service clean up", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
+		c := newKubeClient()
 
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
 		version := "v1alpha1"
@@ -1553,10 +1553,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("update same deployment name", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins")
@@ -1737,10 +1737,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("update different deployment name", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins2")
@@ -1919,10 +1919,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("update multiple intermediates", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins3")
@@ -2107,10 +2107,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("update in place", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins")
@@ -2261,10 +2261,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("update multiple version CRD", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create initial CRD which has 2 versions: v1alpha1 & v1alpha2
 		crdPlural := genName("ins4")
@@ -2542,10 +2542,10 @@ var _ = Describe("CSV", func() {
 	})
 	It("update modify deployment name", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins2")
@@ -2694,7 +2694,7 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("emits CSV requirement events", func() {
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
 		c := ctx.Ctx().KubeClient()
 		crc := ctx.Ctx().OperatorClient()
@@ -2782,10 +2782,10 @@ var _ = Describe("CSV", func() {
 	// TODO: test behavior when replaces field doesn't point to existing CSV
 	It("status invalid CSV", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create CRD
 		crdPlural := genName("ins")
@@ -2896,10 +2896,10 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("api service resource migrated if adoptable", func() {
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -2980,10 +2980,10 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("API service resource not migrated if not adoptable", func() {
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -3067,10 +3067,10 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("multiple API services on a single pod", func() {
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		// Create the deployment that both APIServices will be deployed to.
 		depName := genName("hat-server")
@@ -3512,7 +3512,7 @@ func waitForNotFound(t GinkgoTInterface, getFunction func() error) error {
 }
 
 func deleteLegacyAPIResources(desc v1alpha1.APIServiceDescription) {
-	c := newKubeClient(GinkgoT())
+	c := newKubeClient()
 
 	apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
 
@@ -3536,7 +3536,7 @@ func deleteLegacyAPIResources(desc v1alpha1.APIServiceDescription) {
 }
 
 func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1.APIServiceDescription) {
-	c := newKubeClient(GinkgoT())
+	c := newKubeClient()
 
 	apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
 
@@ -3623,7 +3623,7 @@ func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1
 }
 
 func checkLegacyAPIResources(desc v1alpha1.APIServiceDescription, expectedIsNotFound bool) {
-	c := newKubeClient(GinkgoT())
+	c := newKubeClient()
 	apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
 
 	// Attempt to create the legacy service

--- a/test/e2e/dynamic_resource_e2e_test.go
+++ b/test/e2e/dynamic_resource_e2e_test.go
@@ -4,103 +4,161 @@ import (
 	"context"
 	"strings"
 
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
-var _ = Describe("Dynamic Resource", func() {
-	It("resolve prometheus API", func() {
-		Skip("this test disabled pending fix of the v1 CRD feature")
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+var _ = Describe("Subscriptions create required objects from Catalogs", func() {
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
-		dynamicClient := ctx.Ctx().DynamicClient()
+	var (
+		c             operatorclient.ClientInterface
+		crc           versioned.Interface
+		dynamicClient dynamic.Interface
+		deleteOpts    *metav1.DeleteOptions
+	)
 
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
-			},
-		}, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
+	BeforeEach(func() {
+		c = newKubeClient()
+		crc = newCRClient()
+		dynamicClient = ctx.Ctx().DynamicClient()
 
-		deleteOpts := &metav1.DeleteOptions{}
-		defer func() {
-			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), *deleteOpts))
-		}()
-
-		catsrc := &v1alpha1.CatalogSource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      genName("dynamic-catalog-"),
-				Namespace: ns.GetName(),
-			},
-			Spec: v1alpha1.CatalogSourceSpec{
-				Image:      "quay.io/olmtest/catsrc_dynamic_resources:e2e-test",
-				SourceType: v1alpha1.SourceTypeGrpc,
-			},
-		}
-
-		catsrc, err = crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Create(context.TODO(), catsrc, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
-
-		defer func() {
-			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Delete(context.TODO(), catsrc.GetName(), *deleteOpts))
-		}()
-
-		// Wait for the CatalogSource to be ready
-		catsrc, err = fetchCatalogSource(GinkgoT(), crc, catsrc.GetName(), catsrc.GetNamespace(), catalogSourceRegistryPodSynced)
-		require.NoError(GinkgoT(), err)
-
-		// Generate a Subscription
-		subName := genName("dynamic-resources")
-		cleanupSub := createSubscriptionForCatalog(GinkgoT(), crc, catsrc.GetNamespace(), subName, catsrc.GetName(), "etcd", "singlenamespace-alpha", "", v1alpha1.ApprovalAutomatic)
-		defer cleanupSub()
-
-		sub, err := fetchSubscription(GinkgoT(), crc, catsrc.GetNamespace(), subName, subscriptionHasInstallPlanChecker)
-		require.NoError(GinkgoT(), err)
-
-		// Wait for the expected InstallPlan's execution to either fail or succeed
-		ipName := sub.Status.InstallPlanRef.Name
-		ip, err := waitForInstallPlan(GinkgoT(), crc, ipName, sub.GetNamespace(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseFailed, v1alpha1.InstallPlanPhaseComplete))
-		require.NoError(GinkgoT(), err)
-		// Ensure the InstallPlan contains the steps resolved from the bundle image
-		expectedSteps := map[registry.ResourceKey]struct{}{
-			{Name: "my-prometheusrule", Kind: "PrometheusRule"}: {},
-			{Name: "my-servicemonitor", Kind: "ServiceMonitor"}: {},
-		}
-
-		for _, step := range ip.Status.Plan {
-			key := registry.ResourceKey{
-				Name: step.Resource.Name,
-				Kind: step.Resource.Kind,
-			}
-			for expected := range expectedSteps {
-				if strings.HasPrefix(key.Name, expected.Name) && key.Kind == expected.Kind {
-					delete(expectedSteps, expected)
-				}
-			}
-		}
-		require.Lenf(GinkgoT(), expectedSteps, 0, "Resource steps do not match expected: %#v", expectedSteps)
-
-		// Confirm that the expected types exist
-		gvr := schema.GroupVersionResource{
-			Group:    "monitoring.coreos.com",
-			Version:  "v1",
-			Resource: "prometheusrules",
-		}
-
-		err = waitForGVR(dynamicClient, gvr, "my-prometheusrule", ns.GetName())
-		require.NoError(GinkgoT(), err)
-
-		gvr.Resource = "servicemonitors"
-		err = waitForGVR(dynamicClient, gvr, "my-servicemonitor", ns.GetName())
-		require.NoError(GinkgoT(), err)
+		deleteOpts = &metav1.DeleteOptions{}
 	})
+
+	AfterEach(func() {
+		cleaner.NotifyTestComplete(true)
+	})
+
+	Context("Given a Namespace", func() {
+		When("a CatalogSource is created with a bundle that contains prometheus objects", func() {
+			Context("creating a subscription using the CatalogSource", func() {
+
+				var (
+					ns         *corev1.Namespace
+					catsrc     *v1alpha1.CatalogSource
+					subName    string
+					cleanupSub cleanupFunc
+				)
+
+				BeforeEach(func() {
+
+					// Create Namespace
+					var err error
+					ns, err = c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: genName("ns-"),
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Create CatalogSource
+					catsrc = &v1alpha1.CatalogSource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      genName("dynamic-catalog-"),
+							Namespace: ns.GetName(),
+						},
+						Spec: v1alpha1.CatalogSourceSpec{
+							Image:      "quay.io/olmtest/catsrc_dynamic_resources:e2e-test",
+							SourceType: v1alpha1.SourceTypeGrpc,
+						},
+					}
+
+					catsrc, err = crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Create(context.TODO(), catsrc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Wait for the CatalogSource to be ready
+					_, err = fetchCatalogSourceOnStatus(crc, catsrc.GetName(), catsrc.GetNamespace(), catalogSourceRegistryPodSynced)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Generate a Subscription
+					subName = genName("dynamic-resources")
+					cleanupSub = createSubscriptionForCatalog(crc, catsrc.GetNamespace(), subName, catsrc.GetName(), "etcd", "singlenamespace-alpha", "", v1alpha1.ApprovalAutomatic)
+
+				})
+
+				AfterEach(func() {
+
+					// clean up subscription
+					if cleanupSub != nil {
+						cleanupSub()
+					}
+
+					// Delete CatalogSource
+					if catsrc != nil {
+						err := crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Delete(context.TODO(), catsrc.GetName(), *deleteOpts)
+						Expect(err).NotTo(HaveOccurred())
+					}
+
+					// Delete Namespace
+					if ns != nil {
+						err := c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), *deleteOpts)
+						Expect(err).NotTo(HaveOccurred())
+					}
+
+				})
+
+				It("should install the operator successfully", func() {
+					Skip("this test disabled pending fix of the v1 CRD feature")
+					_, err := fetchSubscription(crc, catsrc.GetNamespace(), subName, subscriptionHasInstallPlanChecker)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should have created the expected prometheus objects", func() {
+					Skip("this test disabled pending fix of the v1 CRD feature")
+					sub, err := fetchSubscription(crc, catsrc.GetNamespace(), subName, subscriptionHasInstallPlanChecker)
+					Expect(err).NotTo(HaveOccurred())
+
+					ipName := sub.Status.InstallPlanRef.Name
+					ip, err := waitForInstallPlan(crc, ipName, sub.GetNamespace(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseFailed, v1alpha1.InstallPlanPhaseComplete))
+					Expect(err).NotTo(HaveOccurred())
+
+					// Ensure the InstallPlan contains the steps resolved from the bundle image
+					expectedSteps := map[registry.ResourceKey]struct{}{
+						{Name: "my-prometheusrule", Kind: "PrometheusRule"}: {},
+						{Name: "my-servicemonitor", Kind: "ServiceMonitor"}: {},
+					}
+
+					// Verify Resource steps match expected steps
+					for _, step := range ip.Status.Plan {
+						key := registry.ResourceKey{
+							Name: step.Resource.Name,
+							Kind: step.Resource.Kind,
+						}
+						for expected := range expectedSteps {
+							if strings.HasPrefix(key.Name, expected.Name) && key.Kind == expected.Kind {
+								delete(expectedSteps, expected)
+							}
+						}
+					}
+					Expect(len(expectedSteps)).To(BeZero(), "Resource steps do not match expected: %#v", expectedSteps)
+
+					// Confirm that the expected types exist
+					gvr := schema.GroupVersionResource{
+						Group:    "monitoring.coreos.com",
+						Version:  "v1",
+						Resource: "prometheusrules",
+					}
+
+					err = waitForGVR(dynamicClient, gvr, "my-prometheusrule", ns.GetName())
+					Expect(err).NotTo(HaveOccurred())
+
+					gvr.Resource = "servicemonitors"
+					err = waitForGVR(dynamicClient, gvr, "my-servicemonitor", ns.GetName())
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+		})
+
+	})
+
 })

--- a/test/e2e/gc_e2e_test.go
+++ b/test/e2e/gc_e2e_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 	})
 
 	AfterEach(func() {
-		cleaner.NotifyTestComplete(GinkgoT(), true)
+		cleaner.NotifyTestComplete(true)
 	})
 
 	Context("Given a ClusterRole owned by a CustomResourceDefinition", func() {

--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -23,8 +23,8 @@ var _ = Describe("Metrics", func() {
 
 		// TestMetrics tests the metrics endpoint of the OLM pod.
 
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 
 		failingCSV := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{

--- a/test/e2e/packagemanifest_e2e_test.go
+++ b/test/e2e/packagemanifest_e2e_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Package Manifest", func() {
 
 		// as long as it has a package name we consider the status non-empty
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
 		// create a simple catalogsource
 		packageName := genName("nginx")
@@ -48,8 +48,8 @@ var _ = Describe("Package Manifest", func() {
 		csv.SetLabels(map[string]string{"projected": "label"})
 		csv.Spec.NativeAPIs = []metav1.GroupVersionKind{{Group: "kubenative.io", Version: "v1", Kind: "Native"}}
 		csvJSON, _ := json.Marshal(csv)
-		c := newKubeClient(GinkgoT())
-		crc := newCRClient(GinkgoT())
+		c := newKubeClient()
+		crc := newCRClient()
 		pmc := newPMClient(GinkgoT())
 
 		expectedStatus := packagev1.PackageManifestStatus{
@@ -81,7 +81,7 @@ var _ = Describe("Package Manifest", func() {
 		require.NoError(GinkgoT(), err)
 		defer cleanupCatalogSource()
 
-		_, err = fetchCatalogSource(GinkgoT(), crc, catalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
+		_, err = fetchCatalogSourceOnStatus(crc, catalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		pm, err := fetchPackageManifest(GinkgoT(), pmc, testNamespace, packageName, packageManifestHasStatus)
@@ -104,13 +104,13 @@ var _ = Describe("Package Manifest", func() {
 	})
 	It("loading relatedImages", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), true)
+		defer cleaner.NotifyTestComplete(true)
 
 		sourceName := genName("catalog-")
 		packageName := "etcd-test"
 		image := "quay.io/olmtest/catsrc-update-test:related"
 
-		crc := newCRClient(GinkgoT())
+		crc := newCRClient()
 		pmc := newPMClient(GinkgoT())
 
 		source := &v1alpha1.CatalogSource{
@@ -152,7 +152,7 @@ var _ = Describe("Package Manifest", func() {
 		})
 		require.NoError(GinkgoT(), err, "package-server not available")
 
-		_, err = fetchCatalogSource(GinkgoT(), crc, source.GetName(), testNamespace, catalogSourceRegistryPodSynced)
+		_, err = fetchCatalogSourceOnStatus(crc, source.GetName(), testNamespace, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		pm, err := fetchPackageManifest(GinkgoT(), pmc, testNamespace, packageName, packageManifestHasStatus)

--- a/test/e2e/scoped_client_test.go
+++ b/test/e2e/scoped_client_test.go
@@ -37,8 +37,8 @@ var _ = Describe("Scoped Client", func() {
 	BeforeEach(func() {
 		config = ctx.Ctx().RESTConfig()
 
-		kubeclient = newKubeClient(GinkgoT())
-		crclient = newCRClient(GinkgoT())
+		kubeclient = newKubeClient()
+		crclient = newCRClient()
 		dynamicclient = ctx.Ctx().DynamicClient()
 
 		logger = logrus.New()

--- a/test/e2e/user_defined_sa_test.go
+++ b/test/e2e/user_defined_sa_test.go
@@ -23,10 +23,10 @@ import (
 var _ = Describe("User defined service account", func() {
 	It("with no permission", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), false)
+		defer cleaner.NotifyTestComplete(false)
 
-		kubeclient := newKubeClient(GinkgoT())
-		crclient := newCRClient(GinkgoT())
+		kubeclient := newKubeClient()
+		crclient := newCRClient()
 
 		namespace := genName("scoped-ns-")
 		_, cleanupNS := newNamespace(GinkgoT(), kubeclient, namespace)
@@ -47,15 +47,15 @@ var _ = Describe("User defined service account", func() {
 		defer catsrcCleanup()
 
 		// Ensure that the catalog source is resolved before we create a subscription.
-		_, err := fetchCatalogSource(GinkgoT(), crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("scoped-sub-")
-		cleanupSubscription := createSubscriptionForCatalog(GinkgoT(), crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
+		cleanupSubscription := createSubscriptionForCatalog(crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
 		defer cleanupSubscription()
 
 		// Wait until an install plan is created.
-		subscription, err := fetchSubscription(GinkgoT(), crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
@@ -77,11 +77,11 @@ var _ = Describe("User defined service account", func() {
 	})
 	It("with permission", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), false)
+		defer cleaner.NotifyTestComplete(false)
 
 		// Create the CatalogSource
-		kubeclient := newKubeClient(GinkgoT())
-		crclient := newCRClient(GinkgoT())
+		kubeclient := newKubeClient()
+		crclient := newCRClient()
 
 		namespace := genName("scoped-ns-")
 		_, cleanupNS := newNamespace(GinkgoT(), kubeclient, namespace)
@@ -104,15 +104,15 @@ var _ = Describe("User defined service account", func() {
 		defer catsrcCleanup()
 
 		// Ensure that the catalog source is resolved before we create a subscription.
-		_, err := fetchCatalogSource(GinkgoT(), crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("scoped-sub-")
-		cleanupSubscription := createSubscriptionForCatalog(GinkgoT(), crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
+		cleanupSubscription := createSubscriptionForCatalog(crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
 		defer cleanupSubscription()
 
 		// Wait until an install plan is created.
-		subscription, err := fetchSubscription(GinkgoT(), crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
@@ -134,10 +134,10 @@ var _ = Describe("User defined service account", func() {
 	})
 	It("with retry", func() {
 
-		defer cleaner.NotifyTestComplete(GinkgoT(), false)
+		defer cleaner.NotifyTestComplete(false)
 
-		kubeclient := newKubeClient(GinkgoT())
-		crclient := newCRClient(GinkgoT())
+		kubeclient := newKubeClient()
+		crclient := newCRClient()
 
 		namespace := genName("scoped-ns-")
 		_, cleanupNS := newNamespace(GinkgoT(), kubeclient, namespace)
@@ -158,15 +158,15 @@ var _ = Describe("User defined service account", func() {
 		defer catsrcCleanup()
 
 		// Ensure that the catalog source is resolved before we create a subscription.
-		_, err := fetchCatalogSource(GinkgoT(), crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("scoped-sub-")
-		cleanupSubscription := createSubscriptionForCatalog(GinkgoT(), crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
+		cleanupSubscription := createSubscriptionForCatalog(crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
 		defer cleanupSubscription()
 
 		// Wait until an install plan is created.
-		subscription, err := fetchSubscription(GinkgoT(), crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 

--- a/test/e2e/webhook_e2e_test.go
+++ b/test/e2e/webhook_e2e_test.go
@@ -33,8 +33,8 @@ var _ = Describe("CSVs with a Webhook", func() {
 	var nsCleanupFunc cleanupFunc
 	var nsLabels map[string]string
 	BeforeEach(func() {
-		c = newKubeClient(GinkgoT())
-		crc = newCRClient(GinkgoT())
+		c = newKubeClient()
+		crc = newCRClient()
 		nsLabels = map[string]string{
 			"foo": "bar",
 		}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change adds more structure to the tests by leveraging ginkgo's container/It blocks. The changes also cleans up some of the functions in util_test.go. I have posted some questions in the Files changed section for which I need some inputs. Thanks!

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
