### PR TITLE
Fix failing E2E bundle unpacking test.

### DIFF
--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch
+# ./pkg/controller/bundle/bundle_unpacker.go requires "/bin/cp"
+FROM busybox
 COPY olm catalog package-server wait cpb /bin/
 EXPOSE 8080
 EXPOSE 5443


### PR DESCRIPTION
The local E2E image didn't contain /bin/cp, which bundle unpacking
requires.
