### PR TITLE
Bug 1828550: add check for storage version changes when installing CRDs

### DIFF
--- a/pkg/lib/crd/storage.go
+++ b/pkg/lib/crd/storage.go
@@ -1,0 +1,68 @@
+package crd
+
+import (
+	"fmt"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// SafeStorageVersionUpgrade determines whether the new CRD spec includes all the storage versions of the existing on-cluster CRD.
+// For each stored version in the status of the CRD on the cluster (there will be at least one) - each version must exist in the spec of the new CRD that is being installed.
+// See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version.
+func SafeStorageVersionUpgrade(existingCRD runtime.Object, newCRD runtime.Object) (bool, error) {
+	newSpecVersions, existingStatusVersions := getStoredVersions(existingCRD, newCRD)
+	if newSpecVersions == nil {
+		return true, fmt.Errorf("could not find any versions in the new CRD")
+	}
+	if existingStatusVersions == nil {
+		// every on-cluster CRD should have at least one stored version in its status
+		// in the case where there are no existing stored versions, checking against new versions is not relevant
+		return true, nil
+	}
+
+	for name := range existingStatusVersions {
+		if _, ok := newSpecVersions[name]; !ok {
+			// a storage version in the status of the old CRD is not present in the spec of the new CRD
+			// potential data loss of CRs without a storage migration - throw error and block the CRD upgrade
+			return false, fmt.Errorf("new CRD removes version %s that is listed as a stored version on the existing CRD", name)
+		}
+	}
+
+	return true, nil
+}
+
+// getStoredVersions returns the storage versions listed in the status of the old on-cluster CRD
+// and all the versions listed in the spec of the new CRD.
+func getStoredVersions(oldCRD runtime.Object, newCRD runtime.Object) (newSpecVersions map[string]struct{}, existingStatusVersions map[string]struct{}) {
+	existingStatusVersions = make(map[string]struct{})
+	newSpecVersions = make(map[string]struct{})
+
+	// find old storage versions by inspect the status field of the existing on-cluster CRD
+	switch crd := oldCRD.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		for _, version := range crd.Status.StoredVersions {
+			existingStatusVersions[version] = struct{}{}
+		}
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		for _, version := range crd.Status.StoredVersions {
+			existingStatusVersions[version] = struct{}{}
+		}
+	}
+
+	switch crd := newCRD.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		for _, version := range crd.Spec.Versions {
+			newSpecVersions[version.Name] = struct{}{}
+		}
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		if crd.Spec.Version != "" {
+			newSpecVersions[crd.Spec.Version] = struct{}{}
+		}
+		for _, version := range crd.Spec.Versions {
+			newSpecVersions[version.Name] = struct{}{}
+		}
+	}
+
+	return newSpecVersions, existingStatusVersions
+}

--- a/pkg/lib/crd/storage_test.go
+++ b/pkg/lib/crd/storage_test.go
@@ -1,0 +1,155 @@
+package crd
+
+import (
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+const crdName = "test"
+
+func TestSafeStorageVersionUpgradeFailure(t *testing.T) {
+	existingCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cluster.com",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha2",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+			},
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			StoredVersions: []string{"v1alpha2"},
+		},
+	}
+
+	newCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cluster.com",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha3",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	safe, err := SafeStorageVersionUpgrade(existingCRD, newCRD)
+	// expect safe to be false, since crd upgrade is not safe
+	require.False(t, safe)
+	// expect error, since crd upgrade is not safe
+	require.Error(t, err, "expected error for unsafe CRD upgrade")
+	// error should be related to the storage upgrade removing a version
+	require.Contains(t, err.Error(), "new CRD removes version", "expected storage version error")
+}
+
+func TestSafeStorageVersionUpgradeSuccess(t *testing.T) {
+	existingCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cluster.com",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha2",
+					Served:  true,
+					Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+				{
+					Name:    "v1alpha3",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+			},
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			StoredVersions: []string{"v1alpha2", "v1alpha3"},
+		},
+	}
+
+	newCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "cluster.com",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha2",
+					Served:  true,
+					Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+				{
+					Name:    "v1alpha3",
+					Served:  true,
+					Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+				{
+					Name:    "v1alpha4",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	safe, err := SafeStorageVersionUpgrade(existingCRD, newCRD)
+	// expect safe to be true, since crd upgrade is safe
+	require.True(t, safe)
+	// expect no error, since crd upgrade is safe
+	require.NoError(t, err, "did not expect error for safe CRD upgrade")
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Minimal bugfix to avoid  potential dataloss when upgrading CRDs. Additional work in this area will be done as part of the CRD epic in the upcoming release. 

Related to #1529 #1504 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
