### PR TITLE
fix: use busybox csv for catalog polling e2e test

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -774,8 +774,8 @@ var _ = Describe("Catalog", func() {
 		defer cleaner.NotifyTestComplete(GinkgoT(), true)
 
 		sourceName := genName("catalog-")
-		packageName := "etcd"
-		channelName := "clusterwide-alpha"
+		packageName := "busybox"
+		channelName := "alpha"
 
 		// Create gRPC CatalogSource using an external registry image and poll interval
 		var image string
@@ -912,7 +912,7 @@ var _ = Describe("Catalog", func() {
 		require.NoError(GinkgoT(), err, "error awaiting registry pod")
 
 		subChecker := func(sub *v1alpha1.Subscription) bool {
-			return sub.Status.InstalledCSV == "etcdoperator.v0.9.2-clusterwide"
+			return sub.Status.InstalledCSV == "busybox.v2.0.0"
 		}
 		// Wait for the Subscription to succeed
 		subscription, err = fetchSubscription(GinkgoT(), crc, testNamespace, subscriptionName, subChecker)
@@ -925,17 +925,12 @@ var _ = Describe("Catalog", func() {
 
 		// check version of running csv to ensure the latest version (0.9.2) was installed onto the cluster
 		v := csv.Spec.Version
-		etcdVersion := semver.Version{
-			Major: 0,
-			Minor: 9,
-			Patch: 2,
-			Pre: []semver.PRVersion{
-				{
-					VersionStr: "clusterwide",
-				},
-			},
+		busyboxVersion := semver.Version{
+			Major: 2,
+			Minor: 0,
+			Patch: 0,
 		}
-		if !reflect.DeepEqual(v, version.OperatorVersion{Version: etcdVersion}) {
+		if !reflect.DeepEqual(v, version.OperatorVersion{Version: busyboxVersion}) {
 			GinkgoT().Errorf("latest version of operator not installed: catalog souce update failed")
 		}
 	})


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This test fixes the catalog polling test that seems to flake very badly in kube 1.18. 

The operator being deployed in the test is now a simple busybox csv instead of the whole etcd 0.9.0 operator. Tags were updated on quay and this PR reflects the code changes required. Test now passes locally consistently. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
