### PR TITLE
Catch failed Ginkgo assertion in test goroutine.

### DIFF
--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -423,6 +423,7 @@ var _ = Describe("Subscription", func() {
 		// Set up async watches that will fail the test if csvB doesn't get created in between csvA and csvC
 		var wg sync.WaitGroup
 		go func(t GinkgoTInterface) {
+			defer GinkgoRecover()
 			wg.Add(1)
 			defer wg.Done()
 			_, err := awaitCSV(GinkgoT(), crc, testNamespace, csvB.GetName(), csvReplacingChecker)


### PR DESCRIPTION
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/operator-framework_operator-lifecycle-manager/1462/pull-ci-operator-framework-operator-lifecycle-manager-master-e2e-aws-olm/5098