### PR TITLE
feat: support configmap creation from the bundle

### DIFF
--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -414,6 +414,27 @@ func TestExecutePlan(t *testing.T) {
 			err:  nil,
 		},
 		{
+			testName: "CreateConfigMap",
+			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+				[]*v1alpha1.Step{
+					{
+						Resource: v1alpha1.StepResource{
+							CatalogSource:          "catalog",
+							CatalogSourceNamespace: namespace,
+							Group:                  "",
+							Version:                "v1",
+							Kind:                   "ConfigMap",
+							Name:                   "cfg",
+							Manifest: toManifest(t, configmap("cfg", namespace)),
+						},
+						Status: v1alpha1.StepStatusUnknown,
+					},
+				},
+			),
+			want: []runtime.Object{configmap("cfg", namespace)},
+			err:  nil,
+		},
+		{
 			testName: "UpdateServiceAccountWithSameFields",
 			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
@@ -557,6 +578,8 @@ func TestExecutePlan(t *testing.T) {
 					fetched, err = op.opClient.GetSecret(namespace, o.GetName())
 				case *corev1.Service:
 					fetched, err = op.opClient.GetService(namespace, o.GetName())
+				case *corev1.ConfigMap:
+					fetched, err = op.opClient.GetConfigMap(namespace, o.GetName())
 				case *v1beta1.CustomResourceDefinition:
 					fetched, err = op.opClient.ApiextensionsV1beta1Interface().ApiextensionsV1beta1().CustomResourceDefinitions().Get(o.GetName(), getOpts)
 				case *v1alpha1.ClusterServiceVersion:
@@ -1319,6 +1342,13 @@ func serviceAccount(name, namespace, generateName string, secretRef *corev1.Obje
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, GenerateName: generateName},
 		Secrets:    []corev1.ObjectReference{*secretRef},
+	}
+}
+
+func configmap(name, namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: configMapKind},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 	}
 }
 

--- a/pkg/lib/operatorclient/client.go
+++ b/pkg/lib/operatorclient/client.go
@@ -31,6 +31,7 @@ type ClientInterface interface {
 	ClusterRoleBindingClient
 	ClusterRoleClient
 	DeploymentClient
+	ConfigMapClient
 }
 
 // CustomResourceClient contains methods for the Custom Resource.
@@ -125,6 +126,14 @@ type DeploymentClient interface {
 	RollingPatchDeploymentMigrations(namespace, name string, f PatchFunction) (*appsv1.Deployment, bool, error)
 	CreateOrRollingUpdateDeployment(*appsv1.Deployment) (*appsv1.Deployment, bool, error)
 	ListDeploymentsWithLabels(namespace string, labels labels.Set) (*appsv1.DeploymentList, error)
+}
+
+// ConfigMapClient contains methods for the ConfigMap resource
+type ConfigMapClient interface {
+	CreateConfigMap(*v1.ConfigMap) (*v1.ConfigMap, error)
+	GetConfigMap(namespace, name string) (*v1.ConfigMap, error)
+	UpdateConfigMap(modified *v1.ConfigMap) (*v1.ConfigMap, error)
+	DeleteConfigMap(namespace, name string, options *metav1.DeleteOptions) error
 }
 
 // Interface assertion.

--- a/pkg/lib/operatorclient/configmap.go
+++ b/pkg/lib/operatorclient/configmap.go
@@ -1,0 +1,39 @@
+package operatorclient
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+)
+
+// CreateConfigMap creates the ConfigMap.
+func (c *Client) CreateConfigMap(ig *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return c.CoreV1().ConfigMaps(ig.GetNamespace()).Create(ig)
+}
+
+// GetConfigMap returns the existing ConfigMap.
+func (c *Client) GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
+	return c.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+}
+
+// DeleteConfigMap deletes the ConfigMap.
+func (c *Client) DeleteConfigMap(namespace, name string, options *metav1.DeleteOptions) error {
+	return c.CoreV1().ConfigMaps(namespace).Delete(name, options)
+}
+
+// UpdateConfigMap will update the given ConfigMap resource.
+func (c *Client) UpdateConfigMap(configmap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	klog.V(4).Infof("[UPDATE ConfigMap]: %s", configmap.GetName())
+	oldSa, err := c.GetConfigMap(configmap.GetNamespace(), configmap.GetName())
+	if err != nil {
+		return nil, err
+	}
+	patchBytes, err := createPatch(oldSa, configmap)
+	if err != nil {
+		return nil, fmt.Errorf("error creating patch for ConfigMap: %v", err)
+	}
+	return c.CoreV1().ConfigMaps(configmap.GetNamespace()).Patch(configmap.GetName(), types.StrategicMergePatchType, patchBytes)
+}

--- a/pkg/lib/operatorclient/operatorclientmocks/mock_client.go
+++ b/pkg/lib/operatorclient/operatorclientmocks/mock_client.go
@@ -886,6 +886,65 @@ func (mr *MockClientInterfaceMockRecorder) ListDeploymentsWithLabels(namespace, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeploymentsWithLabels", reflect.TypeOf((*MockClientInterface)(nil).ListDeploymentsWithLabels), namespace, labels)
 }
 
+// CreateConfigMap mocks base method
+func (m *MockClientInterface) CreateConfigMap(arg0 *v10.ConfigMap) (*v10.ConfigMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateConfigMap", arg0)
+	ret0, _ := ret[0].(*v10.ConfigMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateConfigMap indicates an expected call of CreateConfigMap
+func (mr *MockClientInterfaceMockRecorder) CreateConfigMap(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConfigMap", reflect.TypeOf((*MockClientInterface)(nil).CreateConfigMap), arg0)
+}
+
+// GetConfigMap mocks base method
+func (m *MockClientInterface) GetConfigMap(namespace, name string) (*v10.ConfigMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfigMap", namespace, name)
+	ret0, _ := ret[0].(*v10.ConfigMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConfigMap indicates an expected call of GetConfigMap
+func (mr *MockClientInterfaceMockRecorder) GetConfigMap(namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockClientInterface)(nil).GetConfigMap), namespace, name)
+}
+
+// UpdateConfigMap mocks base method
+func (m *MockClientInterface) UpdateConfigMap(modified *v10.ConfigMap) (*v10.ConfigMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateConfigMap", modified)
+	ret0, _ := ret[0].(*v10.ConfigMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateConfigMap indicates an expected call of UpdateConfigMap
+func (mr *MockClientInterfaceMockRecorder) UpdateConfigMap(modified interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfigMap", reflect.TypeOf((*MockClientInterface)(nil).UpdateConfigMap), modified)
+}
+
+// DeleteConfigMap mocks base method
+func (m *MockClientInterface) DeleteConfigMap(namespace, name string, options *v12.DeleteOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteConfigMap", namespace, name, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteConfigMap indicates an expected call of DeleteConfigMap
+func (mr *MockClientInterfaceMockRecorder) DeleteConfigMap(namespace, name, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteConfigMap", reflect.TypeOf((*MockClientInterface)(nil).DeleteConfigMap), namespace, name, options)
+}
+
 // MockCustomResourceClient is a mock of CustomResourceClient interface
 type MockCustomResourceClient struct {
 	ctrl     *gomock.Controller
@@ -1915,4 +1974,86 @@ func (m *MockDeploymentClient) ListDeploymentsWithLabels(namespace string, label
 func (mr *MockDeploymentClientMockRecorder) ListDeploymentsWithLabels(namespace, labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeploymentsWithLabels", reflect.TypeOf((*MockDeploymentClient)(nil).ListDeploymentsWithLabels), namespace, labels)
+}
+
+// MockConfigMapClient is a mock of ConfigMapClient interface
+type MockConfigMapClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockConfigMapClientMockRecorder
+}
+
+// MockConfigMapClientMockRecorder is the mock recorder for MockConfigMapClient
+type MockConfigMapClientMockRecorder struct {
+	mock *MockConfigMapClient
+}
+
+// NewMockConfigMapClient creates a new mock instance
+func NewMockConfigMapClient(ctrl *gomock.Controller) *MockConfigMapClient {
+	mock := &MockConfigMapClient{ctrl: ctrl}
+	mock.recorder = &MockConfigMapClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockConfigMapClient) EXPECT() *MockConfigMapClientMockRecorder {
+	return m.recorder
+}
+
+// CreateConfigMap mocks base method
+func (m *MockConfigMapClient) CreateConfigMap(arg0 *v10.ConfigMap) (*v10.ConfigMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateConfigMap", arg0)
+	ret0, _ := ret[0].(*v10.ConfigMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateConfigMap indicates an expected call of CreateConfigMap
+func (mr *MockConfigMapClientMockRecorder) CreateConfigMap(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConfigMap", reflect.TypeOf((*MockConfigMapClient)(nil).CreateConfigMap), arg0)
+}
+
+// GetConfigMap mocks base method
+func (m *MockConfigMapClient) GetConfigMap(namespace, name string) (*v10.ConfigMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfigMap", namespace, name)
+	ret0, _ := ret[0].(*v10.ConfigMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConfigMap indicates an expected call of GetConfigMap
+func (mr *MockConfigMapClientMockRecorder) GetConfigMap(namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockConfigMapClient)(nil).GetConfigMap), namespace, name)
+}
+
+// UpdateConfigMap mocks base method
+func (m *MockConfigMapClient) UpdateConfigMap(modified *v10.ConfigMap) (*v10.ConfigMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateConfigMap", modified)
+	ret0, _ := ret[0].(*v10.ConfigMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateConfigMap indicates an expected call of UpdateConfigMap
+func (mr *MockConfigMapClientMockRecorder) UpdateConfigMap(modified interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfigMap", reflect.TypeOf((*MockConfigMapClient)(nil).UpdateConfigMap), modified)
+}
+
+// DeleteConfigMap mocks base method
+func (m *MockConfigMapClient) DeleteConfigMap(namespace, name string, options *v12.DeleteOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteConfigMap", namespace, name, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteConfigMap indicates an expected call of DeleteConfigMap
+func (mr *MockConfigMapClientMockRecorder) DeleteConfigMap(namespace, name, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteConfigMap", reflect.TypeOf((*MockConfigMapClient)(nil).DeleteConfigMap), namespace, name, options)
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Follow up on https://github.com/operator-framework/operator-registry/pull/256.

Now that configmap objects are supported in bundles as first-class citizens, OLM needs to be able to create config maps from the bundle and lifecycle them along with the CSV. This PR enables the catalog operator to work with configmap types. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
