### PR TITLE
Bug 1857424: fix(resolver): Exclude all installed packages in dependency search

### DIFF
--- a/pkg/controller/registry/resolver/evolver.go
+++ b/pkg/controller/registry/resolver/evolver.go
@@ -132,9 +132,14 @@ func (e *NamespaceGenerationEvolver) queryForRequiredAPIs() error {
 			initialSource = operator.SourceInfo()
 			break
 		}
+		// Get the list of installed operators in the namespace
+		opList := make(map[string]struct{})
+		for _, operator := range e.gen.Operators() {
+			opList[operator.SourceInfo().Package] = struct{}{}
+		}
 
 		// attempt to find a bundle that provides that api
-		if bundle, key, err := e.querier.FindProvider(*api, initialSource.Catalog, initialSource.Package); err == nil {
+		if bundle, key, err := e.querier.FindProvider(*api, initialSource.Catalog, opList); err == nil {
 			// add a bundle that provides the api to the generation
 			o, err := NewOperatorFromBundle(bundle, "", *key)
 			if err != nil {

--- a/pkg/controller/registry/resolver/fakes/fake_registry_client_interface.go
+++ b/pkg/controller/registry/resolver/fakes/fake_registry_client_interface.go
@@ -22,14 +22,14 @@ type FakeClientInterface struct {
 	closeReturnsOnCall map[int]struct {
 		result1 error
 	}
-	FindBundleThatProvidesStub        func(context.Context, string, string, string, string) (*api.Bundle, error)
+	FindBundleThatProvidesStub        func(context.Context, string, string, string, map[string]struct{}) (*api.Bundle, error)
 	findBundleThatProvidesMutex       sync.RWMutex
 	findBundleThatProvidesArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
 		arg4 string
-		arg5 string
+		arg5 map[string]struct{}
 	}
 	findBundleThatProvidesReturns struct {
 		result1 *api.Bundle
@@ -201,7 +201,7 @@ func (fake *FakeClientInterface) CloseReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeClientInterface) FindBundleThatProvides(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 string) (*api.Bundle, error) {
+func (fake *FakeClientInterface) FindBundleThatProvides(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 map[string]struct{}) (*api.Bundle, error) {
 	fake.findBundleThatProvidesMutex.Lock()
 	ret, specificReturn := fake.findBundleThatProvidesReturnsOnCall[len(fake.findBundleThatProvidesArgsForCall)]
 	fake.findBundleThatProvidesArgsForCall = append(fake.findBundleThatProvidesArgsForCall, struct {
@@ -209,7 +209,7 @@ func (fake *FakeClientInterface) FindBundleThatProvides(arg1 context.Context, ar
 		arg2 string
 		arg3 string
 		arg4 string
-		arg5 string
+		arg5 map[string]struct{}
 	}{arg1, arg2, arg3, arg4, arg5})
 	fake.recordInvocation("FindBundleThatProvides", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.findBundleThatProvidesMutex.Unlock()
@@ -229,13 +229,13 @@ func (fake *FakeClientInterface) FindBundleThatProvidesCallCount() int {
 	return len(fake.findBundleThatProvidesArgsForCall)
 }
 
-func (fake *FakeClientInterface) FindBundleThatProvidesCalls(stub func(context.Context, string, string, string, string) (*api.Bundle, error)) {
+func (fake *FakeClientInterface) FindBundleThatProvidesCalls(stub func(context.Context, string, string, string, map[string]struct{}) (*api.Bundle, error)) {
 	fake.findBundleThatProvidesMutex.Lock()
 	defer fake.findBundleThatProvidesMutex.Unlock()
 	fake.FindBundleThatProvidesStub = stub
 }
 
-func (fake *FakeClientInterface) FindBundleThatProvidesArgsForCall(i int) (context.Context, string, string, string, string) {
+func (fake *FakeClientInterface) FindBundleThatProvidesArgsForCall(i int) (context.Context, string, string, string, map[string]struct{}) {
 	fake.findBundleThatProvidesMutex.RLock()
 	defer fake.findBundleThatProvidesMutex.RUnlock()
 	argsForCall := fake.findBundleThatProvidesArgsForCall[i]

--- a/pkg/controller/registry/resolver/querier.go
+++ b/pkg/controller/registry/resolver/querier.go
@@ -28,7 +28,7 @@ type SourceRef struct {
 }
 
 type SourceQuerier interface {
-	FindProvider(api opregistry.APIKey, initialSource CatalogKey, excludedPkgName string) (*api.Bundle, *CatalogKey, error)
+	FindProvider(api opregistry.APIKey, initialSource CatalogKey, excludedPackages map[string]struct{}) (*api.Bundle, *CatalogKey, error)
 	FindBundle(pkgName, channelName, bundleName string, initialSource CatalogKey) (*api.Bundle, *CatalogKey, error)
 	FindLatestBundle(pkgName, channelName string, initialSource CatalogKey) (*api.Bundle, *CatalogKey, error)
 	FindReplacement(currentVersion *semver.Version, bundleName, pkgName, channelName string, initialSource CatalogKey) (*api.Bundle, *CatalogKey, error)
@@ -54,23 +54,23 @@ func (q *NamespaceSourceQuerier) Queryable() error {
 	return nil
 }
 
-func (q *NamespaceSourceQuerier) FindProvider(api opregistry.APIKey, initialSource CatalogKey, excludedPkgName string) (*registryapi.Bundle, *CatalogKey, error) {
+func (q *NamespaceSourceQuerier) FindProvider(api opregistry.APIKey, initialSource CatalogKey, excludedPackages map[string]struct{}) (*registryapi.Bundle, *CatalogKey, error) {
 	if initialSource.Name != "" && initialSource.Namespace != "" {
 		source, ok := q.sources[initialSource]
 		if ok {
-			if bundle, err := source.FindBundleThatProvides(context.TODO(), api.Group, api.Version, api.Kind, excludedPkgName); err == nil {
+			if bundle, err := source.FindBundleThatProvides(context.TODO(), api.Group, api.Version, api.Kind, excludedPackages); err == nil {
 				return bundle, &initialSource, nil
 			}
-			if bundle, err := source.FindBundleThatProvides(context.TODO(), api.Plural+"."+api.Group, api.Version, api.Kind, excludedPkgName); err == nil {
+			if bundle, err := source.FindBundleThatProvides(context.TODO(), api.Plural+"."+api.Group, api.Version, api.Kind, excludedPackages); err == nil {
 				return bundle, &initialSource, nil
 			}
 		}
 	}
 	for key, source := range q.sources {
-		if bundle, err := source.FindBundleThatProvides(context.TODO(), api.Group, api.Version, api.Kind, excludedPkgName); err == nil {
+		if bundle, err := source.FindBundleThatProvides(context.TODO(), api.Group, api.Version, api.Kind, excludedPackages); err == nil {
 			return bundle, &key, nil
 		}
-		if bundle, err := source.FindBundleThatProvides(context.TODO(), api.Plural+"."+api.Group, api.Version, api.Kind, excludedPkgName); err == nil {
+		if bundle, err := source.FindBundleThatProvides(context.TODO(), api.Plural+"."+api.Group, api.Version, api.Kind, excludedPackages); err == nil {
 			return bundle, &key, nil
 		}
 	}

--- a/pkg/controller/registry/resolver/querier_test.go
+++ b/pkg/controller/registry/resolver/querier_test.go
@@ -121,6 +121,7 @@ func TestNamespaceSourceQuerier_FindProvider(t *testing.T) {
 		CatalogKey{"test", "ns"}:  &fakeSource,
 		CatalogKey{"test2", "ns"}: &fakeSource2,
 	}
+	excludedPkgs := make(map[string]struct{})
 	bundle := &api.Bundle{CsvName: "test", PackageName: "testPkg", ChannelName: "testChannel"}
 	bundle2 := &api.Bundle{CsvName: "test2", PackageName: "testPkg2", ChannelName: "testChannel2"}
 	fakeSource.GetBundleThatProvidesStub = func(ctx context.Context, group, version, kind string) (*api.Bundle, error) {
@@ -135,13 +136,13 @@ func TestNamespaceSourceQuerier_FindProvider(t *testing.T) {
 		}
 		return bundle2, nil
 	}
-	fakeSource.FindBundleThatProvidesStub = func(ctx context.Context, group, version, kind, pkgName string) (*api.Bundle, error) {
+	fakeSource.FindBundleThatProvidesStub = func(ctx context.Context, group, version, kind string, excludedPkgs map[string]struct{}) (*api.Bundle, error) {
 		if group != "group" || version != "version" || kind != "kind" {
 			return nil, fmt.Errorf("Not Found")
 		}
 		return bundle, nil
 	}
-	fakeSource2.FindBundleThatProvidesStub = func(ctx context.Context, group, version, kind, pkgName string) (*api.Bundle, error) {
+	fakeSource2.FindBundleThatProvidesStub = func(ctx context.Context, group, version, kind string, excludedPkgs map[string]struct{}) (*api.Bundle, error) {
 		if group != "group2" || version != "version2" || kind != "kind2" {
 			return nil, fmt.Errorf("Not Found")
 		}
@@ -228,7 +229,7 @@ func TestNamespaceSourceQuerier_FindProvider(t *testing.T) {
 			q := &NamespaceSourceQuerier{
 				sources: tt.fields.sources,
 			}
-			bundle, key, err := q.FindProvider(tt.args.api, tt.args.catalogKey, "")
+			bundle, key, err := q.FindProvider(tt.args.api, tt.args.catalogKey, excludedPkgs)
 			require.Equal(t, tt.out.err, err)
 			require.Equal(t, tt.out.bundle, bundle)
 			require.Equal(t, tt.out.key, key)

--- a/pkg/controller/registry/resolver/util_test.go
+++ b/pkg/controller/registry/resolver/util_test.go
@@ -360,7 +360,7 @@ func NewFakeSourceQuerier(bundlesByCatalog map[CatalogKey][]*api.Bundle) *Namesp
 			return nil, fmt.Errorf("no bundle found")
 		}
 
-		source.FindBundleThatProvidesStub = func(ctx context.Context, groupOrName, version, kind, pkgName string) (*api.Bundle, error) {
+		source.FindBundleThatProvidesStub = func(ctx context.Context, groupOrName, version, kind string, excludedPkgs map[string]struct{}) (*api.Bundle, error) {
 			bundles, ok := bundlesByCatalog[catKey]
 			if !ok {
 				return nil, fmt.Errorf("API (%s/%s/%s) not provided by a package in %s CatalogSource", groupOrName, version, kind, catKey)
@@ -368,7 +368,7 @@ func NewFakeSourceQuerier(bundlesByCatalog map[CatalogKey][]*api.Bundle) *Namesp
 			sortedBundles := SortBundleInPackageChannel(bundles)
 			for k, v := range sortedBundles {
 				pkgname := getPkgName(k)
-				if pkgname == pkgName {
+				if _, ok := excludedPkgs[pkgname]; ok {
 					continue
 				}
 

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -1244,9 +1244,9 @@ var _ = Describe("Subscription", func() {
 		require.Len(GinkgoT(), installPlan.Status.CatalogSources, 1)
 	})
 
-	// CatSrc:
+	// CatSrc1:
 	//
-	// Package A (apackage)
+	// Package 1 (apackage)
 	// Default Channel: Stable
 	// Channel Stable:
 	// Operator A (Requires: CRD 1, CRD 2 )
@@ -1256,12 +1256,19 @@ var _ = Describe("Subscription", func() {
 	// Default Channel: Stable
 	// Channel Stable:
 	// Operator B (Provides: CRD)
-	// CatSrc2:
+	// Channel Alpha:
+	// Operator D (Provides: CRD)
 	//
-	// Package B (bpackage)
+	// CatSrc2:
+	// Package 2 (bpackage)
 	// Default Channel: Stable
 	// Channel Stable:
 	// Operator C (Provides: CRD 2)
+	// Package 3 (cpackage)
+	// Default Channel: Stable
+	// Channel Stable:
+	// Operator E (Provides: CRD 2)
+	//
 	// Then create a subscription:
 	//
 	// CatalogSource: CatSrc
@@ -1270,11 +1277,182 @@ var _ = Describe("Subscription", func() {
 	// StartingCSV: CSV A
 	//
 	// Check installed:
+	// CSV A, CSV B, CSV E
 	//
-	// CSV A, CSV B, CSV C
-	//
-	// CSV A required B and C but didn't get them from Package A
+	// CSV ABC: not chosen as it is the same package with CSV A
+	// CSV D: not chosen as it is in non-default channel
+	// CSV C: not chosen as it is the same package with CSV B (which is chosen)
 	It("creation with dependencies required and provided in different versions of an operator in the same package", func() {
+
+		kubeClient := newKubeClient()
+		crClient := newCRClient()
+
+		permissions := deploymentPermissions()
+
+		crdPlural := genName("ins")
+		crdName := crdPlural + ".cluster.com"
+		crdPlural2 := genName("ins")
+		crdName2 := crdPlural2 + ".cluster.com"
+
+		crd := apiextensions.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crdName,
+			},
+			Spec: apiextensions.CustomResourceDefinitionSpec{
+				Group:   "cluster.com",
+				Version: "v1alpha1",
+				Names: apiextensions.CustomResourceDefinitionNames{
+					Plural:   crdPlural,
+					Singular: crdPlural,
+					Kind:     crdPlural,
+					ListKind: "list" + crdPlural,
+				},
+				Scope: "Namespaced",
+			},
+		}
+
+		crd2 := apiextensions.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crdName2,
+			},
+			Spec: apiextensions.CustomResourceDefinitionSpec{
+				Group:   "cluster.com",
+				Version: "v1alpha1",
+				Names: apiextensions.CustomResourceDefinitionNames{
+					Plural:   crdPlural2,
+					Singular: crdPlural2,
+					Kind:     crdPlural2,
+					ListKind: "list" + crdPlural2,
+				},
+				Scope: "Namespaced",
+			},
+		}
+
+		// Create CSV
+		packageName1 := genName("apackage")
+		packageName2 := genName("bpackage")
+		packageName3 := genName("cpackage")
+
+		namedStrategy := newNginxInstallStrategy((genName("dep")), permissions, nil)
+		depNamedStrategy := newNginxInstallStrategy((genName("dep")), permissions, nil)
+		depNamedStrategy2 := newNginxInstallStrategy((genName("dep")), permissions, nil)
+		// csvA requires CRD1 and CRD2
+		csvA := newCSV("nginx-a", testNamespace, "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{crd, crd2}, namedStrategy)
+		// csvABC provides CRD1 and CRD2 in the same catalogsource with csvA (apackage)
+		// also in the same package with csvA but different channel
+		csvABC := newCSV("nginx-a-bc", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd, crd2}, nil, namedStrategy)
+		// csvB provides CRD1 in the same catalogsource with csvA (apackage)
+		csvB := newCSV("nginx-b-dep", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, depNamedStrategy)
+		// csvC provides CRD2 in the different catalogsource with csvA (apackage)
+		csvC := newCSV("nginx-c-dep", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd2}, nil, depNamedStrategy2)
+		// csvD provides CRD1 in the same catalogsource with csvA (apackage)
+		csvD := newCSV("nginx-d-dep", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, depNamedStrategy)
+		// csvE provides CRD2 in the different catalogsource with csvC (bpackage)
+		csvE := newCSV("nginx-e-dep", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd2}, nil, depNamedStrategy2)
+
+		// Create PackageManifests 1
+		// Contain csvA, ABC and B
+		manifests := []registry.PackageManifest{
+			{
+				PackageName: packageName1,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: csvA.GetName()},
+					{Name: alphaChannel, CurrentCSVName: csvABC.GetName()},
+				},
+				DefaultChannelName: stableChannel,
+			},
+			{
+				PackageName: packageName2,
+				Channels: []registry.PackageChannel{
+					{Name: alphaChannel, CurrentCSVName: csvD.GetName()},
+					{Name: stableChannel, CurrentCSVName: csvB.GetName()},
+				},
+				DefaultChannelName: stableChannel,
+			},
+		}
+
+		// Create PackageManifests 2
+		// Contain csvC
+		manifests2 := []registry.PackageManifest{
+			{
+				PackageName: packageName2,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: csvC.GetName()},
+				},
+				DefaultChannelName: stableChannel,
+			},
+			{
+				PackageName: packageName3,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: csvE.GetName()},
+				},
+				DefaultChannelName: stableChannel,
+			},
+		}
+
+		catalogSourceName := genName("catsrc")
+		catsrc, cleanup := createInternalCatalogSource(kubeClient, crClient, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd, crd2}, []v1alpha1.ClusterServiceVersion{csvA, csvABC, csvB, csvD})
+		defer cleanup()
+
+		// Ensure that the catalog source is resolved before we create a subscription.
+		_, err := fetchCatalogSourceOnStatus(crClient, catsrc.GetName(), testNamespace, catalogSourceRegistryPodSynced)
+		require.NoError(GinkgoT(), err)
+
+		subscriptionSpec := &v1alpha1.SubscriptionSpec{
+			CatalogSource:          catsrc.GetName(),
+			CatalogSourceNamespace: catsrc.GetNamespace(),
+			Package:                packageName1,
+			Channel:                stableChannel,
+			StartingCSV:            csvA.GetName(),
+			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
+		}
+
+		catalogSourceName2 := genName("catsrc")
+		catsrc2, cleanup2 := createInternalCatalogSource(kubeClient, crClient, catalogSourceName2, testNamespace, manifests2, []apiextensions.CustomResourceDefinition{crd2}, []v1alpha1.ClusterServiceVersion{csvC, csvE})
+		defer cleanup2()
+
+		// Ensure that the catalog source is resolved before we create a subscription.
+		_, err = fetchCatalogSourceOnStatus(crClient, catsrc2.GetName(), testNamespace, catalogSourceRegistryPodSynced)
+		require.NoError(GinkgoT(), err)
+
+		// Create a subscription that has a dependency
+		subscriptionName := genName("sub-")
+		cleanupSubscription := createSubscriptionForCatalogWithSpec(GinkgoT(), crClient, testNamespace, subscriptionName, subscriptionSpec)
+		defer cleanupSubscription()
+
+		subscription, err := fetchSubscription(crClient, testNamespace, subscriptionName, subscriptionStateAtLatestChecker)
+		require.NoError(GinkgoT(), err)
+		require.NotNil(GinkgoT(), subscription)
+
+		// Check that a single catalog source was used to resolve the InstallPlan
+		_, err = fetchInstallPlan(GinkgoT(), crClient, subscription.Status.InstallPlanRef.Name, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+		require.NoError(GinkgoT(), err)
+		// Fetch CSVs A, B and C
+		_, err = fetchCSV(crClient, csvB.Name, testNamespace, csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+		_, err = fetchCSV(crClient, csvE.Name, testNamespace, csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+		_, err = fetchCSV(crClient, csvA.Name, testNamespace, csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+		// Ensure csvABC is not installed
+		_, err = crClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), csvABC.Name, metav1.GetOptions{})
+		require.Error(GinkgoT(), err)
+		// Ensure csvD is not installed -- this implies the dependent subscription selected the default channel
+		_, err = crClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), csvD.Name, metav1.GetOptions{})
+		require.Error(GinkgoT(), err)
+	})
+
+	// csvA owns CRD1 & csvB owns CRD2 and requires CRD1
+	// Create subscription for csvB lead to installation of csvB and csvA
+	// Update catsrc to upgrade csvA to csvNewA which now requires CRD1
+	// csvNewA can't be installed due to no other operators provide CRD1 for it
+	// (Note: OLM can't pick csvA as dependency for csvNewA as it is from the same
+	// same package)
+	// Update catsrc again to upgrade csvB to csvNewB which now owns both CRD1 and
+	// CRD2.
+	// Now csvNewA and csvNewB are installed successfully as csvNewB provides CRD1
+	// that csvNewA requires
+	It("creation in case of transferring providedAPIs", func() {
 
 		kubeClient := newKubeClient()
 		crClient := newCRClient()
@@ -1325,19 +1503,15 @@ var _ = Describe("Subscription", func() {
 		packageName2 := genName("bpackage")
 
 		namedStrategy := newNginxInstallStrategy((genName("dep")), permissions, nil)
-		depNamedStrategy := newNginxInstallStrategy((genName("dep")), permissions, nil)
-		depNamedStrategy2 := newNginxInstallStrategy((genName("dep")), permissions, nil)
-		// csvA requires CRD1 and CRD2
-		csvA := newCSV("nginx-a", testNamespace, "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{crd, crd2}, namedStrategy)
-		// csvABC provides CRD1 and CRD2 in the same catalogsource with csvA (apackage)
-		// also in the same package with csvA but different channel
-		csvABC := newCSV("nginx-a-bc", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd, crd2}, nil, namedStrategy)
-		// csvB provides CRD1 in the same catalogsource with csvA (apackage)
-		csvB := newCSV("nginx-b-dep", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, depNamedStrategy)
-		// csvC provides CRD2 in the different catalogsource with csvA (apackage)
-		csvC := newCSV("nginx-c-dep", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd2}, nil, depNamedStrategy2)
-		// csvD provides CRD1 in the same catalogsource with csvA (apackage)
-		csvD := newCSV("nginx-d-dep", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, depNamedStrategy)
+		namedStrategy2 := newNginxInstallStrategy((genName("dep")), permissions, nil)
+		// csvA provides CRD
+		csvA := newCSV("nginx-a", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, namedStrategy)
+		// csvB provides CRD2 and requires CRD
+		csvB := newCSV("nginx-b", testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd2}, []apiextensions.CustomResourceDefinition{crd}, namedStrategy2)
+		// New csvA requires CRD (transfer CRD ownership to the new csvB)
+		csvNewA := newCSV("nginx-new-a", testNamespace, "nginx-a", semver.MustParse("0.2.0"), nil, []apiextensions.CustomResourceDefinition{crd}, namedStrategy)
+		// New csvB provides CRD and CRD2
+		csvNewB := newCSV("nginx-new-b", testNamespace, "nginx-b", semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{crd, crd2}, nil, namedStrategy2)
 
 		// Create PackageManifests 1
 		// Contain csvA, ABC and B
@@ -1346,34 +1520,20 @@ var _ = Describe("Subscription", func() {
 				PackageName: packageName1,
 				Channels: []registry.PackageChannel{
 					{Name: stableChannel, CurrentCSVName: csvA.GetName()},
-					{Name: alphaChannel, CurrentCSVName: csvABC.GetName()},
 				},
 				DefaultChannelName: stableChannel,
 			},
 			{
 				PackageName: packageName2,
 				Channels: []registry.PackageChannel{
-					{Name: alphaChannel, CurrentCSVName: csvD.GetName()},
 					{Name: stableChannel, CurrentCSVName: csvB.GetName()},
 				},
 				DefaultChannelName: stableChannel,
 			},
 		}
 
-		// Create PackageManifests 2
-		// Contain csvC
-		manifests2 := []registry.PackageManifest{
-			{
-				PackageName: packageName2,
-				Channels: []registry.PackageChannel{
-					{Name: stableChannel, CurrentCSVName: csvC.GetName()},
-				},
-				DefaultChannelName: stableChannel,
-			},
-		}
-
 		catalogSourceName := genName("catsrc")
-		catsrc, cleanup := createInternalCatalogSource(kubeClient, crClient, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd, crd2}, []v1alpha1.ClusterServiceVersion{csvA, csvABC, csvB, csvD})
+		catsrc, cleanup := createInternalCatalogSource(kubeClient, crClient, catalogSourceName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd, crd2}, []v1alpha1.ClusterServiceVersion{csvA, csvB})
 		defer cleanup()
 
 		// Ensure that the catalog source is resolved before we create a subscription.
@@ -1383,19 +1543,11 @@ var _ = Describe("Subscription", func() {
 		subscriptionSpec := &v1alpha1.SubscriptionSpec{
 			CatalogSource:          catsrc.GetName(),
 			CatalogSourceNamespace: catsrc.GetNamespace(),
-			Package:                packageName1,
+			Package:                packageName2,
 			Channel:                stableChannel,
-			StartingCSV:            csvA.GetName(),
+			StartingCSV:            csvB.GetName(),
 			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 		}
-
-		catalogSourceName2 := genName("catsrc")
-		catsrc2, cleanup2 := createInternalCatalogSource(kubeClient, crClient, catalogSourceName2, testNamespace, manifests2, []apiextensions.CustomResourceDefinition{crd2}, []v1alpha1.ClusterServiceVersion{csvC})
-		defer cleanup2()
-
-		// Ensure that the catalog source is resolved before we create a subscription.
-		_, err = fetchCatalogSourceOnStatus(crClient, catsrc2.GetName(), testNamespace, catalogSourceRegistryPodSynced)
-		require.NoError(GinkgoT(), err)
 
 		// Create a subscription that has a dependency
 		subscriptionName := genName("sub-")
@@ -1409,19 +1561,66 @@ var _ = Describe("Subscription", func() {
 		// Check that a single catalog source was used to resolve the InstallPlan
 		_, err = fetchInstallPlan(GinkgoT(), crClient, subscription.Status.InstallPlanRef.Name, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
-		// Fetch CSVs A, B and C
-		_, err = fetchCSV(crClient, csvB.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
-		_, err = fetchCSV(crClient, csvC.Name, testNamespace, csvSucceededChecker)
-		require.NoError(GinkgoT(), err)
+		// Fetch CSVs A and B
 		_, err = fetchCSV(crClient, csvA.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
-		// Ensure csvABC is not installed
-		_, err = crClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), csvABC.Name, metav1.GetOptions{})
+		_, err = fetchCSV(crClient, csvB.Name, testNamespace, csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+
+		// Update PackageManifest
+		manifests = []registry.PackageManifest{
+			{
+				PackageName: packageName1,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: csvNewA.GetName()},
+				},
+				DefaultChannelName: stableChannel,
+			},
+			{
+				PackageName: packageName2,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: csvB.GetName()},
+				},
+				DefaultChannelName: stableChannel,
+			},
+		}
+		updateInternalCatalog(GinkgoT(), kubeClient, crClient, catalogSourceName, testNamespace, []apiextensions.CustomResourceDefinition{crd, crd2}, []v1alpha1.ClusterServiceVersion{csvNewA, csvA, csvB}, manifests)
+		csvAsub := strings.Join([]string{packageName1, stableChannel, catalogSourceName, testNamespace}, "-")
+		_, err = fetchSubscription(crClient, testNamespace, csvAsub, subscriptionStateUpgradeAvailableChecker)
+		require.NoError(GinkgoT(), err)
+		// Ensure csvNewA is not installed
+		_, err = crClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), csvNewA.Name, metav1.GetOptions{})
 		require.Error(GinkgoT(), err)
-		// Ensure csvD is not installed -- this implies the dependent subscription selected the default channel
-		_, err = crClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), csvD.Name, metav1.GetOptions{})
-		require.Error(GinkgoT(), err)
+		// Ensure csvA still exists
+		_, err = fetchCSV(crClient, csvA.Name, testNamespace, csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+
+		// Update packagemanifest again
+		manifests = []registry.PackageManifest{
+			{
+				PackageName: packageName1,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: csvNewA.GetName()},
+				},
+				DefaultChannelName: stableChannel,
+			},
+			{
+				PackageName: packageName2,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: csvNewB.GetName()},
+				},
+				DefaultChannelName: stableChannel,
+			},
+		}
+		updateInternalCatalog(GinkgoT(), kubeClient, crClient, catalogSourceName, testNamespace, []apiextensions.CustomResourceDefinition{crd, crd2}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvNewA, csvNewB}, manifests)
+		_, err = fetchSubscription(crClient, testNamespace, subscriptionName, subscriptionStateUpgradePendingChecker)
+		require.NoError(GinkgoT(), err)
+		// Ensure csvNewA is installed
+		_, err = fetchCSV(crClient, csvNewA.Name, testNamespace, csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+		// Ensure csvNewB is installed
+		_, err = fetchCSV(crClient, csvNewB.Name, testNamespace, csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
 	})
 })
 


### PR DESCRIPTION
Currently, resolver only excludes one installed package at a time during
dependency search. However, this is not enough as there is a corner case
where there are two operators that are requiring the same CRD(s). As a
result, resolver only excludes one package but not the other(s).

Now, the list of installed packages in the same namespace will be added
to list of packages that are not considered during dependency
search.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
