### PR TITLE
Remove failfast from operator e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ e2e-local-docker:
 	. ./scripts/run_e2e_docker.sh $(TEST)
 
 e2e-operator-metrics:
-	go test -v $(MOD_FLAGS) -failfast -timeout 70m ./test/rh-operators/...
+	go test -v $(MOD_FLAGS) -timeout 70m ./test/rh-operators/...
 
 vendor:
 	go mod tidy


### PR DESCRIPTION
The operator e2e test would like to resume testing regardless of
some operators failed to install. This commit drops the failfast
cmd in the make file which is called by the ci periodic job.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
