### PR TITLE
Bug 1827821: Generation bug 4.4 Backport

### DIFF
--- a/pkg/controller/registry/resolver/evolver.go
+++ b/pkg/controller/registry/resolver/evolver.go
@@ -68,10 +68,14 @@ func (e *NamespaceGenerationEvolver) checkForUpdates() error {
 			return errors.Wrap(err, "error parsing bundle")
 		}
 		o.SetReplaces(op.Identifier())
+
+		// Remove the old operator and the APIs it provides before adding the new operator to the generation.
+		e.gen.RemoveOperator(op)
+
+		// Add the new operator and the APIs it provides to the generation.
 		if err := e.gen.AddOperator(o); err != nil {
 			return errors.Wrap(err, "error calculating generation changes due to new bundle")
 		}
-		e.gen.RemoveOperator(op)
 	}
 	return nil
 }

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -120,7 +120,7 @@ func TestNamespaceResolver(t *testing.T) {
 				},
 				lookups: []v1alpha1.BundleLookup{
 					{
-						Path: "quay.io/test/bundle@sha256:abcd",
+						Path:       "quay.io/test/bundle@sha256:abcd",
 						Identifier: "b.v1",
 						CatalogSourceRef: &corev1.ObjectReference{
 							Namespace: catalog.Namespace,
@@ -234,9 +234,9 @@ func TestNamespaceResolver(t *testing.T) {
 				steps: [][]*v1alpha1.Step{},
 				lookups: []v1alpha1.BundleLookup{
 					{
-						Path:     "quay.io/test/bundle@sha256:abcd",
+						Path:       "quay.io/test/bundle@sha256:abcd",
 						Identifier: "a.v2",
-						Replaces: "a.v1",
+						Replaces:   "a.v1",
 						CatalogSourceRef: &corev1.ObjectReference{
 							Namespace: catalog.Namespace,
 							Name:      catalog.Name,
@@ -422,6 +422,43 @@ func TestNamespaceResolver(t *testing.T) {
 				},
 				subs: []*v1alpha1.Subscription{
 					updatedSub(namespace, "a.v3", "a", "alpha", catalog),
+				},
+			},
+		},
+		{
+			// This test uses logic that implements the FakeSourceQuerier to ensure
+			// that the required API is provided by the new Operator.
+			//
+			// Background:
+			// OLM used to add the new operator to the generation before removing
+			// the old operator from the generation. The logic that removes an operator
+			// from the current generation removes the APIs it provides from the list of
+			// "available" APIs. This caused OLM to search for an operator that provides the API.
+			// If the operator that provides the API uses a skipRange rather than the Spec.Replaces
+			// field, the Replaces field is set to an empty string, causing OLM to fail to upgrade.
+			name: "InstalledSubs/ExistingOperators/OldCSVsReplaced",
+			clusterState: []runtime.Object{
+				existingSub(namespace, "a.v1", "a", "alpha", catalog),
+				existingSub(namespace, "b.v1", "b", "beta", catalog),
+				existingOperator(namespace, "a.v1", "a", "alpha", "", nil, Requires1, nil, nil),
+				existingOperator(namespace, "b.v1", "b", "beta", "", Provides1, nil, nil, nil),
+			},
+			querier: NewFakeSourceQuerier(map[CatalogKey][]*api.Bundle{
+				catalog: {
+					bundle("a.v1", "a", "alpha", "", nil, nil, nil, nil),
+					bundle("a.v2", "a", "alpha", "a.v1", nil, Requires1, nil, nil),
+					bundle("b.v1", "b", "beta", "", Provides1, nil, nil, nil),
+					bundle("b.v2", "b", "beta", "b.v1", Provides1, nil, nil, nil),
+				},
+			}),
+			out: out{
+				steps: [][]*v1alpha1.Step{
+					bundleSteps(bundle("a.v2", "a", "alpha", "a.v1", nil, Requires1, nil, nil), namespace, "", catalog),
+					bundleSteps(bundle("b.v2", "b", "beta", "b.v1", Provides1, nil, nil, nil), namespace, "", catalog),
+				},
+				subs: []*v1alpha1.Subscription{
+					updatedSub(namespace, "a.v2", "a", "alpha", catalog),
+					updatedSub(namespace, "b.v2", "b", "beta", catalog),
 				},
 			},
 		},


### PR DESCRIPTION
This PR fixes two issues with OLM's "Generation Calculator":

Problem:
If an operator is being upgraded that provides a required API whose GVK
has not changed since the previous version of the operator and
uses a skipRange instead of the Spec.Replaces field, OLM will:
* Add the new operator to the generation, and marking the APIs it
  provides as "present".
* Remove the old operator from the generation, marking the APIs it
  provides as "absent", despite being provided by the new version of the
  operator.
* Attempt to resolve the "missing" APIs, overwriting the new version
  of the operator with a copy that  does not have its Spec.Replaces field
  set.

This causes OLM to fail the upgrade, where the old operator's CSV will
not be replaced and the new operators CSV will run into an intercepting
API Provider issue.

Solution:
Update OLM to remove the old operator from the current generation before
adding the new operator to the generation.

Problem:
In an upgrade where v1 of Operator A provides an API and v1 of Operator
B depends on the API, where the ownership of the API is transferred from
Operator A to Operator B during the upgrade, OLM may run into a
situation where Operator B is updated first. This causes OLM to fail to
calculate the generation because multiple operator provide the same
API.

Solution:
Add and remove updates as a set to prevent the situation described
above.