### PR TITLE
Bug 1822040: Fix delay when OLM applies label to Namespaces

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -100,7 +100,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 
 	if namespacesChanged(targetNamespaces, op.Status.Namespaces) {
 		logger.Debug("OperatorGroup namespaces change detected")
-		outOfSyncNamespaces := namespacesAddedOrRemoved(op.Spec.TargetNamespaces, op.Status.Namespaces)
+		outOfSyncNamespaces := namespacesAddedOrRemoved(op.Status.Namespaces, targetNamespaces)
 
 		// Update operatorgroup target namespace selection
 		logger.WithField("targets", targetNamespaces).Debug("namespace change detected")


### PR DESCRIPTION
**Description of the change:**

When reconciling OperatorGroup, all the namespaces
that appear in targetNamespace or have a matching label selector,
there was a delay in OLM applying labels to these namespaces. This was because the `og.spec.TargetNamespaces` took a long time to update its list of namespaces.

Solution: The fix was to use the pre-calculated `targetNamespaces` instead to compare with `og.Status.Namespaces` to identify the change in namespace list which ensured there was no delay.

Added e2e tests: I added the following e2e tests for a scenario when OLM applies labels:
1. When OperatorGroup has a list of namespaces specified in `targetNamespaces` field
2. When OperatorGroup has a matching label selector defined which matches the labels on the namespaces.
In both these scenarios, OLM applies labels. See [Jira](https://issues.redhat.com/browse/OLM-1651)

Signed-off-by: Harish <hgovinda@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
