### PR TITLE
Add boolean flag to enable resolver v2

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -33,6 +33,7 @@ const (
 	defaultConfigMapServerImage = "quay.io/operatorframework/configmap-operator-registry:latest"
 	defaultUtilImage            = "quay.io/operator-framework/olm:latest"
 	defaultOperatorName         = ""
+	resolverV2EnableEnvVarName  = "RESOLVER_V2_ENABLE"
 )
 
 // config flags defined globally so that they appear on the test binary as well
@@ -68,6 +69,9 @@ var (
 
 	profiling = flag.Bool(
 		"profiling", false, "serve profiling data (on port 8080)")
+
+	resolverV2Enable = flag.Bool(
+		resolverV2EnableEnvVarName, false, "using resolver V2")
 )
 
 func init() {
@@ -100,6 +104,11 @@ func main() {
 	if catalogNamespaceEnvVarValue := os.Getenv(catalogNamespaceEnvVarName); catalogNamespaceEnvVarValue != "" {
 		logger.Infof("%s environment variable is set. Updating Global Catalog Namespace to %s", catalogNamespaceEnvVarName, catalogNamespaceEnvVarValue)
 		*catalogNamespace = catalogNamespaceEnvVarValue
+	}
+
+	if resolverV2EnableEnvVarValue := os.Getenv(resolverV2EnableEnvVarName); resolverV2EnableEnvVarValue != "" {
+		logger.Infof("%s environment variable is set. Updating resolverV2Enable to be true", resolverV2EnableEnvVarName)
+		*resolverV2Enable = true
 	}
 
 	var useTLS bool
@@ -172,7 +181,7 @@ func main() {
 	}
 
 	// Create a new instance of the operator.
-	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *utilImage, *catalogNamespace)
+	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *utilImage, *catalogNamespace, *resolverV2Enable)
 	if err != nil {
 		log.Panicf("error configuring operator: %s", err.Error())
 	}

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -98,7 +98,7 @@ type Operator struct {
 type CatalogSourceSyncFunc func(logger *logrus.Entry, in *v1alpha1.CatalogSource) (out *v1alpha1.CatalogSource, continueSync bool, syncError error)
 
 // NewOperator creates a new Catalog Operator.
-func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clock, logger *logrus.Logger, resync time.Duration, configmapRegistryImage, utilImage string, operatorNamespace string) (*Operator, error) {
+func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clock, logger *logrus.Logger, resync time.Duration, configmapRegistryImage, utilImage string, operatorNamespace string, resolverV2Enable bool) (*Operator, error) {
 	resyncPeriod := queueinformer.ResyncWithJitter(resync, 0.2)
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
@@ -137,7 +137,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		client:                   crClient,
 		lister:                   lister,
 		namespace:                operatorNamespace,
-		resolver:                 resolver.NewOperatorsV1alpha1Resolver(lister, crClient, opClient.KubernetesInterface()),
+		resolver:                 resolver.NewOperatorsV1alpha1Resolver(lister, crClient, opClient.KubernetesInterface(), resolverV2Enable),
 		catsrcQueueSet:           queueinformer.NewEmptyResourceQueueSet(),
 		subQueueSet:              queueinformer.NewEmptyResourceQueueSet(),
 		ipQueueSet:               queueinformer.NewEmptyResourceQueueSet(),


### PR DESCRIPTION
The new resolver (v2) can be enabled using `RESOLVER_V2_ENABLE` flag
in catalog operator deployment. The new resolver will be able to
resolver operator-version dependencies on top of existing gvk
dependencies. If not enabled, existing resolver will be used and
only resolver gvk dependencies.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
