### PR TITLE
Replace assertions within async assertions.

### DIFF
--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -307,8 +307,12 @@ var _ = Describe("CRD Versions", func() {
 		_, err = crc.OperatorsV1alpha1().Subscriptions(testNamespace).Update(context.TODO(), sub, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred(), "could not update subscription")
 
+		subscriptionAtLatestWithDifferentInstallPlan := func(v *operatorsv1alpha1.Subscription) bool {
+			return subscriptionStateAtLatestChecker(v) && v.Status.InstallPlanRef != nil && v.Status.InstallPlanRef.Name != fetchedInstallPlan.Name
+		}
+
 		// fetch new subscription
-		s, err := fetchSubscription(crc, testNamespace, subscriptionName, subscriptionStateAtLatestChecker)
+		s, err := fetchSubscription(crc, testNamespace, subscriptionName, subscriptionAtLatestWithDifferentInstallPlan)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(s).ToNot(BeNil())
 		Expect(s.Status.InstallPlanRef).ToNot(Equal(nil))

--- a/test/e2e/gc_e2e_test.go
+++ b/test/e2e/gc_e2e_test.go
@@ -458,16 +458,15 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			})
 
 			It("OLM should have upgraded associated configmap in place", func() {
-				Eventually(func() bool {
+				Eventually(func() (string, error) {
 					cfg, err := kubeClient.GetConfigMap(testNamespace, configmapName)
 					if err != nil {
-						return false
+						return "", err
 					}
 					// check data in configmap to ensure it is the new data (configmap was updated in the newer bundle)
 					// new value in the configmap is "updated-very-much"
-					data := cfg.Data["special.how"]
-					return data == "updated-very-much"
-				}).Should(BeTrue())
+					return cfg.Data["special.how"], nil
+				}).Should(Equal("updated-very-much"))
 				ctx.Ctx().Logf("dependent successfully updated after csv owner was updated")
 			})
 		})


### PR DESCRIPTION
Functions passed to Gomega's async assertions (Eventually/Consistently) are called repeatedly until the first return value satisfies the given matcher and any other return values are their respective type's zero value.

In several cases, functions passed to async assertions are themselves directly making assertions. If one of those fails, it can cause the entire test to fail immediately rather than continue retrying the async condition.
