### PR TITLE
Bug 1827822: Generation bug 4.3

### DIFF
--- a/pkg/controller/registry/resolver/evolver.go
+++ b/pkg/controller/registry/resolver/evolver.go
@@ -67,10 +67,15 @@ func (e *NamespaceGenerationEvolver) checkForUpdates() error {
 		if err != nil {
 			return errors.Wrap(err, "error parsing bundle")
 		}
+		o.SetReplaces(op.Identifier())
+
+		// Remove the old operator and the APIs it provides before adding the new operator to the generation.
+		e.gen.RemoveOperator(op)
+
+		// Add the new operator and the APIs it provides to the generation.
 		if err := e.gen.AddOperator(o); err != nil {
 			return errors.Wrap(err, "error calculating generation changes due to new bundle")
 		}
-		e.gen.RemoveOperator(op)
 	}
 	return nil
 }

--- a/pkg/controller/registry/resolver/operators.go
+++ b/pkg/controller/registry/resolver/operators.go
@@ -356,6 +356,10 @@ func (o *Operator) Replaces() string {
 	return o.replaces
 }
 
+func (o *Operator) SetReplaces(replacing string) {
+	o.replaces = replacing
+}
+
 func (o *Operator) Package() string {
 	return o.bundle.PackageName
 }

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -99,40 +99,6 @@ func TestNamespaceResolver(t *testing.T) {
 			},
 		},
 		{
-<<<<<<< HEAD
-=======
-			name: "SingleNewSubscription/ResolveOne/BundlePath",
-			clusterState: []runtime.Object{
-				newSub(namespace, "a", "alpha", catalog),
-			},
-			querier: NewFakeSourceQuerier(map[CatalogKey][]*api.Bundle{
-				catalog: {
-					bundle("a.v1", "a", "alpha", "", nil, Requires1, nil, nil),
-					stripManifests(withBundlePath(bundle("b.v1", "b", "beta", "", Provides1, nil, nil, nil), "quay.io/test/bundle@sha256:abcd")),
-				},
-			}),
-			out: out{
-				steps: [][]*v1alpha1.Step{
-					bundleSteps(bundle("a.v1", "a", "alpha", "", nil, Requires1, nil, nil), namespace, "", catalog),
-					subSteps(namespace, "b.v1", "b", "beta", catalog),
-				},
-				lookups: []v1alpha1.BundleLookup{
-					{
-						Path:       "quay.io/test/bundle@sha256:abcd",
-						Identifier: "b.v1",
-						CatalogSourceRef: &corev1.ObjectReference{
-							Namespace: catalog.Namespace,
-							Name:      catalog.Name,
-						},
-					},
-				},
-				subs: []*v1alpha1.Subscription{
-					updatedSub(namespace, "a.v1", "a", "alpha", catalog),
-				},
-			},
-		},
-		{
->>>>>>> fa4b13b9... Fix Operator Generation code
 			name: "SingleNewSubscription/ResolveOne/AdditionalBundleObjects",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
@@ -223,34 +189,6 @@ func TestNamespaceResolver(t *testing.T) {
 			},
 		},
 		{
-<<<<<<< HEAD
-=======
-			name: "InstalledSub/UpdateAvailable/FromBundlePath",
-			clusterState: []runtime.Object{
-				existingSub(namespace, "a.v1", "a", "alpha", catalog),
-				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
-			},
-			querier: NewFakeSourceQuerierCustomReplacement(catalog, stripManifests(withBundlePath(bundle("a.v2", "a", "alpha", "a.v1", Provides1, nil, nil, nil), "quay.io/test/bundle@sha256:abcd"))),
-			out: out{
-				steps: [][]*v1alpha1.Step{},
-				lookups: []v1alpha1.BundleLookup{
-					{
-						Path:       "quay.io/test/bundle@sha256:abcd",
-						Identifier: "a.v2",
-						Replaces:   "a.v1",
-						CatalogSourceRef: &corev1.ObjectReference{
-							Namespace: catalog.Namespace,
-							Name:      catalog.Name,
-						},
-					},
-				},
-				subs: []*v1alpha1.Subscription{
-					updatedSub(namespace, "a.v2", "a", "alpha", catalog),
-				},
-			},
-		},
-		{
->>>>>>> fa4b13b9... Fix Operator Generation code
 			name: "InstalledSub/NoRunningOperator",
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
@@ -408,6 +346,55 @@ func TestNamespaceResolver(t *testing.T) {
 				subs: []*v1alpha1.Subscription{
 					updatedSub(namespace, "a.v2", "a", "alpha", catalog),
 					updatedSub(namespace, "b.v2", "b", "alpha", catalog),
+				},
+			},
+		},
+		{
+			// This test verifies that ownership of an api can be migrated between two operators
+			name: "OwnedAPITransfer",
+			clusterState: []runtime.Object{
+				existingSub(namespace, "a.v1", "a", "alpha", catalog),
+				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				existingSub(namespace, "b.v1", "b", "alpha", catalog),
+				existingOperator(namespace, "b.v1", "b", "alpha", "", nil, Requires1, nil, nil),
+			},
+			querier: NewFakeSourceQuerier(map[CatalogKey][]*api.Bundle{
+				catalog: {
+					bundle("a.v2", "a", "alpha", "a.v1", nil, nil, nil, nil),
+					bundle("b.v2", "b", "alpha", "b.v1", Provides1, nil, nil, nil),
+				},
+			}),
+			out: out{
+				steps: [][]*v1alpha1.Step{
+					bundleSteps(bundle("a.v2", "a", "alpha", "a.v1", nil, nil, nil, nil), namespace, "", catalog),
+					bundleSteps(bundle("b.v2", "b", "alpha", "b.v1", Provides1, nil, nil, nil), namespace, "", catalog),
+				},
+				subs: []*v1alpha1.Subscription{
+					updatedSub(namespace, "a.v2", "a", "alpha", catalog),
+					updatedSub(namespace, "b.v2", "b", "alpha", catalog),
+				},
+			},
+		},
+		{
+			name: "PicksOlderProvider",
+			clusterState: []runtime.Object{
+				newSub(namespace, "b", "alpha", catalog),
+			},
+			querier: NewFakeSourceQuerier(map[CatalogKey][]*api.Bundle{
+				catalog: {
+					bundle("a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+					bundle("a.v2", "a", "alpha", "a.v1", nil, nil, nil, nil),
+					bundle("b.v1", "b", "alpha", "", nil, Requires1, nil, nil),
+				},
+			}),
+			out: out{
+				steps: [][]*v1alpha1.Step{
+					bundleSteps(bundle("a.v1", "a", "alpha", "", Provides1, nil, nil, nil), namespace, "", catalog),
+					bundleSteps(bundle("b.v1", "b", "alpha", "", nil, Requires1, nil, nil), namespace, "", catalog),
+					subSteps(namespace, "a.v1", "a", "alpha", catalog),
+				},
+				subs: []*v1alpha1.Subscription{
+					updatedSub(namespace, "b.v1", "b", "alpha", catalog),
 				},
 			},
 		},

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/blang/semver"
@@ -691,6 +692,116 @@ func TestDeleteGRPCRegistryPodTriggersRecreation(t *testing.T) {
 	require.NoError(t, err, "error waiting for replacement registry pod")
 	require.NotNil(t, registryPods, "nil replacement registry pods")
 	require.Equal(t, 1, len(registryPods.Items), "unexpected number of replacement registry pods found")
+}
+
+func TestDependencySkipRange(t *testing.T) {
+	// Create a CatalogSource that contains the busybox v1 and busybox-dependency v1 images
+	// Create a Subscription for busybox v1, which has a dependency on busybox-dependency v1.
+	// Wait for the busybox and busybox2 Subscriptions to succeed
+	// Wait for the CSVs to succeed
+	// Update the catalog to point to an image that contains the busybox v2 and busybox-dependency v2 images.
+	// Wait for the new Subscriptions to succeed and check if they include the new CSVs
+	// Wait for the CSVs to succeed and confirm that the have the correct Spec.Replaces fields.
+	defer cleaner.NotifyTestComplete(t, true)
+
+	sourceName := genName("catalog-")
+	packageName := "busybox"
+	channelName := "alpha"
+
+	catSrcImage := "quay.io/olmtest/busybox-dependencies-index"
+
+	// Create gRPC CatalogSource
+	source := &v1alpha1.CatalogSource{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.CatalogSourceKind,
+			APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sourceName,
+			Namespace: testNamespace,
+		},
+		Spec: v1alpha1.CatalogSourceSpec{
+			SourceType: v1alpha1.SourceTypeGrpc,
+			Image:      catSrcImage + ":1.0.0",
+		},
+	}
+
+	crc := newCRClient(t)
+	source, err := crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(source)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Delete(source.GetName(), &metav1.DeleteOptions{}))
+	}()
+
+	// Create a Subscription for busybox
+	subscriptionName := genName("sub-")
+	cleanupSubscription := createSubscriptionForCatalog(t, crc, source.GetNamespace(), subscriptionName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
+	defer cleanupSubscription()
+
+	// Wait for the Subscription to succeed
+	subscription, err := fetchSubscription(t, crc, testNamespace, subscriptionName, subscriptionStateAtLatestChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	require.Equal(t, subscription.Status.InstalledCSV, "busybox.v1.0.0")
+
+	// Confirm that a subscription was created for busybox-dependency
+	subscriptionList, err := crc.OperatorsV1alpha1().Subscriptions(source.GetNamespace()).List(metav1.ListOptions{})
+	require.NoError(t, err)
+	dependencySubscriptionName := ""
+	for _, sub := range subscriptionList.Items {
+		if strings.HasPrefix(sub.GetName(), "busybox-dependency") {
+			dependencySubscriptionName = sub.GetName()
+		}
+	}
+
+	require.NotEmpty(t, dependencySubscriptionName)
+	// Wait for the Subscription to succeed
+	subscription, err = fetchSubscription(t, crc, testNamespace, dependencySubscriptionName, subscriptionStateAtLatestChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	require.Equal(t, subscription.Status.InstalledCSV, "busybox-dependency.v1.0.0")
+
+	// Update the catalog image
+	err = wait.PollImmediate(pollInterval, pollDuration, func() (bool, error) {
+		existingSource, err := crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Get(sourceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		existingSource.Spec.Image = catSrcImage + ":2.0.0"
+
+		source, err = crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Update(existingSource)
+		if err == nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	// Wait for the busybox v2 Subscription to succeed
+	subChecker := func(sub *v1alpha1.Subscription) bool {
+		return sub.Status.InstalledCSV == "busybox.v2.0.0"
+	}
+	subscription, err = fetchSubscription(t, crc, testNamespace, subscriptionName, subChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+
+	// Wait for busybox v2 csv to succeed and check the replaces field
+	csv, err := fetchCSV(t, crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+	require.NoError(t, err)
+	require.Equal(t, "busybox.v1.0.0", csv.Spec.Replaces)
+
+	// Wait for the busybox-dependency v2 Subscription to succeed
+	subChecker = func(sub *v1alpha1.Subscription) bool {
+		return sub.Status.InstalledCSV == "busybox-dependency.v2.0.0"
+	}
+	subscription, err = fetchSubscription(t, crc, testNamespace, dependencySubscriptionName, subChecker)
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+
+	// Wait for busybox-dependency v2 csv to succeed and check the replaces field
+	csv, err = fetchCSV(t, crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+	require.NoError(t, err)
+	require.Equal(t, "busybox-dependency.v1.0.0", csv.Spec.Replaces)
 }
 
 func getOperatorDeployment(c operatorclient.ClientInterface, namespace string, operatorLabels labels.Set) (*appsv1.Deployment, error) {


### PR DESCRIPTION
This PR fixes two issues with OLM's "Generation Calculator":

Problem:
If an operator is being upgraded that provides a required API whose GVK
has not changed since the previous version of the operator and
uses a skipRange instead of the Spec.Replaces field, OLM will:

Add the new operator to the generation, and marking the APIs it
provides as "present".
Remove the old operator from the generation, marking the APIs it
provides as "absent", despite being provided by the new version of the
operator.
Attempt to resolve the "missing" APIs, overwriting the new version
of the operator with a copy that does not have its Spec.Replaces field
set.
This causes OLM to fail the upgrade, where the old operator's CSV will
not be replaced and the new operators CSV will run into an intercepting
API Provider issue.

Solution:
Update OLM to remove the old operator from the current generation before
adding the new operator to the generation.

Problem:
In an upgrade where v1 of Operator A provides an API and v1 of Operator
B depends on the API, where the ownership of the API is transferred from
Operator A to Operator B during the upgrade, OLM may run into a
situation where Operator B is updated first. This causes OLM to fail to
calculate the generation because multiple operator provide the same
API.

Solution:
Add and remove updates as a set to prevent the situation described
above.