### PR TITLE
Allow ConsoleYAMLSample resources from bundle manifests

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1947,6 +1947,7 @@ const (
 	PodDisruptionBudgetKind   = "PodDisruptionBudget"
 	PriorityClassKind         = "PriorityClass"
 	VerticalPodAutoscalerKind = "VerticalPodAutoscaler"
+	ConsoleYAMLSampleKind     = "ConsoleYAMLSample"
 )
 
 var supportedKinds = map[string]struct{}{
@@ -1955,6 +1956,7 @@ var supportedKinds = map[string]struct{}{
 	PodDisruptionBudgetKind:   {},
 	PriorityClassKind:         {},
 	VerticalPodAutoscalerKind: {},
+	ConsoleYAMLSampleKind:     {},
 }
 
 // isSupported returns true if OLM supports this type of CustomResource.


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Allow the inclusion of samples in the bundle manifest

Closes #1615

**Motivation for the change:**
Ease of deployment of samples for the console

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


