### PR TITLE
chore(gh-actions): install conntrack before minikube

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -4,6 +4,7 @@ on:
     paths:
     - 'scripts/**'
     - 'Makefile'
+    - '.github/workflows/test-scripts.yml'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
+        sudo apt-get install conntrack
         curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
         chmod +x minikube
         sudo mv minikube /bin/


### PR DESCRIPTION
Get minikube action working by installing its missing conntrack dependency.
