### PR TITLE
Bug 1836905: fix(queues): use a single gc queue

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -661,8 +661,9 @@ func (a *Operator) syncObject(obj interface{}) (syncError error) {
 					kubestate.ResourceUpdated,
 					metaObj,
 				)
-				syncError = a.objGCQueueSet.RequeueEvent(ns, resourceEvent)
-				logger.Debugf("syncObject - requeued update event for %v, res=%v", resourceEvent, syncError)
+				if syncError = a.objGCQueueSet.RequeueEvent("", resourceEvent); syncError != nil {
+					logger.WithError(syncError).Warnf("failed to requeue gc event: %v", resourceEvent)
+				}
 				return
 			}
 		}
@@ -855,8 +856,9 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 		logger.WithError(err).Warn("cannot list cluster role bindings")
 	}
 	for _, crb := range crbs {
-		syncError := a.objGCQueueSet.RequeueEvent("", kubestate.NewResourceEvent(kubestate.ResourceUpdated, crb))
-		logger.Debugf("handleCSVdeletion - requeued update event for %v, res=%v", crb, syncError)
+		if err := a.objGCQueueSet.RequeueEvent("", kubestate.NewResourceEvent(kubestate.ResourceUpdated, crb)); err != nil {
+			logger.WithError(err).Warnf("failed to requeue gc event: %v", crb)
+		}
 	}
 
 	crs, err := a.lister.RbacV1().ClusterRoleLister().List(ownerSelector)
@@ -864,8 +866,9 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 		logger.WithError(err).Warn("cannot list cluster roles")
 	}
 	for _, cr := range crs {
-		syncError := a.objGCQueueSet.RequeueEvent("", kubestate.NewResourceEvent(kubestate.ResourceUpdated, cr))
-		logger.Debugf("handleCSVdeletion - requeued update event for %v, res=%v", cr, syncError)
+		if err := a.objGCQueueSet.RequeueEvent("", kubestate.NewResourceEvent(kubestate.ResourceUpdated, cr)); err != nil {
+			logger.WithError(err).Warnf("failed to requeue gc event: %v", cr)
+		}
 	}
 }
 

--- a/pkg/lib/queueinformer/resourcequeue.go
+++ b/pkg/lib/queueinformer/resourcequeue.go
@@ -39,6 +39,11 @@ func (r *ResourceQueueSet) RequeueEvent(namespace string, resourceEvent kubestat
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
+	if queue, ok := r.queueSet[metav1.NamespaceAll]; len(r.queueSet) == 1 && ok {
+		queue.AddRateLimited(resourceEvent)
+		return nil
+	}
+
 	if queue, ok := r.queueSet[namespace]; ok {
 		queue.AddRateLimited(resourceEvent)
 		return nil


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

All namespace GC was not being used for ClusteRoles/RoleBindings.

Manual cherry-pick of #1513. 

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
