### PR TITLE
Bug 1849164: don't store full manifests in installplan status (for bundle images)

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -71,6 +71,14 @@ func TestConfigMapUnpacker(t *testing.T) {
 						Namespace: "ns-a",
 						Name:      "src-a",
 					},
+					Conditions: []operatorsv1alpha1.BundleLookupCondition{
+						{
+							Type:    operatorsv1alpha1.BundleLookupPending,
+							Status:  corev1.ConditionTrue,
+							Reason:  JobNotStartedReason,
+							Message: JobNotStartedMessage,
+						},
+					},
 				},
 			},
 			expected: expected{
@@ -115,6 +123,14 @@ func TestConfigMapUnpacker(t *testing.T) {
 					CatalogSourceRef: &corev1.ObjectReference{
 						Namespace: "ns-a",
 						Name:      "src-a",
+					},
+					Conditions: []operatorsv1alpha1.BundleLookupCondition{
+						{
+							Type:    operatorsv1alpha1.BundleLookupPending,
+							Status:  corev1.ConditionTrue,
+							Reason:  JobNotStartedReason,
+							Message: JobNotStartedMessage,
+						},
 					},
 				},
 			},

--- a/pkg/controller/operators/catalog/manifests.go
+++ b/pkg/controller/operators/catalog/manifests.go
@@ -1,0 +1,109 @@
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-registry/pkg/configmap"
+	errorwrap "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/client-go/listers/core/v1"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
+)
+
+// ManifestResolver can dereference a manifest for a step. Steps may embed manifests directly or reference content
+// in configmaps
+type ManifestResolver interface {
+	ManifestForStep(step *v1alpha1.Step) (string, error)
+}
+
+// manifestResolver caches manifest from unpacked bundles (via configmaps)
+type manifestResolver struct {
+	configMapLister v1.ConfigMapLister
+	unpackedSteps   map[string][]v1alpha1.StepResource
+	namespace       string
+	logger          logrus.FieldLogger
+}
+
+func newManifestResolver(namespace string, configMapLister v1.ConfigMapLister, logger logrus.FieldLogger) *manifestResolver {
+	return &manifestResolver{
+		namespace:       namespace,
+		configMapLister: configMapLister,
+		unpackedSteps:   map[string][]v1alpha1.StepResource{},
+		logger:          logger,
+	}
+}
+
+// ManifestForStep always returns the manifest that should be applied to the cluster for a given step
+// the manifest field in the installplan status can contain a reference to a configmap instead
+func (r *manifestResolver) ManifestForStep(step *v1alpha1.Step) (string, error) {
+	manifest := step.Resource.Manifest
+	ref := refForStep(step, r.logger)
+	if ref == nil {
+		return manifest, nil
+	}
+
+	log := r.logger.WithFields(logrus.Fields{"resolving": step.Resolving, "step": step.Resource.Name})
+	log.WithField("ref", ref).Debug("step is a reference to configmap")
+
+	usteps, err := r.unpackedStepsForBundle(step.Resolving, ref)
+	if err != nil  {
+		return "", err
+	}
+
+	log.Debugf("checking cache for unpacked step")
+	// need to find the real manifest from the unpacked steps
+	for _, u := range usteps {
+		if u.Name == step.Resource.Name &&
+			u.Kind == step.Resource.Kind &&
+			u.Version == step.Resource.Version &&
+			u.Group == step.Resource.Group {
+			manifest = u.Manifest
+			log.WithField("manifest", manifest).Debug("step replaced with unpacked value")
+			break
+		}
+	}
+	if manifest == step.Resource.Manifest {
+		return "", fmt.Errorf("couldn't find unpacked step for %v", step)
+	}
+	return manifest, nil
+}
+
+func (r *manifestResolver) unpackedStepsForBundle(bundleName string, ref *UnpackedBundleReference) ([]v1alpha1.StepResource, error) {
+	usteps, ok := r.unpackedSteps[bundleName]
+	if ok {
+		return usteps, nil
+	}
+	cm, err := r.configMapLister.ConfigMaps(ref.Namespace).Get(ref.Name)
+	if err != nil {
+		return nil, errorwrap.Wrapf(err, "error finding unpacked bundle configmap for ref %v", *ref)
+	}
+	loader := configmap.NewBundleLoader()
+	bundle, err := loader.Load(cm)
+	if err != nil {
+		return nil, errorwrap.Wrapf(err, "error loading unpacked bundle configmap for ref %v", *ref)
+	}
+	steps, err := resolver.NewStepResourceFromBundle(bundle, r.namespace, ref.Replaces, ref.CatalogSourceName, ref.CatalogSourceNamespace)
+	if err != nil {
+		return nil, errorwrap.Wrapf(err, "error calculating steps for ref %v", *ref)
+	}
+	r.unpackedSteps[bundleName] = steps
+	return steps, nil
+}
+
+func refForStep(step *v1alpha1.Step, log logrus.FieldLogger) *UnpackedBundleReference {
+	log = log.WithFields(logrus.Fields{"resolving": step.Resolving, "step": step.Resource.Name})
+	var ref UnpackedBundleReference
+	if err := json.Unmarshal([]byte(step.Resource.Manifest), &ref); err != nil {
+		log.Debug("step is not a reference to an unpacked bundle (this is not an error if the step is a manifest)")
+		return nil
+	}
+	log = log.WithField("ref", ref)
+	if ref.Kind != "ConfigMap" || ref.Name == "" || ref.Namespace == "" || ref.CatalogSourceName == "" || ref.CatalogSourceNamespace == "" {
+		log.Debug("step is not a reference to an unpacked bundle (this is not an error if the step is a manifest)")
+		return nil
+	}
+	return &ref
+}

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1105,6 +1105,16 @@ func (o *Operator) createInstallPlan(namespace string, gen int, subs []*v1alpha1
 	return reference.GetReference(res)
 }
 
+type UnpackedBundleReference struct {
+	Kind                   string `json:"kind"`
+	Name                   string `json:"name"`
+	Namespace              string `json:"namespace"`
+	CatalogSourceName      string `json:"catalogSourceName"`
+	CatalogSourceNamespace string `json:"catalogSourceNamespace"`
+	Replaces               string `json:"replaces"`
+}
+
+// unpackBundles makes one walk through the bundlelookups and attempts to progress them
 func (o *Operator) unpackBundles(plan *v1alpha1.InstallPlan) (bool, *v1alpha1.InstallPlan, error) {
 	out := plan.DeepCopy()
 	unpacked := true
@@ -1117,32 +1127,53 @@ func (o *Operator) unpackBundles(plan *v1alpha1.InstallPlan) (bool, *v1alpha1.In
 			errs = append(errs, err)
 			continue
 		}
-
-		if res == nil {
-			unpacked = false
-			continue
-		}
-
 		out.Status.BundleLookups[i] = *res.BundleLookup
-		if res.Bundle() == nil || len(res.Bundle().GetObject()) == 0 {
+
+		// if pending condition is present, still waiting for the job to unpack to configmap
+		if res.GetCondition(v1alpha1.BundleLookupPending).Status == corev1.ConditionTrue {
 			unpacked = false
 			continue
 		}
 
+		// if packed condition is missing, bundle has already been unpacked into steps, continue
+		if res.GetCondition(resolver.BundleLookupConditionPacked).Status == corev1.ConditionUnknown {
+			continue
+		}
+
+		// Ensure that bundle can be applied by the current version of OLM by converting to steps
 		steps, err := resolver.NewStepsFromBundle(res.Bundle(), out.GetNamespace(), res.Replaces, res.CatalogSourceRef.Name, res.CatalogSourceRef.Namespace)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to turn bundle into steps: %s", err.Error()))
+			errs = append(errs, fmt.Errorf("failed to turn bundle into steps: %v", err))
 			unpacked = false
 			continue
 		}
 
-		// Add steps and remove resolved bundle lookup
+		// step manifests are replaced with references to the configmap containing them
+		for i, s := range steps {
+			ref := UnpackedBundleReference{
+				Kind:                   "ConfigMap",
+				Namespace:              res.CatalogSourceRef.Namespace,
+				Name:                   res.Name(),
+				CatalogSourceName:      res.CatalogSourceRef.Name,
+				CatalogSourceNamespace: res.CatalogSourceRef.Namespace,
+				Replaces:               res.Replaces,
+			}
+			r, err := json.Marshal(&ref)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to generate reference for configmap: %v", err))
+				unpacked = false
+				continue
+			}
+			s.Resource.Manifest = string(r)
+			steps[i] = s
+		}
+		res.RemoveCondition(resolver.BundleLookupConditionPacked)
+		out.Status.BundleLookups[i] = *res.BundleLookup
 		out.Status.Plan = append(out.Status.Plan, steps...)
-		out.Status.BundleLookups = append(out.Status.BundleLookups[:i], out.Status.BundleLookups[i+1:]...)
-		i--
 	}
 
 	if err := utilerrors.NewAggregate(errs); err != nil {
+		o.logger.Debugf("failed to unpack bundles: %v", err)
 		return false, nil, err
 	}
 
@@ -1416,7 +1447,8 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 	}
 
 	ensurer := newStepEnsurer(kubeclient, crclient, dynamicClient)
-	b := newBuilder(kubeclient, dynamicClient, o.csvProvidedAPIsIndexer, o.logger)
+	r := newManifestResolver(plan.GetNamespace(), o.lister.CoreV1().ConfigMapLister(), o.logger)
+	b := newBuilder(kubeclient, dynamicClient, o.csvProvidedAPIsIndexer, r, o.logger)
 
 	for i, step := range plan.Status.Plan {
 		doStep := true
@@ -1443,12 +1475,16 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 		case v1alpha1.StepStatusPresent, v1alpha1.StepStatusCreated, v1alpha1.StepStatusWaitingForAPI:
 			continue
 		case v1alpha1.StepStatusUnknown, v1alpha1.StepStatusNotPresent:
+			manifest, err := r.ManifestForStep(step)
+			if err != nil {
+				return err
+			}
 			o.logger.WithFields(logrus.Fields{"kind": step.Resource.Kind, "name": step.Resource.Name}).Debug("execute resource")
 			switch step.Resource.Kind {
 			case v1alpha1.ClusterServiceVersionKind:
 				// Marshal the manifest into a CSV instance.
 				var csv v1alpha1.ClusterServiceVersion
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &csv)
+				err := json.Unmarshal([]byte(manifest), &csv)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1481,7 +1517,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			case v1alpha1.SubscriptionKind:
 				// Marshal the manifest into a subscription instance.
 				var sub v1alpha1.Subscription
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &sub)
+				err := json.Unmarshal([]byte(manifest), &sub)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1505,7 +1541,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 
 			case resolver.BundleSecretKind:
 				var s corev1.Secret
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &s)
+				err := json.Unmarshal([]byte(manifest), &s)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1544,7 +1580,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			case clusterRoleKind:
 				// Marshal the manifest into a ClusterRole instance.
 				var cr rbacv1.ClusterRole
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &cr)
+				err := json.Unmarshal([]byte(manifest), &cr)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1559,7 +1595,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			case clusterRoleBindingKind:
 				// Marshal the manifest into a RoleBinding instance.
 				var rb rbacv1.ClusterRoleBinding
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &rb)
+				err := json.Unmarshal([]byte(manifest), &rb)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1574,7 +1610,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			case roleKind:
 				// Marshal the manifest into a Role instance.
 				var r rbacv1.Role
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &r)
+				err := json.Unmarshal([]byte(manifest), &r)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1597,7 +1633,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			case roleBindingKind:
 				// Marshal the manifest into a RoleBinding instance.
 				var rb rbacv1.RoleBinding
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &rb)
+				err := json.Unmarshal([]byte(manifest), &rb)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1620,7 +1656,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			case serviceAccountKind:
 				// Marshal the manifest into a ServiceAccount instance.
 				var sa corev1.ServiceAccount
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &sa)
+				err := json.Unmarshal([]byte(manifest), &sa)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1643,7 +1679,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			case serviceKind:
 				// Marshal the manifest into a Service instance
 				var s corev1.Service
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &s)
+				err := json.Unmarshal([]byte(manifest), &s)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1673,7 +1709,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 
 			case configMapKind:
 				var cfg corev1.ConfigMap
-				err := json.Unmarshal([]byte(step.Resource.Manifest), &cfg)
+				err := json.Unmarshal([]byte(manifest), &cfg)
 				if err != nil {
 					return errorwrap.Wrapf(err, "error parsing step manifest: %s", step.Resource.Name)
 				}
@@ -1709,7 +1745,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 				}
 
 				// Marshal the manifest into an unstructured object
-				dec := yaml.NewYAMLOrJSONDecoder(strings.NewReader(step.Resource.Manifest), 10)
+				dec := yaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 10)
 				unstructuredObject := &unstructured.Unstructured{}
 				if err := dec.Decode(unstructuredObject); err != nil {
 					return errorwrap.Wrapf(err, "error decoding %s object to an unstructured object", step.Resource.Name)

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -269,13 +269,13 @@ func TestExecutePlan(t *testing.T) {
 							Version:                "v1",
 							Kind:                   "ConfigMap",
 							Name:                   "cfg",
-							Manifest:               toManifest(t, configmap("cfg", namespace)),
+							Manifest:               toManifest(t, configMap("cfg", namespace)),
 						},
 						Status: v1alpha1.StepStatusUnknown,
 					},
 				},
 			),
-			want: []runtime.Object{configmap("cfg", namespace)},
+			want: []runtime.Object{configMap("cfg", namespace)},
 			err:  nil,
 		},
 		{
@@ -1307,7 +1307,7 @@ func serviceAccount(name, namespace, generateName string, secretRef *corev1.Obje
 	}
 }
 
-func configmap(name, namespace string) *corev1.ConfigMap {
+func configMap(name, namespace string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta:   metav1.TypeMeta{Kind: configMapKind},
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},

--- a/pkg/controller/registry/resolver/rbac.go
+++ b/pkg/controller/registry/resolver/rbac.go
@@ -2,19 +2,30 @@ package resolver
 
 import (
 	"fmt"
+	"hash/fnv"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/storage/names"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
+	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 )
 
-var generateName = func(base string) string {
-	return names.SimpleNameGenerator.GenerateName(base + "-")
+const maxNameLength = 63
+
+func generateName(base string, o interface{}) string {
+	hasher := fnv.New32a()
+	hashutil.DeepHashObject(hasher, o)
+	hash := utilrand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+	if len(base)+len(hash) > maxNameLength {
+		base = base[:maxNameLength - len(hash) - 1]
+	}
+
+	return fmt.Sprintf("%s-%s", base, hash)
 }
 
 type OperatorPermissions struct {
@@ -82,7 +93,7 @@ func RBACForClusterServiceVersion(csv *v1alpha1.ClusterServiceVersion) (map[stri
 		// Create Role
 		role := &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            generateName(csv.GetName()),
+				Name:            generateName(csv.GetName(), permission.Rules),
 				Namespace:       csv.GetNamespace(),
 				OwnerReferences: []metav1.OwnerReference{ownerutil.NonBlockingOwner(csv)},
 				Labels:          ownerutil.OwnerLabel(csv, v1alpha1.ClusterServiceVersionKind),
@@ -94,7 +105,7 @@ func RBACForClusterServiceVersion(csv *v1alpha1.ClusterServiceVersion) (map[stri
 		// Create RoleBinding
 		roleBinding := &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            generateName(fmt.Sprintf("%s-%s", role.GetName(), permission.ServiceAccountName)),
+				Name:     		 generateName(role.GetName(), role),
 				Namespace:       csv.GetNamespace(),
 				OwnerReferences: []metav1.OwnerReference{ownerutil.NonBlockingOwner(csv)},
 				Labels:          ownerutil.OwnerLabel(csv, v1alpha1.ClusterServiceVersionKind),
@@ -126,7 +137,7 @@ func RBACForClusterServiceVersion(csv *v1alpha1.ClusterServiceVersion) (map[stri
 		// Create ClusterRole
 		role := &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   generateName(csv.GetName()),
+				Name:   generateName(csv.GetName(), permission.Rules),
 				Labels: ownerutil.OwnerLabel(csv, v1alpha1.ClusterServiceVersionKind),
 			},
 			Rules: permission.Rules,
@@ -136,7 +147,7 @@ func RBACForClusterServiceVersion(csv *v1alpha1.ClusterServiceVersion) (map[stri
 		// Create ClusterRoleBinding
 		roleBinding := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      generateName(fmt.Sprintf("%s-%s", role.GetName(), permission.ServiceAccountName)),
+				Name:      generateName(role.GetName(), role),
 				Namespace: csv.GetNamespace(),
 				Labels:    ownerutil.OwnerLabel(csv, v1alpha1.ClusterServiceVersionKind),
 			},

--- a/pkg/controller/registry/resolver/rbac_test.go
+++ b/pkg/controller/registry/resolver/rbac_test.go
@@ -1,0 +1,65 @@
+package resolver
+
+import (
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/quick"
+)
+
+func TestGenerateName(t *testing.T) {
+	type args struct {
+		base string
+		o    interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "generate",
+			args: args{
+				base: "myname",
+				o: []string{"something"},
+			},
+			want: "myname-9c895f74f",
+		},
+		{
+			name: "truncated",
+			args: args{
+				base: strings.Repeat("name", 100),
+				o: []string{"something", "else"},
+			},
+			want: "namenamenamenamenamenamenamenamenamenamenamenamename-78fd8b4d6b",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateName(tt.args.base, tt.args.o)
+			require.Equal(t, tt.want, got)
+			require.LessOrEqual(t, len(got), maxNameLength)
+		})
+	}
+}
+
+var runeSet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-")
+
+type validKubeName string
+
+func (validKubeName) Generate(rand *rand.Rand, size int) reflect.Value {
+	b := make([]rune, size)
+	for i := range b {
+		b[i] = runeSet[rand.Intn(len(runeSet))]
+	}
+	return reflect.ValueOf(validKubeName(b))
+}
+
+func TestGeneratesWithinRange(t *testing.T) {
+	f := func(base validKubeName, o string) bool {
+		return len(generateName(string(base), o)) <= maxNameLength
+	}
+	require.NoError(t, quick.Check(f, nil))
+}

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -16,7 +16,12 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	v1alpha1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	controllerbundle "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
+)
+
+const (
+	BundleLookupConditionPacked v1alpha1.BundleLookupConditionType = "BundleLookupNotPersisted"
 )
 
 var timeNow = func() metav1.Time { return metav1.NewTime(time.Now().UTC()) }
@@ -116,6 +121,20 @@ func (r *OperatorsV1alpha1Resolver) ResolveSteps(namespace string, sourceQuerier
 					CatalogSourceRef: &corev1.ObjectReference{
 						Namespace: op.SourceInfo().Catalog.Namespace,
 						Name:      op.SourceInfo().Catalog.Name,
+					},
+					Conditions: []v1alpha1.BundleLookupCondition{
+						{
+							Type:    BundleLookupConditionPacked,
+							Status:  corev1.ConditionTrue,
+							Reason:  controllerbundle.NotUnpackedReason,
+							Message: controllerbundle.NotUnpackedMessage,
+						},
+						{
+							Type:    v1alpha1.BundleLookupPending,
+							Status:  corev1.ConditionTrue,
+							Reason:  controllerbundle.JobNotStartedReason,
+							Message: controllerbundle.JobNotStartedMessage,
+						},
 					},
 				})
 			}

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions"
+	controllerbundle "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 )
 
@@ -125,6 +126,20 @@ func TestNamespaceResolver(t *testing.T) {
 						CatalogSourceRef: &corev1.ObjectReference{
 							Namespace: catalog.Namespace,
 							Name:      catalog.Name,
+						},
+						Conditions: []v1alpha1.BundleLookupCondition{
+							{
+								Type:    BundleLookupConditionPacked,
+								Status:  corev1.ConditionTrue,
+								Reason:  controllerbundle.NotUnpackedReason,
+								Message: controllerbundle.NotUnpackedMessage,
+							},
+							{
+								Type:    v1alpha1.BundleLookupPending,
+								Status:  corev1.ConditionTrue,
+								Reason:  controllerbundle.JobNotStartedReason,
+								Message: controllerbundle.JobNotStartedMessage,
+							},
 						},
 					},
 				},
@@ -240,6 +255,20 @@ func TestNamespaceResolver(t *testing.T) {
 						CatalogSourceRef: &corev1.ObjectReference{
 							Namespace: catalog.Namespace,
 							Name:      catalog.Name,
+						},
+						Conditions: []v1alpha1.BundleLookupCondition{
+							{
+								Type:    BundleLookupConditionPacked,
+								Status:  corev1.ConditionTrue,
+								Reason:  controllerbundle.NotUnpackedReason,
+								Message: controllerbundle.NotUnpackedMessage,
+							},
+							{
+								Type:    v1alpha1.BundleLookupPending,
+								Status:  corev1.ConditionTrue,
+								Reason:  controllerbundle.JobNotStartedReason,
+								Message: controllerbundle.JobNotStartedMessage,
+							},
 						},
 					},
 				},
@@ -540,10 +569,6 @@ func TestNamespaceResolver(t *testing.T) {
 }
 
 func TestNamespaceResolverRBAC(t *testing.T) {
-	generateName = func(base string) string {
-		return "a"
-	}
-
 	namespace := "catsrc-namespace"
 	catalog := CatalogKey{"catsrc", namespace}
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
If a manifest comes from a bundle image, instead of storing the manifest itself in the installplan status, we now store a reference to the configmap that contains the manifest. When installing, OLM will look up the manifest and use the correct one.

One additional change was necessary - role/rolebinding name generation is now deterministic. This is because some resources for an installplan are generated by OLM, rather than read directly from the unpacked bundle, and we need identities for them so that we can track the the status of an individual step.

Steps that are references will look like this:

```yaml
    - resolving: ibm-cloud-databases-redis.v1.0.0
      resource:
        group: rbac.authorization.k8s.io
        kind: ClusterRoleBinding
        manifest: >-
         {"kind":"ConfigMap","name":"cbd102757181a13f9cee81c42815586023b4840d95543e67c1d68f1572e4667","namespace":"openshift-marketplace","catalogSourceName":"aspera","catalogSourceNamespace":"openshift-marketplace","replaces":""}
        name: ibm-cloud-databases-redis.v1.0.079b98b8bd4-i7bdf84b456
        sourceName: aspera
        sourceNamespace: openshift-marketplace
        version: v1
      status: Created
```
where the configmap references the unpacked bundle for that step.

**Motivation for the change:**
It is possible to hit size limits in the installplan, if resolution results in lots of large manifests. Bundle images are already unpacked into configmaps on-cluster, so persisting the unpacked manifests in the installplan is not necessary.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
