### PR TITLE
cleanup: delete duplicated import in olm

### DIFF
--- a/cmd/olm/cleanup.go
+++ b/cmd/olm/cleanup.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,7 +65,7 @@ func cleanup(logger *logrus.Logger, c operatorclient.ClientInterface, crc versio
 }
 
 func waitForDelete(checkResource checkResourceFunc, deleteResource deleteResourceFunc) error {
-	if err := checkResource(); err != nil && errors.IsNotFound(err) {
+	if err := checkResource(); err != nil && k8serrors.IsNotFound(err) {
 		return nil
 	}
 	if err := deleteResource(); err != nil {
@@ -74,7 +73,7 @@ func waitForDelete(checkResource checkResourceFunc, deleteResource deleteResourc
 	}
 	err := wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		err := checkResource()
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return true, nil
 		}
 		if err != nil {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
The errors package is being imported twice in same package, this delete one import.

**Motivation for the change:**
\kind cleanup codebase

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
