### PR TITLE
Add flake analyzer periodics

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: make -f x.mk e2e-local NODES=2 JUNIT_DIRECTORY=./artifacts/
-      - name: Archive production artifacts # test results are only uploaded if any of the e2e tests fails
+      - name: Archive Test Artifacts # test results are only uploaded if any of the e2e tests fails
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/flake-analyzer-periodics.yml
+++ b/.github/workflows/flake-analyzer-periodics.yml
@@ -1,0 +1,25 @@
+name: flake-analyzer-periodics
+on:
+  schedule:
+    - cron: '0 1 * * *'
+jobs:
+  generate-flake-analysis-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Periodic Flake Report
+        env:
+          OWNER: operator-framework
+          REPO: operator-lifecycle-manager
+          TEST_SUITE: e2e-test-output
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git clone -b v0.1.1 https://github.com/operator-framework/flake-analyzer.git
+          cd ./flake-analyzer
+          make report-today  OUTPUT_FILE=./report/artifacts/flake-report-today-$(date +"%m-%d-%Y").yaml
+          make report-last-7-days OUTPUT_FILE=./report/artifacts/flake-report-last-7-days-$(date +"%m-%d-%Y").yaml
+          make report-prev-7-days OUTPUT_FILE=./report/artifacts/flake-report-prev-7-days-$(date +"%m-%d-%Y").yaml
+      - name: Archive Reoport artifacts # test results are only uploaded if any of the e2e tests fails
+        uses: actions/upload-artifact@v2
+        with:
+          name: flake-report-${{ github.run_id }}
+          path: ${{ github.workspace }}/flake-analyzer/report/artifacts/*


### PR DESCRIPTION
This commit introduces the flake analyzer to OLM to create weekly flake reports for the past and previous 7 days. The result will be uploaded to GITHUB as artifacts.
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
