### PR TITLE
Update ocp manifests with latest template

### DIFF
--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -77,7 +77,7 @@ spec:
           secretName: olm-operator-serving-cert
       
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
       tolerations:
       - effect: NoSchedule

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -72,7 +72,7 @@ spec:
           secretName: catalog-operator-serving-cert
       
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
       tolerations:
       - effect: NoSchedule

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -81,7 +81,7 @@ spec:
               serviceAccountName: olm-operator-serviceaccount
               priorityClassName: "system-cluster-critical"
               nodeSelector:
-                beta.kubernetes.io/os: linux
+                kubernetes.io/os: linux
                 node-role.kubernetes.io/master: ""
               tolerations:
               - effect: NoSchedule


### PR DESCRIPTION
Use latest templated node selector key, replace beta.kubernetes.io/os with kubernetes.io/os