### PR TITLE
Removing delineation of APIService and CRD requirements

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -761,10 +761,10 @@ func apiService(group, version, serviceName, serviceNamespace, deploymentName st
 	return apiService
 }
 
-func crd(name, version, group string) *apiextensionsv1.CustomResourceDefinition {
+func crd(kind, version, group string) *apiextensionsv1.CustomResourceDefinition {
 	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name + "." + group,
+			Name: kind + "." + group,
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Group: group,
@@ -776,7 +776,7 @@ func crd(name, version, group string) *apiextensionsv1.CustomResourceDefinition 
 				},
 			},
 			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Kind: name,
+				Kind: kind,
 			},
 		},
 		Status: apiextensionsv1.CustomResourceDefinitionStatus{
@@ -3383,9 +3383,9 @@ func TestSyncOperatorGroups(t *testing.T) {
 			Message: "CSV minKubeVersion (0.0.0) less than server version (" + serverVersion + ")",
 		},
 		{
-			Group:   "apiextensions.k8s.io",
+			Group:   "fake.api.group",
 			Version: "v1",
-			Kind:    "CustomResourceDefinition",
+			Kind:    "c1",
 			Name:    crd.GetName(),
 			Status:  v1alpha1.RequirementStatusReasonPresent,
 			Message: "CRD is present and Established condition is true",

--- a/pkg/controller/operators/olm/requirements_test.go
+++ b/pkg/controller/operators/olm/requirements_test.go
@@ -410,14 +410,14 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 						},
 					},
 				},
-				{"apiextensions.k8s.io", "v1", "CustomResourceDefinition", "c1.g1"}: {
+				{"g1", "v1", "c1", "c1.g1"}: {
 					Group:   "apiextensions.k8s.io",
 					Version: "v1",
 					Kind:    "CustomResourceDefinition",
 					Name:    "c1.g1",
 					Status:  v1alpha1.RequirementStatusReasonPresent,
 				},
-				{"apiextensions.k8s.io", "v1", "CustomResourceDefinition", "c2.g2"}: {
+				{"g2", "v1", "c2", "c2.g2"}: {
 					Group:   "apiextensions.k8s.io",
 					Version: "v1",
 					Kind:    "CustomResourceDefinition",
@@ -451,7 +451,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 			},
 			met: false,
 			expectedRequirementStatuses: map[gvkn]v1alpha1.RequirementStatus{
-				{"apiextensions.k8s.io", "v1", "CustomResourceDefinition", "c1.g1"}: {
+				{"g1", "v2", "c1", "c1.g1"}: {
 					Group:   "apiextensions.k8s.io",
 					Version: "v1",
 					Kind:    "CustomResourceDefinition",
@@ -485,7 +485,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 			},
 			met: false,
 			expectedRequirementStatuses: map[gvkn]v1alpha1.RequirementStatus{
-				{"apiextensions.k8s.io", "v1", "CustomResourceDefinition", "c1.g1"}: {
+				{"g1", "version-not-found", "c1", "c1.g1"}: {
 					Group:   "apiextensions.k8s.io",
 					Version: "v1",
 					Kind:    "CustomResourceDefinition",
@@ -525,9 +525,9 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 			},
 			met: false,
 			expectedRequirementStatuses: map[gvkn]v1alpha1.RequirementStatus{
-				{"apiextensions.k8s.io", "v1", "CustomResourceDefinition", "c1.g1"}: {
+				{"g1", "v2", "c1", "c1.g1"}: {
 					Group:   "apiextensions.k8s.io",
-					Version: "v1",
+					Version: "v1beta1",
 					Kind:    "CustomResourceDefinition",
 					Name:    "c1.g1",
 					Status:  v1alpha1.RequirementStatusReasonNotAvailable,
@@ -565,9 +565,9 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 			},
 			met: false,
 			expectedRequirementStatuses: map[gvkn]v1alpha1.RequirementStatus{
-				{"apiextensions.k8s.io", "v1", "CustomResourceDefinition", "c1.g1"}: {
+				{"g1", "v2", "c1", "c1.g1"}: {
 					Group:   "apiextensions.k8s.io",
-					Version: "v1",
+					Version: "v1beta1",
 					Kind:    "CustomResourceDefinition",
 					Name:    "c1.g1",
 					Status:  v1alpha1.RequirementStatusReasonNotAvailable,

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -2871,13 +2871,14 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
+		// notServedStatus stating what is specified in CSV not getting served.
 		notServedStatus := v1alpha1.RequirementStatus{
-			Group:   "apiextensions.k8s.io",
-			Version: "v1",
-			Kind:    "CustomResourceDefinition",
+			Group:   "cluster.com",
+			Version: "apiextensions.k8s.io/v1alpha1",
+			Kind:    crdPlural,
 			Name:    crdName,
 			Status:  v1alpha1.RequirementStatusReasonNotPresent,
-			Message: "CRD version not served",
+			Message: "resource does not exist",
 		}
 		csvCheckPhaseAndRequirementStatus := func(csv *v1alpha1.ClusterServiceVersion) bool {
 			if csv.Status.Phase == v1alpha1.CSVPhasePending {

--- a/test/e2e/dynamic_resource_e2e_test.go
+++ b/test/e2e/dynamic_resource_e2e_test.go
@@ -96,11 +96,11 @@ var _ = Describe("Dynamic Resource", func() {
 			Resource: "prometheusrules",
 		}
 
-		err = waitForGVR(dynamicClient, gvr, "my-prometheusrule", ns.GetName())
+		err = waitForGVR(dynamicClient, gvr, "prometheusrules.monitoring.coreos.com", ns.GetName())
 		require.NoError(GinkgoT(), err)
 
 		gvr.Resource = "servicemonitors"
-		err = waitForGVR(dynamicClient, gvr, "my-servicemonitor", ns.GetName())
+		err = waitForGVR(dynamicClient, gvr, "servicemonitors.monitoring.coreos.com", ns.GetName())
 		require.NoError(GinkgoT(), err)
 	})
 })


### PR DESCRIPTION
OLM treats APIService and CRD the same in the backend. The differeciation between the two concepts forces Users to understand the difference and increase deficulties implmeneting easy UX. This commit gets rid of OLM differentiating between APIService and CRD. The requirement of them are say tobe met if the GVK of those resource exists.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
