### PR TITLE
Bug 1838054: fix(catalog): no operatorgroups in a namespace should be an error when resolving

### DIFF
--- a/pkg/lib/scoped/querier_test.go
+++ b/pkg/lib/scoped/querier_test.go
@@ -1,0 +1,159 @@
+package scoped
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+)
+
+func TestUserDefinedServiceAccountQuerier(t *testing.T) {
+	tests := []struct {
+		name          string
+		crclient      versioned.Interface
+		namespace     string
+		wantReference *corev1.ObjectReference
+		wantErr       bool
+		err           error
+	}{
+		{
+			name:      "NoOperatorGroup",
+			crclient:  fake.NewSimpleClientset(),
+			namespace: "ns",
+			wantErr:   true,
+			err:       fmt.Errorf("no operator group found that is managing this namespace"),
+		},
+		{
+			name: "OperatorGroup/NamespaceNotInSpec",
+			crclient: fake.NewSimpleClientset(&v1.OperatorGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "og",
+					Namespace: "ns",
+				},
+				Spec: v1.OperatorGroupSpec{
+					TargetNamespaces: []string{"other"},
+				},
+			}),
+			namespace: "ns",
+			wantErr:   true,
+			err:       fmt.Errorf("no operator group found that is managing this namespace"),
+		},
+		{
+			name: "OperatorGroup/NamespaceNotInStatus",
+			crclient: fake.NewSimpleClientset(&v1.OperatorGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "og",
+					Namespace: "ns",
+				},
+				Spec: v1.OperatorGroupSpec{
+					TargetNamespaces: []string{"ns"},
+				},
+			}),
+			namespace: "ns",
+			wantErr:   true,
+			err:       fmt.Errorf("no operator group found that is managing this namespace"),
+		},
+		{
+			name: "OperatorGroup/Multiple",
+			crclient: fake.NewSimpleClientset(
+				&v1.OperatorGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "og",
+						Namespace: "ns",
+					},
+					Spec: v1.OperatorGroupSpec{
+						TargetNamespaces: []string{"ns"},
+					},
+					Status: v1.OperatorGroupStatus{
+						Namespaces: []string{"ns"},
+					},
+				},
+				&v1.OperatorGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "og2",
+						Namespace: "ns",
+					},
+					Spec: v1.OperatorGroupSpec{
+						TargetNamespaces: []string{"ns"},
+					},
+					Status: v1.OperatorGroupStatus{
+						Namespaces: []string{"ns"},
+					},
+				},
+			),
+			namespace: "ns",
+			wantErr:   true,
+			err:       fmt.Errorf("more than one operator group(s) are managing this namespace count=2"),
+		},
+		{
+			name: "OperatorGroup/NamespaceInStatus/NoSA",
+			crclient: fake.NewSimpleClientset(&v1.OperatorGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "og",
+					Namespace: "ns",
+				},
+				Spec: v1.OperatorGroupSpec{
+					TargetNamespaces: []string{"ns"},
+				},
+				Status: v1.OperatorGroupStatus{
+					Namespaces: []string{"ns"},
+				},
+			}),
+			namespace: "ns",
+			wantErr:   false,
+			err:       nil,
+		},
+		{
+			name: "OperatorGroup/NamespaceInStatus/ServiceAccountRef",
+			crclient: fake.NewSimpleClientset(&v1.OperatorGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "og",
+					Namespace: "ns",
+				},
+				Spec: v1.OperatorGroupSpec{
+					TargetNamespaces:   []string{"ns"},
+					ServiceAccountName: "sa",
+				},
+				Status: v1.OperatorGroupStatus{
+					Namespaces: []string{"ns"},
+					ServiceAccountRef: &corev1.ObjectReference{
+						Kind:      "ServiceAccount",
+						Namespace: "ns",
+						Name:      "sa",
+					},
+				},
+			}),
+			namespace: "ns",
+			wantErr:   false,
+			err:       nil,
+			wantReference: &corev1.ObjectReference{
+				Kind:      "ServiceAccount",
+				Namespace: "ns",
+				Name:      "sa",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			f := &UserDefinedServiceAccountQuerier{
+				crclient: tt.crclient,
+				logger:   logger,
+			}
+			gotReference, err := f.NamespaceQuerier(tt.namespace)()
+			if tt.wantErr {
+				require.Equal(t, tt.err, err)
+			} else {
+				require.Nil(t, tt.err)
+			}
+			require.Equal(t, tt.wantReference, gotReference)
+		})
+	}
+}

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -2401,6 +2401,11 @@ var _ = Describe("Install Plan", func() {
 		}, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
 
+		og := &operatorsv1.OperatorGroup{}
+		og.SetName("og")
+		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
+		require.NoError(GinkgoT(), err)
+
 		deleteOpts := &metav1.DeleteOptions{}
 		defer func() {
 			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), *deleteOpts))
@@ -2621,7 +2626,75 @@ var _ = Describe("Install Plan", func() {
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), 1, len(ips.Items), "If this test fails it should be taken seriously and not treated as a flake. \n%v", ips.Items)
 	})
+	
+	It("without an operatorgroup", func() {
+		defer cleaner.NotifyTestComplete(true)
 
+		log := func(s string) {
+			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
+		}
+
+		ns := &corev1.Namespace{}
+		ns.SetName(genName("ns-"))
+
+		c := newKubeClient()
+		crc := newCRClient()
+
+		// Create a namespace
+		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+		require.NoError(GinkgoT(), err)
+		deleteOpts := &metav1.DeleteOptions{}
+		defer func() {
+			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), *deleteOpts))
+		}()
+
+		mainPackageName := genName("nginx-")
+		mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
+		stableChannel := "stable"
+		mainNamedStrategy := newNginxInstallStrategy(genName("dep-"), nil, nil)
+		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, mainNamedStrategy)
+
+		defer func() {
+			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+		}()
+
+		mainCatalogName := genName("mock-ocs-main-")
+		mainManifests := []registry.PackageManifest{
+			{
+				PackageName: mainPackageName,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: mainPackageStable},
+				},
+				DefaultChannelName: stableChannel,
+			},
+		}
+
+		// Create the main catalog source
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		defer cleanupMainCatalogSource()
+
+		// Attempt to get the catalog source before creating install plan
+		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+		require.NoError(GinkgoT(), err)
+
+		subscriptionName := genName("sub-nginx-")
+		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		defer subscriptionCleanup()
+
+		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+		require.NoError(GinkgoT(), err)
+		require.NotNil(GinkgoT(), subscription)
+
+		installPlanName := subscription.Status.InstallPlanRef.Name
+
+		fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
+		require.NoError(GinkgoT(), err)
+		log(fmt.Sprintf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
+
+		fetchedInstallPlan, err = fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
+		require.NoError(GinkgoT(), err)
+		log(fmt.Sprintf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
+	})
 })
 
 type checkInstallPlanFunc func(fip *operatorsv1alpha1.InstallPlan) bool

--- a/vendor/github.com/sirupsen/logrus/hooks/test/test.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/test/test.go
@@ -1,0 +1,92 @@
+// The Test package is used for testing logrus. It is here for backwards
+// compatibility from when logrus' organization was upper-case. Please use
+// lower-case logrus and the `null` package instead of this one.
+package test
+
+import (
+	"io/ioutil"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Hook is a hook designed for dealing with logs in test scenarios.
+type Hook struct {
+	// Entries is an array of all entries that have been received by this hook.
+	// For safe access, use the AllEntries() method, rather than reading this
+	// value directly.
+	Entries []logrus.Entry
+	mu      sync.RWMutex
+}
+
+// NewGlobal installs a test hook for the global logger.
+func NewGlobal() *Hook {
+
+	hook := new(Hook)
+	logrus.AddHook(hook)
+
+	return hook
+
+}
+
+// NewLocal installs a test hook for a given local logger.
+func NewLocal(logger *logrus.Logger) *Hook {
+
+	hook := new(Hook)
+	logger.Hooks.Add(hook)
+
+	return hook
+
+}
+
+// NewNullLogger creates a discarding logger and installs the test hook.
+func NewNullLogger() (*logrus.Logger, *Hook) {
+
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	return logger, NewLocal(logger)
+
+}
+
+func (t *Hook) Fire(e *logrus.Entry) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = append(t.Entries, *e)
+	return nil
+}
+
+func (t *Hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// LastEntry returns the last entry that was logged or nil.
+func (t *Hook) LastEntry() *logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	i := len(t.Entries) - 1
+	if i < 0 {
+		return nil
+	}
+	return &t.Entries[i]
+}
+
+// AllEntries returns all entries that were logged.
+func (t *Hook) AllEntries() []*logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	// Make a copy so the returned value won't race with future log requests
+	entries := make([]*logrus.Entry, len(t.Entries))
+	for i := 0; i < len(t.Entries); i++ {
+		// Make a copy, for safety
+		entries[i] = &t.Entries[i]
+	}
+	return entries
+}
+
+// Reset removes all Entries from this test hook.
+func (t *Hook) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = make([]logrus.Entry, 0)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -503,6 +503,7 @@ github.com/russross/blackfriday/v2
 github.com/shurcooL/sanitized_anchor_name
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
+github.com/sirupsen/logrus/hooks/test
 # github.com/spf13/cast v1.3.1
 github.com/spf13/cast
 # github.com/spf13/cobra v1.0.0


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This is a 1-line fix plus tests, to avoid applying installplans when there is no operatorgroup in the namespace. 

There should be follow-up work to address the UX - this should probably fail earlier in the process with a message that users can understand (i.e. in status, on subscriptions, may an event)

**Motivation for the change:**
InstallPlans were creating service accounts with RBAC in namespaces that don't have operatorgroups.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
