### PR TITLE
Bug 1827000: Pod Config Deployment Hash Error

### DIFF
--- a/pkg/controller/install/errors.go
+++ b/pkg/controller/install/errors.go
@@ -38,11 +38,11 @@ func IsErrorUnrecoverable(err error) bool {
 	if err == nil {
 		return false
 	}
-	_, ok := unrecoverableErrors[reasonForError(err)]
+	_, ok := unrecoverableErrors[ReasonForError(err)]
 	return ok
 }
 
-func reasonForError(err error) string {
+func ReasonForError(err error) string {
 	switch t := err.(type) {
 	case StrategyError:
 		return t.Reason

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1617,7 +1617,11 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 	}
 
 	if strategyErr != nil {
-		csv.SetPhaseWithEventIfChanged(requeuePhase, requeueConditionReason, fmt.Sprintf("installing: %s", strategyErr), now, a.recorder)
+		if install.ReasonForError(strategyErr) == install.StrategyErrDeploymentUpdated {
+			csv.SetPhaseWithEventIfChanged(v1alpha1.CSVPhaseInstallReady, requeueConditionReason, fmt.Sprintf("installing: %s", strategyErr), now, a.recorder)
+		} else {
+			csv.SetPhaseWithEventIfChanged(requeuePhase, requeueConditionReason, fmt.Sprintf("installing: %s", strategyErr), now, a.recorder)
+		}
 		if err := a.csvQueueSet.Requeue(csv.GetNamespace(), csv.GetName()); err != nil {
 			a.logger.Warn(err.Error())
 		}

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -1353,10 +1353,6 @@ func TestCreateNewSubscriptionWithPodConfig(t *testing.T) {
 	require.NotNil(t, subscription)
 
 	csv, err := fetchCSV(t, crClient, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
-	if err != nil {
-		// TODO: If OLM doesn't have the subscription in its cache when it initially creates the deployment, the CSV will hang on "Installing" until it reaches the five-minute timeout, then succeed on a retry. It should be possible to skip the wait and retry immediately, but in the meantime, giving this test a little extra patience should mitigate flakes.
-		csv, err = fetchCSV(t, crClient, subscription.Status.CurrentCSV, testNamespace, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
-	}
 	require.NoError(t, err)
 
 	proxyEnv := proxyEnvVarFunc(t, config)


### PR DESCRIPTION
The Pod Config e2e test have been failing because the deployment is not reinstalled when the actual deployment hash does not match the calculated deployment hash. This commit updates OLM to reinstall a deployment when the hash doesn't match the calculated hash.
