### PR TITLE
Reduce install.sh flakiness.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,21 +15,25 @@ release=$1
 url=https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${release}
 namespace=olm
 
-kubectl apply -f ${url}/crds.yaml
-kubectl apply -f ${url}/olm.yaml
+kubectl apply -f "${url}/crds.yaml"
+kubectl wait --for=condition=Established -f "${url}/crds.yaml"
+kubectl apply -f "${url}/olm.yaml"
 
 # wait for deployments to be ready
 kubectl rollout status -w deployment/olm-operator --namespace="${namespace}"
 kubectl rollout status -w deployment/catalog-operator --namespace="${namespace}"
 
-retries=50
-until [[ $retries == 0 || $new_csv_phase == "Succeeded" ]]; do
+retries=30
+until [[ $retries == 0 ]]; do
     new_csv_phase=$(kubectl get csv -n "${namespace}" packageserver -o jsonpath='{.status.phase}' 2>/dev/null || echo "Waiting for CSV to appear")
     if [[ $new_csv_phase != "$csv_phase" ]]; then
         csv_phase=$new_csv_phase
         echo "Package server phase: $csv_phase"
     fi
-    sleep 1
+    if [[ "$new_csv_phase" == "Succeeded" ]]; then
+	break
+    fi
+    sleep 10
     retries=$((retries - 1))
 done
 


### PR DESCRIPTION
Occasionally install.sh flakes out when a CRD takes too long to become
Established, or when the packageserver CSV takes longer than 30s to
reach the Succeeded phase. This commit adds a kubectl wait after
applying the CRDs and bumps the packageserver CSV timeout to 5
minutes, which should make the script more reliable.
