### PR TITLE
[WIP] Update workflow to save e2e test artifacts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,5 +8,12 @@ jobs:
   run-e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: make -f x.mk e2e-local
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Run e2e tests
+        run: make -f x.mk e2e-local
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: e2e-test-output
+          path: ${{ github.workspace }}/bin/junit_e2e_*.xml


### PR DESCRIPTION
Signed-off-by: Harish <hgovinda@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR allows persisting of e2e test logs by uploading the junit_e2e.xml report that is generated using Ginkgo as part of PR #1512.  Refer [this](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts) for more details.
With this change, for the "e2e_tests.yml" workflow under the Actions tab, you can view the artifact's name and size in the UI

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
