### PR TITLE
Bug 1833195: delete bundle objects after CSV gets deleted

### DIFF
--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -314,6 +314,18 @@ func InferGroupVersionKind(obj runtime.Object) error {
 			Version: "v1",
 			Kind:    "ServiceAccount",
 		})
+	case *corev1.ConfigMap:
+		objectKind.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "ConfigMap",
+		})
+	case *corev1.Secret:
+		objectKind.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Secret",
+		})
 	case *rbac.ClusterRole:
 		objectKind.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "rbac.authorization.k8s.io",


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
OLM now supports secrets and configmaps in the bundle. These should have ownerrefs associated with the CSV in the bundle. When the CSV is deleted, these objects should be deleted as well. Since they are namespaced scoped, the kube gc will delete them automatically. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
