### PR TITLE
Bug 1822396: Update metric when Subscription is updated

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -267,5 +267,7 @@ func UpdateSubsSyncCounterStorage(sub *olmv1alpha1.Subscription) {
 		counterValues.installedCSV = sub.Status.InstalledCSV
 		counterValues.pkg = sub.Spec.Package
 		counterValues.channel = sub.Spec.Channel
+
+		subscriptionSyncCounters[sub.GetName()] = counterValues
 	}
 }

--- a/test/e2e/like_metric_matcher_test.go
+++ b/test/e2e/like_metric_matcher_test.go
@@ -47,6 +47,30 @@ func WithLabel(n, v string) MetricPredicate {
 	}
 }
 
+func WithName(name string) MetricPredicate {
+	return WithLabel("name", name)
+}
+
+func WithChannel(channel string) MetricPredicate {
+	return WithLabel("channel", channel)
+}
+
+func WithPackage(pkg string) MetricPredicate {
+	return WithLabel("package", pkg)
+}
+
+func WithPhase(phase string) MetricPredicate {
+	return WithLabel("phase", phase)
+}
+
+func WithReason(reason string) MetricPredicate {
+	return WithLabel("reason", reason)
+}
+
+func WithVersion(version string) MetricPredicate {
+	return WithLabel("version", version)
+}
+
 func WithValue(v float64) MetricPredicate {
 	return MetricPredicate{
 		name: fmt.Sprintf("WithValue(%g)", v),


### PR DESCRIPTION
**Description of the change:**

In #1519, the subscription_sync_total metric was updated when the
related subscription object was updated. However, the PR had a bug,
in which the map used to store metric related information was not
being updated when the metric was udpated. As a result of which any
update after the first update was not removing the old metric. This
PR fixes that bug.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
