### PR TITLE
Omit (hopefully) redundant yum update from downstream builder stage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM openshift/origin-release:golang-1.13 as builder
-RUN yum update -y
-RUN yum install -y make git
 
 ENV GO111MODULE auto
 ENV GOPATH /go


### PR DESCRIPTION
Downstream builds have been running into transient issues with yum mirrors, and these directives look vestigal.