### PR TITLE
Fix upstream image build

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
+        sudo apt-get install conntrack
         curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
         chmod +x minikube
         sudo mv minikube /bin/

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,12 +1,24 @@
-name: test-scripts
+name: upstream-tests
 on:
   pull_request:
     paths:
-    - 'scripts/**'
-    - 'Makefile'
+    - '**'
+    - '!doc/contributors/**'
+    - '!doc/design/**'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:
+  image-build:
+    runs-on: ubuntu-latest
+    steps: 
+    - name: Check out the repo
+      uses: actions/checkout@v2
+    - name: Build the container image
+      uses: docker/build-push-action@v1
+      with:
+        repository: operator-framework/olm
+        dockerfile: ./upstream.Dockerfile
+        push: false
   run-local-minikube:
     runs-on: ubuntu-latest
     steps:

--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -15,6 +15,7 @@ COPY vendor vendor
 COPY go.mod go.mod
 COPY go.sum go.sum
 COPY cmd cmd
+COPY util util
 COPY test test
 RUN make build
 RUN make build-util


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

- Fix the upstream image build by including the util directory
- Add an `image-build` stage to the GitHub workflow

**Motivation for the change:**

Upstream e2e tests fail because an olm image -- containing the `util/cpb` command -- hasn't successfully been built.
