### PR TITLE
[release-4.3] Bug 1821318: feat(packagemanifest): add default os/arch labels if not present

### DIFF
--- a/pkg/package-server/provider/labels.go
+++ b/pkg/package-server/provider/labels.go
@@ -1,0 +1,30 @@
+package provider
+
+import "strings"
+
+const (
+	OsLabelPrefix    = "operatorframework.io/os"
+	ArchLabelPrefix  = "operatorframework.io/arch"
+	DefaultOsLabel   = "operatorframework.io/os.linux"
+	DefaultArchLabel = "operatorframework.io/arch.amd64"
+	Supported        = "supported"
+)
+
+func setDefaultOsArchLabels(labels map[string]string) {
+	needsOsLabel := true
+	needsArchLabel := true
+	for k := range labels {
+		if strings.HasPrefix(k, OsLabelPrefix) {
+			needsOsLabel = false
+		}
+		if strings.HasPrefix(k, ArchLabelPrefix) {
+			needsArchLabel = false
+		}
+	}
+	if needsOsLabel {
+		labels[DefaultOsLabel] = Supported
+	}
+	if needsArchLabel {
+		labels[DefaultArchLabel] = Supported
+	}
+}

--- a/pkg/package-server/provider/labels_test.go
+++ b/pkg/package-server/provider/labels_test.go
@@ -1,0 +1,59 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetDefaultOsArchLabels(t *testing.T) {
+	type args struct {
+		labels map[string]string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected map[string]string
+	}{
+		{
+			name: "NoneSet",
+			args: args{labels: map[string]string{}},
+			expected: map[string]string{
+				DefaultArchLabel: Supported,
+				DefaultOsLabel:   Supported,
+			},
+		},
+		{
+			name: "OthersPreserved",
+			args: args{labels: map[string]string{"other": "label"}},
+			expected: map[string]string{
+				"other":          "label",
+				DefaultArchLabel: Supported,
+				DefaultOsLabel:   Supported,
+			},
+		},
+		{
+			name: "OsSet",
+			args: args{labels: map[string]string{OsLabelPrefix + ".windows": Supported}},
+			expected: map[string]string{
+				DefaultArchLabel:           Supported,
+				OsLabelPrefix + ".windows": Supported,
+			},
+		},
+		{
+			name: "ArchSet",
+			args: args{labels: map[string]string{ArchLabelPrefix + ".arm": Supported}},
+			expected: map[string]string{
+				ArchLabelPrefix + ".arm": Supported,
+				DefaultOsLabel:           Supported,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := tt.args.labels
+			setDefaultOsArchLabels(labels)
+			require.Equal(t, tt.expected, labels)
+		})
+	}
+}

--- a/pkg/package-server/provider/registry.go
+++ b/pkg/package-server/provider/registry.go
@@ -472,6 +472,7 @@ func newPackageManifest(ctx context.Context, logger *logrus.Entry, pkg *api.Pack
 	var (
 		providerSet   bool
 		defaultElided bool
+		defaultCsv    *operatorsv1alpha1.ClusterServiceVersion
 	)
 	for _, pkgChannel := range pkgChannels {
 		bundle, err := client.GetBundleForChannel(ctx, &api.GetBundleInChannelRequest{PkgName: pkg.GetName(), ChannelName: pkgChannel.GetName()})
@@ -488,11 +489,9 @@ func newPackageManifest(ctx context.Context, logger *logrus.Entry, pkg *api.Pack
 			defaultElided = defaultElided || pkgChannel.Name == manifest.Status.DefaultChannel
 			continue
 		}
-		manifestLabels := manifest.GetLabels()
-		for k, v := range csv.GetLabels() {
-			manifestLabels[k] = v
+		if defaultCsv == nil || pkgChannel.GetName() == manifest.Status.DefaultChannel {
+			defaultCsv = &csv
 		}
-		manifest.SetLabels(manifest.GetLabels())
 		manifest.Status.Channels = append(manifest.Status.Channels, operators.PackageChannel{
 			Name:           pkgChannel.GetName(),
 			CurrentCSV:     csv.GetName(),
@@ -518,6 +517,11 @@ func newPackageManifest(ctx context.Context, logger *logrus.Entry, pkg *api.Pack
 		logger.Warn("default channel elided, setting as first in packagemanifest")
 		manifest.Status.DefaultChannel = manifest.Status.Channels[0].Name
 	}
-
+	manifestLabels := manifest.GetLabels()
+	for k, v := range defaultCsv.GetLabels() {
+		manifestLabels[k] = v
+	}
+	setDefaultOsArchLabels(manifestLabels)
+	manifest.SetLabels(manifestLabels)
 	return manifest, nil
 }

--- a/pkg/package-server/provider/registry_test.go
+++ b/pkg/package-server/provider/registry_test.go
@@ -8,12 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/selection"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/operator-framework/operator-registry/pkg/api"
 	registryserver "github.com/operator-framework/operator-registry/pkg/server"
@@ -35,7 +36,7 @@ import (
 )
 
 const (
-	port    = "50051"
+	port    = "50054"
 	address = "localhost:"
 	dbName  = "test.db"
 )
@@ -172,10 +173,12 @@ func TestToPackageManifest(t *testing.T) {
 					Name:      "etcd",
 					Namespace: "ns",
 					Labels: labels.Set{
-						"catalog":           "cool-operators",
-						"catalog-namespace": "ns",
-						"provider":          "CoreOS, Inc",
-						"provider-url":      "",
+						"catalog":                         "cool-operators",
+						"catalog-namespace":               "ns",
+						"provider":                        "CoreOS, Inc",
+						"provider-url":                    "",
+						"operatorframework.io/arch.amd64": "supported",
+						"operatorframework.io/os.linux":   "supported",
 					},
 				},
 				Status: operators.PackageManifestStatus{
@@ -231,11 +234,13 @@ func TestToPackageManifest(t *testing.T) {
 					Name:      "etcd",
 					Namespace: "ns",
 					Labels: labels.Set{
-						"test":              "label",
-						"catalog":           "cool-operators",
-						"catalog-namespace": "ns",
-						"provider":          "CoreOS, Inc",
-						"provider-url":      "",
+						"test":                            "label",
+						"catalog":                         "cool-operators",
+						"catalog-namespace":               "ns",
+						"provider":                        "CoreOS, Inc",
+						"provider-url":                    "",
+						"operatorframework.io/arch.amd64": "supported",
+						"operatorframework.io/os.linux":   "supported",
 					},
 				},
 				Status: operators.PackageManifestStatus{
@@ -295,10 +300,12 @@ func TestToPackageManifest(t *testing.T) {
 					Name:      "etcd",
 					Namespace: "ns",
 					Labels: labels.Set{
-						"catalog":           "cool-operators",
-						"catalog-namespace": "ns",
-						"provider":          "CoreOS, Inc",
-						"provider-url":      "",
+						"catalog":                         "cool-operators",
+						"catalog-namespace":               "ns",
+						"provider":                        "CoreOS, Inc",
+						"provider-url":                    "",
+						"operatorframework.io/arch.amd64": "supported",
+						"operatorframework.io/os.linux":   "supported",
 					},
 				},
 				Status: operators.PackageManifestStatus{
@@ -358,10 +365,12 @@ func TestToPackageManifest(t *testing.T) {
 					Name:      "etcd",
 					Namespace: "ns",
 					Labels: labels.Set{
-						"catalog":           "cool-operators",
-						"catalog-namespace": "ns",
-						"provider":          "CoreOS, Inc",
-						"provider-url":      "",
+						"catalog":                         "cool-operators",
+						"catalog-namespace":               "ns",
+						"provider":                        "CoreOS, Inc",
+						"provider-url":                    "",
+						"operatorframework.io/arch.amd64": "supported",
+						"operatorframework.io/os.linux":   "supported",
 					},
 				},
 				Status: operators.PackageManifestStatus{
@@ -476,10 +485,12 @@ func TestRegistryProviderGet(t *testing.T) {
 					Name:      "etcd",
 					Namespace: "ns",
 					Labels: labels.Set{
-						"catalog":           "cool-operators",
-						"catalog-namespace": "ns",
-						"provider":          "CoreOS, Inc",
-						"provider-url":      "",
+						"catalog":                         "cool-operators",
+						"catalog-namespace":               "ns",
+						"provider":                        "CoreOS, Inc",
+						"provider-url":                    "",
+						"operatorframework.io/arch.amd64": "supported",
+						"operatorframework.io/os.linux":   "supported",
 					},
 				},
 				Status: operators.PackageManifestStatus{
@@ -523,10 +534,12 @@ func TestRegistryProviderGet(t *testing.T) {
 					Name:      "etcd",
 					Namespace: "ns",
 					Labels: labels.Set{
-						"catalog":           "cool-operators",
-						"catalog-namespace": "ns",
-						"provider":          "CoreOS, Inc",
-						"provider-url":      "",
+						"catalog":                         "cool-operators",
+						"catalog-namespace":               "ns",
+						"provider":                        "CoreOS, Inc",
+						"provider-url":                    "",
+						"operatorframework.io/arch.amd64": "supported",
+						"operatorframework.io/os.linux":   "supported",
 					},
 				},
 				Status: operators.PackageManifestStatus{
@@ -569,10 +582,12 @@ func TestRegistryProviderGet(t *testing.T) {
 					Name:      "etcd",
 					Namespace: "ns",
 					Labels: labels.Set{
-						"catalog":           "cool-operators",
-						"catalog-namespace": "global",
-						"provider":          "CoreOS, Inc",
-						"provider-url":      "",
+						"catalog":                         "cool-operators",
+						"catalog-namespace":               "global",
+						"provider":                        "CoreOS, Inc",
+						"provider-url":                    "",
+						"operatorframework.io/arch.amd64": "supported",
+						"operatorframework.io/os.linux":   "supported",
 					},
 				},
 				Status: operators.PackageManifestStatus{
@@ -654,10 +669,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "prometheus",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "Red Hat",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "Red Hat",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -686,10 +703,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "etcd",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "CoreOS, Inc",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "CoreOS, Inc",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -730,10 +749,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "prometheus",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "Red Hat",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "Red Hat",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -762,10 +783,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "etcd",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "CoreOS, Inc",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "CoreOS, Inc",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -806,10 +829,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "prometheus",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "Red Hat",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "Red Hat",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -838,10 +863,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "etcd",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "CoreOS, Inc",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "CoreOS, Inc",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -870,10 +897,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "prometheus",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators-2",
-							"catalog-namespace": "ns",
-							"provider":          "Red Hat",
-							"provider-url":      "",
+							"catalog":                         "cool-operators-2",
+							"catalog-namespace":               "ns",
+							"provider":                        "Red Hat",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -902,10 +931,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "etcd",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators-2",
-							"catalog-namespace": "ns",
-							"provider":          "CoreOS, Inc",
-							"provider-url":      "",
+							"catalog":                         "cool-operators-2",
+							"catalog-namespace":               "ns",
+							"provider":                        "CoreOS, Inc",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -989,10 +1020,12 @@ func TestRegistryProviderList(t *testing.T) {
 						Name:      "has-bundle",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "CoreOS, Inc",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "CoreOS, Inc",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -1079,10 +1112,12 @@ func TestRegistryProviderListLabels(t *testing.T) {
 						Name:      "prometheus",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "Red Hat",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "Red Hat",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -1111,10 +1146,12 @@ func TestRegistryProviderListLabels(t *testing.T) {
 						Name:      "etcd",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "CoreOS, Inc",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "CoreOS, Inc",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -1158,10 +1195,12 @@ func TestRegistryProviderListLabels(t *testing.T) {
 						Name:      "prometheus",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "Red Hat",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "Red Hat",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -1190,10 +1229,12 @@ func TestRegistryProviderListLabels(t *testing.T) {
 						Name:      "etcd",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "CoreOS, Inc",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "CoreOS, Inc",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -1247,10 +1288,12 @@ func TestRegistryProviderListLabels(t *testing.T) {
 						Name:      "prometheus",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "Red Hat",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "Red Hat",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{
@@ -1279,10 +1322,12 @@ func TestRegistryProviderListLabels(t *testing.T) {
 						Name:      "etcd",
 						Namespace: "ns",
 						Labels: labels.Set{
-							"catalog":           "cool-operators",
-							"catalog-namespace": "ns",
-							"provider":          "CoreOS, Inc",
-							"provider-url":      "",
+							"catalog":                         "cool-operators",
+							"catalog-namespace":               "ns",
+							"provider":                        "CoreOS, Inc",
+							"provider-url":                    "",
+							"operatorframework.io/arch.amd64": "supported",
+							"operatorframework.io/os.linux":   "supported",
 						},
 					},
 					Status: operators.PackageManifestStatus{

--- a/pkg/package-server/storage/reststorage.go
+++ b/pkg/package-server/storage/reststorage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/fields"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -114,7 +115,6 @@ func (m *PackageManifestStorage) Get(ctx context.Context, name string, opts *met
 func (m *PackageManifestStorage) NamespaceScoped() bool {
 	return true
 }
-
 
 func nameFor(fs fields.Selector) (string, error) {
 	if fs == nil {

--- a/pkg/package-server/storage/subresources_test.go
+++ b/pkg/package-server/storage/subresources_test.go
@@ -2,10 +2,11 @@ package storage
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/labels"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/stretchr/testify/require"
 

--- a/test/e2e/packagemanifest_e2e_test.go
+++ b/test/e2e/packagemanifest_e2e_test.go
@@ -108,10 +108,12 @@ func TestPackageManifestLoading(t *testing.T) {
 	require.NotNil(t, pm)
 	require.Equal(t, packageName, pm.GetName())
 	require.Equal(t, expectedStatus, pm.Status)
-	require.Equal(t, pm.GetLabels()["projected"], "label")
+	require.Equal(t, "label", pm.GetLabels()["projected"])
+	require.Equal(t, "supported", pm.GetLabels()["operatorframework.io/arch.amd64"])
+	require.Equal(t, "supported", pm.GetLabels()["operatorframework.io/os.linux"])
 
-	// Filter PackageManifestList and ensure it has the correct items
-	pmList, err := pmc.OperatorsV1().PackageManifests(testNamespace).List(metav1.ListOptions{LabelSelector: "projected=label"})
+	// Get a PackageManifestList and ensure it has the correct items
+	pmList, err := pmc.OperatorsV1().PackageManifests(testNamespace).List(metav1.ListOptions{})
 	require.NoError(t, err, "could not access package manifests list meta")
 	require.NotNil(t, pmList.ListMeta, "package manifest list metadata empty")
 	require.NotNil(t, pmList.Items)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Manual cherry-pick of: #1220

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
