### PR TITLE
Bug 1825088: Generation should not be a required field

### DIFF
--- a/deploy/chart/crds/0000_50_olm_04-installplan.crd.yaml
+++ b/deploy/chart/crds/0000_50_olm_04-installplan.crd.yaml
@@ -67,7 +67,6 @@ spec:
           - approval
           - approved
           - clusterServiceVersionNames
-          - generation
           properties:
             approval:
               description: Approval is the user approval policy for an InstallPlan.

--- a/manifests/0000_50_olm_04-installplan.crd.yaml
+++ b/manifests/0000_50_olm_04-installplan.crd.yaml
@@ -67,7 +67,6 @@ spec:
           - approval
           - approved
           - clusterServiceVersionNames
-          - generation
           properties:
             approval:
               description: Approval is the user approval policy for an InstallPlan.

--- a/pkg/api/apis/operators/v1alpha1/installplan_types.go
+++ b/pkg/api/apis/operators/v1alpha1/installplan_types.go
@@ -28,7 +28,7 @@ type InstallPlanSpec struct {
 	ClusterServiceVersionNames []string `json:"clusterServiceVersionNames"`
 	Approval                   Approval `json:"approval"`
 	Approved                   bool     `json:"approved"`
-	Generation                 int      `json:"generation"`
+	Generation                 int      `json:"generation,omitempty"`
 }
 
 // InstallPlanPhase is the current status of a InstallPlan as a whole.


### PR DESCRIPTION
In the InstallPlan, the Generation field should not be required and may
be omitted.