### PR TITLE
fix(metrics): query cache for object count metrics

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -175,7 +175,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 	op.ipQueueSet.Set(metav1.NamespaceAll, ipQueue)
 	ipQueueInformer, err := queueinformer.NewQueueInformer(
 		ctx,
-		queueinformer.WithMetricsProvider(metrics.NewMetricsInstallPlan(op.client)),
+		queueinformer.WithMetricsProvider(metrics.NewMetricsInstallPlan(op.lister.OperatorsV1alpha1().InstallPlanLister())),
 		queueinformer.WithLogger(op.logger),
 		queueinformer.WithQueue(ipQueue),
 		queueinformer.WithInformer(ipInformer.Informer()),
@@ -195,7 +195,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 	op.catsrcQueueSet.Set(metav1.NamespaceAll, catsrcQueue)
 	catsrcQueueInformer, err := queueinformer.NewQueueInformer(
 		ctx,
-		queueinformer.WithMetricsProvider(metrics.NewMetricsCatalogSource(op.client)),
+		queueinformer.WithMetricsProvider(metrics.NewMetricsCatalogSource(op.lister.OperatorsV1alpha1().CatalogSourceLister())),
 		queueinformer.WithLogger(op.logger),
 		queueinformer.WithQueue(catsrcQueue),
 		queueinformer.WithInformer(catsrcInformer.Informer()),
@@ -237,7 +237,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 	}
 	subQueueInformer, err := queueinformer.NewQueueInformer(
 		ctx,
-		queueinformer.WithMetricsProvider(metrics.NewMetricsSubscription(op.client)),
+		queueinformer.WithMetricsProvider(metrics.NewMetricsSubscription(op.lister.OperatorsV1alpha1().SubscriptionLister())),
 		queueinformer.WithLogger(op.logger),
 		queueinformer.WithQueue(subQueue),
 		queueinformer.WithInformer(subInformer.Informer()),

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,14 +1,11 @@
 package metrics
 
 import (
-	"context"
-
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	v1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 )
 
@@ -45,54 +42,54 @@ func (m *metricsCSV) HandleMetrics() error {
 }
 
 type metricsInstallPlan struct {
-	client versioned.Interface
+	lister v1alpha1.InstallPlanLister
 }
 
-func NewMetricsInstallPlan(client versioned.Interface) MetricsProvider {
-	return &metricsInstallPlan{client}
+func NewMetricsInstallPlan(lister v1alpha1.InstallPlanLister) MetricsProvider {
+	return &metricsInstallPlan{lister}
 }
 
 func (m *metricsInstallPlan) HandleMetrics() error {
-	cList, err := m.client.OperatorsV1alpha1().InstallPlans(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	cList, err := m.lister.InstallPlans(metav1.NamespaceAll).List(labels.Everything())
 	if err != nil {
 		return err
 	}
-	installPlanCount.Set(float64(len(cList.Items)))
+	installPlanCount.Set(float64(len(cList)))
 	return nil
 }
 
 type metricsSubscription struct {
-	client versioned.Interface
+	 lister v1alpha1.SubscriptionLister
 }
 
-func NewMetricsSubscription(client versioned.Interface) MetricsProvider {
-	return &metricsSubscription{client}
+func NewMetricsSubscription(lister v1alpha1.SubscriptionLister) MetricsProvider {
+	return &metricsSubscription{lister}
 }
 
 func (m *metricsSubscription) HandleMetrics() error {
-	cList, err := m.client.OperatorsV1alpha1().Subscriptions(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	cList, err := m.lister.Subscriptions(metav1.NamespaceAll).List(labels.Everything())
 	if err != nil {
 		return err
 	}
-	subscriptionCount.Set(float64(len(cList.Items)))
+	subscriptionCount.Set(float64(len(cList)))
 	return nil
 }
 
 type metricsCatalogSource struct {
-	client versioned.Interface
+	lister v1alpha1.CatalogSourceLister
 }
 
-func NewMetricsCatalogSource(client versioned.Interface) MetricsProvider {
-	return &metricsCatalogSource{client}
+func NewMetricsCatalogSource(lister v1alpha1.CatalogSourceLister) MetricsProvider {
+	return &metricsCatalogSource{lister}
 
 }
 
 func (m *metricsCatalogSource) HandleMetrics() error {
-	cList, err := m.client.OperatorsV1alpha1().CatalogSources(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	cList, err := m.lister.CatalogSources(metav1.NamespaceAll).List(labels.Everything())
 	if err != nil {
 		return err
 	}
-	catalogSourceCount.Set(float64(len(cList.Items)))
+	catalogSourceCount.Set(float64(len(cList)))
 	return nil
 }
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Query the cache for count of objects, instead of hitting the apiserver.

**Motivation for the change:**
Metrics were listing everything on every sync.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
