### PR TITLE
Add an AtMost cardinality constraint to the solver package.

### DIFF
--- a/pkg/controller/registry/resolver/solver/constraints_test.go
+++ b/pkg/controller/registry/resolver/solver/constraints_test.go
@@ -1,86 +1,10 @@
 package solver
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestConstraints(t *testing.T) {
-	type tc struct {
-		Name       string
-		Constraint Constraint
-		Subject    Identifier
-		Expected   constrainer
-	}
-
-	for _, tt := range []tc{
-		{
-			Name:       "mandatory",
-			Constraint: Mandatory(),
-			Subject:    "a",
-			Expected: constrainer{
-				pos: []Identifier{"a"},
-			},
-		},
-		{
-			Name:       "prohibited",
-			Constraint: Prohibited(),
-			Subject:    "a",
-			Expected: constrainer{
-				neg: []Identifier{"a"},
-			},
-		},
-		{
-			Name:       "empty dependency",
-			Constraint: Dependency(),
-			Subject:    "a",
-			Expected:   constrainer{},
-		},
-		{
-			Name:       "single dependency",
-			Constraint: Dependency("b"),
-			Subject:    "a",
-			Expected: constrainer{
-				pos: []Identifier{"b"},
-				neg: []Identifier{"a"},
-			},
-		},
-		{
-			Name:       "multiple dependency",
-			Constraint: Dependency("x", "y", "z"),
-			Subject:    "a",
-			Expected: constrainer{
-				pos: []Identifier{"x", "y", "z"},
-				neg: []Identifier{"a"},
-			},
-		},
-		{
-			Name:       "conflict",
-			Constraint: Conflict("b"),
-			Subject:    "a",
-			Expected: constrainer{
-				neg: []Identifier{"a", "b"},
-			},
-		},
-	} {
-		t.Run(tt.Name, func(t *testing.T) {
-			var x constrainer
-			tt.Constraint.apply(&x, tt.Subject)
-
-			// Literals in lexically increasing order:
-			sort.Slice(x.pos, func(i, j int) bool {
-				return x.pos[i] < x.pos[j]
-			})
-			sort.Slice(x.neg, func(i, j int) bool {
-				return x.neg[i] < x.neg[j]
-			})
-
-			assert.Equal(t, tt.Expected, x)
-		})
-	}
-}
 
 func TestOrder(t *testing.T) {
 	type tc struct {

--- a/pkg/controller/registry/resolver/solver/lit_mapping.go
+++ b/pkg/controller/registry/resolver/solver/lit_mapping.go
@@ -48,26 +48,15 @@ func newLitMapping(installables []Installable) *litMapping {
 		d.installables[im] = installable
 	}
 
-	var x constrainer
 	for _, installable := range installables {
 		for _, constraint := range installable.Constraints() {
-			x.Reset()
-			constraint.apply(&x, installable.Identifier())
-			if x.Empty() {
+			m := constraint.apply(d.c, &d, installable.Identifier())
+			if m == z.LitNull {
 				// This constraint doesn't have a
 				// useful representation in the SAT
 				// inputs.
 				continue
 			}
-
-			d.buf = d.buf[:0]
-			for _, p := range x.pos {
-				d.buf = append(d.buf, d.LitOf(p))
-			}
-			for _, n := range x.neg {
-				d.buf = append(d.buf, d.LitOf(n).Not())
-			}
-			m := d.c.Ors(d.buf...)
 
 			d.constraints[m] = AppliedConstraint{
 				Installable: installable,

--- a/pkg/controller/registry/resolver/solver/solve_test.go
+++ b/pkg/controller/registry/resolver/solver/solve_test.go
@@ -228,6 +228,42 @@ func TestSolve(t *testing.T) {
 			},
 		},
 		{
+			Name: "cardinality constraint prevents resolution",
+			Installables: []Installable{
+				installable("a", Mandatory(), Dependency("x", "y"), AtMost(1, "x", "y")),
+				installable("x", Mandatory()),
+				installable("y", Mandatory()),
+			},
+			Error: NotSatisfiable{
+				{
+					Installable: installable("a", Mandatory(), Dependency("x", "y"), AtMost(1, "x", "y")),
+					Constraint:  AtMost(1, "x", "y"),
+				},
+				{
+					Installable: installable("x", Mandatory()),
+					Constraint:  Mandatory(),
+				},
+				{
+					Installable: installable("y", Mandatory()),
+					Constraint:  Mandatory(),
+				},
+			},
+		},
+		{
+			Name: "cardinality constraint forces alternative",
+			Installables: []Installable{
+				installable("a", Mandatory(), Dependency("x", "y"), AtMost(1, "x", "y")),
+				installable("b", Mandatory(), Dependency("y")),
+				installable("x"),
+				installable("y"),
+			},
+			Installed: []Installable{
+				installable("a", Mandatory(), Dependency("x", "y"), AtMost(1, "x", "y")),
+				installable("b", Mandatory(), Dependency("y")),
+				installable("y"),
+			},
+		},
+		{
 			Name: "two dependencies satisfied by one installable",
 			Installables: []Installable{
 				installable("a", Mandatory(), Dependency("y")),


### PR DESCRIPTION
Expressing an at-most-one constraint, as in "at most one bundle per package," would blow up on large inputs using one-to-one Conflict constraints. This new constraint is implemented more efficiently via a sorting network.