### PR TITLE
Retry update in flaky test of CSV w/owned API Service.

### DIFF
--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -1029,11 +1029,12 @@ var _ = Describe("CSV", func() {
 		require.True(GinkgoT(), ok, "expected olm sha annotation not present on existing pod template")
 
 		// Induce a cert rotation
-		now := metav1.Now()
-		fetchedCSV.Status.CertsLastUpdated = &now
-		fetchedCSV.Status.CertsRotateAt = &now
-		fetchedCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).UpdateStatus(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
-		require.NoError(GinkgoT(), err)
+		Eventually(Apply(fetchedCSV, func(csv *v1alpha1.ClusterServiceVersion) error {
+			now := metav1.Now()
+			csv.Status.CertsLastUpdated = &now
+			csv.Status.CertsRotateAt = &now
+			return nil
+		})).Should(Succeed())
 
 		_, err = fetchCSV(crc, csv.Name, testNamespace, func(csv *v1alpha1.ClusterServiceVersion) bool {
 			// Should create deployment

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -22,7 +22,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 
@@ -962,11 +961,6 @@ var _ = Describe("Subscription", func() {
 		plan := &v1alpha1.InstallPlan{}
 		plan.SetNamespace(ref.Namespace)
 		plan.SetName(ref.Name)
-		plan.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   v1alpha1.GroupName,
-			Version: v1alpha1.GroupVersion,
-			Kind:    v1alpha1.InstallPlanKind,
-		})
 
 		// Set the InstallPlan's approval mode to Manual
 		Eventually(Apply(plan, func(p *v1alpha1.InstallPlan) error {


### PR DESCRIPTION
This test updates `CertsLastUpdated` and `CertsRotateAt` on the status of a CSV in order to induce a cert rotation, but can conflict with concurrent status updates by OLM.

```
Failure [14.797 seconds]
CSV
/go/src/github.com/operator-framework/operator-lifecycle-manager/test/e2e/csv_e2e_test.go:36
  create with owned API service [It]
  /go/src/github.com/operator-framework/operator-lifecycle-manager/test/e2e/csv_e2e_test.go:891
  
      
  	Error Trace:	csv_e2e_test.go:1036
  	            				runner.go:113
  	            				runner.go:64
  	            				it_node.go:26
  	            				spec.go:215
  	            				spec.go:138
  	            				spec_runner.go:200
  	            				spec_runner.go:170
  	            				spec_runner.go:66
  	            				suite.go:62
  	            				ginkgo_dsl.go:226
  	            				ginkgo_dsl.go:214
  	            				e2e_test.go:54
  	Error:      	Received unexpected error:
  	            	Operation cannot be fulfilled on clusterserviceversions.operators.coreos.com "hat-server2xgrj": the object has been modified; please apply your changes to the latest version and try again 
```

https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/pr-logs/pull/operator-framework_operator-lifecycle-manager/1603/pull-ci-operator-framework-operator-lifecycle-manager-master-e2e-aws-olm/1276015846690394112#1:build-log.txt%3A455