### PR TITLE
test(resolver): add a test case that explicitly verifies ownership transfer

### DIFF
--- a/pkg/controller/registry/resolver/evolver.go
+++ b/pkg/controller/registry/resolver/evolver.go
@@ -51,8 +51,13 @@ func (e *NamespaceGenerationEvolver) Evolve(add map[OperatorSourceInfo]struct{})
 }
 
 func (e *NamespaceGenerationEvolver) checkForUpdates() error {
+	// maps the old operator identifier to the new operator
+	updates := EmptyOperatorSet()
+
 	// take a snapshot of the current generation so that we don't update the same operator twice in one resolution
-	for _, op := range e.gen.Operators().Snapshot() {
+	snapshot := e.gen.Operators().Snapshot()
+
+	for _, op := range snapshot {
 		// only check for updates if we have sourceinfo
 		if op.SourceInfo() == &ExistingOperator {
 			continue
@@ -68,11 +73,21 @@ func (e *NamespaceGenerationEvolver) checkForUpdates() error {
 			return errors.Wrap(err, "error parsing bundle")
 		}
 		o.SetReplaces(op.Identifier())
-		if err := e.gen.AddOperator(o); err != nil {
+		updates[op.Identifier()] = o
+	}
+
+	// remove any operators we found updates for
+	for old := range updates {
+		e.gen.RemoveOperator(e.gen.Operators().Snapshot()[old])
+	}
+
+	// add the new operators we found
+	for _, new := range updates {
+		if err := e.gen.AddOperator(new); err != nil {
 			return errors.Wrap(err, "error calculating generation changes due to new bundle")
 		}
-		e.gen.RemoveOperator(op)
 	}
+
 	return nil
 }
 

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -410,6 +410,55 @@ func TestNamespaceResolver(t *testing.T) {
 			},
 		},
 		{
+			// This test verifies that ownership of an api can be migrated between two operators
+			name: "OwnedAPITransfer",
+			clusterState: []runtime.Object{
+				existingSub(namespace, "a.v1", "a", "alpha", catalog),
+				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				existingSub(namespace, "b.v1", "b", "alpha", catalog),
+				existingOperator(namespace, "b.v1", "b", "alpha", "", Provides2, Requires1, nil, nil),
+			},
+			querier: NewFakeSourceQuerier(map[CatalogKey][]*api.Bundle{
+				catalog: {
+					bundle("a.v2", "a", "alpha", "a.v1", nil, nil, nil, nil),
+					bundle("b.v2", "b", "alpha", "b.v1", Provides1.Union(Provides2), nil, nil, nil),
+				},
+			}),
+			out: out{
+				steps: [][]*v1alpha1.Step{
+					bundleSteps(bundle("a.v2", "a", "alpha", "a.v1", nil, nil, nil, nil), namespace, "", catalog),
+					bundleSteps(bundle("b.v2", "b", "alpha", "b.v1", Provides1.Union(Provides2), nil, nil, nil), namespace, "", catalog),
+				},
+				subs: []*v1alpha1.Subscription{
+					updatedSub(namespace, "a.v2", "a", "alpha", catalog),
+					updatedSub(namespace, "b.v2", "b", "alpha", catalog),
+				},
+			},
+		},
+		{
+			name: "PicksOlderProvider",
+			clusterState: []runtime.Object{
+				newSub(namespace, "b", "alpha", catalog),
+			},
+			querier: NewFakeSourceQuerier(map[CatalogKey][]*api.Bundle{
+				catalog: {
+					bundle("a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+					bundle("a.v2", "a", "alpha", "a.v1", nil, nil, nil, nil),
+					bundle("b.v1", "b", "alpha", "", nil, Requires1, nil, nil),
+				},
+			}),
+			out: out{
+				steps: [][]*v1alpha1.Step{
+					bundleSteps(bundle("a.v1", "a", "alpha", "", Provides1, nil, nil, nil), namespace, "", catalog),
+					bundleSteps(bundle("b.v1", "b", "alpha", "", nil, Requires1, nil, nil), namespace, "", catalog),
+					subSteps(namespace, "a.v1", "a", "alpha", catalog),
+				},
+				subs: []*v1alpha1.Subscription{
+					updatedSub(namespace, "b.v1", "b", "alpha", catalog),
+				},
+			},
+		},
+		{
 			name: "InstalledSub/UpdateInHead/SkipRange",
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -416,18 +416,18 @@ func TestNamespaceResolver(t *testing.T) {
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
 				existingSub(namespace, "b.v1", "b", "alpha", catalog),
-				existingOperator(namespace, "b.v1", "b", "alpha", "", Provides2, Requires1, nil, nil),
+				existingOperator(namespace, "b.v1", "b", "alpha", "", nil, Requires1, nil, nil),
 			},
 			querier: NewFakeSourceQuerier(map[CatalogKey][]*api.Bundle{
 				catalog: {
 					bundle("a.v2", "a", "alpha", "a.v1", nil, nil, nil, nil),
-					bundle("b.v2", "b", "alpha", "b.v1", Provides1.Union(Provides2), nil, nil, nil),
+					bundle("b.v2", "b", "alpha", "b.v1", Provides1, nil, nil, nil),
 				},
 			}),
 			out: out{
 				steps: [][]*v1alpha1.Step{
 					bundleSteps(bundle("a.v2", "a", "alpha", "a.v1", nil, nil, nil, nil), namespace, "", catalog),
-					bundleSteps(bundle("b.v2", "b", "alpha", "b.v1", Provides1.Union(Provides2), nil, nil, nil), namespace, "", catalog),
+					bundleSteps(bundle("b.v2", "b", "alpha", "b.v1", Provides1, nil, nil, nil), namespace, "", catalog),
 				},
 				subs: []*v1alpha1.Subscription{
 					updatedSub(namespace, "a.v2", "a", "alpha", catalog),


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This adds a test case to the resolver that explicitly checks that an api can transfer ownership from one operator to another during an upgrade.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
