### PR TITLE
Bug 1834136: fix(queues): use a single gc queue

### DIFF
--- a/pkg/lib/queueinformer/resourcequeue.go
+++ b/pkg/lib/queueinformer/resourcequeue.go
@@ -39,6 +39,11 @@ func (r *ResourceQueueSet) RequeueEvent(namespace string, resourceEvent kubestat
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
+	if queue, ok := r.queueSet[metav1.NamespaceAll]; len(r.queueSet) == 1 && ok {
+		queue.AddRateLimited(resourceEvent)
+		return nil
+	}
+
 	if queue, ok := r.queueSet[namespace]; ok {
 		queue.AddRateLimited(resourceEvent)
 		return nil


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

- Use a single GC queue for notifying CSVs of changes to resources that affect them
- Requeue events all-namespace queues if registered
