### PR TITLE
[metrics] Dependency resolution metrics

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -132,6 +132,9 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 	// Create an OperatorLister
 	lister := operatorlister.NewLister()
 
+	operatorV1alpha1Resolver := resolver.NewOperatorsV1alpha1Resolver(lister, crClient, opClient.KubernetesInterface())
+	successMetricsEmitter := metrics.RegisterDependencyResolutionSuccess
+	failureMetricsEmitter := metrics.RegisterDependencyResolutionFailure
 	// Allocate the new instance of an Operator.
 	op := &Operator{
 		Operator:                 queueOperator,
@@ -142,7 +145,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		client:                   crClient,
 		lister:                   lister,
 		namespace:                operatorNamespace,
-		resolver:                 resolver.NewOperatorsV1alpha1Resolver(lister, crClient, opClient.KubernetesInterface()),
+		resolver:                 resolver.NewInstrumentedResolver(operatorV1alpha1Resolver, successMetricsEmitter, failureMetricsEmitter),
 		catsrcQueueSet:           queueinformer.NewEmptyResourceQueueSet(),
 		subQueueSet:              queueinformer.NewEmptyResourceQueueSet(),
 		ipQueueSet:               queueinformer.NewEmptyResourceQueueSet(),

--- a/pkg/controller/registry/resolver/instrumented_resolver.go
+++ b/pkg/controller/registry/resolver/instrumented_resolver.go
@@ -1,0 +1,34 @@
+package resolver
+
+import (
+	"time"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+type InstrumentedResolver struct {
+	operatorsV1alpha1Resolver Resolver
+	successMetricsEmitter     func(time.Duration)
+	failureMetricsEmitter     func(time.Duration)
+}
+
+var _ Resolver = &OperatorsV1alpha1Resolver{}
+
+func NewInstrumentedResolver(resolver Resolver, successMetricsEmitter, failureMetricsEmitter func(time.Duration)) *InstrumentedResolver {
+	return &InstrumentedResolver{
+		operatorsV1alpha1Resolver: resolver,
+		successMetricsEmitter:     successMetricsEmitter,
+		failureMetricsEmitter:     failureMetricsEmitter,
+	}
+}
+
+func (ir *InstrumentedResolver) ResolveSteps(namespace string, sourceQuerier SourceQuerier) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {
+	start := time.Now()
+	steps, lookups, subs, err := ir.operatorsV1alpha1Resolver.ResolveSteps(namespace, sourceQuerier)
+	if err != nil {
+		ir.failureMetricsEmitter(time.Now().Sub(start))
+	} else {
+		ir.successMetricsEmitter(time.Now().Sub(start))
+	}
+	return steps, lookups, subs, err
+}

--- a/pkg/controller/registry/resolver/instrumented_resolver_test.go
+++ b/pkg/controller/registry/resolver/instrumented_resolver_test.go
@@ -1,0 +1,69 @@
+package resolver
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	failure = time.Duration(0)
+	success = time.Duration(1)
+	reset   = time.Duration(99999)
+)
+
+type fakeResolverWithError struct{}
+type fakeResolverWithoutError struct{}
+
+func (r *fakeResolverWithError) ResolveSteps(namespace string, sourceQuerier SourceQuerier) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {
+	return nil, nil, nil, errors.New("Fake error")
+}
+
+func (r *fakeResolverWithoutError) ResolveSteps(namespace string, sourceQuerier SourceQuerier) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {
+	return nil, nil, nil, nil
+}
+
+func newFakeResolverWithError() *fakeResolverWithError {
+	return &fakeResolverWithError{}
+}
+
+func newFakeResolverWithoutError() *fakeResolverWithoutError {
+	return &fakeResolverWithoutError{}
+}
+
+func TestInstrumentedResolverFailure(t *testing.T) {
+	result := []time.Duration{}
+
+	changeToFailure := func(num time.Duration) {
+		result = append(result, failure)
+	}
+
+	changeToSuccess := func(num time.Duration) {
+		result = append(result, success)
+	}
+
+	instrumentedResolver := NewInstrumentedResolver(newFakeResolverWithError(), changeToSuccess, changeToFailure)
+	instrumentedResolver.ResolveSteps("", nil)
+	require.Equal(t, len(result), 1)     // check that only one call was made to a change function
+	require.Equal(t, result[0], failure) // check that the call was made to changeToFailure function
+}
+
+func TestInstrumentedResolverSuccess(t *testing.T) {
+	result := []time.Duration{}
+
+	changeToFailure := func(num time.Duration) {
+		result = append(result, failure)
+	}
+
+	changeToSuccess := func(num time.Duration) {
+		result = append(result, success)
+	}
+
+	instrumentedResolver := NewInstrumentedResolver(newFakeResolverWithoutError(), changeToSuccess, changeToFailure)
+	instrumentedResolver.ResolveSteps("", nil)
+	require.Equal(t, len(result), 1)     // check that only one call was made to a change function
+	require.Equal(t, result[0], success) // check that the call was made to changeToSuccess function
+}

--- a/test/e2e/like_metric_matcher_test.go
+++ b/test/e2e/like_metric_matcher_test.go
@@ -80,6 +80,15 @@ func WithValue(v float64) MetricPredicate {
 	}
 }
 
+func WithValueGreaterThan(v float64) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithValueGreaterThan(%g)", v),
+		f: func(m Metric) bool {
+			return m.Value > v
+		},
+	}
+}
+
 type LikeMetricMatcher struct {
 	Predicates []MetricPredicate
 }

--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 		})
 	})
 
-	Context("Subscription Metric", func() {
+	Context("Metrics emitted by objects during operator installation", func() {
 		var (
 			subscriptionCleanup cleanupFunc
 			subscription        *v1alpha1.Subscription
@@ -137,6 +137,20 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 					WithChannel(stableChannel),
 					WithPackage(testPackageName),
 				)))
+			})
+
+			It("generates dependency_resolution metric", func() {
+
+				// Verify metrics have been emitted for dependency resolution
+				Eventually(func() bool {
+					return Eventually(func() []Metric {
+						return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					}).Should(ContainElement(LikeMetric(
+						WithFamily("olm_resolution_duration_seconds"),
+						WithLabel("outcome", "failed"),
+						WithValueGreaterThan(0),
+					)))
+				})
 			})
 		})
 


### PR DESCRIPTION
**Description of the change:**

This PR introduces two histrogram metrics to help in analysing the
time taken by dependency resolution requests.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive