### PR TITLE
test(e2e): delete all subs, installplans, catalogs, and csvs in test teardown

### DIFF
--- a/test/e2e/bundle_e2e_test.go
+++ b/test/e2e/bundle_e2e_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -30,7 +29,7 @@ var _ = Describe("Installing bundles with new object types", func() {
 	})
 
 	AfterEach(func() {
-		cleaner.NotifyTestComplete(true)
+		TearDown(testNamespace)
 	})
 
 	When("a bundle with a pdb, priorityclass, and VPA object is installed", func() {

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -29,10 +29,11 @@ import (
 )
 
 var _ = Describe("Catalog", func() {
+	AfterEach(func() {
+		TearDown(testNamespace)
+	})
+
 	It("loading between restarts", func() {
-
-		defer cleaner.NotifyTestComplete(true)
-
 		// create a simple catalogsource
 		packageName := genName("nginx")
 		stableChannel := "stable"
@@ -87,8 +88,6 @@ var _ = Describe("Catalog", func() {
 		GinkgoT().Logf("Catalog source sucessfully loaded after rescale")
 	})
 	It("global update triggers subscription sync", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		globalNS := operatorNamespace
 		c := newKubeClient()
@@ -196,8 +195,6 @@ var _ = Describe("Catalog", func() {
 		require.True(GinkgoT(), timeLapse < 60)
 	})
 	It("config map update triggers registry pod rollout", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		mainPackageName := genName("nginx-")
 		dependentPackageName := genName("nginxdep-")
@@ -316,8 +313,6 @@ var _ = Describe("Catalog", func() {
 	})
 	It("config map replace triggers registry pod rollout", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		mainPackageName := genName("nginx-")
 		dependentPackageName := genName("nginxdep-")
 
@@ -405,8 +400,6 @@ var _ = Describe("Catalog", func() {
 		// Wait for the stable CSV to be Successful
 		// Update the "address" CatalogSources's Spec.Address field with the PodIP of the replacement copied pod's PodIP
 		// Wait for the replacement CSV to be Successful
-
-		defer cleaner.NotifyTestComplete(true)
 
 		mainPackageName := genName("nginx-")
 		dependentPackageName := genName("nginxdep-")
@@ -543,8 +536,6 @@ var _ = Describe("Catalog", func() {
 		// Delete the registry pod
 		// Wait for a new registry pod to be created
 
-		defer cleaner.NotifyTestComplete(true)
-
 		// Create internal CatalogSource containing csv in package
 		packageName := genName("nginx-")
 		packageStable := fmt.Sprintf("%s-stable", packageName)
@@ -622,8 +613,6 @@ var _ = Describe("Catalog", func() {
 		// Wait for csv to succeed
 		// Delete the registry pod
 		// Wait for a new registry pod to be created
-
-		defer cleaner.NotifyTestComplete(true)
 
 		sourceName := genName("catalog-")
 		packageName := "etcd"
@@ -774,7 +763,6 @@ var _ = Describe("Catalog", func() {
 		}
 
 		// 2. setup catalog source
-		defer cleaner.NotifyTestComplete(true)
 
 		sourceName := genName("catalog-")
 		packageName := "busybox"
@@ -945,7 +933,6 @@ var _ = Describe("Catalog", func() {
 		// Update the catalog to point to an image that contains the busybox v2 and busybox-dependency v2 images.
 		// Wait for the new Subscriptions to succeed and check if they include the new CSVs
 		// Wait for the CSVs to succeed and confirm that the have the correct Spec.Replaces fields.
-		defer cleaner.NotifyTestComplete(true)
 
 		sourceName := genName("catalog-")
 		packageName := "busybox"

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("CRD Versions", func() {
-	AfterEach(func() { cleaner.NotifyTestComplete(true) }, float64(10))
+	AfterEach(func() { TearDown(testNamespace) }, float64(30))
 
 	It("creates v1beta1 crds with a v1beta1 schema successfully", func() {
 		By("This test proves that OLM is able to handle v1beta1 CRDs successfully. Creating v1 CRDs has more " +

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -34,9 +34,11 @@ import (
 )
 
 var _ = Describe("CSV", func() {
-	It("create with unmet requirements mini kube version", func() {
+	AfterEach(func() {
+		TearDown(testNamespace)
+	})
 
-		defer cleaner.NotifyTestComplete(true)
+	It("create with unmet requirements mini kube version", func() {
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -87,8 +89,6 @@ var _ = Describe("CSV", func() {
 	})
 	// TODO: same test but missing serviceaccount instead
 	It("create with unmet requirements CRD", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -149,8 +149,6 @@ var _ = Describe("CSV", func() {
 		require.Error(GinkgoT(), err)
 	})
 	It("create with unmet permissions CRD", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -260,8 +258,6 @@ var _ = Describe("CSV", func() {
 	})
 	It("create with unmet requirements API service", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 		crc := newCRClient()
 
@@ -321,8 +317,6 @@ var _ = Describe("CSV", func() {
 		require.Error(GinkgoT(), err)
 	})
 	It("create with unmet permissions API service", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -412,8 +406,6 @@ var _ = Describe("CSV", func() {
 	})
 	It("create with unmet requirements native API", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 		crc := newCRClient()
 
@@ -464,8 +456,6 @@ var _ = Describe("CSV", func() {
 	})
 	// TODO: same test but create serviceaccount instead
 	It("create requirements met CRD", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -727,8 +717,6 @@ var _ = Describe("CSV", func() {
 	})
 	It("create requirements met API service", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 		crc := newCRClient()
 
@@ -889,8 +877,6 @@ var _ = Describe("CSV", func() {
 		compareResources(GinkgoT(), fetchedCSV, sameCSV)
 	})
 	It("create with owned API service", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -1080,8 +1066,6 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 	})
 	It("update with owned API service", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -1283,8 +1267,6 @@ var _ = Describe("CSV", func() {
 		require.Equal(GinkgoT(), string(v1alpha1.CSVPhaseFailed), string(fetched.Status.Phase))
 	})
 	It("create same CSV with owned API service multi namespace", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -1489,8 +1471,6 @@ var _ = Describe("CSV", func() {
 	})
 	It("orphaned API service clean up", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 
 		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
@@ -1555,8 +1535,6 @@ var _ = Describe("CSV", func() {
 		<-deleted
 	})
 	It("update same deployment name", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -1740,8 +1718,6 @@ var _ = Describe("CSV", func() {
 	})
 	It("update different deployment name", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 		crc := newCRClient()
 
@@ -1921,8 +1897,6 @@ var _ = Describe("CSV", func() {
 		require.NoError(GinkgoT(), err)
 	})
 	It("update multiple intermediates", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -2110,8 +2084,6 @@ var _ = Describe("CSV", func() {
 	})
 	It("update in place", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 		crc := newCRClient()
 
@@ -2263,8 +2235,6 @@ var _ = Describe("CSV", func() {
 		require.Equal(GinkgoT(), *depUpdated.Spec.Replicas, *strategyNew.DeploymentSpecs[0].Spec.Replicas)
 	})
 	It("update multiple version CRD", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -2545,8 +2515,6 @@ var _ = Describe("CSV", func() {
 	})
 	It("update modify deployment name", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 		crc := newCRClient()
 
@@ -2697,7 +2665,6 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("emits CSV requirement events", func() {
-		defer cleaner.NotifyTestComplete(true)
 
 		c := ctx.Ctx().KubeClient()
 		crc := ctx.Ctx().OperatorClient()
@@ -2784,8 +2751,6 @@ var _ = Describe("CSV", func() {
 
 	// TODO: test behavior when replaces field doesn't point to existing CSV
 	It("status invalid CSV", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -2899,7 +2864,6 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("api service resource migrated if adoptable", func() {
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -2983,7 +2947,6 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("API service resource not migrated if not adoptable", func() {
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -3070,7 +3033,6 @@ var _ = Describe("CSV", func() {
 	})
 
 	It("multiple API services on a single pod", func() {
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()

--- a/test/e2e/ctx/ctx.go
+++ b/test/e2e/ctx/ctx.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
@@ -114,6 +115,7 @@ func setDerivedFields(ctx *TestContext) error {
 
 	ctx.scheme = runtime.NewScheme()
 	localSchemeBuilder := runtime.NewSchemeBuilder(
+		apiextensionsv1.AddToScheme,
 		kscheme.AddToScheme,
 		operatorsv1alpha1.AddToScheme,
 		operatorsv1.AddToScheme,

--- a/test/e2e/dynamic_resource_e2e_test.go
+++ b/test/e2e/dynamic_resource_e2e_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Subscriptions create required objects from Catalogs", func() {
 	})
 
 	AfterEach(func() {
-		cleaner.NotifyTestComplete(true)
+		TearDown(testNamespace)
 	})
 
 	Context("Given a Namespace", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -69,9 +69,6 @@ var _ = BeforeSuite(func() {
 	testNamespace = *namespace
 	operatorNamespace = *olmNamespace
 	communityOperatorsImage = *communityOperators
-
-	cleaner = newNamespaceCleaner(testNamespace)
-
 	deprovision = ctx.MustProvision(ctx.Ctx())
 	ctx.MustInstall(ctx.Ctx())
 

--- a/test/e2e/gc_e2e_test.go
+++ b/test/e2e/gc_e2e_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 	})
 
 	AfterEach(func() {
-		cleaner.NotifyTestComplete(true)
+		TearDown(testNamespace)
 	})
 
 	Context("Given a ClusterRole owned by a CustomResourceDefinition", func() {

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -36,9 +36,11 @@ import (
 )
 
 var _ = Describe("Install Plan", func() {
-	It("with CSVs across multiple catalog sources", func() {
+	AfterEach(func() {
+		TearDown(testNamespace)
+	})
 
-		defer cleaner.NotifyTestComplete(true)
+	It("with CSVs across multiple catalog sources", func() {
 
 		log := func(s string) {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
@@ -208,7 +210,6 @@ var _ = Describe("Install Plan", func() {
 	Context("creation with pre existing CRD owners", func() {
 
 		It("OnePreExistingCRDOwner", func() {
-			defer cleaner.NotifyTestComplete(true)
 
 			mainPackageName := genName("nginx-")
 			dependentPackageName := genName("nginx-dep-")
@@ -332,7 +333,6 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), 0, len(expectedSteps), "Actual resource steps do not match expected")
 		})
 		It("PreExistingCRDOwnerIsReplaced", func() {
-			defer cleaner.NotifyTestComplete(true)
 
 			mainPackageName := genName("nginx-")
 			dependentPackageName := genName("nginx-dep-")
@@ -713,7 +713,6 @@ var _ = Describe("Install Plan", func() {
 		}
 
 		table.DescribeTable("Test", func(tt schemaPayload) {
-			defer cleaner.NotifyTestComplete(true)
 
 			mainPackageName := genName("nginx-")
 			mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
@@ -928,7 +927,6 @@ var _ = Describe("Install Plan", func() {
 		}
 
 		table.DescribeTable("Test", func(tt schemaPayload) {
-			defer cleaner.NotifyTestComplete(true)
 
 			mainPackageName := genName("nginx-")
 			mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
@@ -2038,14 +2036,12 @@ var _ = Describe("Install Plan", func() {
 			}
 		})
 		AfterEach(func() {
-			defer cleaner.NotifyTestComplete(true)
+
 		})
 	})
 
 	// This It spec creates an InstallPlan with a CSV containing a set of permissions to be resolved.
 	It("creation with permissions", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		packageName := genName("nginx")
 		stableChannel := "stable"
@@ -2295,7 +2291,6 @@ var _ = Describe("Install Plan", func() {
 	It("CRD validation", func() {
 		// Tests if CRD validation works with the "minimum" property after being
 		// pulled from a CatalogSource's operator-registry.
-		defer cleaner.NotifyTestComplete(true)
 
 		crdPlural := genName("ins")
 		crdName := crdPlural + ".cluster.com"
@@ -2476,8 +2471,6 @@ var _ = Describe("Install Plan", func() {
 		// Should see only 1 installplan created
 		// Should see the main CSV installed
 
-		defer cleaner.NotifyTestComplete(true)
-
 		log := func(s string) {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
 		}
@@ -2623,9 +2616,8 @@ var _ = Describe("Install Plan", func() {
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), 1, len(ips.Items), "If this test fails it should be taken seriously and not treated as a flake. \n%v", ips.Items)
 	})
-	
+
 	It("without an operatorgroup", func() {
-		defer cleaner.NotifyTestComplete(true)
 
 		log := func(s string) {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -33,6 +33,10 @@ import (
 )
 
 var _ = Describe("Operator Group", func() {
+	AfterEach(func() {
+		TearDown(testNamespace)
+	})
+
 	It("e2e functionality", func() {
 
 		// Create namespace with specific label
@@ -48,7 +52,6 @@ var _ = Describe("Operator Group", func() {
 		// Verify the copied CSV transitions to FAILED
 		// Delete CSV
 		// Verify copied CVS is deleted
-		defer cleaner.NotifyTestComplete(true)
 
 		log := func(s string) {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
@@ -416,8 +419,6 @@ var _ = Describe("Operator Group", func() {
 		// Create crd so csv succeeds
 		// Ensure clusterroles created and aggregated for access provided APIs
 
-		defer cleaner.NotifyTestComplete(true)
-
 		// Generate namespaceA
 		nsA := genName("a")
 		c := newKubeClient()
@@ -607,8 +608,6 @@ var _ = Describe("Operator Group", func() {
 		// Ensure csvA transitions to Failed with reason "UnsupportedOperatorGroup"
 		// Update csvA to have AllNamespaces supported=true
 		// Ensure csvA transitions to Pending
-
-		defer cleaner.NotifyTestComplete(true)
 
 		// Generate namespaceA and namespaceB
 		nsA := genName("a")
@@ -848,8 +847,6 @@ var _ = Describe("Operator Group", func() {
 		// Wait for csvB to be successful
 		// Wait for operatorGroupB to have providedAPI annotation with crdB's Kind.version.group
 		// Wait for csvB to have a CSV with a copied status in namespace C
-
-		defer cleaner.NotifyTestComplete(true)
 
 		// Create a catalog for csvA, csvB, and csvD
 		pkgA := genName("a-")
@@ -1131,8 +1128,6 @@ var _ = Describe("Operator Group", func() {
 		// Wait for KindA.version.group providedAPI annotation to be removed from operatorGroupC's providedAPIs annotation
 		// Ensure KindA.version.group providedAPI annotation on operatorGroupA
 
-		defer cleaner.NotifyTestComplete(true)
-
 		// Create a catalog for csvA, csvB
 		pkgA := genName("a-")
 		pkgB := genName("b-")
@@ -1324,7 +1319,6 @@ var _ = Describe("Operator Group", func() {
 	// TODO: Test Subscription upgrade paths with + and - providedAPIs
 	It("CSV copy watching all namespaces", func() {
 
-		defer cleaner.NotifyTestComplete(true)
 		c := newKubeClient()
 		crc := newCRClient()
 		csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
@@ -1569,8 +1563,6 @@ var _ = Describe("Operator Group", func() {
 	})
 	It("insufficient permissions resolve via RBAC", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		log := func(s string) {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
 		}
@@ -1706,8 +1698,6 @@ var _ = Describe("Operator Group", func() {
 	})
 	It("insufficient permissions resolve via service account removal", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		log := func(s string) {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
 		}
@@ -1809,7 +1799,6 @@ var _ = Describe("Operator Group", func() {
 	// preventing them from being GCd. This ensures that any leftover CSVs in that state are properly cleared up.
 	It("cleanup csvs with bad owner operator groups", func() {
 
-		defer cleaner.NotifyTestComplete(true)
 		c := newKubeClient()
 		crc := newCRClient()
 		csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation

--- a/test/e2e/packagemanifest_e2e_test.go
+++ b/test/e2e/packagemanifest_e2e_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 	})
 
 	AfterEach(func() {
-		cleaner.NotifyTestComplete(true)
+		TearDown(testNamespace)
 	})
 
 	Context("Given a CatalogSource created using the ConfigMap as catalog source type", func() {

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -38,11 +38,13 @@ import (
 
 var _ = Describe("Subscription", func() {
 
+	AfterEach(func() {
+		TearDown(testNamespace)
+	})
+
 	//   I. Creating a new subscription
 	//      A. If package is not installed, creating a subscription should install latest version
 	It("creation if not installed", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		c := newKubeClient()
 		crc := newCRClient()
@@ -67,8 +69,6 @@ var _ = Describe("Subscription", func() {
 	//         version
 	It("creation using existing CSV", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 		crc := newCRClient()
 		defer func() {
@@ -90,8 +90,6 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), err)
 	})
 	It("skip range", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		crdPlural := genName("ins")
 		crdName := crdPlural + ".cluster.com"
@@ -179,8 +177,6 @@ var _ = Describe("Subscription", func() {
 	// If installPlanApproval is set to manual, the installplans created should be created with approval: manual
 	It("creation manual approval", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		c := newKubeClient()
 		crc := newCRClient()
 		defer func() {
@@ -215,8 +211,6 @@ var _ = Describe("Subscription", func() {
 	})
 
 	It("with starting CSV", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		crdPlural := genName("ins")
 		crdName := crdPlural + ".cluster.com"
@@ -356,8 +350,6 @@ var _ = Describe("Subscription", func() {
 
 	It("updates multiple intermediates", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		crdPlural := genName("ins")
 		crdName := crdPlural + ".cluster.com"
 
@@ -464,7 +456,6 @@ var _ = Describe("Subscription", func() {
 	It("updates existing install plan", func() {
 
 		Skip("ToDo: This test was skipped before ginkgo conversion")
-		defer cleaner.NotifyTestComplete(true)
 
 		// Create CSV
 		packageName := genName("nginx-")
@@ -595,7 +586,7 @@ var _ = Describe("Subscription", func() {
 		})
 
 		AfterEach(func() {
-			defer cleaner.NotifyTestComplete(true)
+
 			err := crc.OperatorsV1alpha1().Subscriptions(testNamespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -1067,8 +1058,6 @@ var _ = Describe("Subscription", func() {
 
 	It("creation with pod config", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		newConfigClient := func(t GinkgoTInterface) configv1client.ConfigV1Interface {
 			client, err := configv1client.NewForConfig(ctx.Ctx().RESTConfig())
 			require.NoError(GinkgoT(), err)
@@ -1218,8 +1207,6 @@ var _ = Describe("Subscription", func() {
 
 	It("creation with dependencies", func() {
 
-		defer cleaner.NotifyTestComplete(true)
-
 		kubeClient := newKubeClient()
 		crClient := newCRClient()
 
@@ -1288,8 +1275,6 @@ var _ = Describe("Subscription", func() {
 	//
 	// CSV A required B and C but didn't get them from Package A
 	It("creation with dependencies required and provided in different versions of an operator in the same package", func() {
-
-		defer cleaner.NotifyTestComplete(true)
 
 		kubeClient := newKubeClient()
 		crClient := newCRClient()

--- a/test/e2e/user_defined_sa_test.go
+++ b/test/e2e/user_defined_sa_test.go
@@ -21,9 +21,11 @@ import (
 )
 
 var _ = Describe("User defined service account", func() {
-	It("with no permission", func() {
+	AfterEach(func() {
+		TearDown(testNamespace)
+	})
 
-		defer cleaner.NotifyTestComplete(false)
+	It("with no permission", func() {
 
 		kubeclient := newKubeClient()
 		crclient := newCRClient()
@@ -76,8 +78,6 @@ var _ = Describe("User defined service account", func() {
 		}
 	})
 	It("with permission", func() {
-
-		defer cleaner.NotifyTestComplete(false)
 
 		// Create the CatalogSource
 		kubeclient := newKubeClient()
@@ -133,8 +133,6 @@ var _ = Describe("User defined service account", func() {
 		}
 	})
 	It("with retry", func() {
-
-		defer cleaner.NotifyTestComplete(false)
 
 		kubeclient := newKubeClient()
 		crclient := newCRClient()


### PR DESCRIPTION
Replace the existing test cleaner, which preserved test resources on
failure, with a tear down function that always deletes
non-essential Subscriptions, InstallPlans, CatalogSources, and
ClusterServiceVersions in the given test namespace.
