### PR TITLE
Add workflow to save e2e test artifacts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,4 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: make -f x.mk e2e-local NODES=2
+      - run: make -f x.mk e2e-local NODES=2 JUNIT_DIRECTORY=./artifacts/
+      - name: Archive production artifacts # test results are only uploaded if any of the e2e tests fails
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: e2e-test-output-${{ github.sha }}-${{ github.run_id }}
+          path: ${{ github.workspace }}/bin/artifacts/*


### PR DESCRIPTION
This commit uploads e2e testing results to OLM repo
artifect for 90 days for test flak analysis.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
