### PR TITLE
Bug 1916624: Add CsvAbnornalReplacing alerts

### DIFF
--- a/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
+++ b/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
@@ -12,7 +12,7 @@ spec:
     - name: olm.csv_abnormal.rules
       rules:
         - alert: CsvAbnormalFailedOver2Min
-          expr: csv_abnormal{phase=~"^Failed$",exported_namespace=~"(^openshift.*|^kube.*|^redhat.*|^default$)"}
+          expr: csv_abnormal{phase=~"^Failed$"}
           for: 2m
           labels:
             severity: warning
@@ -21,7 +21,7 @@ spec:
             message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Reason-{{ printf "{{ $labels.reason }}" }}
 
         - alert: CsvAbnormalOver30Min
-          expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)",exported_namespace=~"(^openshift.*|^kube.*|^redhat.*|^default$)"}
+          expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)"}
           for: 30m
           labels:
             severity: warning

--- a/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
+++ b/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
@@ -9,12 +9,23 @@ metadata:
     role: alert-rules
 spec:
   groups:
-    - name: olm.failing_operators.rules
+    - name: olm.csv_abnormal.rules
       rules:
-        - alert: FailingOperator
-          annotations:
-            message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Reason-{{ printf "{{ $labels.reason }}" }}
-          expr: csv_abnormal{phase="Failed"}
+        - alert: CsvAbnormalFailedOver2Min
+          expr: csv_abnormal{phase=~"^Failed$",exported_namespace=~"(^openshift.*|^kube.*|^redhat.*|^default$)"}
+          for: 2m
           labels:
             severity: warning
+            namespace: "{{ "{{ $labels.namespace }}" }}"
+          annotations:
+            message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Reason-{{ printf "{{ $labels.reason }}" }}
+
+        - alert: CsvAbnormalOver30Min
+          expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)",exported_namespace=~"(^openshift.*|^kube.*|^redhat.*|^default$)"}
+          for: 30m
+          labels:
+            severity: warning
+            namespace: "{{ "{{ $labels.namespace }}" }}"
+          annotations:
+            message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Phase-{{ printf "{{ $labels.phase }}" }} Reason-{{ printf "{{ $labels.reason }}" }}
 {{ end }}

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -8,11 +8,22 @@ metadata:
     role: alert-rules
 spec:
   groups:
-    - name: olm.failing_operators.rules
+    - name: olm.csv_abnormal.rules
       rules:
-        - alert: FailingOperator
-          annotations:
-            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Reason-{{ $labels.reason }}
-          expr: csv_abnormal{phase="Failed"}
+        - alert: CsvAbnormalFailedOver2Min
+          expr: csv_abnormal{phase=~"^Failed$",exported_namespace=~"(^openshift.*|^kube.*|^redhat.*|^default$)"}
+          for: 2m
           labels:
             severity: warning
+            namespace: "{{ $labels.namespace }}"
+          annotations:
+            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Reason-{{ $labels.reason }}
+
+        - alert: CsvAbnormalOver30Min
+          expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)",exported_namespace=~"(^openshift.*|^kube.*|^redhat.*|^default$)"}
+          for: 30m
+          labels:
+            severity: warning
+            namespace: "{{ $labels.namespace }}"
+          annotations:
+            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Phase-{{ $labels.phase }} Reason-{{ $labels.reason }}


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This pr adds two alerts `CsvAbnormalReplacingOver30Min` and `CsvAbnormalReplacingOver4Hr`, porting from https://github.com/openshift/managed-cluster-config/blob/master/deploy/sre-prometheus/100-csv-abnormal.PrometheusRule.yaml#L20.

**Motivation for the change:**

https://issues.redhat.com/browse/OSD-4435
https://issues.redhat.com/browse/OSD-4436

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
