### PR TITLE
Convert package manifest e2e to ginkgo test

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Catalog", func() {
 		crc := newCRClient()
 
 		catalogSourceName := genName("mock-ocs-")
-		_, cleanupSource := createInternalCatalogSource(GinkgoT(), c, crc, catalogSourceName, operatorNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
+		_, cleanupSource := createInternalCatalogSource(c, crc, catalogSourceName, operatorNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
 		defer cleanupSource()
 
 		// ensure the mock catalog exists and has been synced by the catalog operator
@@ -132,7 +132,7 @@ var _ = Describe("Catalog", func() {
 		}
 
 		// Create the initial catalog source
-		createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, globalNS, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []v1alpha1.ClusterServiceVersion{mainCSV})
+		createInternalCatalogSource(c, crc, mainCatalogName, globalNS, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []v1alpha1.ClusterServiceVersion{mainCSV})
 
 		// Attempt to get the catalog source before creating install plan
 		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, globalNS, catalogSourceRegistryPodSynced)
@@ -243,7 +243,7 @@ var _ = Describe("Catalog", func() {
 		}
 
 		// Create the initial catalogsource
-		createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
+		createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
 
 		// Attempt to get the catalog source before creating install plan
 		fetchedInitialCatalog, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, testNamespace, catalogSourceRegistryPodSynced)
@@ -363,7 +363,7 @@ var _ = Describe("Catalog", func() {
 		}
 
 		// Create the initial catalogsource
-		_, cleanupSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
 
 		// Attempt to get the catalog source before creating install plan
 		fetchedInitialCatalog, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, testNamespace, catalogSourceRegistryPodSynced)
@@ -381,7 +381,7 @@ var _ = Describe("Catalog", func() {
 		cleanupSource()
 
 		// create a catalog with the same name
-		createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, append(mainManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV})
+		createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, append(mainManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV})
 
 		// Create Subscription
 		subscriptionName := genName("sub-")
@@ -465,8 +465,8 @@ var _ = Describe("Catalog", func() {
 		}
 
 		// Create ConfigMap CatalogSources
-		createInternalCatalogSource(GinkgoT(), c, crc, mainSourceName, testNamespace, append(mainManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV})
-		createInternalCatalogSource(GinkgoT(), c, crc, replacementSourceName, testNamespace, append(replacementManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{replacementCSV, mainCSV, dependentCSV})
+		createInternalCatalogSource(c, crc, mainSourceName, testNamespace, append(mainManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV})
+		createInternalCatalogSource(c, crc, replacementSourceName, testNamespace, append(replacementManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{replacementCSV, mainCSV, dependentCSV})
 
 		// Wait for ConfigMap CatalogSources to be ready
 		mainSource, err := fetchCatalogSourceOnStatus(crc, mainSourceName, testNamespace, catalogSourceRegistryPodSynced)
@@ -565,7 +565,7 @@ var _ = Describe("Catalog", func() {
 
 		c := newKubeClient()
 		crc := newCRClient()
-		_, cleanupSource := createInternalCatalogSource(GinkgoT(), c, crc, sourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
+		_, cleanupSource := createInternalCatalogSource(c, crc, sourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
 		defer cleanupSource()
 
 		// Wait for a new registry pod to be created

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -76,7 +76,7 @@ var _ = Describe("CRD Versions", func() {
 		}
 
 		// Create the catalog sources
-		_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -968,6 +968,7 @@ var _ = Describe("CSV", func() {
 
 			deleted := make(chan struct{})
 			go func() {
+				defer GinkgoRecover()
 				events := watcher.ResultChan()
 				for {
 					select {
@@ -1514,6 +1515,7 @@ var _ = Describe("CSV", func() {
 		quit := make(chan struct{})
 		defer close(quit)
 		go func() {
+			defer GinkgoRecover()
 			events := watcher.ResultChan()
 			for {
 				select {

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -93,14 +93,14 @@ var _ = Describe("Install Plan", func() {
 
 		// Create the catalog sources
 		require.NotEqual(GinkgoT(), "", testNamespace)
-		_, cleanupDependentCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, dependentCatalogName, testNamespace, dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
+		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, testNamespace, dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
 		defer cleanupDependentCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
 		_, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, testNamespace, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
-		_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
@@ -265,7 +265,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-" + strings.ToLower(CurrentGinkgoTestDescription().TestText) + "-")
-			_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{dependentCRD, mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainStableCSV, mainBetaCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{dependentCRD, mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainStableCSV, mainBetaCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
@@ -390,7 +390,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-" + strings.ToLower(CurrentGinkgoTestDescription().TestText) + "-")
-			_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{dependentCRD, mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainStableCSV, mainBetaCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{dependentCRD, mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainStableCSV, mainBetaCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
@@ -764,7 +764,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-")
-			_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
@@ -966,7 +966,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-")
-			_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
@@ -1197,7 +1197,7 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
@@ -1384,7 +1384,7 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
@@ -1588,7 +1588,7 @@ var _ = Describe("Install Plan", func() {
 					DefaultChannelName: stableChannel,
 				},
 			}
-			_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
@@ -1795,7 +1795,7 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create the catalog sources
-			_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
@@ -1979,7 +1979,7 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create the catalog sources
-			_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
@@ -2115,7 +2115,7 @@ var _ = Describe("Install Plan", func() {
 
 		// Create CatalogSource
 		mainCatalogSourceName := genName("nginx-catalog")
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{stableCSV})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{stableCSV})
 		defer cleanupCatalogSource()
 
 		// Attempt to get CatalogSource
@@ -2224,6 +2224,7 @@ var _ = Describe("Install Plan", func() {
 		done := make(chan struct{})
 		errExit := make(chan error)
 		go func() {
+			defer GinkgoRecover()
 			for {
 				select {
 				case evt, ok := <-crWatcher.ResultChan():
@@ -2363,7 +2364,7 @@ var _ = Describe("Install Plan", func() {
 		c := newKubeClient()
 		crc := newCRClient()
 		catalogSourceName := genName("mock-nginx-")
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csv})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csv})
 		defer cleanupCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
@@ -2544,7 +2545,7 @@ var _ = Describe("Install Plan", func() {
 		}
 
 		// Create the dependent catalog source
-		_, cleanupDependentCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, dependentCatalogName, ns.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
+		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, ns.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
 		defer cleanupDependentCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
@@ -2556,6 +2557,7 @@ var _ = Describe("Install Plan", func() {
 		for i := 0; i < 4; i++ { // Creating more increases the odds that the race condition will be triggered
 			wg.Add(1)
 			go func(i int) {
+				defer GinkgoRecover()
 				// Create a CatalogSource pointing to the grpc pod
 				addressSource := &operatorsv1alpha1.CatalogSource{
 					TypeMeta: metav1.TypeMeta{
@@ -2581,7 +2583,7 @@ var _ = Describe("Install Plan", func() {
 		wg.Wait()
 
 		// Create the main catalog source
-		_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -293,7 +293,10 @@ var _ = Describe("Operator Group", func() {
 		}()
 
 		for _, informer := range []cache.SharedIndexInformer{roleInformer.Informer(), roleBindingInformer.Informer(), clusterRoleInformer.Informer(), clusterRoleBindingInformer.Informer()} {
-			go informer.Run(stopCh)
+			go func() {
+				defer GinkgoRecover()
+				informer.Run(stopCh)
+			}()
 
 			synced := func() (bool, error) {
 				return informer.HasSynced(), nil
@@ -911,15 +914,15 @@ var _ = Describe("Operator Group", func() {
 		}
 
 		catalog := genName("catalog-")
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, catalog, nsA, manifests, []apiextensions.CustomResourceDefinition{crdA, crdD, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvD})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalog, nsA, manifests, []apiextensions.CustomResourceDefinition{crdA, crdD, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvD})
 		defer cleanupCatalogSource()
 		_, err := fetchCatalogSourceOnStatus(crc, catalog, nsA, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
-		_, cleanupCatalogSource = createInternalCatalogSource(GinkgoT(), c, crc, catalog, nsB, manifests, []apiextensions.CustomResourceDefinition{crdA, crdD, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvD})
+		_, cleanupCatalogSource = createInternalCatalogSource(c, crc, catalog, nsB, manifests, []apiextensions.CustomResourceDefinition{crdA, crdD, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvD})
 		defer cleanupCatalogSource()
 		_, err = fetchCatalogSourceOnStatus(crc, catalog, nsB, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
-		_, cleanupCatalogSource = createInternalCatalogSource(GinkgoT(), c, crc, catalog, nsD, manifests, []apiextensions.CustomResourceDefinition{crdA, crdD, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvD})
+		_, cleanupCatalogSource = createInternalCatalogSource(c, crc, catalog, nsD, manifests, []apiextensions.CustomResourceDefinition{crdA, crdD, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvD})
 		defer cleanupCatalogSource()
 		_, err = fetchCatalogSourceOnStatus(crc, catalog, nsD, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
@@ -1181,11 +1184,11 @@ var _ = Describe("Operator Group", func() {
 
 		// Create catalog in namespaceB and namespaceC
 		catalog := genName("catalog-")
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, catalog, nsB, manifests, []apiextensions.CustomResourceDefinition{crdA, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalog, nsB, manifests, []apiextensions.CustomResourceDefinition{crdA, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
 		defer cleanupCatalogSource()
 		_, err := fetchCatalogSourceOnStatus(crc, catalog, nsB, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
-		_, cleanupCatalogSource = createInternalCatalogSource(GinkgoT(), c, crc, catalog, nsC, manifests, []apiextensions.CustomResourceDefinition{crdA, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
+		_, cleanupCatalogSource = createInternalCatalogSource(c, crc, catalog, nsC, manifests, []apiextensions.CustomResourceDefinition{crdA, crdB}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
 		defer cleanupCatalogSource()
 		_, err = fetchCatalogSourceOnStatus(crc, catalog, nsC, catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)

--- a/test/e2e/packagemanifest_e2e_test.go
+++ b/test/e2e/packagemanifest_e2e_test.go
@@ -3,188 +3,198 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"time"
-
 	"github.com/blang/semver"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 
-	. "github.com/onsi/ginkgo"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	packagev1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	pmversioned "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
-var _ = Describe("Package Manifest", func() {
-	It("loading", func() {
+var _ = Describe("Package Manifest API lists available Operators from Catalog Sources", func() {
 
-		// as long as it has a package name we consider the status non-empty
-
-		defer cleaner.NotifyTestComplete(true)
-
-		// create a simple catalogsource
-		packageName := genName("nginx")
-		stableChannel := "stable"
-		packageStable := packageName + "-stable"
-		manifests := []registry.PackageManifest{
-			{
-				PackageName: packageName,
-				Channels: []registry.PackageChannel{
-					{Name: stableChannel, CurrentCSVName: packageStable},
-				},
-				DefaultChannelName: stableChannel,
-			},
-		}
-
-		crdPlural := genName("ins")
-		crd := newCRD(crdPlural)
-		catalogSourceName := genName("mock-ocs")
-		namedStrategy := newNginxInstallStrategy(genName("dep-"), nil, nil)
-		csv := newCSV(packageStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, namedStrategy)
-		csv.SetLabels(map[string]string{"projected": "label"})
-		csv.Spec.Keywords = []string{"foo", "bar"}
-		csv.Spec.Links = []v1alpha1.AppLink{
-			{
-				Name: "foo",
-				URL:  "example.com",
-			},
-		}
-		csv.Spec.Maintainers = []v1alpha1.Maintainer{
-			{
-				Name:  "foo",
-				Email: "example@gmail.com",
-			},
-		}
-		csv.Spec.Maturity = "foo"
-		csv.Spec.NativeAPIs = []metav1.GroupVersionKind{{Group: "kubenative.io", Version: "v1", Kind: "Native"}}
-		csvJSON, _ := json.Marshal(csv)
-		c := newKubeClient()
-		crc := newCRClient()
-		pmc := newPMClient(GinkgoT())
-
-		expectedStatus := packagev1.PackageManifestStatus{
-			CatalogSource:          catalogSourceName,
-			CatalogSourceNamespace: testNamespace,
-			PackageName:            packageName,
-			Channels: []packagev1.PackageChannel{
-				{
-					Name:           stableChannel,
-					CurrentCSV:     packageStable,
-					CurrentCSVDesc: packagev1.CreateCSVDescription(&csv, string(csvJSON)),
-				},
-			},
-			DefaultChannel: stableChannel,
-		}
-
-		// Wait for package-server to be ready
-		err := wait.Poll(pollInterval, 1*time.Minute, func() (bool, error) {
-			GinkgoT().Logf("Polling package-server...")
-			_, err := pmc.OperatorsV1().PackageManifests(testNamespace).List(context.TODO(), metav1.ListOptions{})
-			if err == nil {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(GinkgoT(), err, "package-server not available")
-
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
-		require.NoError(GinkgoT(), err)
-		defer cleanupCatalogSource()
-
-		_, err = fetchCatalogSourceOnStatus(crc, catalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
-		require.NoError(GinkgoT(), err)
-
-		pm, err := fetchPackageManifest(GinkgoT(), pmc, testNamespace, packageName, packageManifestHasStatus)
-		require.NoError(GinkgoT(), err, "error getting package manifest")
-		require.NotNil(GinkgoT(), pm)
-		require.Equal(GinkgoT(), packageName, pm.GetName())
-		require.Equal(GinkgoT(), expectedStatus, pm.Status)
-		require.Equal(GinkgoT(), "0.0.0", pm.Status.Channels[0].CurrentCSVDesc.MinKubeVersion)
-		require.Equal(GinkgoT(), *dummyImage, pm.Status.Channels[0].CurrentCSVDesc.RelatedImages[0])
-		require.Equal(GinkgoT(), csv.Spec.NativeAPIs, pm.Status.Channels[0].CurrentCSVDesc.NativeAPIs)
-		require.Equal(GinkgoT(), "label", pm.GetLabels()["projected"])
-		require.Equal(GinkgoT(), "supported", pm.GetLabels()["operatorframework.io/arch.amd64"])
-		require.Equal(GinkgoT(), "supported", pm.GetLabels()["operatorframework.io/os.linux"])
-		require.Equal(GinkgoT(), []string{"foo", "bar"}, pm.Status.Channels[0].CurrentCSVDesc.Keywords)
-		require.Equal(GinkgoT(), "foo", pm.Status.Channels[0].CurrentCSVDesc.Maturity)
-		require.Equal(GinkgoT(), []packagev1.AppLink{{Name: "foo", URL: "example.com"}}, pm.Status.Channels[0].CurrentCSVDesc.Links)
-		require.Equal(GinkgoT(), []packagev1.Maintainer{{Name: "foo", Email: "example@gmail.com"}}, pm.Status.Channels[0].CurrentCSVDesc.Maintainers)
-
-		// Get a PackageManifestList and ensure it has the correct items
-		pmList, err := pmc.OperatorsV1().PackageManifests(testNamespace).List(context.TODO(), metav1.ListOptions{})
-		require.NoError(GinkgoT(), err, "could not access package manifests list meta")
-		require.NotNil(GinkgoT(), pmList.ListMeta, "package manifest list metadata empty")
-		require.NotNil(GinkgoT(), pmList.Items)
+	var (
+		crc versioned.Interface
+		pmc pmversioned.Interface
+		c   operatorclient.ClientInterface
+	)
+	BeforeEach(func() {
+		crc = newCRClient()
+		pmc = newPMClient()
+		c = newKubeClient()
 	})
-	It("loading relatedImages", func() {
 
-		defer cleaner.NotifyTestComplete(true)
+	AfterEach(func() {
+		cleaner.NotifyTestComplete(true)
+	})
 
-		sourceName := genName("catalog-")
-		packageName := "etcd-test"
-		image := "quay.io/olmtest/catsrc-update-test:related"
+	Context("Given a CatalogSource created using the ConfigMap as catalog source type", func() {
 
-		crc := newCRClient()
-		pmc := newPMClient(GinkgoT())
+		var (
+			packageName          string
+			packageStable        string
+			cleanupCatalogSource cleanupFunc
+			csvJSON              []byte
+			csv                  v1alpha1.ClusterServiceVersion
+			catsrcName           string
+		)
+		BeforeEach(func() {
 
-		source := &v1alpha1.CatalogSource{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       v1alpha1.CatalogSourceKind,
-				APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      sourceName,
-				Namespace: testNamespace,
-				Labels:    map[string]string{"olm.catalogSource": sourceName},
-			},
-			Spec: v1alpha1.CatalogSourceSpec{
-				SourceType: v1alpha1.SourceTypeGrpc,
-				Image:      image,
-			},
-		}
-
-		expectedRelatedImages := map[string]string{
-			"quay.io/coreos/etcd@sha256:3816b6daf9b66d6ced6f0f966314e2d4f894982c6b1493061502f8c2bf86ac84":          "",
-			"quay.io/coreos/etcd@sha256:49d3d4a81e0d030d3f689e7167f23e120abf955f7d08dbedf3ea246485acee9f":          "",
-			"quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2": "",
-		}
-
-		source, err := crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(context.TODO(), source, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
-		defer func() {
-			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Delete(context.TODO(), source.GetName(), metav1.DeleteOptions{}))
-		}()
-
-		// Wait for package-server to be ready
-		err = wait.Poll(pollInterval, 1*time.Minute, func() (bool, error) {
-			GinkgoT().Logf("Polling package-server...")
-			_, err := pmc.OperatorsV1().PackageManifests(testNamespace).List(context.TODO(), metav1.ListOptions{})
-			if err == nil {
-				return true, nil
+			// create a simple catalogsource
+			packageName = genName("nginx")
+			stableChannel := "stable"
+			packageStable = packageName + "-stable"
+			manifests := []registry.PackageManifest{
+				{
+					PackageName: packageName,
+					Channels: []registry.PackageChannel{
+						{Name: stableChannel, CurrentCSVName: packageStable},
+					},
+					DefaultChannelName: stableChannel,
+				},
 			}
-			return false, nil
+
+			crdPlural := genName("ins")
+			crd := newCRD(crdPlural)
+			catsrcName = genName("mock-ocs")
+			namedStrategy := newNginxInstallStrategy(genName("dep-"), nil, nil)
+			csv = newCSV(packageStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, namedStrategy)
+			csv.SetLabels(map[string]string{"projected": "label"})
+			csv.Spec.Keywords = []string{"foo", "bar"}
+			csv.Spec.Links = []v1alpha1.AppLink{
+				{
+					Name: "foo",
+					URL:  "example.com",
+				},
+			}
+			csv.Spec.Maintainers = []v1alpha1.Maintainer{
+				{
+					Name:  "foo",
+					Email: "example@gmail.com",
+				},
+			}
+			csv.Spec.Maturity = "foo"
+			csv.Spec.NativeAPIs = []metav1.GroupVersionKind{{Group: "kubenative.io", Version: "v1", Kind: "Native"}}
+
+			var err error
+			csvJSON, err = json.Marshal(csv)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, cleanupCatalogSource = createInternalCatalogSource(c, crc, catsrcName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
+
+			// Verify catalog source was created
+			_, err = fetchCatalogSourceOnStatus(crc, catsrcName, testNamespace, catalogSourceRegistryPodSynced)
+			Expect(err).ToNot(HaveOccurred())
 		})
-		require.NoError(GinkgoT(), err, "package-server not available")
 
-		_, err = fetchCatalogSourceOnStatus(crc, source.GetName(), testNamespace, catalogSourceRegistryPodSynced)
-		require.NoError(GinkgoT(), err)
+		AfterEach(func() {
+			if cleanupCatalogSource != nil {
+				cleanupCatalogSource()
+			}
+		})
 
-		pm, err := fetchPackageManifest(GinkgoT(), pmc, testNamespace, packageName, packageManifestHasStatus)
-		require.NoError(GinkgoT(), err, "error getting package manifest")
-		require.NotNil(GinkgoT(), pm)
-		require.Equal(GinkgoT(), packageName, pm.GetName())
+		It("retrieves the PackageManifest by package name and validates its fields", func() {
 
-		relatedImages := pm.Status.Channels[0].CurrentCSVDesc.RelatedImages
-		require.Equal(GinkgoT(), len(expectedRelatedImages), len(relatedImages))
+			expectedStatus := packagev1.PackageManifestStatus{
+				CatalogSource:          catsrcName,
+				CatalogSourceNamespace: testNamespace,
+				PackageName:            packageName,
+				Channels: []packagev1.PackageChannel{
+					{
+						Name:           stableChannel,
+						CurrentCSV:     packageStable,
+						CurrentCSVDesc: packagev1.CreateCSVDescription(&csv, string(csvJSON)),
+					},
+				},
+				DefaultChannel: stableChannel,
+			}
 
-		for _, v := range relatedImages {
-			_, ok := expectedRelatedImages[v]
-			require.True(GinkgoT(), ok, "Expect this image %s to exist in the related images list\n", v)
-		}
+			pm, err := fetchPackageManifest(pmc, testNamespace, packageName, packageManifestHasStatus)
+			Expect(err).ToNot(HaveOccurred(), "error getting package manifest")
+			Expect(pm).ShouldNot(BeNil())
+			Expect(pm.GetName()).Should(Equal(packageName))
+			Expect(pm.Status).Should(Equal(expectedStatus))
+			Expect(pm.Status.Channels[0].CurrentCSVDesc.MinKubeVersion).Should(Equal("0.0.0"))
+			Expect(pm.Status.Channels[0].CurrentCSVDesc.RelatedImages[0]).Should(Equal(*dummyImage))
+			Expect(pm.Status.Channels[0].CurrentCSVDesc.NativeAPIs).Should(Equal(csv.Spec.NativeAPIs))
+			Expect(pm.GetLabels()["projected"]).Should(Equal("label"))
+			Expect(pm.GetLabels()["operatorframework.io/arch.amd64"]).Should(Equal("supported"))
+			Expect(pm.GetLabels()["operatorframework.io/os.linux"]).Should(Equal("supported"))
+			Expect(pm.Status.Channels[0].CurrentCSVDesc.Keywords).Should(Equal([]string{"foo", "bar"}))
+			Expect(pm.Status.Channels[0].CurrentCSVDesc.Maturity).Should(Equal("foo"))
+			Expect(pm.Status.Channels[0].CurrentCSVDesc.Links).Should(Equal([]packagev1.AppLink{{Name: "foo", URL: "example.com"}}))
+			Expect(pm.Status.Channels[0].CurrentCSVDesc.Maintainers).Should(Equal([]packagev1.Maintainer{{Name: "foo", Email: "example@gmail.com"}}))
+		})
+		It("lists PackageManifest and ensures it has valid PackageManifest item", func() {
+			// Get a PackageManifestList and ensure it has the correct items
+			Eventually(func() (bool, error) {
+				pmList, err := pmc.OperatorsV1().PackageManifests(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				return containsPackageManifest(pmList.Items, packageName), err
+			}).Should(BeTrue(), "required package name not found in the list")
+		})
+
+	})
+
+	Context("Given a CatalogSource created using gRPC catalog source type", func() {
+		var (
+			packageName   string
+			catalogSource *v1alpha1.CatalogSource
+		)
+		BeforeEach(func() {
+			sourceName := genName("catalog-")
+			packageName = "etcd-test"
+			image := "quay.io/olmtest/catsrc-update-test:related"
+
+			catalogSource = &v1alpha1.CatalogSource{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       v1alpha1.CatalogSourceKind,
+					APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{"olm.catalogSource": sourceName},
+				},
+				Spec: v1alpha1.CatalogSourceSpec{
+					SourceType: v1alpha1.SourceTypeGrpc,
+					Image:      image,
+				},
+			}
+
+			var err error
+			catalogSource, err = crc.OperatorsV1alpha1().CatalogSources(catalogSource.GetNamespace()).Create(context.TODO(), catalogSource, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := crc.OperatorsV1alpha1().CatalogSources(catalogSource.GetNamespace()).Delete(context.TODO(), catalogSource.GetName(), metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("lists the CatalogSource contents using the PackageManifest API", func() {
+
+			pm, err := fetchPackageManifest(pmc, testNamespace, packageName, packageManifestHasStatus)
+			Expect(err).NotTo(HaveOccurred(), "error getting package manifest")
+			Expect(pm).ShouldNot(BeNil())
+			Expect(pm.GetName()).Should(Equal(packageName))
+
+			// Verify related images from the package manifest
+			relatedImages := pm.Status.Channels[0].CurrentCSVDesc.RelatedImages
+
+			Expect(relatedImages).To(ConsistOf([]string{
+				"quay.io/coreos/etcd@sha256:3816b6daf9b66d6ced6f0f966314e2d4f894982c6b1493061502f8c2bf86ac84",
+				"quay.io/coreos/etcd@sha256:49d3d4a81e0d030d3f689e7167f23e120abf955f7d08dbedf3ea246485acee9f",
+				"quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2",
+			}), "Expected images to exist in the related images list\n")
+		})
 	})
 })
 
@@ -196,18 +206,27 @@ func packageManifestHasStatus(pm *packagev1.PackageManifest) bool {
 
 }
 
-func fetchPackageManifest(t GinkgoTInterface, pmc pmversioned.Interface, namespace, name string, check packageManifestCheckFunc) (*packagev1.PackageManifest, error) {
+func fetchPackageManifest(pmc pmversioned.Interface, namespace, name string, check packageManifestCheckFunc) (*packagev1.PackageManifest, error) {
 	var fetched *packagev1.PackageManifest
 	var err error
 
-	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-		t.Logf("Polling...")
+	Eventually(func() (bool, error) {
+		ctx.Ctx().Logf("Polling...")
 		fetched, err = pmc.OperatorsV1().PackageManifests(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			return true, err
 		}
 		return check(fetched), nil
-	})
+	}).Should(BeTrue())
 
 	return fetched, err
+}
+
+func containsPackageManifest(pmList []packagev1.PackageManifest, pkgName string) bool {
+	for _, pm := range pmList {
+		if pm.GetName() == pkgName {
+			return true
+		}
+	}
+	return false
 }

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Subscription", func() {
 		}
 
 		// Create catalog source
-		_, cleanupMainCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, testNamespace, mainManifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 		// Attempt to get the catalog source before creating subscription
 		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, testNamespace, catalogSourceRegistryPodSynced)
@@ -261,7 +261,7 @@ var _ = Describe("Subscription", func() {
 		c := newKubeClient()
 		crc := newCRClient()
 		catalogSourceName := genName("mock-nginx-")
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
 		defer cleanupCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
@@ -402,7 +402,7 @@ var _ = Describe("Subscription", func() {
 		c := newKubeClient()
 		crc := newCRClient()
 		catalogSourceName := genName("mock-nginx-")
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA})
 		defer cleanupCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
@@ -488,7 +488,7 @@ var _ = Describe("Subscription", func() {
 		c := newKubeClient()
 		crc := newCRClient()
 		catalogSourceName := genName("mock-nginx-")
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, catalogSourceName, testNamespace, manifests, nil, []v1alpha1.ClusterServiceVersion{csvA, csvB})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, testNamespace, manifests, nil, []v1alpha1.ClusterServiceVersion{csvA, csvB})
 		defer cleanupCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
@@ -920,7 +920,7 @@ var _ = Describe("Subscription", func() {
 			},
 		}
 		catalogName := genName("catalog-")
-		_, cleanupCatalogSource := createInternalCatalogSource(GinkgoT(), c, crc, catalogName, ns.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogName, ns.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
 		defer cleanupCatalogSource()
 		_, err = fetchCatalogSourceOnStatus(crc, catalogName, ns.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
@@ -1808,7 +1808,7 @@ func updateInternalCatalog(t GinkgoTInterface, c operatorclient.ClientInterface,
 	var crdsRaw []byte
 	crdStrings := []string{}
 	for _, crd := range crds {
-		crdStrings = append(crdStrings, serializeCRD(t, crd))
+		crdStrings = append(crdStrings, serializeCRD(crd))
 	}
 	crdsRaw, err = yaml.Marshal(crdStrings)
 	require.NoError(t, err)

--- a/test/e2e/user_defined_sa_test.go
+++ b/test/e2e/user_defined_sa_test.go
@@ -298,7 +298,7 @@ func newCatalogSource(t GinkgoTInterface, kubeclient operatorclient.ClientInterf
 	}
 
 	catalogSourceName := genName(prefixFunc("catsrc"))
-	catsrc, cleanup = createInternalCatalogSource(t, kubeclient, crclient, catalogSourceName, namespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
+	catsrc, cleanup = createInternalCatalogSource(kubeclient, crclient, catalogSourceName, namespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
 	require.NotNil(t, catsrc)
 	require.NotNil(t, cleanup)
 
@@ -366,7 +366,7 @@ func newCatalogSourceWithDependencies(t GinkgoTInterface, kubeclient operatorcli
 	}
 
 	catalogSourceName := genName(prefixFunc("catsrc"))
-	catsrc, cleanup = createInternalCatalogSource(t, kubeclient, crclient, catalogSourceName, namespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
+	catsrc, cleanup = createInternalCatalogSource(kubeclient, crclient, catalogSourceName, namespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
 	require.NotNil(t, catsrc)
 	require.NotNil(t, cleanup)
 
@@ -431,8 +431,8 @@ func grantPermission(t GinkgoTInterface, client operatorclient.ClientInterface, 
 
 	clusterrole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:genName("scoped-clusterrole-"),
-		Namespace: namespace},
+			Name:      genName("scoped-clusterrole-"),
+			Namespace: namespace},
 		Rules: []rbacv1.PolicyRule{
 			{
 				Verbs:     []string{rbac.VerbAll},


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change converts packagemanifest_e2e_test.go to leverage ginkgo's BDD approach.
The change also involves adding `GinkgoRecover` wherever go routines are called

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
