### PR TITLE
feat(resolver): don't build new clauses for weights

### DIFF
--- a/pkg/controller/registry/resolver/sat/dict.go
+++ b/pkg/controller/registry/resolver/sat/dict.go
@@ -159,7 +159,6 @@ func compileDict(installables []Installable) *dict {
 		im := d.c.Lit()
 		d.installables[im] = installable
 		d.lits[installable.Identifier()] = im
-		weights = append(weights, im)
 	}
 
 	// Then build the constraints:
@@ -170,9 +169,7 @@ func compileDict(installables []Installable) *dict {
 
 			clauses := make([]z.Lit, 0, x.weight)
 			for w := 0; w < x.weight; w++ {
-				wm := d.c.Lit()
-				weights = append(weights, wm)
-				clauses = append(clauses, d.c.Implies(d.LitOf(installable.Identifier()), wm))
+				weights = append(weights, d.lits[installable.Identifier()])
 			}
 
 			if !x.Empty() {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This builds a sorting network with multiple entries to signal weight, instead of explicit weight literals and constraints on them. 

For example:

**Prior to this change:**

Installable x of weight 3 and y of weight 2 would give:

(x, w0, w1, w2, y, wy0, wy1) literals (cardinality is minimized)
(x -> w0,  x -> w1,  x-> w2, y -> wy0, y -> wy1) constraints

so the cardinality of picking x is 3 and the cardinality of picking y is 2

Benchmarks:
```
BenchmarkCompileDict-12    	      18	  55723828 ns/op
BenchmarkDictSolve-12      	       1	1656260078 ns/op
PASS
```


**After this change:**

Installable x of weight 3 and y of weight 2 would give:

(x, x, x, y, y) literals (cardinality is minimized)
no constraints

so the cardinality of picking x is 3 and the cardinality of picking y is 2

Benchmarks:
```
BenchmarkCompileDict-12    	   12636	     90925 ns/op
BenchmarkDictSolve-12      	      22	  52780348 ns/op
PASS
```

**Motivation for the change:**
Speed up resolution.

Source: page 13 of [Translating Pseudo-Boolean Constraints into SAT](http://minisat.se/downloads/MiniSat+.pdf)

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
