### PR TITLE
Bug 1828550: safely deprecate stored versions of CRDs

### DIFF
--- a/pkg/lib/crd/version.go
+++ b/pkg/lib/crd/version.go
@@ -2,10 +2,14 @@ package crd
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 
 // V1Beta1 refers to the deprecated v1beta1 APIVersion of CRD objects
@@ -37,5 +41,132 @@ func Version(manifest *string) (string, error) {
 	}
 
 	return v, nil
+}
+
+// Versions returns all resource versions present in the CRD. Compatible with both v1beta1 and v1 CRDs.
+func ResourceVersions(obj runtime.Object) (map[string]struct{}, error) {
+	versions := make(map[string]struct{})
+
+	switch crd := obj.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		for _, version := range crd.Spec.Versions {
+			versions[version.Name] = struct{}{}
+		}
+		return versions, nil
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		for _, version := range crd.Spec.Versions {
+			versions[version.Name] = struct{}{}
+		}
+		if crd.Spec.Version != "" {
+			versions[crd.Spec.Version] = struct{}{}
+		}
+		return versions, nil
+	default:
+		return nil, fmt.Errorf("could not find all versions present in CRD")
+	}
+}
+
+func StoredVersions(obj runtime.Object) []string {
+	switch crd := obj.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		return crd.Status.StoredVersions
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		return crd.Status.StoredVersions
+	}
+	return nil
+}
+
+// RunStorageMigration determines whether the new CRD changes the storage version of the existing CRD.
+// If true, OLM must run a migration process to ensure all CRs can be stored at the new version.
+// See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version
+func RunStorageMigration(oldCRD runtime.Object, newCRD runtime.Object) bool {
+	newStoredVersions, oldStoredVersions := getStoredVersions(oldCRD, newCRD)
+
+	for name := range oldStoredVersions {
+		if _, ok := newStoredVersions[name]; ok {
+			// new storage version exists in old CRD present on the cluster
+			// no need to run migration
+			return false
+		}
+	}
+	return true
+}
+
+func getStoredVersions(oldCRD runtime.Object, newCRD runtime.Object) (newStoredVersions map[string]struct{}, oldStoredVersions map[string]struct{}) {
+	oldStoredVersions = make(map[string]struct{})
+	newStoredVersions = make(map[string]struct{})
+
+	// find old storage versions by inspect the status field of the existing on-cluster CRD
+	switch crd := oldCRD.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		for _, version := range crd.Status.StoredVersions {
+			oldStoredVersions[version] = struct{}{}
+		}
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		for _, version := range crd.Status.StoredVersions {
+			oldStoredVersions[version] = struct{}{}
+		}
+	}
+
+	switch crd := newCRD.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		for _, version := range crd.Spec.Versions {
+			if version.Storage {
+				newStoredVersions[version.Name] = struct{}{}
+			}
+		}
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		for _, version := range crd.Spec.Versions {
+			if version.Storage {
+				newStoredVersions[version.Name] = struct{}{}
+			}
+		}
+	}
+
+	return newStoredVersions, oldStoredVersions
+}
+
+// GetNewStorageVersion returns the storage version defined in the CRD.
+// Only one version may be specified as the storage version.
+func GetNewStorageVersion(crd runtime.Object) string {
+	switch crd := crd.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		for _, version := range crd.Spec.Versions {
+			if version.Storage {
+				return version.Name
+			}
+		}
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		for _, version := range crd.Spec.Versions {
+			if version.Storage {
+				return version.Name
+			}
+		}
+	}
+	return ""
+}
+
+// GetDeprecatedStorageVersion returns the storage version that is being deprecated
+func GetDeprecatedStorageVersion(oldCRD runtime.Object, newCRD runtime.Object) string {
+	newStoredVersions, oldStoredVersions := getStoredVersions(oldCRD, newCRD)
+
+	for name := range oldStoredVersions {
+		if _, ok := newStoredVersions[name]; !ok {
+			// old storage version does not exist in new CRD - this is the deprecated version
+			return name
+		}
+	}
+
+	return ""
+}
+
+func RemoveStorageVersion(versions []string, deprecated string) []string {
+	for i, v := range versions {
+		if v == deprecated {
+			return append(versions[:i], versions[i+1:]...)
+		}
+		return versions
+	}
+	return nil
 }
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR adds back the ability for OLM to deprecate storage versions of CRDs during the CRD upgrade process. This was removed when adding support for v1 CRDs because the existing storage deprecation code could cause data loss issues - CRs of removed storage versions would remain in etcd but would not be `GET`able from the client, causing data loss. 

**Motivation for the change:**
Implement a safe way to deprecate old storage versions of CRDs. This can be done in several ways, but [the k8s docs](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version) suggest writing each CR to the new storage version first before removing the old stored version. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
