### PR TITLE
Remove unneeded toleration from catalog source pod

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -137,11 +137,6 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, labels map[s
 					ImagePullPolicy: pullPolicy,
 				},
 			},
-			Tolerations: []v1.Toleration{
-				{
-					Operator: v1.TolerationOpExists,
-				},
-			},
 			NodeSelector: map[string]string{
 				"kubernetes.io/os": "linux",
 			},


### PR DESCRIPTION
**Description of the change:**

This toleration will try to go to any node, but does not handle
nodes that are not schedulable or pods that have been evicted from a
node.

**Motivation for the change:**

I don't see a good reason for using this toleration, it will only cause issues with pod that are evicted and nodes that are not ready or schedulable.


**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage 
- [x] Docs updated or added to `/docs`   n/a
- [x] Commit messages sensible and descriptive

Closes #1677
