### PR TITLE
Run upstream E2E workflow in parallel across multiple runners.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,7 +6,25 @@ on:
   pull_request:
 jobs:
   run-e2e-tests:
+    strategy:
+      matrix:
+        job_index: [0, 1, 2, 3, 4, 5, 6, 7]
+      fail-fast: false
     runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      E2E_CI_NODES: 2
+      E2E_CI_SEED: ${{ github.run_id }}
+      E2E_CI_JOBS: 8
+      E2E_CI_JOB: ${{ matrix.job_index }}
+      JUNIT_DIRECTORY: ${{ github.workspace }}/.junit-${{ matrix.job_index }}
     steps:
       - uses: actions/checkout@v2
-      - run: make -f x.mk e2e-local
+      - run: make -f x.mk e2e-ci
+  merge-test-results:
+    runs-on: ubuntu-latest
+    needs: run-e2e-tests
+    steps:
+      - run: |
+          sudo apt-get install -y golang
+          go run ./test/e2e/reportmerger/main.go ${{ github.workspace }}/.junit-*/* | tee ${{ github.workspace }}/junit.xml

--- a/test/e2e/reportmerger/main.go
+++ b/test/e2e/reportmerger/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func main() {
+	flag.Parse()
+
+	var merged reporters.JUnitTestSuite
+	for _, input := range flag.Args() {
+		func(input string) {
+			fd, err := os.Open(input)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to open file %q: %s\n", input, err)
+				os.Exit(1)
+			}
+			defer func() {
+				if err := fd.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: error while closing %q: %s\n", input, err)
+				}
+			}()
+
+			var suite reporters.JUnitTestSuite
+			if err := xml.NewDecoder(fd).Decode(&suite); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to decode xml from %q: %s\n", input, err)
+				os.Exit(1)
+			}
+
+			if merged.Name == "" {
+				merged.Name = suite.Name
+			}
+			merged.Tests += suite.Tests
+			merged.Failures += suite.Failures
+			merged.Errors += suite.Errors
+			merged.Time += suite.Time
+			merged.TestCases = append(merged.TestCases, suite.TestCases...)
+		}(input)
+	}
+
+	if _, err := io.Copy(os.Stdout, strings.NewReader(xml.Header)); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing output: %s\n", err)
+		os.Exit(1)
+	}
+
+	e := xml.NewEncoder(os.Stdout)
+	e.Indent("", "  ")
+	if err := e.Encode(&merged); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing output: %s\n", err)
+		os.Exit(1)
+	}
+
+	if _, err := os.Stdout.WriteString("\n"); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing output: %s\n", err)
+		os.Exit(1)
+	}
+
+	if merged.Failures > 0 || merged.Errors > 0 {
+		os.Exit(2)
+	}
+}


### PR DESCRIPTION
Forgive my AWK. Github allows up to twenty concurrent jobs, so I've
configured the end-to-end test workflow to split the specs across
multiple jobs.
