### PR TITLE
chore(docker): add kubebuilder to base image

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -2,4 +2,12 @@
 
 FROM openshift/origin-release:golang-1.13
 
-RUN yum install -y skopeo
+# Install test dependencies
+RUN yum install -y skopeo && \
+    export OS=$(go env GOOS) && \
+    export ARCH=$(go env GOARCH) && \
+    curl -L "https://go.kubebuilder.io/dl/2.3.1/${OS}/${ARCH}" | tar -xz -C /tmp/ && \
+    mv /tmp/kubebuilder_2.3.1_${OS}_${ARCH}/ /usr/local/kubebuilder && \
+    export PATH=$PATH:/usr/local/kubebuilder/bin && \
+    echo "Kubebuilder installation complete!"
+


### PR DESCRIPTION
Add kubebuilder to base image to make it available for tests in openshift-ci.

Blocks #1431 
