### PR TITLE
Disable parallel e2e-local runs by default.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: make -f x.mk e2e-local
+      - run: make -f x.mk e2e-local NODES=2

--- a/x.mk
+++ b/x.mk
@@ -28,7 +28,7 @@ bin/e2e-local.image.tar: e2e.Dockerfile bin/wait bin/cpb $(CMDS)
 
 .PHONY: e2e-local
 e2e-local: bin/e2e-local.test bin/e2e-local.image.tar
-	$(GINKGO) -p -randomizeAllSpecs $(if $(TEST),-focus "$(TEST)") -v -timeout 70m $< -- -namespace=operators -olmNamespace=operator-lifecycle-manager -dummyImage=bitnami/nginx:latest -kind.images=e2e-local.image.tar
+	$(GINKGO) -nodes $(or $(NODES),1) -randomizeAllSpecs $(if $(TEST),-focus "$(TEST)") -v -timeout 70m $< -- -namespace=operators -olmNamespace=operator-lifecycle-manager -dummyImage=bitnami/nginx:latest -kind.images=e2e-local.image.tar
 
 # Phony prerequisite for targets that rely on the go build cache to
 # determine staleness.


### PR DESCRIPTION
Relying on Ginkgo's -p heuristic is confusing, so parallel runs are now opt-in via NODES.
