### PR TITLE
Fix validate CRD compatibility check and deprecated CRD test case

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1359,7 +1359,7 @@ func validateV1CRDCompatibility(dynamicClient dynamic.Interface, oldCRD *apiexte
 		return err
 	}
 	for _, version := range oldCRD.Spec.Versions {
-		if !version.Served {
+		if version.Served {
 			gvr := schema.GroupVersionResource{Group: oldCRD.Spec.Group, Version: version.Name, Resource: oldCRD.Spec.Names.Plural}
 			err := validateExistingCRs(dynamicClient, gvr, convertedCRD)
 			if err != nil {
@@ -1382,7 +1382,7 @@ func validateV1Beta1CRDCompatibility(dynamicClient dynamic.Interface, oldCRD *ap
 		return err
 	}
 	for _, version := range oldCRD.Spec.Versions {
-		if !version.Served {
+		if version.Served {
 			gvr := schema.GroupVersionResource{Group: oldCRD.Spec.Group, Version: version.Name, Resource: oldCRD.Spec.Names.Plural}
 			err := validateExistingCRs(dynamicClient, gvr, convertedCRD)
 			if err != nil {


### PR DESCRIPTION
1. Fix validate CRD compatibility
Should only run against served versions instead the non-served
versions (! operator error)
2. Clean up the deprecated CRD versions test:
Using standup catsrc upgrade and get rid of unnecessary subscription
deletion.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
