### PR TITLE
Changed address for readiness and liveness probes on registry-server

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -114,7 +114,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 					ReadinessProbe: &v1.Probe{
 						Handler: v1.Handler{
 							Exec: &v1.ExecAction{
-								Command: []string{"grpc_health_probe", "-addr=localhost:50051"},
+								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: readinessDelay,
@@ -123,7 +123,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 					LivenessProbe: &v1.Probe{
 						Handler: v1.Handler{
 							Exec: &v1.ExecAction{
-								Command: []string{"grpc_health_probe", "-addr=localhost:50051"},
+								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: livenessDelay,


### PR DESCRIPTION
**Description of the change:**

Removed 'localhost' hostname from GRPC readiness and liveness probes on the registry-server.

**Motivation for the change:**

The readiness and liveness probes are failing for the registry-server because the GRPC health check cannot connect using the localhost hostname. 

This can be demonstrated manually as shown below:

With 'localhost' hostname as part of the address:
```
root@devops:~/operator-lifecycle-manager# kubectl -n olm exec -it operatorhubio-catalog-lnh9k  -- grpc_health_probe -addr=localhost:50051 -connect-timeout 10s -v
parsed options:
> addr=localhost:50051 conn_timeout=10s rpc_timeout=1s
> tls=false
establishing connection
timeout: failed to connect service "localhost:50051" within 10s
command terminated with exit code 2
```

Without 'localhost' hostname as part of the address:
```
root@devops:~/operator-lifecycle-manager# kubectl -n olm exec -it operatorhubio-catalog-lnh9k  -- grpc_health_probe -addr=:50051 -connect-timeout 10s -v
parsed options:
> addr=:50051 conn_timeout=10s rpc_timeout=1s
> tls=false
establishing connection
time elapsed: connect=567.314µs rpc=844.357µs
status: SERVING
```

This aligns the probes with the readiness and liveness probes for the other pods, which do not specify a hostname.

