### PR TITLE
Convert metrics_e2e_test to ginkgo

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Catalog", func() {
 		subscription, err := fetchSubscription(crc, testNamespace, subscriptionName, subscriptionStateAtLatestChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 
 		ipList, err := crc.OperatorsV1alpha1().InstallPlans(testNamespace).List(context.TODO(), metav1.ListOptions{})
@@ -390,7 +390,7 @@ var _ = Describe("Catalog", func() {
 		subscription, err := fetchSubscription(crc, testNamespace, subscriptionName, subscriptionStateAtLatestChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 	})
 	It("gRPC address catalog source", func() {
@@ -519,7 +519,7 @@ var _ = Describe("Catalog", func() {
 		subscription, err := fetchSubscription(crc, testNamespace, subscriptionName, subscriptionStateAtLatestChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update the catalog's address to point at the other registry pod's cluster ip
@@ -591,7 +591,7 @@ var _ = Describe("Catalog", func() {
 		require.NotNil(GinkgoT(), subscription)
 
 		// Wait for csv to succeed
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Delete the registry pod
@@ -676,7 +676,7 @@ var _ = Describe("Catalog", func() {
 		require.NotNil(GinkgoT(), subscription)
 
 		// Wait for csv to succeed
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Delete the registry pod
@@ -832,7 +832,7 @@ var _ = Describe("Catalog", func() {
 		require.NotNil(GinkgoT(), subscription)
 
 		// Wait for csv to succeed
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		registryCheckFunc := func(podList *corev1.PodList) bool {
@@ -923,7 +923,7 @@ var _ = Describe("Catalog", func() {
 		require.NotNil(GinkgoT(), subscription)
 
 		// Wait for csv to succeed
-		csv, err := fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		csv, err := fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// check version of running csv to ensure the latest version (0.9.2) was installed onto the cluster
@@ -1029,7 +1029,7 @@ var _ = Describe("Catalog", func() {
 		require.NotNil(GinkgoT(), subscription)
 
 		// Wait for busybox v2 csv to succeed and check the replaces field
-		csv, err := fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		csv, err := fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), "busybox.v1.0.0", csv.Spec.Replaces)
 
@@ -1042,7 +1042,7 @@ var _ = Describe("Catalog", func() {
 		require.NotNil(GinkgoT(), subscription)
 
 		// Wait for busybox-dependency v2 csv to succeed and check the replaces field
-		csv, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		csv, err = fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), "busybox-dependency.v1.0.0", csv.Spec.Replaces)
 	})

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -74,11 +74,11 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvPendingChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Shouldn't create deployment
@@ -137,11 +137,11 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvPendingChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Shouldn't create deployment
@@ -247,11 +247,11 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 		defer cleanupCRD()
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, true, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvPendingChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Shouldn't create deployment
@@ -309,11 +309,11 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvPendingChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Shouldn't create deployment
@@ -399,11 +399,11 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvPendingChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Shouldn't create deployment
@@ -451,11 +451,11 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvPendingChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Shouldn't create deployment
@@ -553,11 +553,11 @@ var _ = Describe("CSV", func() {
 		}
 
 		// Create CSV first, knowing it will fail
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, true, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvPendingChecker)
+		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
 		require.NoError(GinkgoT(), err)
 
 		crd := apiextensions.CustomResourceDefinition{
@@ -706,14 +706,14 @@ var _ = Describe("CSV", func() {
 		})
 		require.NoError(GinkgoT(), err)
 
-		fetchedCSV, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Delete CRD
 		cleanupCRD()
 
 		// Wait for CSV failure
-		fetchedCSV, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvPendingChecker)
+		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Recreate the CRD
@@ -722,7 +722,7 @@ var _ = Describe("CSV", func() {
 		defer cleanupCRD()
 
 		// Wait for CSV success again
-		fetchedCSV, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 	})
 	It("create requirements met API service", func() {
@@ -876,15 +876,15 @@ var _ = Describe("CSV", func() {
 		_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
 		require.NoError(GinkgoT(), err, "could not create ClusterRoleBinding")
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		sameCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 	})
@@ -960,7 +960,7 @@ var _ = Describe("CSV", func() {
 		csv.SetName(depName)
 
 		// Create the APIService CSV
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer func() {
 			watcher, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + apiServiceName})
@@ -987,7 +987,7 @@ var _ = Describe("CSV", func() {
 			<-deleted
 		}()
 
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should create Deployment
@@ -1035,7 +1035,7 @@ var _ = Describe("CSV", func() {
 		fetchedCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).UpdateStatus(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 		require.NoError(GinkgoT(), err)
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, func(csv *v1alpha1.ClusterServiceVersion) bool {
+		_, err = fetchCSV(crc, csv.Name, testNamespace, func(csv *v1alpha1.ClusterServiceVersion) bool {
 			// Should create deployment
 			dep, err = c.GetDeployment(testNamespace, depName)
 			require.NoError(GinkgoT(), err)
@@ -1061,7 +1061,7 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Wait for CSV success
-		fetchedCSV, err = fetchCSV(GinkgoT(), crc, csv.GetName(), testNamespace, func(csv *v1alpha1.ClusterServiceVersion) bool {
+		fetchedCSV, err = fetchCSV(crc, csv.GetName(), testNamespace, func(csv *v1alpha1.ClusterServiceVersion) bool {
 			// Should create an APIService
 			apiService, err := c.GetAPIService(apiServiceName)
 			if err != nil {
@@ -1150,10 +1150,10 @@ var _ = Describe("CSV", func() {
 		csv.SetName("csv-hat-1")
 
 		// Create the APIService CSV
-		_, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		_, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should create Deployment
@@ -1225,11 +1225,11 @@ var _ = Describe("CSV", func() {
 		csv2.SetName("csv-hat-2")
 
 		// Create CSV2 to replace CSV
-		cleanupCSV2, err := createCSV(GinkgoT(), c, crc, csv2, testNamespace, false, true)
+		cleanupCSV2, err := createCSV(c, crc, csv2, testNamespace, false, true)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV2()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv2.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv2.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should create Deployment
@@ -1273,11 +1273,11 @@ var _ = Describe("CSV", func() {
 		csv.SetName("csv-hat-3")
 
 		// Recreate the old CSV
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, true)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, true)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		fetched, err := fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, buildCSVReasonChecker(v1alpha1.CSVReasonOwnerConflict))
+		fetched, err := fetchCSV(crc, csv.Name, testNamespace, buildCSVReasonChecker(v1alpha1.CSVReasonOwnerConflict))
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), string(v1alpha1.CSVPhaseFailed), string(fetched.Status.Phase))
 	})
@@ -1405,11 +1405,11 @@ var _ = Describe("CSV", func() {
 		csv.SetName("csv-hat-1")
 
 		// Create the initial CSV
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should create Deployment
@@ -1480,10 +1480,10 @@ var _ = Describe("CSV", func() {
 		csv2.SetName("csv-hat-2")
 
 		// Create CSV2 to replace CSV
-		_, err = createCSV(GinkgoT(), c, crc, csv2, secondNamespaceName, false, true)
+		_, err = createCSV(c, crc, csv2, secondNamespaceName, false, true)
 		require.NoError(GinkgoT(), err)
 
-		_, err = fetchCSV(GinkgoT(), crc, csv2.Name, secondNamespaceName, csvFailedChecker)
+		_, err = fetchCSV(crc, csv2.Name, secondNamespaceName, csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 	})
 	It("orphaned API service clean up", func() {
@@ -1642,11 +1642,11 @@ var _ = Describe("CSV", func() {
 		}
 
 		// Don't need to cleanup this CSV, it will be deleted by the upgrade process
-		_, err = createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		_, err = createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 
 		// Wait for current CSV to succeed
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should have created deployment
@@ -1714,12 +1714,12 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupNewCSV, err := createCSV(GinkgoT(), c, crc, csvNew, testNamespace, true, false)
+		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupNewCSV()
 
 		// Wait for updated CSV to succeed
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csvNew.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should have updated existing deployment
@@ -1733,7 +1733,7 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(GinkgoT(), crc, csvNew.Name, testNamespace, csvSucceededChecker)
+		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 	})
@@ -1825,11 +1825,11 @@ var _ = Describe("CSV", func() {
 		}
 
 		// don't need to clean up this CSV, it will be deleted by the upgrade process
-		_, err = createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		_, err = createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 
 		// Wait for current CSV to succeed
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should have created deployment
@@ -1895,16 +1895,16 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupNewCSV, err := createCSV(GinkgoT(), c, crc, csvNew, testNamespace, true, false)
+		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupNewCSV()
 
 		// Wait for updated CSV to succeed
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csvNew.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(GinkgoT(), crc, csvNew.Name, testNamespace, csvSucceededChecker)
+		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 
@@ -2013,11 +2013,11 @@ var _ = Describe("CSV", func() {
 		}
 
 		// don't need to clean up this CSV, it will be deleted by the upgrade process
-		_, err = createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		_, err = createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 
 		// Wait for current CSV to succeed
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should have created deployment
@@ -2083,16 +2083,16 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupNewCSV, err := createCSV(GinkgoT(), c, crc, csvNew, testNamespace, true, false)
+		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupNewCSV()
 
 		// Wait for updated CSV to succeed
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csvNew.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(GinkgoT(), crc, csvNew.Name, testNamespace, csvSucceededChecker)
+		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 
@@ -2195,12 +2195,12 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, true)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, true)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
 		// Wait for current CSV to succeed
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should have created deployment
@@ -2247,7 +2247,7 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Wait for updated CSV to succeed
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		depUpdated, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
@@ -2361,11 +2361,11 @@ var _ = Describe("CSV", func() {
 		}
 
 		// CSV will be deleted by the upgrade process later
-		_, err = createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		_, err = createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 
 		// Wait for current CSV to succeed
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should have created deployment
@@ -2440,15 +2440,15 @@ var _ = Describe("CSV", func() {
 		}
 
 		// Create newly updated CSV
-		_, err = createCSV(GinkgoT(), c, crc, csvNew, testNamespace, false, false)
+		_, err = createCSV(c, crc, csvNew, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 
 		// Wait for updated CSV to succeed
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csvNew.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(GinkgoT(), crc, csvNew.Name, testNamespace, csvSucceededChecker)
+		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 
@@ -2518,16 +2518,16 @@ var _ = Describe("CSV", func() {
 		}
 
 		// Create newly updated CSV
-		cleanupNewCSV, err := createCSV(GinkgoT(), c, crc, csvNew2, testNamespace, true, false)
+		cleanupNewCSV, err := createCSV(c, crc, csvNew2, testNamespace, true, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupNewCSV()
 
 		// Wait for updated CSV to succeed
-		fetchedCSV, err = fetchCSV(GinkgoT(), crc, csvNew2.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err = fetchCSV(crc, csvNew2.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err = fetchCSV(GinkgoT(), crc, csvNew2.Name, testNamespace, csvSucceededChecker)
+		sameCSV, err = fetchCSV(crc, csvNew2.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 
@@ -2632,12 +2632,12 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, true, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
 		// Wait for current CSV to succeed
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should have created deployments
@@ -2665,7 +2665,7 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Fetch the current csv
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update csv with same strategy with different deployment's name
@@ -2680,7 +2680,7 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Wait for updated CSV to succeed
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should have created new deployment and deleted old
@@ -2751,11 +2751,11 @@ var _ = Describe("CSV", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer w.Stop()
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, *csv, csv.GetNamespace(), false, false)
+		cleanupCSV, err := createCSV(c, crc, *csv, csv.GetNamespace(), false, false)
 		Expect(err).ToNot(HaveOccurred())
 		defer cleanupCSV()
 
-		csv, err = fetchCSV(GinkgoT(), crc, csv.GetName(), csv.GetNamespace(), csvPendingChecker)
+		csv, err = fetchCSV(crc, csv.GetName(), csv.GetNamespace(), csvPendingChecker)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("emitting when requirements are not met")
@@ -2868,7 +2868,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, true, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
@@ -2891,7 +2891,7 @@ var _ = Describe("CSV", func() {
 			return false
 		}
 
-		fetchedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvCheckPhaseAndRequirementStatus)
+		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvCheckPhaseAndRequirementStatus)
 		require.NoError(GinkgoT(), err)
 
 		require.Contains(GinkgoT(), fetchedCSV.Status.RequirementStatus, notServedStatus)
@@ -2971,11 +2971,11 @@ var _ = Describe("CSV", func() {
 		createLegacyAPIResources(&csv, owned[0])
 
 		// Create the APIService CSV
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		checkLegacyAPIResources(owned[0], true)
@@ -3055,11 +3055,11 @@ var _ = Describe("CSV", func() {
 		createLegacyAPIResources(nil, owned[0])
 
 		// Create the APIService CSV
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		checkLegacyAPIResources(owned[0], false)
@@ -3174,11 +3174,11 @@ var _ = Describe("CSV", func() {
 		csv.SetNamespace(testNamespace)
 
 		// Create the APIService CSV
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, testNamespace, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Check that the APIService caBundles are equal
@@ -3214,9 +3214,11 @@ func findLastEvent(events *corev1.EventList) (event corev1.Event) {
 	return events.Items[latestInd]
 }
 
-func buildCSVCleanupFunc(t GinkgoTInterface, c operatorclient.ClientInterface, crc versioned.Interface, csv v1alpha1.ClusterServiceVersion, namespace string, deleteCRDs, deleteAPIServices bool) cleanupFunc {
+func buildCSVCleanupFunc(c operatorclient.ClientInterface, crc versioned.Interface, csv v1alpha1.ClusterServiceVersion, namespace string, deleteCRDs, deleteAPIServices bool) cleanupFunc {
 	return func() {
-		require.NoError(t, crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).Delete(context.TODO(), csv.GetName(), metav1.DeleteOptions{}))
+		err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).Delete(context.TODO(), csv.GetName(), metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
 		if deleteCRDs {
 			for _, crd := range csv.Spec.CustomResourceDefinitions.Owned {
 				buildCRDCleanupFunc(c, crd.Name)()
@@ -3229,19 +3231,20 @@ func buildCSVCleanupFunc(t GinkgoTInterface, c operatorclient.ClientInterface, c
 			}
 		}
 
-		require.NoError(t, waitForDelete(func() error {
+		err = waitForDelete(func() error {
 			_, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
 			return err
-		}))
+		})
+		Expect(err).ToNot(HaveOccurred())
 	}
 }
 
-func createCSV(t GinkgoTInterface, c operatorclient.ClientInterface, crc versioned.Interface, csv v1alpha1.ClusterServiceVersion, namespace string, cleanupCRDs, cleanupAPIServices bool) (cleanupFunc, error) {
+func createCSV(c operatorclient.ClientInterface, crc versioned.Interface, csv v1alpha1.ClusterServiceVersion, namespace string, cleanupCRDs, cleanupAPIServices bool) (cleanupFunc, error) {
 	csv.Kind = v1alpha1.ClusterServiceVersionKind
 	csv.APIVersion = v1alpha1.SchemeGroupVersion.String()
 	_, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).Create(context.TODO(), &csv, metav1.CreateOptions{})
-	require.NoError(t, err)
-	return buildCSVCleanupFunc(t, c, crc, csv, namespace, cleanupCRDs, cleanupAPIServices), nil
+	Expect(err).ToNot(HaveOccurred())
+	return buildCSVCleanupFunc(c, crc, csv, namespace, cleanupCRDs, cleanupAPIServices), nil
 
 }
 
@@ -3408,7 +3411,7 @@ var csvFailedChecker = buildCSVConditionChecker(v1alpha1.CSVPhaseFailed)
 var csvAnyChecker = buildCSVConditionChecker(v1alpha1.CSVPhasePending, v1alpha1.CSVPhaseSucceeded, v1alpha1.CSVPhaseReplacing, v1alpha1.CSVPhaseDeleting, v1alpha1.CSVPhaseFailed)
 var csvCopiedChecker = buildCSVReasonChecker(v1alpha1.CSVReasonCopied)
 
-func fetchCSV(t GinkgoTInterface, c versioned.Interface, name, namespace string, checker csvConditionChecker) (*v1alpha1.ClusterServiceVersion, error) {
+func fetchCSV(c versioned.Interface, name, namespace string, checker csvConditionChecker) (*v1alpha1.ClusterServiceVersion, error) {
 	var fetched *v1alpha1.ClusterServiceVersion
 	var err error
 
@@ -3417,12 +3420,12 @@ func fetchCSV(t GinkgoTInterface, c versioned.Interface, name, namespace string,
 		if err != nil {
 			return false, err
 		}
-		t.Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
+		ctx.Ctx().Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
 		return checker(fetched), nil
 	})
 
 	if err != nil {
-		t.Logf("never got correct status: %#v", fetched.Status)
+		ctx.Ctx().Logf("never got correct status: %#v", fetched.Status)
 	}
 	return fetched, err
 }

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Install Plan", func() {
 			cleanupCRD, err := createCRD(c, dependentCRD)
 			require.NoError(GinkgoT(), err)
 			defer cleanupCRD()
-			cleanupCSV, err := createCSV(GinkgoT(), c, crc, dependentBetaCSV, testNamespace, true, false)
+			cleanupCSV, err := createCSV(c, crc, dependentBetaCSV, testNamespace, true, false)
 			require.NoError(GinkgoT(), err)
 			defer cleanupCSV()
 			GinkgoT().Log("Dependent CRD and preexisting CSV created")
@@ -468,7 +468,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(GinkgoT(), crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
 		})
@@ -846,7 +846,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(GinkgoT(), crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			GinkgoT().Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
@@ -1037,7 +1037,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(GinkgoT(), crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), testNamespace, csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Ensure CRD versions are accurate
@@ -1091,7 +1091,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err = fetchCSV(GinkgoT(), crc, mainDeltaCSV.GetName(), testNamespace, csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, mainDeltaCSV.GetName(), testNamespace, csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Ensure CRD versions are accurate

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -360,7 +360,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err, "could not update csv installmodes")
 
 		// Ensure CSV fails
-		_, err = fetchCSV(GinkgoT(), crc, csvName, opGroupNamespace, csvFailedChecker)
+		_, err = fetchCSV(crc, csvName, opGroupNamespace, csvFailedChecker)
 		require.NoError(GinkgoT(), err, "csv did not transition to failed as expected")
 
 		// ensure deletion cleans up copied CSV
@@ -457,7 +457,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 		defer cleanupCRD()
 
-		_, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, csvSucceededChecker)
+		_, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Create a csv for an apiserver
@@ -524,11 +524,11 @@ var _ = Describe("Operator Group", func() {
 		csvB.SetName(depName)
 
 		// Create the APIService CSV
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csvB, nsA, false, true)
+		cleanupCSV, err := createCSV(c, crc, csvB, nsA, false, true)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csvB.GetName(), nsA, csvSucceededChecker)
+		_, err = fetchCSV(crc, csvB.GetName(), nsA, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure clusterroles created and aggregated for access provided APIs
@@ -669,7 +669,7 @@ var _ = Describe("Operator Group", func() {
 		failedWithUnsupportedOperatorGroup := func(csv *v1alpha1.ClusterServiceVersion) bool {
 			return csvFailedChecker(csv) && csv.Status.Reason == v1alpha1.CSVReasonUnsupportedOperatorGroup
 		}
-		csvA, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
+		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
 		require.NoError(GinkgoT(), err)
 
 		// Update csvA to have OwnNamespace supported=true
@@ -700,7 +700,7 @@ var _ = Describe("Operator Group", func() {
 		defer cleanupCRD()
 
 		// Ensure csvA transitions to Succeeded
-		csvA, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, csvSucceededChecker)
+		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update operatorGroupA's target namespaces to select namespaceB
@@ -711,7 +711,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Failed with reason "UnsupportedOperatorGroup"
-		csvA, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
+		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
 		require.NoError(GinkgoT(), err)
 
 		// Update csvA to have SingleNamespace supported=true
@@ -737,7 +737,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Succeeded
-		csvA, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, csvSucceededChecker)
+		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update operatorGroupA's target namespaces to select namespaceA and namespaceB
@@ -748,7 +748,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Failed with reason "UnsupportedOperatorGroup"
-		csvA, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
+		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
 		require.NoError(GinkgoT(), err)
 
 		// Update csvA to have MultiNamespace supported=true
@@ -774,7 +774,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Succeeded
-		csvA, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, csvSucceededChecker)
+		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update operatorGroupA's target namespaces to select all namespaces
@@ -785,7 +785,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Failed with reason "UnsupportedOperatorGroup"
-		csvA, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
+		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
 		require.NoError(GinkgoT(), err)
 
 		// Update csvA to have AllNamespaces supported=true
@@ -811,7 +811,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Pending
-		csvA, err = fetchCSV(GinkgoT(), crc, csvA.GetName(), nsA, csvSucceededChecker)
+		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 	})
 	It("intersection", func() {
@@ -1440,7 +1440,7 @@ var _ = Describe("Operator Group", func() {
 		_, err = c.UpdateRoleBinding(createdRoleBinding)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for CSV to succeed")
-		_, err = fetchCSV(GinkgoT(), crc, createdCSV.GetName(), opGroupNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, createdCSV.GetName(), opGroupNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for roles to be promoted to clusterroles")
 		var fetchedRole *rbacv1.ClusterRole
@@ -1925,7 +1925,7 @@ var _ = Describe("Operator Group", func() {
 		_, err = c.UpdateRoleBinding(createdRoleBinding)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for CSV to succeed")
-		_, err = fetchCSV(GinkgoT(), crc, createdCSV.GetName(), opGroupNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, createdCSV.GetName(), opGroupNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for roles to be promoted to clusterroles")
 		var fetchedRole *rbacv1.ClusterRole

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -77,7 +77,7 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), initCatalog(GinkgoT(), c, crc))
 
 		// Will be cleaned up by the upgrade process
-		_, err := createCSV(GinkgoT(), c, crc, stableCSV, testNamespace, false, false)
+		_, err := createCSV(c, crc, stableCSV, testNamespace, false, false)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionCleanup := createSubscription(GinkgoT(), crc, testNamespace, testSubscriptionName, testPackageName, alphaChannel, v1alpha1.ApprovalAutomatic)
@@ -86,7 +86,7 @@ var _ = Describe("Subscription", func() {
 		subscription, err := fetchSubscription(crc, testNamespace, testSubscriptionName, subscriptionStateAtLatestChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 	})
 	It("skip range", func() {
@@ -210,7 +210,7 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
-		_, err = fetchCSV(GinkgoT(), crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -1203,7 +1203,7 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
-		csv, err := fetchCSV(GinkgoT(), crClient, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		csv, err := fetchCSV(crClient, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 
 		proxyEnv := proxyEnvVarFunc(GinkgoT(), config)
@@ -1419,11 +1419,11 @@ var _ = Describe("Subscription", func() {
 		_, err = fetchInstallPlan(GinkgoT(), crClient, subscription.Status.InstallPlanRef.Name, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		// Fetch CSVs A, B and C
-		_, err = fetchCSV(GinkgoT(), crClient, csvB.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crClient, csvB.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
-		_, err = fetchCSV(GinkgoT(), crClient, csvC.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crClient, csvC.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
-		_, err = fetchCSV(GinkgoT(), crClient, csvA.Name, testNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crClient, csvA.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		// Ensure csvABC is not installed
 		_, err = crClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.TODO(), csvABC.Name, metav1.GetOptions{})

--- a/test/e2e/webhook_e2e_test.go
+++ b/test/e2e/webhook_e2e_test.go
@@ -90,10 +90,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -129,10 +129,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -189,10 +189,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 			csv.Spec.WebhookDefinitions = append(csv.Spec.WebhookDefinitions, webhook)
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvFailedChecker)
+			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
 			Expect(err).Should(BeNil())
 		})
 		It("Fails if the webhooks intercepts all resources", func() {
@@ -219,10 +219,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("Webhook rules cannot include all groups"))
 		})
@@ -250,10 +250,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("Webhook rules cannot include the OLM group"))
 		})
@@ -281,10 +281,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("Webhook rules cannot include MutatingWebhookConfiguration or ValidatingWebhookConfiguration resources"))
 		})
@@ -314,10 +314,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 		})
 		It("Can be installed and upgraded successfully", func() {
@@ -345,11 +345,11 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 
-			_, err := createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			_, err := createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 			// cleanup by upgrade
 
-			_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			_, err = getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -361,10 +361,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			previousWebhookName := webhook.GenerateName
 			webhook.GenerateName = "webhook2.test.com"
 			csv.Spec.WebhookDefinitions[0] = webhook
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(GinkgoT(), crc, csv.GetName(), namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.GetName(), namespace.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			_, err = getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -394,10 +394,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			fetchedCSV, err := fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -419,7 +419,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			fetchedCSV.Status.CertsRotateAt = &now
 			fetchedCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.Name).UpdateStatus(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 			Expect(err).Should(BeNil())
-			_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, func(csv *v1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, csv.Name, namespace.Name, func(csv *v1alpha1.ClusterServiceVersion) bool {
 				// Should create deployment
 				dep, err = c.GetDeployment(namespace.Name, csv.Spec.WebhookDefinitions[0].DeploymentName)
 				Expect(err).Should(BeNil())
@@ -471,10 +471,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			csv := createCSVWithWebhook(namespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())
@@ -515,19 +515,19 @@ var _ = Describe("CSVs with a Webhook", func() {
 		csv = createCSVWithWebhook(namespace.GetName(), webhook)
 
 		csv.Namespace = namespace1.GetName()
-		cleanupCSV, err := createCSV(GinkgoT(), c, crc, csv, namespace1.Name, false, false)
+		cleanupCSV, err := createCSV(c, crc, csv, namespace1.Name, false, false)
 		Expect(err).Should(BeNil())
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace1.Name, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, namespace1.Name, csvSucceededChecker)
 		Expect(err).Should(BeNil())
 
 		csv.Namespace = namespace2.Name
-		cleanupCSV, err = createCSV(GinkgoT(), c, crc, csv, namespace2.Name, false, false)
+		cleanupCSV, err = createCSV(c, crc, csv, namespace2.Name, false, false)
 		Expect(err).Should(BeNil())
 		defer cleanupCSV()
 
-		_, err = fetchCSV(GinkgoT(), crc, csv.Name, namespace2.Name, csvSucceededChecker)
+		_, err = fetchCSV(crc, csv.Name, namespace2.Name, csvSucceededChecker)
 		Expect(err).Should(BeNil())
 
 		webhooks, err := c.KubernetesInterface().AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{})


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change converts metrics_e2e_test.go to leverage ginkgo's BDD approach

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
