### PR TITLE
Bug 1851213: Set Resource to plural in CSV RelatedObjects field

### DIFF
--- a/pkg/lib/operatorstatus/builder_test.go
+++ b/pkg/lib/operatorstatus/builder_test.go
@@ -336,7 +336,7 @@ func TestBuilder(t *testing.T) {
 		{
 			name: "WithRelatedObject/ReferenceNotPresentInStatus",
 			action: func(b *Builder) {
-				b.WithRelatedObject("group", "resource", "namespace", "name")
+				b.WithRelatedObject("group", "resources", "namespace", "name")
 			},
 			expected: &configv1.ClusterOperatorStatus{
 				Conditions: []configv1.ClusterOperatorStatusCondition{},
@@ -344,7 +344,7 @@ func TestBuilder(t *testing.T) {
 				RelatedObjects: []configv1.ObjectReference{
 					configv1.ObjectReference{
 						Group:     "group",
-						Resource:  "resource",
+						Resource:  "resources",
 						Namespace: "namespace",
 						Name:      "name",
 					},
@@ -357,7 +357,7 @@ func TestBuilder(t *testing.T) {
 		{
 			name: "WithRelatedObject/ReferencePresentInStatus",
 			action: func(b *Builder) {
-				b.WithRelatedObject("group", "resource", "namespace", "name")
+				b.WithRelatedObject("group", "resources", "namespace", "name")
 			},
 			existing: &configv1.ClusterOperatorStatus{
 				Conditions: []configv1.ClusterOperatorStatusCondition{},
@@ -365,7 +365,7 @@ func TestBuilder(t *testing.T) {
 				RelatedObjects: []configv1.ObjectReference{
 					configv1.ObjectReference{
 						Group:     "group",
-						Resource:  "resource",
+						Resource:  "resources",
 						Namespace: "namespace",
 						Name:      "name",
 					},
@@ -377,7 +377,7 @@ func TestBuilder(t *testing.T) {
 				RelatedObjects: []configv1.ObjectReference{
 					configv1.ObjectReference{
 						Group:     "group",
-						Resource:  "resource",
+						Resource:  "resources",
 						Namespace: "namespace",
 						Name:      "name",
 					},
@@ -390,7 +390,7 @@ func TestBuilder(t *testing.T) {
 		{
 			name: "WithoutRelatedObject/ReferenceBeingRemoved",
 			action: func(b *Builder) {
-				b.WithoutRelatedObject("group", "resource", "namespace", "name")
+				b.WithoutRelatedObject("group", "resources", "namespace", "name")
 			},
 			existing: &configv1.ClusterOperatorStatus{
 				Conditions: []configv1.ClusterOperatorStatusCondition{},
@@ -398,7 +398,7 @@ func TestBuilder(t *testing.T) {
 				RelatedObjects: []configv1.ObjectReference{
 					configv1.ObjectReference{
 						Group:     "group",
-						Resource:  "resource",
+						Resource:  "resources",
 						Namespace: "namespace",
 						Name:      "name",
 					},

--- a/pkg/lib/operatorstatus/csv_reporter.go
+++ b/pkg/lib/operatorstatus/csv_reporter.go
@@ -21,7 +21,7 @@ func newCSVStatusReporter(releaseVersion string) *csvStatusReporter {
 	}
 }
 
-// csvStatusReporter provides the logic for initialzing ClusterOperator and
+// csvStatusReporter provides the logic for initializing ClusterOperator and
 // ClusterOperatorStatus types.
 type csvStatusReporter struct {
 	clock          clock.Clock
@@ -76,7 +76,7 @@ func (r *csvStatusReporter) GetNewStatus(existing *configv1.ClusterOperatorStatu
 		gvk := csv.GetObjectKind().GroupVersionKind()
 
 		builder.WithoutVersion(csv.GetName(), csv.Spec.Version.String()).
-			WithoutRelatedObject(gvk.Group, gvk.Kind, csv.GetNamespace(), csv.GetName())
+			WithoutRelatedObject(gvk.Group, clusterServiceVersionResource, csv.GetNamespace(), csv.GetName())
 
 		if context.WorkingToward == nil {
 			builder.WithProgressing(configv1.ConditionFalse, fmt.Sprintf("Uninstalled version %s", csv.Spec.Version)).
@@ -94,7 +94,7 @@ func (r *csvStatusReporter) GetNewStatus(existing *configv1.ClusterOperatorStatu
 
 	gvk := csv.GetObjectKind().GroupVersionKind()
 	builder.WithRelatedObject("", "namespaces", "", csv.GetNamespace()).
-		WithRelatedObject(gvk.Group, gvk.Kind, csv.GetNamespace(), csv.GetName())
+		WithRelatedObject(gvk.Group, clusterServiceVersionResource, csv.GetNamespace(), csv.GetName())
 
 	switch phase {
 	case v1alpha1.CSVPhaseSucceeded:

--- a/pkg/lib/operatorstatus/csv_reporter_test.go
+++ b/pkg/lib/operatorstatus/csv_reporter_test.go
@@ -83,7 +83,7 @@ func TestGetNewStatus(t *testing.T) {
 					},
 					{
 						Group:     v1alpha1.GroupName,
-						Resource:  v1alpha1.ClusterServiceVersionKind,
+						Resource:  clusterServiceVersionResource,
 						Namespace: "foo-namespace",
 						Name:      "foo",
 					},
@@ -159,7 +159,7 @@ func TestGetNewStatus(t *testing.T) {
 					},
 					{
 						Group:     v1alpha1.GroupName,
-						Resource:  v1alpha1.ClusterServiceVersionKind,
+						Resource:  clusterServiceVersionResource,
 						Namespace: "foo-namespace",
 						Name:      "foo",
 					},

--- a/pkg/lib/operatorstatus/status.go
+++ b/pkg/lib/operatorstatus/status.go
@@ -25,9 +25,12 @@ import (
 )
 
 const (
-	clusterOperatorOLM           = "operator-lifecycle-manager"
-	clusterOperatorCatalogSource = "operator-lifecycle-manager-catalog"
-	openshiftNamespace           = "openshift-operator-lifecycle-manager"
+	clusterOperatorOLM            = "operator-lifecycle-manager"
+	clusterOperatorCatalogSource  = "operator-lifecycle-manager-catalog"
+	openshiftNamespace            = "openshift-operator-lifecycle-manager"
+	clusterServiceVersionResource = "clusterserviceversions"
+	subscriptionResource          = "subscriptions"
+	installPlanResource           = "installplans"
 )
 
 func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct{}, opClient operatorclient.ClientInterface, configClient configv1client.ConfigV1Interface, crClient versioned.Interface) {
@@ -280,7 +283,7 @@ func relatedObjects(name string, opClient operatorclient.ClientInterface, crClie
 			}
 			objectReferences = append(objectReferences, configv1.ObjectReference{
 				Group:     olmv1alpha1.GroupName,
-				Resource:  olmv1alpha1.ClusterServiceVersionKind,
+				Resource:  clusterServiceVersionResource,
 				Namespace: csv.GetNamespace(),
 				Name:      csv.GetName(),
 			})
@@ -299,7 +302,7 @@ func relatedObjects(name string, opClient operatorclient.ClientInterface, crClie
 		for _, sub := range subList.Items {
 			objectReferences = append(objectReferences, configv1.ObjectReference{
 				Group:     olmv1alpha1.GroupName,
-				Resource:  olmv1alpha1.SubscriptionKind,
+				Resource:  subscriptionResource,
 				Namespace: sub.GetNamespace(),
 				Name:      sub.GetName(),
 			})
@@ -307,7 +310,7 @@ func relatedObjects(name string, opClient operatorclient.ClientInterface, crClie
 		for _, ip := range installPlanList.Items {
 			objectReferences = append(objectReferences, configv1.ObjectReference{
 				Group:     olmv1alpha1.GroupName,
-				Resource:  olmv1alpha1.InstallPlanKind,
+				Resource:  installPlanResource,
 				Namespace: ip.GetNamespace(),
 				Name:      ip.GetName(),
 			})


### PR DESCRIPTION
**Description of the change:**
The `Resource` property in `RelatedObjects` field of `ClusterServiceVersionStatus` is meant to be the lowercase plural value, but were being populated with the `Kind` instead. Made modifications in this PR to switch all `Kind` values in `Resource` to the expected format.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


