### PR TITLE
Bug 1819308: Deleting a CSV removes related CSV metrics

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -856,6 +856,8 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 		"phase":     clusterServiceVersion.Status.Phase,
 	})
 
+	metrics.DeleteCSVMetric(clusterServiceVersion)
+
 	defer func(csv v1alpha1.ClusterServiceVersion) {
 		if clusterServiceVersion.IsCopied() {
 			logger.Debug("deleted csv is copied. skipping operatorgroup requeue")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"context"
-
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -187,6 +186,12 @@ func RegisterCatalog() {
 
 func CounterForSubscription(name, installedCSV, channelName, packageName string) prometheus.Counter {
 	return SubscriptionSyncCount.WithLabelValues(name, installedCSV, channelName, packageName)
+}
+
+func DeleteCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion) {
+	// Delete the old CSV metrics
+	csvAbnormal.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String(), string(oldCSV.Status.Phase), string(oldCSV.Status.Reason))
+	csvSucceeded.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String())
 }
 
 func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha1.ClusterServiceVersion) {

--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -44,7 +44,6 @@ var _ = Describe("Metrics", func() {
 
 		cleanupCSV, err := createCSV(GinkgoT(), c, crc, failingCSV, testNamespace, false, false)
 		Expect(err).ToNot(HaveOccurred())
-		defer cleanupCSV()
 
 		_, err = fetchCSV(GinkgoT(), crc, failingCSV.Name, testNamespace, csvFailedChecker)
 		Expect(err).ToNot(HaveOccurred())
@@ -57,6 +56,14 @@ var _ = Describe("Metrics", func() {
 			ContainSubstring("reason=\"UnsupportedOperatorGroup\""),
 			ContainSubstring("version=\"0.0.0\""),
 			ContainSubstring("csv_succeeded"),
+		))
+
+		cleanupCSV()
+
+		// Verify that when the csv has been deleted, it deletes the corresponding CSV metrics
+		Expect(getMetricsFromPod(c, getOLMPod(c), "8081")).ToNot(And(
+			ContainSubstring("csv_abnormal{name=\"%s\"", failingCSV.Name),
+			ContainSubstring("csv_succeeded{name=\"%s\"", failingCSV.Name),
 		))
 	})
 })


### PR DESCRIPTION
Problem: When creating a CSV fails, deleting it did
not clear the CSV metrics. So, when the same CSV was created
again and allowed to succeed, the olm pod still retained the
old CSV metrics

Solution: Added a new method that deletes the CSV metrics when the CSV gets deleted
Signed-off-by: Harish <hgovinda@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
