### PR TITLE
Bug: Fix incorrect deployment annotations

### DIFF
--- a/pkg/controller/install/deployment.go
+++ b/pkg/controller/install/deployment.go
@@ -253,8 +253,10 @@ func (i *StrategyDeploymentInstaller) checkForDeployments(deploymentSpecs []v1al
 			return StrategyError{Reason: StrategyErrReasonAnnotationsMissing, Message: fmt.Sprintf("no annotations found on deployment")}
 		}
 		for key, value := range i.templateAnnotations {
-			if dep.Spec.Template.Annotations[key] != value {
-				return StrategyError{Reason: StrategyErrReasonAnnotationsMissing, Message: fmt.Sprintf("annotations on deployment don't match. couldn't find %s: %s", key, value)}
+			if actualValue, ok := dep.Spec.Template.Annotations[key]; !ok {
+				return StrategyError{Reason: StrategyErrReasonAnnotationsMissing, Message: fmt.Sprintf("annotations on deployment does not contain expected key: %s", key)}
+			} else if dep.Spec.Template.Annotations[key] != value {
+				return StrategyError{Reason: StrategyErrReasonAnnotationsMissing, Message: fmt.Sprintf("unexpected annotation on deployment. Expected %s:%s, found %s:%s", key, value, key, actualValue)}
 			}
 		}
 

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1775,7 +1775,8 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 	}
 
 	if strategyErr != nil {
-		if install.ReasonForError(strategyErr) == install.StrategyErrDeploymentUpdated {
+		reasonForError := install.ReasonForError(strategyErr)
+		if reasonForError == install.StrategyErrDeploymentUpdated || reasonForError == install.StrategyErrReasonAnnotationsMissing {
 			csv.SetPhaseWithEventIfChanged(v1alpha1.CSVPhaseInstallReady, requeueConditionReason, fmt.Sprintf("installing: %s", strategyErr), now, a.recorder)
 		} else {
 			csv.SetPhaseWithEventIfChanged(requeuePhase, requeueConditionReason, fmt.Sprintf("installing: %s", strategyErr), now, a.recorder)

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -2274,6 +2274,32 @@ func TestTransitionCSV(t *testing.T) {
 			},
 		},
 		{
+			name: "SingleCSVInstallingToInstallReadyDueToAnnotations",
+			initial: initial{
+				csvs: []runtime.Object{
+					csvWithAnnotations(csv("csv1",
+						namespace,
+						"0.0.0",
+						"",
+						installStrategy("csv1-dep1", nil, nil),
+						[]*apiextensionsv1.CustomResourceDefinition{},
+						[]*apiextensionsv1.CustomResourceDefinition{},
+						v1alpha1.CSVPhaseInstalling,
+					), defaultTemplateAnnotations),
+				},
+				clientObjs: []runtime.Object{defaultOperatorGroup},
+				crds:       []runtime.Object{},
+				objs: []runtime.Object{
+					deployment("csv1-dep1", namespace, "sa", map[string]string{}),
+				},
+			},
+			expected: expected{
+				csvStates: map[string]csvState{
+					"csv1": {exists: true, phase: v1alpha1.CSVPhaseInstallReady, reason: ""},
+				},
+			},
+		},
+		{
 			name: "SingleCSVSucceededToSucceeded/UnmanagedDeploymentInNamespace",
 			initial: initial{
 				csvs: []runtime.Object{


### PR DESCRIPTION
Problem: When OLM checks that the Operator's Deployment was created with the correct annotations, it will not update and redeploy the operator if the annotations are incorrect.

Cause: This issue was found when creating an Operator in an OperatorGroup that uses a LabelSelector to identify namespaces in the OperatorGroup. When the operator is created, the set of namespaces returned by the LabelSelector may be different from the set of namespaces when checking the deployment annotations.

Solution: OLM should rebuild the deployment with the correct set of annotations.
