### PR TITLE
add InstallplanApproval (automatic/manual) to OLM metrics

### DIFF
--- a/test/e2e/like_metric_matcher_test.go
+++ b/test/e2e/like_metric_matcher_test.go
@@ -67,6 +67,10 @@ func WithReason(reason string) MetricPredicate {
 	return WithLabel("reason", reason)
 }
 
+func WithApproval(approvalStrategy string) MetricPredicate {
+	return WithLabel("approval", approvalStrategy)
+}
+
 func WithVersion(version string) MetricPredicate {
 	return WithLabel("version", version)
 }

--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -136,6 +136,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 					WithName("metric-subscription-for-create"),
 					WithChannel(stableChannel),
 					WithPackage(testPackageName),
+					WithApproval(string(v1alpha1.ApprovalManual)),
 				)))
 			})
 
@@ -187,12 +188,14 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 						WithName("metric-subscription-for-update"),
 						WithChannel(stableChannel),
 						WithPackage(testPackageName),
+						WithApproval(string(v1alpha1.ApprovalManual)),
 					))),
 					ContainElement(LikeMetric(
 						WithFamily("subscription_sync_total"),
 						WithName("metric-subscription-for-update"),
 						WithChannel(betaChannel),
 						WithPackage(testPackageName),
+						WithApproval(string(v1alpha1.ApprovalManual)),
 					)),
 				))
 			})
@@ -224,12 +227,14 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 							WithName("metric-subscription-for-update"),
 							WithChannel(betaChannel),
 							WithPackage(testPackageName),
+							WithApproval(string(v1alpha1.ApprovalManual)),
 						))),
 						ContainElement(LikeMetric(
 							WithFamily("subscription_sync_total"),
 							WithName("metric-subscription-for-update"),
 							WithChannel(alphaChannel),
 							WithPackage(testPackageName),
+							WithApproval(string(v1alpha1.ApprovalManual)),
 						))))
 				})
 			})


### PR DESCRIPTION
This PR adds the InstallPlanApproval strategy (automatic/manual) to OLM metrics.