### PR TITLE
[wip] Perodic e2e test results analysis

### DIFF
--- a/.github/workflows/e2e-tests-periodic-flak-analysis.yml
+++ b/.github/workflows/e2e-tests-periodic-flak-analysis.yml
@@ -2,6 +2,7 @@ name: e2e-tests-periodic-flak-analysis
 on:
   schedule:
     - cron: '0 0 12 * * SUN'
+  pull_request:
 jobs:
   flak-analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests-periodic-flak-analysis.yml
+++ b/.github/workflows/e2e-tests-periodic-flak-analysis.yml
@@ -10,4 +10,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           path: ${{ github.workspace }}/bin/artifacts/
-      - run: make e2e-test-report-analysis
+    # - run: make e2e-test-report-analysis
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{ github.workspace }}/bin/artifacts/

--- a/.github/workflows/e2e-tests-periodic-flak-analysis.yml
+++ b/.github/workflows/e2e-tests-periodic-flak-analysis.yml
@@ -2,6 +2,9 @@ name: e2e-tests-periodic-flak-analysis
 on:
   schedule:
     - cron: '0 0 12 * * SUN'
+  push:
+    branches:
+      - master
   pull_request:
 jobs:
   flak-analysis:

--- a/.github/workflows/e2e-tests-periodic-flak-analysis.yml
+++ b/.github/workflows/e2e-tests-periodic-flak-analysis.yml
@@ -1,11 +1,11 @@
 name: e2e-tests-periodic-flak-analysis
 on:
-  pull_request:
-  schedule:
-    - cron: '0 0 12 * * SUN'
+  #    - cron: '0 0 12 * * SUN'
+  #  schedule:
   push:
     branches:
     - master
+  pull_request:
 jobs:
   flak-analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests-periodic-flak-analysis.yml
+++ b/.github/workflows/e2e-tests-periodic-flak-analysis.yml
@@ -1,11 +1,11 @@
 name: e2e-tests-periodic-flak-analysis
 on:
+  pull_request:
   schedule:
     - cron: '0 0 12 * * SUN'
   push:
     branches:
-      - master
-  pull_request:
+    - master
 jobs:
   flak-analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests-periodic-flak-analysis.yml
+++ b/.github/workflows/e2e-tests-periodic-flak-analysis.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
-        with:
-          path: ${{ github.workspace }}/bin/artifacts/
     # - run: make e2e-test-report-analysis
       - name: Display structure of downloaded files
         run: ls -R
-        working-directory: ${{ github.workspace }}/bin/artifacts/

--- a/.github/workflows/e2e-tests-periodic-flak-analysis.yml
+++ b/.github/workflows/e2e-tests-periodic-flak-analysis.yml
@@ -1,0 +1,4 @@
+name: e2e-tests-periodic-flak-analysis
+on:
+  schedule:
+    - cron: '0 0 12 * * SUN'

--- a/.github/workflows/e2e-tests-periodic-flak-analysis.yml
+++ b/.github/workflows/e2e-tests-periodic-flak-analysis.yml
@@ -2,3 +2,12 @@ name: e2e-tests-periodic-flak-analysis
 on:
   schedule:
     - cron: '0 0 12 * * SUN'
+jobs:
+  flak-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          path: ${{ github.workspace }}/bin/artifacts/
+      - run: make e2e-test-report-analysis

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,9 +16,11 @@ jobs:
         with:
           name: e2e-test-output-${{ github.sha }}-${{ github.run_id }}
           path: ${{ github.workspace }}/bin/artifacts/*
-        - uses: actions/download-artifact@v2
-          with:
-            path: ${{ github.workspace }}/bin/artifacts/*
-        - name: Display structure of downloaded files
-          run: ls -R
-          working-directory: ${{ github.workspace }}/bin/artifacts/*
+      - uses: actions/download-artifact@v2
+        if: ${{ failure() }}
+        with:
+          path: ${{ github.workspace }}/bin/artifacts/*
+      - name: Display structure of downloaded files
+        if: ${{ failure() }}
+        run: ls -R
+        working-directory: ${{ github.workspace }}/bin/artifacts/*

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,3 +16,9 @@ jobs:
         with:
           name: e2e-test-output-${{ github.sha }}-${{ github.run_id }}
           path: ${{ github.workspace }}/bin/artifacts/*
+        - uses: actions/download-artifact@v2
+          with:
+            path: ${{ github.workspace }}/bin/artifacts/*
+        - name: Display structure of downloaded files
+          run: ls -R
+          working-directory: ${{ github.workspace }}/bin/artifacts/*

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,9 @@ clean:
 	@rm -rf test/e2e/log
 	@rm -rf e2e.namespace
 
+e2e-test-report-analysis:
+    go run 
+
 
 # Copy CRD manifests
 manifests: vendor


### PR DESCRIPTION
On pull requests, all failed e2e test results are uploaded as artifacts to GitHub for 90 days. These test results are pulled to rank for their flakiness.