### PR TITLE
fix: remove bundle e2e test skip

### DIFF
--- a/test/e2e/bundle_e2e_test.go
+++ b/test/e2e/bundle_e2e_test.go
@@ -22,8 +22,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/testdata/vpa"
 )
 
-// FIXME: Reintegrate this test
-var _ = PDescribe("Installing bundles with new object types", func() {
+var _ = Describe("Installing bundles with new object types", func() {
 	var (
 		kubeClient     operatorclient.ClientInterface
 		operatorClient versioned.Interface


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Removes skip since we have reintegrated the test. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
