### PR TITLE
Add more precise matching to the metric end-to-end tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	github.com/otiai10/copy v1.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.2.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.4.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5

--- a/test/e2e/like_metric_matcher_test.go
+++ b/test/e2e/like_metric_matcher_test.go
@@ -1,0 +1,88 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+type Metric struct {
+	Family string
+	Labels map[string][]string
+	Value  float64 // Zero unless type is Untypted, Gauge, or Counter!
+}
+
+type MetricPredicate struct {
+	f    func(m Metric) bool
+	name string
+}
+
+func (mp MetricPredicate) String() string {
+	return mp.name
+}
+
+func WithFamily(f string) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithFamily(%s)", f),
+		f: func(m Metric) bool {
+			return m.Family == f
+		},
+	}
+}
+
+func WithLabel(n, v string) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithLabel(%s=%s)", n, v),
+		f: func(m Metric) bool {
+			for name, values := range m.Labels {
+				for _, value := range values {
+					if name == n && value == v {
+						return true
+					}
+				}
+			}
+			return false
+		},
+	}
+}
+
+func WithValue(v float64) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithValue(%g)", v),
+		f: func(m Metric) bool {
+			return m.Value == v
+		},
+	}
+}
+
+type LikeMetricMatcher struct {
+	Predicates []MetricPredicate
+}
+
+func (matcher *LikeMetricMatcher) Match(actual interface{}) (bool, error) {
+	metric, ok := actual.(Metric)
+	if !ok {
+		return false, fmt.Errorf("LikeMetric matcher expects Metric (got %T)", actual)
+	}
+	for _, predicate := range matcher.Predicates {
+		if !predicate.f(metric) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (matcher *LikeMetricMatcher) FailureMessage(actual interface{}) string {
+	return format.Message(actual, "to satisfy", matcher.Predicates)
+}
+
+func (matcher *LikeMetricMatcher) NegatedFailureMessage(actual interface{}) string {
+	return format.Message(actual, "not to satisfy", matcher.Predicates)
+}
+
+func LikeMetric(preds ...MetricPredicate) types.GomegaMatcher {
+	return &LikeMetricMatcher{
+		Predicates: preds,
+	}
+}

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -1813,11 +1813,6 @@ func createSubscription(t GinkgoTInterface, crc versioned.Interface, namespace, 
 	return buildSubscriptionCleanupFunc(crc, subscription), subscription
 }
 
-func updateSubscription(t GinkgoTInterface, crc versioned.Interface, subscription *v1alpha1.Subscription) {
-	_, err := crc.OperatorsV1alpha1().Subscriptions(subscription.GetNamespace()).Update(context.TODO(), subscription, metav1.UpdateOptions{})
-	Expect(err).ToNot(HaveOccurred())
-}
-
 func createSubscriptionForCatalog(crc versioned.Interface, namespace, name, catalog, packageName, channel, startingCSV string, approval v1alpha1.Approval) cleanupFunc {
 	subscription := &v1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
The metric tests scrape metrics in the Prometheus text format and have
been mainly asserting based on the presence or absence of substrings
within the entire response body.

Metrics are now parsed into a slice of structs, and there is a new
Gomega matcher that can reference metric family, labels, and
value (for untyped metrics, gauges, and counters).
