### PR TITLE
Replace assertions for csv-e2e to use Gomega's matcher library

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/operator-framework/api/pkg/lib/version"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/operator-framework/api/pkg/lib/version"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
@@ -165,7 +165,7 @@ var _ = Describe("Catalog represents a store of bundles which OLM can use to ins
 		_, err = crc.OperatorsV1alpha1().InstallPlans(testNamespace).Update(context.TODO(), fetchedInstallPlan, metav1.UpdateOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 
-		_, err = awaitCSV(GinkgoT(), crc, testNamespace, mainCSV.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, testNamespace, mainCSV.GetName(), csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Update manifest
@@ -503,7 +503,7 @@ var _ = Describe("Catalog represents a store of bundles which OLM can use to ins
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for the replacement CSV to be installed
-		_, err = awaitCSV(GinkgoT(), crc, testNamespace, replacementCSV.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, testNamespace, replacementCSV.GetName(), csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -34,15 +33,21 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
-var _ = Describe("CSV", func() {
+var _ = Describe("ClusterServiceVersion", func() {
+	var (
+		c   operatorclient.ClientInterface
+		crc versioned.Interface
+	)
+	BeforeEach(func() {
+
+		c = newKubeClient()
+		crc = newCRClient()
+	})
 	AfterEach(func() {
 		TearDown(testNamespace)
 	})
 
-	It("create with unmet requirements mini kube version", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
+	It("create with unmet requirements min kube version", func() {
 
 		depName := genName("dep-")
 		csv := v1alpha1.ClusterServiceVersion{
@@ -78,21 +83,20 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Shouldn't create deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		require.Error(GinkgoT(), err)
+		Consistently(func() bool {
+			_, err := c.GetDeployment(testNamespace, depName)
+			return k8serrors.IsNotFound(err)
+		}).Should(BeTrue())
 	})
 	// TODO: same test but missing serviceaccount instead
 	It("create with unmet requirements CRD", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		depName := genName("dep-")
 		csv := v1alpha1.ClusterServiceVersion{
@@ -139,20 +143,20 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Shouldn't create deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		require.Error(GinkgoT(), err)
+		Consistently(func() bool {
+			_, err := c.GetDeployment(testNamespace, depName)
+			return k8serrors.IsNotFound(err)
+		}).Should(BeTrue())
 	})
-	It("create with unmet permissions CRD", func() {
 
-		c := newKubeClient()
-		crc := newCRClient()
+	It("create with unmet permissions CRD", func() {
 
 		saName := genName("dep-")
 		permissions := []v1alpha1.StrategyDeploymentPermissions{
@@ -243,24 +247,23 @@ var _ = Describe("CSV", func() {
 				Scope: "Namespaced",
 			},
 		})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Shouldn't create deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		require.Error(GinkgoT(), err)
+		Consistently(func() bool {
+			_, err := c.GetDeployment(testNamespace, depName)
+			return k8serrors.IsNotFound(err)
+		}).Should(BeTrue())
 	})
 	It("create with unmet requirements API service", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		depName := genName("dep-")
 		csv := v1alpha1.ClusterServiceVersion{
@@ -307,20 +310,19 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Shouldn't create deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		require.Error(GinkgoT(), err)
+		Consistently(func() bool {
+			_, err := c.GetDeployment(testNamespace, depName)
+			return k8serrors.IsNotFound(err)
+		}).Should(BeTrue())
 	})
 	It("create with unmet permissions API service", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		saName := genName("dep-")
 		permissions := []v1alpha1.StrategyDeploymentPermissions{
@@ -395,20 +397,19 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Shouldn't create deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		require.Error(GinkgoT(), err)
+		Consistently(func() bool {
+			_, err := c.GetDeployment(testNamespace, depName)
+			return k8serrors.IsNotFound(err)
+		}).Should(BeTrue())
 	})
 	It("create with unmet requirements native API", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		depName := genName("dep-")
 		csv := v1alpha1.ClusterServiceVersion{
@@ -445,27 +446,26 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Shouldn't create deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		require.Error(GinkgoT(), err)
+		Consistently(func() bool {
+			_, err := c.GetDeployment(testNamespace, depName)
+			return k8serrors.IsNotFound(err)
+		}).Should(BeTrue())
 	})
 	// TODO: same test but create serviceaccount instead
 	It("create requirements met CRD", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		sa := corev1.ServiceAccount{}
 		sa.SetName(genName("sa-"))
 		sa.SetNamespace(testNamespace)
 		_, err := c.CreateServiceAccount(&sa)
-		require.NoError(GinkgoT(), err, "could not create ServiceAccount %#v", sa)
+		Expect(err).ShouldNot(HaveOccurred(), "could not create ServiceAccount %#v", sa)
 
 		permissions := []v1alpha1.StrategyDeploymentPermissions{
 			{
@@ -545,11 +545,11 @@ var _ = Describe("CSV", func() {
 
 		// Create CSV first, knowing it will fail
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		crd := apiextensions.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{
@@ -575,7 +575,7 @@ var _ = Describe("CSV", func() {
 		}})
 		cleanupCRD, err := createCRD(c, crd)
 		defer cleanupCRD()
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Create Role/Cluster Roles and RoleBindings
 		role := rbacv1.Role{
@@ -590,7 +590,7 @@ var _ = Describe("CSV", func() {
 		role.SetName(genName("dep-"))
 		role.SetNamespace(testNamespace)
 		_, err = c.CreateRole(&role)
-		require.NoError(GinkgoT(), err, "could not create Role")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
 
 		roleBinding := rbacv1.RoleBinding{
 			Subjects: []rbacv1.Subject{
@@ -610,7 +610,7 @@ var _ = Describe("CSV", func() {
 		roleBinding.SetName(genName("dep-"))
 		roleBinding.SetNamespace(testNamespace)
 		_, err = c.CreateRoleBinding(&roleBinding)
-		require.NoError(GinkgoT(), err, "could not create RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
 
 		clusterRole := rbacv1.ClusterRole{
 			Rules: []rbacv1.PolicyRule{
@@ -623,7 +623,7 @@ var _ = Describe("CSV", func() {
 		}
 		clusterRole.SetName(genName("dep-"))
 		_, err = c.CreateClusterRole(&clusterRole)
-		require.NoError(GinkgoT(), err, "could not create ClusterRole")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
 
 		nonResourceClusterRole := rbacv1.ClusterRole{
 			Rules: []rbacv1.PolicyRule{
@@ -635,7 +635,7 @@ var _ = Describe("CSV", func() {
 		}
 		nonResourceClusterRole.SetName(genName("dep-"))
 		_, err = c.CreateClusterRole(&nonResourceClusterRole)
-		require.NoError(GinkgoT(), err, "could not create ClusterRole")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
 
 		clusterRoleBinding := rbacv1.ClusterRoleBinding{
 			Subjects: []rbacv1.Subject{
@@ -654,7 +654,7 @@ var _ = Describe("CSV", func() {
 		}
 		clusterRoleBinding.SetName(genName("dep-"))
 		_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
-		require.NoError(GinkgoT(), err, "could not create ClusterRoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
 
 		nonResourceClusterRoleBinding := rbacv1.ClusterRoleBinding{
 			Subjects: []rbacv1.Subject{
@@ -673,59 +673,55 @@ var _ = Describe("CSV", func() {
 		}
 		nonResourceClusterRoleBinding.SetName(genName("dep-"))
 		_, err = c.CreateClusterRoleBinding(&nonResourceClusterRoleBinding)
-		require.NoError(GinkgoT(), err, "could not create ClusterRoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
 
-		fmt.Println("checking for deployment")
+		ctx.Ctx().Logf("checking for deployment")
 		// Poll for deployment to be ready
-		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		Eventually(func() (bool, error) {
 			dep, err := c.GetDeployment(testNamespace, depName)
 			if k8serrors.IsNotFound(err) {
-				fmt.Printf("deployment %s not found\n", depName)
+				ctx.Ctx().Logf("deployment %s not found\n", depName)
 				return false, nil
 			} else if err != nil {
-				fmt.Printf("unexpected error fetching deployment %s\n", depName)
+				ctx.Ctx().Logf("unexpected error fetching deployment %s\n", depName)
 				return false, err
 			}
 			if dep.Status.UpdatedReplicas == *(dep.Spec.Replicas) &&
 				dep.Status.Replicas == *(dep.Spec.Replicas) &&
 				dep.Status.AvailableReplicas == *(dep.Spec.Replicas) {
-				fmt.Println("deployment ready")
+				ctx.Ctx().Logf("deployment ready")
 				return true, nil
 			}
-			fmt.Println("deployment not ready")
+			ctx.Ctx().Logf("deployment not ready")
 			return false, nil
-		})
-		require.NoError(GinkgoT(), err)
+		}).Should(BeTrue())
 
 		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Delete CRD
 		cleanupCRD()
 
 		// Wait for CSV failure
 		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Recreate the CRD
 		cleanupCRD, err = createCRD(c, crd)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 
 		// Wait for CSV success again
 		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 	It("create requirements met API service", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		sa := corev1.ServiceAccount{}
 		sa.SetName(genName("sa-"))
 		sa.SetNamespace(testNamespace)
 		_, err := c.CreateServiceAccount(&sa)
-		require.NoError(GinkgoT(), err, "could not create ServiceAccount")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create ServiceAccount")
 
 		permissions := []v1alpha1.StrategyDeploymentPermissions{
 			{
@@ -811,7 +807,7 @@ var _ = Describe("CSV", func() {
 		role.SetName(genName("dep-"))
 		role.SetNamespace(testNamespace)
 		_, err = c.CreateRole(&role)
-		require.NoError(GinkgoT(), err, "could not create Role")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
 
 		roleBinding := rbacv1.RoleBinding{
 			Subjects: []rbacv1.Subject{
@@ -831,7 +827,7 @@ var _ = Describe("CSV", func() {
 		roleBinding.SetName(genName("dep-"))
 		roleBinding.SetNamespace(testNamespace)
 		_, err = c.CreateRoleBinding(&roleBinding)
-		require.NoError(GinkgoT(), err, "could not create RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
 
 		clusterRole := rbacv1.ClusterRole{
 			Rules: []rbacv1.PolicyRule{
@@ -844,7 +840,7 @@ var _ = Describe("CSV", func() {
 		}
 		clusterRole.SetName(genName("dep-"))
 		_, err = c.CreateClusterRole(&clusterRole)
-		require.NoError(GinkgoT(), err, "could not create ClusterRole")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
 
 		clusterRoleBinding := rbacv1.ClusterRoleBinding{
 			Subjects: []rbacv1.Subject{
@@ -863,24 +859,21 @@ var _ = Describe("CSV", func() {
 		}
 		clusterRoleBinding.SetName(genName("dep-"))
 		_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
-		require.NoError(GinkgoT(), err, "could not create ClusterRoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 	})
 	It("create with owned API service", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -948,10 +941,10 @@ var _ = Describe("CSV", func() {
 
 		// Create the APIService CSV
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer func() {
 			watcher, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + apiServiceName})
-			require.NoError(GinkgoT(), err)
+			Expect(err).ShouldNot(HaveOccurred())
 
 			deleted := make(chan struct{})
 			go func() {
@@ -965,7 +958,7 @@ var _ = Describe("CSV", func() {
 							return
 						}
 					case <-time.After(pollDuration):
-						require.FailNow(GinkgoT(), "apiservice not cleaned up after CSV deleted")
+						Fail("API service not cleaned up after CSV deleted")
 					}
 				}
 			}()
@@ -975,45 +968,45 @@ var _ = Describe("CSV", func() {
 		}()
 
 		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should create Deployment
 		dep, err := c.GetDeployment(testNamespace, depName)
-		require.NoError(GinkgoT(), err, "error getting expected Deployment")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 		// Should create APIService
 		apiService, err := c.GetAPIService(apiServiceName)
-		require.NoError(GinkgoT(), err, "error getting expected APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
 		// Should create Service
 		serviceName := fmt.Sprintf("%s-service", depName)
 		_, err = c.GetService(testNamespace, serviceName)
-		require.NoError(GinkgoT(), err, "error getting expected Service")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 		// Should create certificate Secret
 		secretName := fmt.Sprintf("%s-cert", serviceName)
 		_, err = c.GetSecret(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting expected Secret")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 		// Should create a Role for the Secret
 		_, err = c.GetRole(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting expected Secret Role")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 		// Should create a RoleBinding for the Secret
 		_, err = c.GetRoleBinding(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting exptected Secret RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 		// Should create a system:auth-delegator Cluster RoleBinding
 		_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
-		require.NoError(GinkgoT(), err, "error getting expected system:auth-delegator ClusterRoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
 
 		// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
 		_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
-		require.NoError(GinkgoT(), err, "error getting expected extension-apiserver-authentication-reader RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
 
 		// Store the ca sha annotation
 		oldCAAnnotation, ok := dep.Spec.Template.GetAnnotations()[install.OLMCAHashAnnotationKey]
-		require.True(GinkgoT(), ok, "expected olm sha annotation not present on existing pod template")
+		Expect(ok).Should(BeTrue(), "expected olm sha annotation not present on existing pod template")
 
 		// Induce a cert rotation
 		Eventually(Apply(fetchedCSV, func(csv *v1alpha1.ClusterServiceVersion) error {
@@ -1026,11 +1019,16 @@ var _ = Describe("CSV", func() {
 		_, err = fetchCSV(crc, csv.Name, testNamespace, func(csv *v1alpha1.ClusterServiceVersion) bool {
 			// Should create deployment
 			dep, err = c.GetDeployment(testNamespace, depName)
-			require.NoError(GinkgoT(), err)
+			if err != nil {
+				return false
+			}
 
 			// Should have a new ca hash annotation
 			newCAAnnotation, ok := dep.Spec.Template.GetAnnotations()[install.OLMCAHashAnnotationKey]
-			require.True(GinkgoT(), ok, "expected olm sha annotation not present in new pod template")
+			if !ok {
+				ctx.Ctx().Logf("expected olm sha annotation not present in new pod template")
+				return false
+			}
 
 			if newCAAnnotation != oldCAAnnotation {
 				// Check for success
@@ -1039,37 +1037,31 @@ var _ = Describe("CSV", func() {
 
 			return false
 		})
-		require.NoError(GinkgoT(), err, "failed to rotate cert")
+		Expect(err).ShouldNot(HaveOccurred(), "failed to rotate cert")
 
 		// Get the APIService UID
 		oldAPIServiceUID := apiService.GetUID()
 
 		// Delete the APIService
 		err = c.DeleteAPIService(apiServiceName, &metav1.DeleteOptions{})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for CSV success
 		fetchedCSV, err = fetchCSV(crc, csv.GetName(), testNamespace, func(csv *v1alpha1.ClusterServiceVersion) bool {
 			// Should create an APIService
 			apiService, err := c.GetAPIService(apiServiceName)
 			if err != nil {
-				require.True(GinkgoT(), k8serrors.IsNotFound(err))
 				return false
 			}
 
 			if csvSucceededChecker(csv) {
-				require.NotEqual(GinkgoT(), oldAPIServiceUID, apiService.GetUID())
-				return true
+				return apiService.GetUID() != oldAPIServiceUID
 			}
-
 			return false
 		})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 	It("update with owned API service", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -1137,44 +1129,44 @@ var _ = Describe("CSV", func() {
 
 		// Create the APIService CSV
 		_, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should create Deployment
 		_, err = c.GetDeployment(testNamespace, depName)
-		require.NoError(GinkgoT(), err, "error getting expected Deployment")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 		// Should create APIService
 		_, err = c.GetAPIService(apiServiceName)
-		require.NoError(GinkgoT(), err, "error getting expected APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
 		// Should create Service
 		serviceName := fmt.Sprintf("%s-service", depName)
 		_, err = c.GetService(testNamespace, serviceName)
-		require.NoError(GinkgoT(), err, "error getting expected Service")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 		// Should create certificate Secret
 		secretName := fmt.Sprintf("%s-cert", serviceName)
 		_, err = c.GetSecret(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting expected Secret")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 		// Should create a Role for the Secret
 		_, err = c.GetRole(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting expected Secret Role")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 		// Should create a RoleBinding for the Secret
 		_, err = c.GetRoleBinding(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting exptected Secret RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 		// Should create a system:auth-delegator Cluster RoleBinding
 		_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
-		require.NoError(GinkgoT(), err, "error getting expected system:auth-delegator ClusterRoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
 
 		// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
 		_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
-		require.NoError(GinkgoT(), err, "error getting expected extension-apiserver-authentication-reader RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
 
 		// Create a new CSV that owns the same API Service and replace the old CSV
 		csv2 := v1alpha1.ClusterServiceVersion{
@@ -1212,65 +1204,63 @@ var _ = Describe("CSV", func() {
 
 		// Create CSV2 to replace CSV
 		cleanupCSV2, err := createCSV(c, crc, csv2, testNamespace, false, true)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV2()
 
 		_, err = fetchCSV(crc, csv2.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should create Deployment
 		_, err = c.GetDeployment(testNamespace, depName)
-		require.NoError(GinkgoT(), err, "error getting expected Deployment")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 		// Should create APIService
 		_, err = c.GetAPIService(apiServiceName)
-		require.NoError(GinkgoT(), err, "error getting expected APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
 		// Should create Service
 		_, err = c.GetService(testNamespace, serviceName)
-		require.NoError(GinkgoT(), err, "error getting expected Service")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 		// Should create certificate Secret
 		secretName = fmt.Sprintf("%s-cert", serviceName)
 		_, err = c.GetSecret(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting expected Secret")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 		// Should create a Role for the Secret
 		_, err = c.GetRole(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting expected Secret Role")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 		// Should create a RoleBinding for the Secret
 		_, err = c.GetRoleBinding(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting exptected Secret RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 		// Should create a system:auth-delegator Cluster RoleBinding
 		_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
-		require.NoError(GinkgoT(), err, "error getting expected system:auth-delegator ClusterRoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
 
 		// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
 		_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
-		require.NoError(GinkgoT(), err, "error getting expected extension-apiserver-authentication-reader RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
 
 		// Should eventually GC the CSV
-		err = waitForCSVToDelete(GinkgoT(), crc, csv.Name)
-		require.NoError(GinkgoT(), err)
+		Eventually(func() bool {
+			return csvExists(crc, csv.Name)
+		}).Should(BeFalse())
 
 		// Rename the initial CSV
 		csv.SetName("csv-hat-3")
 
 		// Recreate the old CSV
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, true)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		fetched, err := fetchCSV(crc, csv.Name, testNamespace, buildCSVReasonChecker(v1alpha1.CSVReasonOwnerConflict))
-		require.NoError(GinkgoT(), err)
-		require.Equal(GinkgoT(), string(v1alpha1.CSVPhaseFailed), string(fetched.Status.Phase))
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(fetched.Status.Phase).Should(Equal(v1alpha1.CSVPhaseFailed))
 	})
 	It("create same CSV with owned API service multi namespace", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create new namespace in a new operator group
 		secondNamespaceName := genName(testNamespace + "-")
@@ -1282,10 +1272,10 @@ var _ = Describe("CSV", func() {
 				Labels: matchingLabel,
 			},
 		}, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer func() {
 			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), secondNamespaceName, metav1.DeleteOptions{})
-			require.NoError(GinkgoT(), err)
+			Expect(err).ShouldNot(HaveOccurred())
 		}()
 
 		// Create a new operator group for the new namespace
@@ -1301,28 +1291,20 @@ var _ = Describe("CSV", func() {
 			},
 		}
 		_, err = crc.OperatorsV1().OperatorGroups(secondNamespaceName).Create(context.TODO(), &operatorGroup, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer func() {
 			err = crc.OperatorsV1().OperatorGroups(secondNamespaceName).Delete(context.TODO(), operatorGroup.Name, metav1.DeleteOptions{})
-			require.NoError(GinkgoT(), err)
+			Expect(err).ShouldNot(HaveOccurred())
 		}()
 
-		expectedOperatorGroupStatus := v1.OperatorGroupStatus{
-			Namespaces: []string{secondNamespaceName},
-		}
-		GinkgoT().Log("Waiting on new operator group to have correct status")
-		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-			fetched, fetchErr := crc.OperatorsV1().OperatorGroups(secondNamespaceName).Get(context.TODO(), operatorGroup.Name, metav1.GetOptions{})
-			if fetchErr != nil {
-				return false, fetchErr
+		ctx.Ctx().Logf("Waiting on new operator group to have correct status")
+		Eventually(func() ([]string, error) {
+			og, err := crc.OperatorsV1().OperatorGroups(secondNamespaceName).Get(context.TODO(), operatorGroup.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
 			}
-			if len(fetched.Status.Namespaces) > 0 {
-				require.ElementsMatch(GinkgoT(), expectedOperatorGroupStatus.Namespaces, fetched.Status.Namespaces)
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(GinkgoT(), err)
+			return og.Status.Namespaces, nil
+		}).Should(ConsistOf([]string{secondNamespaceName}))
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -1390,45 +1372,45 @@ var _ = Describe("CSV", func() {
 
 		// Create the initial CSV
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should create Deployment
 		_, err = c.GetDeployment(testNamespace, depName)
-		require.NoError(GinkgoT(), err, "error getting expected Deployment")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 		// Should create APIService
 		_, err = c.GetAPIService(apiServiceName)
-		require.NoError(GinkgoT(), err, "error getting expected APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
 		// Should create Service
 		serviceName := fmt.Sprintf("%s-service", depName)
 		_, err = c.GetService(testNamespace, serviceName)
-		require.NoError(GinkgoT(), err, "error getting expected Service")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 		// Should create certificate Secret
 		secretName := fmt.Sprintf("%s-cert", serviceName)
 		_, err = c.GetSecret(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting expected Secret")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 		// Should create a Role for the Secret
 		_, err = c.GetRole(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting expected Secret Role")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 		// Should create a RoleBinding for the Secret
 		_, err = c.GetRoleBinding(testNamespace, secretName)
-		require.NoError(GinkgoT(), err, "error getting exptected Secret RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 		// Should create a system:auth-delegator Cluster RoleBinding
 		_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
-		require.NoError(GinkgoT(), err, "error getting expected system:auth-delegator ClusterRoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
 
 		// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
 		_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
-		require.NoError(GinkgoT(), err, "error getting expected extension-apiserver-authentication-reader RoleBinding")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
 
 		// Create a new CSV that owns the same API Service but in a different namespace
 		csv2 := v1alpha1.ClusterServiceVersion{
@@ -1465,14 +1447,12 @@ var _ = Describe("CSV", func() {
 
 		// Create CSV2 to replace CSV
 		_, err = createCSV(c, crc, csv2, secondNamespaceName, false, true)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		_, err = fetchCSV(crc, csv2.Name, secondNamespaceName, csvFailedChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 	It("orphaned API service clean up", func() {
-
-		c := newKubeClient()
 
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
 		version := "v1alpha1"
@@ -1491,7 +1471,7 @@ var _ = Describe("CSV", func() {
 		}
 
 		watcher, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + apiServiceName})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		deleted := make(chan struct{})
 		quit := make(chan struct{})
@@ -1508,37 +1488,34 @@ var _ = Describe("CSV", func() {
 						deleted <- struct{}{}
 					}
 				case <-time.After(pollDuration):
-					require.FailNow(GinkgoT(), "orphaned apiservice not cleaned up as expected")
+					Fail("orphaned apiservice not cleaned up as expected")
 				}
 			}
 		}()
 
 		_, err = c.CreateAPIService(apiService)
-		require.NoError(GinkgoT(), err, "error creating expected APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error creating expected APIService")
 		orphanedAPISvc, err := c.GetAPIService(apiServiceName)
-		require.NoError(GinkgoT(), err, "error getting expected APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
 		newLabels := map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": "nonexistent-namespace"}
 		orphanedAPISvc.SetLabels(newLabels)
 		_, err = c.UpdateAPIService(orphanedAPISvc)
-		require.NoError(GinkgoT(), err, "error updating APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error updating APIService")
 		<-deleted
 
 		_, err = c.CreateAPIService(apiService)
-		require.NoError(GinkgoT(), err, "error creating expected APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error creating expected APIService")
 		orphanedAPISvc, err = c.GetAPIService(apiServiceName)
-		require.NoError(GinkgoT(), err, "error getting expected APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
 		newLabels = map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": testNamespace}
 		orphanedAPISvc.SetLabels(newLabels)
 		_, err = c.UpdateAPIService(orphanedAPISvc)
-		require.NoError(GinkgoT(), err, "error updating APIService")
+		Expect(err).ShouldNot(HaveOccurred(), "error updating APIService")
 		<-deleted
 	})
 	It("update same deployment name", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins")
@@ -1571,9 +1548,9 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 		csv := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -1623,16 +1600,16 @@ var _ = Describe("CSV", func() {
 
 		// Don't need to cleanup this CSV, it will be deleted by the upgrade process
 		_, err = createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for current CSV to succeed
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should have created deployment
 		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), dep)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(dep).ShouldNot(BeNil())
 
 		// Create "updated" CSV
 		strategyNew := v1alpha1.StrategyDetailsDeployment{
@@ -1646,7 +1623,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		csvNew := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -1695,32 +1672,30 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupNewCSV()
 
 		// Wait for updated CSV to succeed
 		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should have updated existing deployment
 		depUpdated, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), depUpdated)
-		require.Equal(GinkgoT(), depUpdated.Spec.Template.Spec.Containers[0].Name, strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(depUpdated).ShouldNot(BeNil())
+		Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
 
 		// Should eventually GC the CSV
-		err = waitForCSVToDelete(GinkgoT(), crc, csv.Name)
-		require.NoError(GinkgoT(), err)
+		Eventually(func() bool {
+			return csvExists(crc, csv.Name)
+		}).Should(BeFalse())
 
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 	})
 	It("update different deployment name", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins2")
@@ -1741,7 +1716,7 @@ var _ = Describe("CSV", func() {
 				Scope: "Namespaced",
 			},
 		})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 
 		// create "current" CSV
@@ -1754,7 +1729,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		csv := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -1804,16 +1779,16 @@ var _ = Describe("CSV", func() {
 
 		// don't need to clean up this CSV, it will be deleted by the upgrade process
 		_, err = createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for current CSV to succeed
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should have created deployment
 		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), dep)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(dep).ShouldNot(BeNil())
 
 		// Create "updated" CSV
 		strategyNew := v1alpha1.StrategyDetailsDeployment{
@@ -1825,7 +1800,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		csvNew := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -1874,33 +1849,31 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupNewCSV()
 
 		// Wait for updated CSV to succeed
 		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 
 		// Should have created new deployment and deleted old
 		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), depNew)
-		err = waitForDeploymentToDelete(GinkgoT(), c, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(depNew).ShouldNot(BeNil())
+		err = waitForDeploymentToDelete(c, strategy.DeploymentSpecs[0].Name)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should eventually GC the CSV
-		err = waitForCSVToDelete(GinkgoT(), crc, csv.Name)
-		require.NoError(GinkgoT(), err)
+		Eventually(func() bool {
+			return csvExists(crc, csv.Name)
+		}).Should(BeFalse())
 	})
 	It("update multiple intermediates", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins3")
@@ -1927,7 +1900,7 @@ var _ = Describe("CSV", func() {
 				Scope: "Namespaced",
 			},
 		})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 
 		// create "current" CSV
@@ -1940,7 +1913,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		csv := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -1990,16 +1963,16 @@ var _ = Describe("CSV", func() {
 
 		// don't need to clean up this CSV, it will be deleted by the upgrade process
 		_, err = createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for current CSV to succeed
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should have created deployment
 		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), dep)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(dep).ShouldNot(BeNil())
 
 		// Create "updated" CSV
 		strategyNew := v1alpha1.StrategyDetailsDeployment{
@@ -2011,7 +1984,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		csvNew := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -2060,33 +2033,31 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupNewCSV()
 
 		// Wait for updated CSV to succeed
 		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 
 		// Should have created new deployment and deleted old
 		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), depNew)
-		err = waitForDeploymentToDelete(GinkgoT(), c, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(depNew).ShouldNot(BeNil())
+		err = waitForDeploymentToDelete(c, strategy.DeploymentSpecs[0].Name)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should eventually GC the CSV
-		err = waitForCSVToDelete(GinkgoT(), crc, csv.Name)
-		require.NoError(GinkgoT(), err)
+		Eventually(func() bool {
+			return csvExists(crc, csv.Name)
+		}).Should(BeFalse())
 	})
 	It("update in place", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins")
@@ -2119,9 +2090,9 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 		csv := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -2170,17 +2141,17 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, true)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		// Wait for current CSV to succeed
 		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should have created deployment
 		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), dep)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(dep).ShouldNot(BeNil())
 
 		// Create "updated" CSV
 		strategyNew := strategy
@@ -2201,44 +2172,40 @@ var _ = Describe("CSV", func() {
 		var five int32 = 5
 		strategyNew.DeploymentSpecs[0].Spec.Replicas = &five
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
 
 		// Update CSV directly
 		_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// wait for deployment spec to be updated
-		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		Eventually(func() (string, error) {
 			fetched, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
 			if err != nil {
-				return false, err
+				return "", err
 			}
-			fmt.Println("waiting for deployment to update...")
-			return fetched.Spec.Template.Spec.Containers[0].Name == strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name, nil
-		})
-		require.NoError(GinkgoT(), err)
+			ctx.Ctx().Logf("waiting for deployment to update...")
+			return fetched.Spec.Template.Spec.Containers[0].Name, nil
+		}).Should(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
 
 		// Wait for updated CSV to succeed
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		depUpdated, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), depUpdated)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(depUpdated).ShouldNot(BeNil())
 
 		// Deployment should have changed even though the CSV is otherwise the same
-		require.Equal(GinkgoT(), depUpdated.Spec.Template.Spec.Containers[0].Name, strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name)
-		require.Equal(GinkgoT(), depUpdated.Spec.Template.Spec.Containers[0].Image, strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Image)
+		Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
+		Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Image).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Image))
 
 		// Field updated even though template spec didn't change, because it was part of a template spec change as well
-		require.Equal(GinkgoT(), *depUpdated.Spec.Replicas, *strategyNew.DeploymentSpecs[0].Spec.Replicas)
+		Expect(*strategyNew.DeploymentSpecs[0].Spec.Replicas).Should(Equal(*depUpdated.Spec.Replicas))
 	})
 	It("update multiple version CRD", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create initial CRD which has 2 versions: v1alpha1 & v1alpha2
 		crdPlural := genName("ins4")
@@ -2270,7 +2237,7 @@ var _ = Describe("CSV", func() {
 				Scope: "Namespaced",
 			},
 		})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 
 		// create initial deployment strategy
@@ -2283,7 +2250,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// First CSV with owning CRD v1alpha1
 		csv := v1alpha1.ClusterServiceVersion{
@@ -2334,16 +2301,16 @@ var _ = Describe("CSV", func() {
 
 		// CSV will be deleted by the upgrade process later
 		_, err = createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for current CSV to succeed
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should have created deployment
 		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), dep)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(dep).ShouldNot(BeNil())
 
 		// Create updated deployment strategy
 		strategyNew := v1alpha1.StrategyDetailsDeployment{
@@ -2355,7 +2322,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Second CSV with owning CRD v1alpha1 and v1alpha2
 		csvNew := v1alpha1.ClusterServiceVersion{
@@ -2413,23 +2380,23 @@ var _ = Describe("CSV", func() {
 
 		// Create newly updated CSV
 		_, err = createCSV(c, crc, csvNew, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for updated CSV to succeed
 		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 
 		// Should have created new deployment and deleted old one
 		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), depNew)
-		err = waitForDeploymentToDelete(GinkgoT(), c, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(depNew).ShouldNot(BeNil())
+		err = waitForDeploymentToDelete(c, strategy.DeploymentSpecs[0].Name)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Create updated deployment strategy
 		strategyNew2 := v1alpha1.StrategyDetailsDeployment{
@@ -2440,7 +2407,7 @@ var _ = Describe("CSV", func() {
 				},
 			},
 		}
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Third CSV with owning CRD v1alpha2
 		csvNew2 := v1alpha1.ClusterServiceVersion{
@@ -2491,33 +2458,31 @@ var _ = Describe("CSV", func() {
 
 		// Create newly updated CSV
 		cleanupNewCSV, err := createCSV(c, crc, csvNew2, testNamespace, true, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupNewCSV()
 
 		// Wait for updated CSV to succeed
 		fetchedCSV, err = fetchCSV(crc, csvNew2.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err = fetchCSV(crc, csvNew2.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 
 		// Should have created new deployment and deleted old one
 		depNew, err = c.GetDeployment(testNamespace, strategyNew2.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), depNew)
-		err = waitForDeploymentToDelete(GinkgoT(), c, strategyNew.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(depNew).ShouldNot(BeNil())
+		err = waitForDeploymentToDelete(c, strategyNew.DeploymentSpecs[0].Name)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should clean up the CSV
-		err = waitForCSVToDelete(GinkgoT(), crc, csvNew.Name)
-		require.NoError(GinkgoT(), err)
+		Eventually(func() bool {
+			return csvExists(crc, csvNew.Name)
+		}).Should(BeFalse())
 	})
 	It("update modify deployment name", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create dependency first (CRD)
 		crdPlural := genName("ins2")
@@ -2538,7 +2503,7 @@ var _ = Describe("CSV", func() {
 				Scope: "Namespaced",
 			},
 		})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 
 		// create "current" CSV
@@ -2555,7 +2520,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		csv := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -2603,20 +2568,20 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		// Wait for current CSV to succeed
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should have created deployments
 		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), dep)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(dep).ShouldNot(BeNil())
 		dep2, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[1].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), dep2)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(dep2).ShouldNot(BeNil())
 
 		// Create "updated" CSV
 		strategyNew := v1alpha1.StrategyDetailsDeployment{
@@ -2632,43 +2597,42 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Fetch the current csv
 		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Update csv with same strategy with different deployment's name
 		fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
 
 		// Update the current csv with the new csv
 		_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for new deployment to exist
 		err = waitForDeployment(c, strategyNew.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Wait for updated CSV to succeed
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Should have created new deployment and deleted old
 		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), depNew)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(depNew).ShouldNot(BeNil())
+
 		// Make sure the unchanged deployment still exists
 		depNew2, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[1].Name)
-		require.NoError(GinkgoT(), err)
-		require.NotNil(GinkgoT(), depNew2)
-		err = waitForDeploymentToDelete(GinkgoT(), c, strategy.DeploymentSpecs[0].Name)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(depNew2).ShouldNot(BeNil())
+
+		err = waitForDeploymentToDelete(c, strategy.DeploymentSpecs[0].Name)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 
 	It("emits CSV requirement events", func() {
-
-		c := ctx.Ctx().KubeClient()
-		crc := ctx.Ctx().OperatorClient()
 
 		csv := &v1alpha1.ClusterServiceVersion{
 			Spec: v1alpha1.ClusterServiceVersionSpec{
@@ -2753,9 +2717,6 @@ var _ = Describe("CSV", func() {
 	// TODO: test behavior when replaces field doesn't point to existing CSV
 	It("status invalid CSV", func() {
 
-		c := newKubeClient()
-		crc := newCRClient()
-
 		// Create CRD
 		crdPlural := genName("ins")
 		crdName := crdPlural + ".cluster.com"
@@ -2775,7 +2736,7 @@ var _ = Describe("CSV", func() {
 				Scope: "Namespaced",
 			},
 		})
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCRD()
 
 		// create CSV
@@ -2788,7 +2749,7 @@ var _ = Describe("CSV", func() {
 			},
 		}
 
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		csv := v1alpha1.ClusterServiceVersion{
 			TypeMeta: metav1.TypeMeta{
@@ -2836,7 +2797,7 @@ var _ = Describe("CSV", func() {
 		}
 
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		notServedStatus := v1alpha1.RequirementStatus{
@@ -2859,15 +2820,12 @@ var _ = Describe("CSV", func() {
 		}
 
 		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvCheckPhaseAndRequirementStatus)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
-		require.Contains(GinkgoT(), fetchedCSV.Status.RequirementStatus, notServedStatus)
+		Expect(fetchedCSV.Status.RequirementStatus).Should(ContainElement(notServedStatus))
 	})
 
 	It("api service resource migrated if adoptable", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -2938,19 +2896,16 @@ var _ = Describe("CSV", func() {
 
 		// Create the APIService CSV
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		checkLegacyAPIResources(owned[0], true)
 	})
 
 	It("API service resource not migrated if not adoptable", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		depName := genName("hat-server")
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -3021,11 +2976,11 @@ var _ = Describe("CSV", func() {
 
 		// Create the APIService CSV
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		checkLegacyAPIResources(owned[0], false)
 
@@ -3034,9 +2989,6 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("multiple API services on a single pod", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create the deployment that both APIServices will be deployed to.
 		depName := genName("hat-server")
@@ -3139,20 +3091,20 @@ var _ = Describe("CSV", func() {
 
 		// Create the APIService CSV
 		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 		defer cleanupCSV()
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// Check that the APIService caBundles are equal
 		apiService1, err := c.GetAPIService(apiService1Name)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		apiService2, err := c.GetAPIService(apiService2Name)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 
-		require.Equal(GinkgoT(), apiService1.Spec.CABundle, apiService2.Spec.CABundle)
+		Expect(apiService2.Spec.CABundle).Should(Equal(apiService1.Spec.CABundle))
 	})
 })
 
@@ -3181,7 +3133,7 @@ func findLastEvent(events *corev1.EventList) (event corev1.Event) {
 func buildCSVCleanupFunc(c operatorclient.ClientInterface, crc versioned.Interface, csv v1alpha1.ClusterServiceVersion, namespace string, deleteCRDs, deleteAPIServices bool) cleanupFunc {
 	return func() {
 		err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).Delete(context.TODO(), csv.GetName(), metav1.DeleteOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred())
 
 		if deleteCRDs {
 			for _, crd := range csv.Spec.CustomResourceDefinitions.Owned {
@@ -3199,7 +3151,8 @@ func buildCSVCleanupFunc(c operatorclient.ClientInterface, crc versioned.Interfa
 			_, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
 			return err
 		})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred())
+
 	}
 }
 
@@ -3399,29 +3352,29 @@ var csvAnyChecker = buildCSVConditionChecker(v1alpha1.CSVPhasePending, v1alpha1.
 var csvCopiedChecker = buildCSVReasonChecker(v1alpha1.CSVReasonCopied)
 
 func fetchCSV(c versioned.Interface, name, namespace string, checker csvConditionChecker) (*v1alpha1.ClusterServiceVersion, error) {
-	var fetched *v1alpha1.ClusterServiceVersion
+	var fetchedCSV *v1alpha1.ClusterServiceVersion
 	var err error
 
-	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-		fetched, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	Eventually(func() (bool, error) {
+		fetchedCSV, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
-		ctx.Ctx().Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
-		return checker(fetched), nil
-	})
+		ctx.Ctx().Logf("%s (%s): %s", fetchedCSV.Status.Phase, fetchedCSV.Status.Reason, fetchedCSV.Status.Message)
+		return checker(fetchedCSV), nil
+	}).Should(BeTrue())
 
 	if err != nil {
-		ctx.Ctx().Logf("never got correct status: %#v", fetched.Status)
+		ctx.Ctx().Logf("never got correct status: %#v", fetchedCSV.Status)
 	}
-	return fetched, err
+	return fetchedCSV, err
 }
 
-func awaitCSV(t GinkgoTInterface, c versioned.Interface, namespace, name string, checker csvConditionChecker) (*v1alpha1.ClusterServiceVersion, error) {
+func awaitCSV(c versioned.Interface, namespace, name string, checker csvConditionChecker) (*v1alpha1.ClusterServiceVersion, error) {
 	var fetched *v1alpha1.ClusterServiceVersion
 	var err error
 
-	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+	Eventually(func() (bool, error) {
 		fetched, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
@@ -3429,12 +3382,12 @@ func awaitCSV(t GinkgoTInterface, c versioned.Interface, namespace, name string,
 			}
 			return false, err
 		}
-		t.Logf("%s - %s (%s): %s", name, fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
+		ctx.Ctx().Logf("%s - %s (%s): %s", name, fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
 		return checker(fetched), nil
-	})
+	}).Should(BeTrue())
 
 	if err != nil {
-		t.Logf("never got correct status: %#v", fetched.Status)
+		ctx.Ctx().Logf("never got correct status: %#v", fetched.Status)
 	}
 	return fetched, err
 }
@@ -3452,55 +3405,36 @@ func waitForDeployment(c operatorclient.ClientInterface, name string) error {
 	})
 }
 
-func waitForDeploymentToDelete(t GinkgoTInterface, c operatorclient.ClientInterface, name string) error {
-	return wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-		t.Logf("waiting for deployment %s to delete", name)
+func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) error {
+	var err error
+
+	Eventually(func() (bool, error) {
+		ctx.Ctx().Logf("waiting for deployment %s to delete", name)
 		_, err := c.GetDeployment(testNamespace, name)
 		if errors.IsNotFound(err) {
-			t.Logf("deleted %s", name)
+			ctx.Ctx().Logf("deleted %s", name)
 			return true, nil
 		}
 		if err != nil {
-			t.Logf("err trying to delete %s: %s", name, err)
+			ctx.Ctx().Logf("err trying to delete %s: %s", name, err)
 			return false, err
 		}
 		return false, nil
-	})
-}
-
-func waitForCSVToDelete(t GinkgoTInterface, c versioned.Interface, name string) error {
-	var err error
-
-	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-		fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.TODO(), name, metav1.GetOptions{})
-		if errors.IsNotFound(err) {
-			return true, nil
-		}
-		t.Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
-		if err != nil {
-			return false, err
-		}
-		return false, nil
-	})
-
+	}).Should(BeTrue())
 	return err
 }
 
-func waitForNotFound(t GinkgoTInterface, getFunction func() error) error {
-	var err error
+func csvExists(c versioned.Interface, name string) bool {
 
-	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-		err := getFunction()
-		if errors.IsNotFound(err) {
-			return true, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return false, nil
-	})
-
-	return err
+	fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return false
+	}
+	ctx.Ctx().Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
+	if err != nil {
+		return true
+	}
+	return true
 }
 
 func deleteLegacyAPIResources(desc v1alpha1.APIServiceDescription) {
@@ -3509,22 +3443,22 @@ func deleteLegacyAPIResources(desc v1alpha1.APIServiceDescription) {
 	apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
 
 	err := c.DeleteService(testNamespace, strings.Replace(apiServiceName, ".", "-", -1), &metav1.DeleteOptions{})
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	err = c.DeleteSecret(testNamespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	err = c.DeleteRole(testNamespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	err = c.DeleteRoleBinding(testNamespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	err = c.DeleteClusterRoleBinding(apiServiceName+"-system:auth-delegator", &metav1.DeleteOptions{})
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	err = c.DeleteRoleBinding("kube-system", apiServiceName+"-auth-reader", &metav1.DeleteOptions{})
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 }
 
 func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1.APIServiceDescription) {
@@ -3538,12 +3472,12 @@ func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1
 	service.SetNamespace(testNamespace)
 	if csv != nil {
 		err := ownerutil.AddOwnerLabels(&service, csv)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 
 	service.Spec.Ports = []corev1.ServicePort{{Port: 433, TargetPort: intstr.FromInt(443)}}
 	_, err := c.CreateService(&service)
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	// Attempt to create the legacy secret
 	secret := corev1.Secret{}
@@ -3551,12 +3485,12 @@ func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1
 	secret.SetNamespace(testNamespace)
 	if csv != nil {
 		err = ownerutil.AddOwnerLabels(&secret, csv)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 
 	_, err = c.CreateSecret(&secret)
 	if err != nil && !errors.IsAlreadyExists(err) {
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 
 	// Attempt to create the legacy secret role
@@ -3565,10 +3499,10 @@ func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1
 	role.SetNamespace(testNamespace)
 	if csv != nil {
 		err = ownerutil.AddOwnerLabels(&role, csv)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 	_, err = c.CreateRole(&role)
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	// Attempt to create the legacy secret role binding
 	roleBinding := rbacv1.RoleBinding{}
@@ -3581,11 +3515,11 @@ func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1
 	}
 	if csv != nil {
 		err = ownerutil.AddOwnerLabels(&roleBinding, csv)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 
 	_, err = c.CreateRoleBinding(&roleBinding)
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	// Attempt to create the legacy authDelegatorClusterRoleBinding
 	clusterRoleBinding := rbacv1.ClusterRoleBinding{}
@@ -3597,10 +3531,10 @@ func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1
 	}
 	if csv != nil {
 		err = ownerutil.AddOwnerLabels(&clusterRoleBinding, csv)
-		require.NoError(GinkgoT(), err)
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 	_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	// Attempt to create the legacy authReadingRoleBinding
 	roleBinding.SetName(apiServiceName + "-auth-reader")
@@ -3611,7 +3545,7 @@ func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1
 		Name:     "extension-apiserver-authentication-reader",
 	}
 	_, err = c.CreateRoleBinding(&roleBinding)
-	require.NoError(GinkgoT(), err)
+	Expect(err).ShouldNot(HaveOccurred())
 }
 
 func checkLegacyAPIResources(desc v1alpha1.APIServiceDescription, expectedIsNotFound bool) {
@@ -3620,25 +3554,25 @@ func checkLegacyAPIResources(desc v1alpha1.APIServiceDescription, expectedIsNotF
 
 	// Attempt to create the legacy service
 	_, err := c.GetService(testNamespace, strings.Replace(apiServiceName, ".", "-", -1))
-	require.Equal(GinkgoT(), expectedIsNotFound, errors.IsNotFound(err))
+	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret
 	_, err = c.GetSecret(testNamespace, apiServiceName+"-cert")
-	require.Equal(GinkgoT(), expectedIsNotFound, errors.IsNotFound(err))
+	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role
 	_, err = c.GetRole(testNamespace, apiServiceName+"-cert")
-	require.Equal(GinkgoT(), expectedIsNotFound, errors.IsNotFound(err))
+	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role binding
 	_, err = c.GetRoleBinding(testNamespace, apiServiceName+"-cert")
-	require.Equal(GinkgoT(), expectedIsNotFound, errors.IsNotFound(err))
+	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authDelegatorClusterRoleBinding
 	_, err = c.GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
-	require.Equal(GinkgoT(), expectedIsNotFound, errors.IsNotFound(err))
+	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authReadingRoleBinding
 	_, err = c.GetRoleBinding("kube-system", apiServiceName+"-auth-reader")
-	require.Equal(GinkgoT(), expectedIsNotFound, errors.IsNotFound(err))
+	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 }

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Install Plan", func() {
 		require.Equal(GinkgoT(), dependentCSV.GetName(), dependentSubscription.Status.CurrentCSV)
 
 		// Verify CSV is created
-		_, err = awaitCSV(GinkgoT(), crc, testNamespace, dependentCSV.GetName(), csvAnyChecker)
+		_, err = awaitCSV(crc, testNamespace, dependentCSV.GetName(), csvAnyChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update dependent subscription in catalog and wait for csv to update
@@ -204,7 +204,7 @@ var _ = Describe("Install Plan", func() {
 		require.NotEqual(GinkgoT(), fetchedInstallPlan.GetName(), fetchedUpdatedDepInstallPlan.GetName())
 
 		// Wait for csv to update
-		_, err = awaitCSV(GinkgoT(), crc, testNamespace, updatedDependentCSV.GetName(), csvAnyChecker)
+		_, err = awaitCSV(crc, testNamespace, updatedDependentCSV.GetName(), csvAnyChecker)
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -1170,7 +1170,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, mainCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, testNamespace, mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Update CatalogSource with a new CSV with more permissions
@@ -1236,7 +1236,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, testNamespace, updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// If the CSV is succeeded, we successfully rolled out the RBAC changes
@@ -1357,7 +1357,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, mainCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, testNamespace, mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Update CatalogSource with a new CSV with more permissions
@@ -1417,7 +1417,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, testNamespace, updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			newSecrets, err := c.KubernetesInterface().CoreV1().Secrets(testNamespace).List(context.TODO(), metav1.ListOptions{})
@@ -1561,7 +1561,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			csv, err := awaitCSV(GinkgoT(), crc, testNamespace, mainCSV.GetName(), csvSucceededChecker)
+			csv, err := awaitCSV(crc, testNamespace, mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			modifiedEnv := []corev1.EnvVar{{Name: "EXAMPLE", Value: "value"}}
@@ -1602,7 +1602,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 
 			// Wait for csv to update
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, csv.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, testNamespace, csv.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Should have the updated env var
@@ -1645,7 +1645,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, testNamespace, updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Should have created deployment and stomped on the env changes
@@ -1774,7 +1774,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 
 			// Verify CSV is created
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, mainCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, testNamespace, mainCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			mainManifests = []registry.PackageManifest{
@@ -1798,7 +1798,7 @@ var _ = Describe("Install Plan", func() {
 			require.NotEqual(GinkgoT(), fetchedInstallPlan.GetName(), fetchedUpdatedInstallPlan.GetName())
 
 			// Wait for csv to update
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, betaCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, testNamespace, betaCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the CRD to see if it is updated
@@ -1957,7 +1957,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 
 			// Verify CSV is created
-			_, err = awaitCSV(GinkgoT(), crc, testNamespace, mainCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, testNamespace, mainCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the CRD to see if it is updated
@@ -2547,7 +2547,7 @@ var _ = Describe("Install Plan", func() {
 		require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 		// Verify CSV is created
-		_, err = awaitCSV(GinkgoT(), crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Make sure to clean up the installed CRD

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -946,11 +946,11 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subD)
 
 		// Await csvD's success
-		_, err = awaitCSV(GinkgoT(), crc, nsD, csvD.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, nsD, csvD.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Await csvD's copy in namespaceE
-		_, err = awaitCSV(GinkgoT(), crc, nsE, csvD.GetName(), csvCopiedChecker)
+		_, err = awaitCSV(crc, nsE, csvD.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Await annotation on groupD
@@ -969,7 +969,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subD2)
 
 		// Await csvD2's failure
-		csvD2, err := awaitCSV(GinkgoT(), crc, nsA, csvD.GetName(), csvFailedChecker)
+		csvD2, err := awaitCSV(crc, nsA, csvD.GetName(), csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.CSVReasonInterOperatorGroupOwnerConflict, csvD2.Status.Reason)
 
@@ -981,7 +981,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), awaitAnnotations(GinkgoT(), q, map[string]string{}))
 
 		// Ensure csvD is still successful
-		_, err = awaitCSV(GinkgoT(), crc, nsD, csvD.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, nsD, csvD.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Create subscription for csvA in namespaceA
@@ -993,7 +993,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subA)
 
 		// Await csvA's success
-		_, err = awaitCSV(GinkgoT(), crc, nsA, csvA.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, nsA, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure clusterroles created and aggregated for access provided APIs
@@ -1032,7 +1032,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), awaitAnnotations(GinkgoT(), q, map[string]string{v1.OperatorGroupProvidedAPIsAnnotationKey: kvgA}))
 
 		// Wait for csvA to have a CSV with copied status in namespace D
-		csvAinNsD, err := awaitCSV(GinkgoT(), crc, nsD, csvA.GetName(), csvCopiedChecker)
+		csvAinNsD, err := awaitCSV(crc, nsD, csvA.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// trigger a resync of operatorgropuD
@@ -1044,7 +1044,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA retains the operatorgroup annotations for operatorgroupA
-		csvAinNsD, err = awaitCSV(GinkgoT(), crc, nsD, csvA.GetName(), csvCopiedChecker)
+		csvAinNsD, err = awaitCSV(crc, nsD, csvA.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		require.Equal(GinkgoT(), groupA.GetName(), csvAinNsD.Annotations[v1.OperatorGroupAnnotationKey])
@@ -1052,7 +1052,7 @@ var _ = Describe("Operator Group", func() {
 		require.Equal(GinkgoT(), nsA, csvAinNsD.Labels[v1alpha1.CopiedLabelKey])
 
 		// Await csvA's copy in namespaceC
-		_, err = awaitCSV(GinkgoT(), crc, nsC, csvA.GetName(), csvCopiedChecker)
+		_, err = awaitCSV(crc, nsC, csvA.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Create subscription for csvB in namespaceB
@@ -1064,7 +1064,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subB)
 
 		// Await csvB's failure
-		fetchedB, err := awaitCSV(GinkgoT(), crc, nsB, csvB.GetName(), csvFailedChecker)
+		fetchedB, err := awaitCSV(crc, nsB, csvB.GetName(), csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.CSVReasonInterOperatorGroupOwnerConflict, fetchedB.Status.Reason)
 
@@ -1086,14 +1086,14 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), awaitAnnotations(GinkgoT(), q, map[string]string{v1.OperatorGroupProvidedAPIsAnnotationKey: ""}))
 
 		// Ensure csvA's deployment is deleted
-		require.NoError(GinkgoT(), waitForDeploymentToDelete(GinkgoT(), c, pkgAStable))
+		require.NoError(GinkgoT(), waitForDeploymentToDelete(c, pkgAStable))
 
 		// Await csvB's success
-		_, err = awaitCSV(GinkgoT(), crc, nsB, csvB.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, nsB, csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Await csvB's copy in namespace C
-		_, err = awaitCSV(GinkgoT(), crc, nsC, csvB.GetName(), csvCopiedChecker)
+		_, err = awaitCSV(crc, nsC, csvB.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure annotations exist on group B
@@ -1210,7 +1210,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subA)
 
 		// Await csvA's failure
-		fetchedCSVA, err := awaitCSV(GinkgoT(), crc, nsB, csvA.GetName(), csvFailedChecker)
+		fetchedCSVA, err := awaitCSV(crc, nsB, csvA.GetName(), csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.CSVReasonInterOperatorGroupOwnerConflict, fetchedCSVA.Status.Reason)
 
@@ -1236,7 +1236,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subAC)
 
 		// Await csvA's success
-		_, err = awaitCSV(GinkgoT(), crc, nsC, csvA.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, nsC, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure operatorGroupC has KindA.version.group in its providedAPIs annotation
@@ -1262,15 +1262,15 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subB)
 
 		// Await csvB's success
-		_, err = awaitCSV(GinkgoT(), crc, nsB, csvB.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, nsB, csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Await copied csvBs
-		_, err = awaitCSV(GinkgoT(), crc, nsA, csvB.GetName(), csvCopiedChecker)
+		_, err = awaitCSV(crc, nsA, csvB.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
-		_, err = awaitCSV(GinkgoT(), crc, nsC, csvB.GetName(), csvCopiedChecker)
+		_, err = awaitCSV(crc, nsC, csvB.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
-		_, err = awaitCSV(GinkgoT(), crc, nsD, csvB.GetName(), csvCopiedChecker)
+		_, err = awaitCSV(crc, nsD, csvB.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure operatorGroupB has KindB.version.group in its providedAPIs annotation
@@ -1295,7 +1295,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Wait for csvA in namespaceC to fail with status "InterOperatorGroupOwnerConflict"
-		fetchedCSVA, err = awaitCSV(GinkgoT(), crc, nsC, csvA.GetName(), csvFailedChecker)
+		fetchedCSVA, err = awaitCSV(crc, nsC, csvA.GetName(), csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.CSVReasonInterOperatorGroupOwnerConflict, fetchedCSVA.Status.Reason)
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR replaces testify/require assertions with Gomega's assertions. This PR will be followed up with another PR that uses ginkgo's Container blocks to ensure BDD style structuring

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
