### PR TITLE
feat(resolver): Add label dependency type to new resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
 	github.com/operator-framework/api v0.3.11
-	github.com/operator-framework/operator-registry v1.13.3
+	github.com/operator-framework/operator-registry v1.13.6
 	github.com/otiai10/copy v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
 github.com/operator-framework/api v0.3.11 h1:+fyck2pcr+vVGnVxM4UNoi7qOSMVCTQOWW2xsJtLSq0=
 github.com/operator-framework/api v0.3.11/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
-github.com/operator-framework/operator-registry v1.13.3 h1:SaZ1IKLKGizVgTtT8AlDgaMXFYOiIPxRf8KLve0/DXM=
-github.com/operator-framework/operator-registry v1.13.3/go.mod h1:YhnIzOVjRU2ZwZtzt+fjcjW8ujJaSFynBEu7QVKaSdU=
+github.com/operator-framework/operator-registry v1.13.6 h1:h/dIjQQS7uneQNRifrSz7h0xg4Xyjg6C9f6XZofbMPg=
+github.com/operator-framework/operator-registry v1.13.6/go.mod h1:YhnIzOVjRU2ZwZtzt+fjcjW8ujJaSFynBEu7QVKaSdU=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/controller/registry/resolver/cache.go
+++ b/pkg/controller/registry/resolver/cache.go
@@ -422,6 +422,25 @@ func WithVersionInRange(r semver.Range) OperatorPredicate {
 	}
 }
 
+func WithLabel(label string) OperatorPredicate {
+	return func(o *Operator) bool {
+		for _, p := range o.Properties() {
+			if p.Type != opregistry.LabelType {
+				continue
+			}
+			var prop opregistry.LabelProperty
+			err := json.Unmarshal([]byte(p.Value), &prop)
+			if err != nil {
+				continue
+			}
+			if prop.Label == label {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 func ProvidingAPI(api opregistry.APIKey) OperatorPredicate {
 	return func(o *Operator) bool {
 		for _, p := range o.Properties() {

--- a/pkg/controller/registry/resolver/operators.go
+++ b/pkg/controller/registry/resolver/operators.go
@@ -258,7 +258,7 @@ func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey reg
 
 	// legacy support - if the api doesn't contain properties/dependencies, build them from required/provided apis
 	properties := bundle.Properties
-	if properties == nil || len(properties) == 0{
+	if properties == nil || len(properties) == 0 {
 		properties, err = apisToProperties(provided)
 		if err != nil {
 			return nil, err
@@ -296,8 +296,6 @@ func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey reg
 		op.bundle = bundle
 		return op, nil
 	}
-
-
 
 	return &Operator{
 		name:         bundle.CsvName,
@@ -445,6 +443,7 @@ func PredicateForDependency(dependency *api.Dependency) (OperatorPredicate, erro
 var predicates = map[string]func(string) (OperatorPredicate, error){
 	opregistry.GVKType:     predicateForGVKDependency,
 	opregistry.PackageType: predicateForPackageDependency,
+	opregistry.LabelType:   predicateForLabelDependency,
 }
 
 func predicateForGVKDependency(value string) (OperatorPredicate, error) {
@@ -470,6 +469,15 @@ func predicateForPackageDependency(value string) (OperatorPredicate, error) {
 	}
 
 	return And(WithPackage(pkg.PackageName), WithVersionInRange(ver)), nil
+}
+
+func predicateForLabelDependency(value string) (OperatorPredicate, error) {
+	var label opregistry.LabelDependency
+	if err := json.Unmarshal([]byte(value), &label); err != nil {
+		return nil, err
+	}
+
+	return WithLabel(label.Label), nil
 }
 
 func apisToDependencies(apis APISet) (out []*api.Dependency, err error) {

--- a/vendor/github.com/operator-framework/operator-registry/pkg/lib/bundle/validate.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/lib/bundle/validate.go
@@ -201,20 +201,18 @@ func validateAnnotations(mediaType string, fileAnnotations *AnnotationMetadata) 
 				aErr := fmt.Errorf("Expecting annotation %q to have value %q instead of %q", label, MetadataDir, val)
 				validationErrors = append(validationErrors, aErr)
 			}
-		case ChannelsLabel, ChannelDefaultLabel:
+		case ChannelsLabel:
 			if val == "" {
 				aErr := fmt.Errorf("Expecting annotation %q to have non-empty value", label)
 				validationErrors = append(validationErrors, aErr)
 			} else {
 				annotations[label] = val
 			}
+		case ChannelDefaultLabel:
+			annotations[label] = val
 		}
 	}
 
-	_, err := ValidateChannelDefault(annotations[ChannelsLabel], annotations[ChannelDefaultLabel])
-	if err != nil {
-		validationErrors = append(validationErrors, err)
-	}
 	return validationErrors
 }
 
@@ -231,6 +229,8 @@ func validateDependencies(dependenciesFile *registry.DependenciesFile) []error {
 			case registry.GVKDependency:
 				errs = dp.Validate()
 			case registry.PackageDependency:
+				errs = dp.Validate()
+			case registry.LabelDependency:
 				errs = dp.Validate()
 			default:
 				errs = append(errs, fmt.Errorf("unsupported dependency type %s", d.GetType()))

--- a/vendor/github.com/operator-framework/operator-registry/pkg/registry/interface.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/registry/interface.go
@@ -12,6 +12,7 @@ type Load interface {
 	AddPackageChannels(manifest PackageManifest) error
 	AddBundlePackageChannels(manifest PackageManifest, bundle *Bundle) error
 	RemovePackage(packageName string) error
+	DeprecateBundle(path string) error
 	ClearNonHeadBundles() error
 }
 

--- a/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/deprecate.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/deprecate.go
@@ -1,0 +1,49 @@
+package sqlite
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/operator-framework/operator-registry/pkg/registry"
+)
+
+type SQLDeprecator interface {
+	Deprecate() error
+}
+
+// BundleDeprecator removes bundles from the database
+type BundleDeprecator struct {
+	store   registry.Load
+	bundles []string
+}
+
+var _ SQLDeprecator = &BundleDeprecator{}
+
+func NewSQLDeprecatorForBundles(store registry.Load, bundles []string) *BundleDeprecator {
+	return &BundleDeprecator{
+		store:   store,
+		bundles: bundles,
+	}
+}
+
+func (d *BundleDeprecator) Deprecate() error {
+	log := logrus.WithField("bundles", d.bundles)
+
+	log.Info("deprecating bundles")
+
+	var errs []error
+
+	for _, bundlePath := range d.bundles {
+		if err := d.store.DeprecateBundle(bundlePath); err != nil {
+			if !errors.Is(err, registry.ErrBundleImageNotInDatabase) && !errors.Is(err, registry.ErrRemovingDefaultChannelDuringDeprecation) {
+				return utilerrors.NewAggregate(append(errs, fmt.Errorf("error deprecating bundle %s: %s", bundlePath, err)))
+			}
+			errs = append(errs, fmt.Errorf("error deprecating bundle %s: %s", bundlePath, err))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}

--- a/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/load.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/load.go
@@ -777,7 +777,8 @@ func (s *sqlLoader) addBundleProperties(tx *sql.Tx, bundle *registry.Bundle) err
 	}
 
 	for _, prop := range bundle.Properties {
-		if err := s.addProperty(tx, prop.Type, prop.Value, bundle.Name, bundleVersion, bundle.BundleImage); err != nil {
+		value, _ := json.Marshal(prop.Value)
+		if err := s.addProperty(tx, prop.Type, string(value), bundle.Name, bundleVersion, bundle.BundleImage); err != nil {
 			return err
 		}
 	}
@@ -803,5 +804,200 @@ func (s *sqlLoader) addBundleProperties(tx *sql.Tx, bundle *registry.Bundle) err
 		}
 	}
 
+	// Add label properties
+	if csv, err := bundle.ClusterServiceVersion(); err == nil {
+		annotations := csv.ObjectMeta.GetAnnotations()
+		if v, ok := annotations[registry.PropertyKey]; ok {
+			var props []registry.Property
+			if err := json.Unmarshal([]byte(v), &props); err == nil {
+				for _, prop := range props {
+					// Only add label type from the list
+					// TODO: Support more types such as GVK and package
+					if prop.Type == registry.LabelType {
+						var label registry.LabelProperty
+						err := json.Unmarshal(prop.Value, &label)
+						if err != nil {
+							continue
+						}
+						value, err := json.Marshal(label)
+						if err != nil {
+							continue
+						}
+						if err := s.addProperty(tx, registry.LabelType, string(value), bundle.Name, bundleVersion, bundle.BundleImage); err != nil {
+							continue
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return nil
+}
+
+func (s *sqlLoader) rmChannelEntry(tx *sql.Tx, csvName string) error {
+	getEntryID := `SELECT entry_id FROM channel_entry WHERE operatorbundle_name=?`
+	rows, err := tx.QueryContext(context.TODO(), getEntryID, csvName)
+	if err != nil {
+		return err
+	}
+	var entryIDs []int64
+	for rows.Next() {
+		var entryID sql.NullInt64
+		rows.Scan(&entryID)
+		entryIDs = append(entryIDs, entryID.Int64)
+	}
+	err = rows.Close()
+	if err != nil {
+		return err
+	}
+
+	updateChannelEntry, err := tx.Prepare(`UPDATE channel_entry SET replaces=NULL WHERE replaces=?`)
+	if err != nil {
+		return err
+	}
+	for _, id := range entryIDs {
+		if _, err := updateChannelEntry.Exec(id); err != nil {
+			return err
+		}
+	}
+	err = updateChannelEntry.Close()
+	if err != nil {
+		return err
+	}
+
+	stmt, err := tx.Prepare("DELETE FROM channel_entry WHERE operatorbundle_name=?")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	if _, err := stmt.Exec(csvName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getTailFromBundle(tx *sql.Tx, name string) (bundles []string, err error) {
+	getReplacesSkips := `SELECT replaces, skips FROM operatorbundle WHERE name=?`
+	isDefaultChannelHead := `SELECT head_operatorbundle_name FROM channel 
+							INNER JOIN package ON channel.name = package.default_channel 
+							WHERE channel.head_operatorbundle_name = ?`
+
+	tail := make(map[string]struct{})
+	next := name
+
+	for next != "" {
+		rows, err := tx.QueryContext(context.TODO(), getReplacesSkips, next)
+		if err != nil {
+			return nil, err
+		}
+		var replaces sql.NullString
+		var skips sql.NullString
+		if rows.Next() {
+			if err := rows.Scan(&replaces, &skips); err != nil {
+				return nil, err
+			}
+		}
+		rows.Close()
+		if skips.Valid && skips.String != "" {
+			for _, skip := range strings.Split(skips.String, ",") {
+				tail[skip] = struct{}{}
+			}
+		}
+		if replaces.Valid && replaces.String != "" {
+			// check if replaces is the head of the defaultChannel
+			// if it is, the defaultChannel will be removed
+			// this is not allowed because we cannot know which channel to promote as the new default
+			rows, err := tx.QueryContext(context.TODO(), isDefaultChannelHead, replaces.String)
+			if err != nil {
+				return nil, err
+			}
+			if rows.Next() {
+				var defaultChannelHead sql.NullString
+				err := rows.Scan(&defaultChannelHead)
+				if err != nil {
+					return nil, err
+				}
+				if defaultChannelHead.Valid {
+					return nil, registry.ErrRemovingDefaultChannelDuringDeprecation
+				}
+			}
+			next = replaces.String
+			tail[replaces.String] = struct{}{}
+		} else {
+			next = ""
+		}
+	}
+	var allTails []string
+
+	for k := range tail {
+		allTails = append(allTails, k)
+	}
+
+	return allTails, nil
+
+}
+
+func getBundleNameAndVersionForImage(tx *sql.Tx, path string) (string, string, error) {
+	query := `SELECT name, version FROM operatorbundle WHERE bundlepath=? LIMIT 1`
+	rows, err := tx.QueryContext(context.TODO(), query, path)
+	if err != nil {
+		return "", "", err
+	}
+	defer rows.Close()
+
+	var name sql.NullString
+	var version sql.NullString
+	if rows.Next() {
+		if err := rows.Scan(&name, &version); err != nil {
+			return "", "", err
+		}
+	}
+	if name.Valid && version.Valid {
+		return name.String, version.String, nil
+	}
+	return "", "", registry.ErrBundleImageNotInDatabase
+}
+
+func (s *sqlLoader) DeprecateBundle(path string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tx.Rollback()
+	}()
+
+	name, version, err := getBundleNameAndVersionForImage(tx, path)
+	if err != nil {
+		return err
+	}
+	tailBundles, err := getTailFromBundle(tx, name)
+	if err != nil {
+		return err
+	}
+
+	for _, bundle := range tailBundles {
+		err := s.rmBundle(tx, bundle)
+		if err != nil {
+			return err
+		}
+		err = s.rmChannelEntry(tx, bundle)
+		if err != nil {
+			return err
+		}
+	}
+
+	deprecatedValue, err := json.Marshal(registry.DeprecatedProperty{})
+	if err != nil {
+		return err
+	}
+	err = s.addProperty(tx, registry.DeprecatedType, string(deprecatedValue), name, version, path)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }

--- a/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/query.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/query.go
@@ -779,7 +779,7 @@ func (s *SQLQuerier) GetBundleVersion(ctx context.Context, image string) (string
 	if version.Valid {
 		return version.String, nil
 	}
-	return "", fmt.Errorf("bundle %s not found", image)
+	return "", nil
 }
 
 func (s *SQLQuerier) GetBundlePathsForPackage(ctx context.Context, pkgName string) ([]string, error) {
@@ -943,30 +943,29 @@ func (s *SQLQuerier) ListBundles(ctx context.Context) (bundles []*api.Bundle, er
 		bundleItem, ok := bundlesMap[bundleKey]
 		if ok {
 			// Create new dependency object
-			dep := &api.Dependency{}
-			if !depType.Valid || !depValue.Valid {
-				continue
-			}
-			dep.Type = depType.String
-			dep.Value = depValue.String
+			if depType.Valid && depValue.Valid {
+				dep := &api.Dependency{}
+				dep.Type = depType.String
+				dep.Value = depValue.String
 
-			// Add new dependency to the existing list
-			existingDeps := bundleItem.Dependencies
-			existingDeps = append(existingDeps, dep)
-			bundleItem.Dependencies = existingDeps
+				// Add new dependency to the existing list
+				existingDeps := bundleItem.Dependencies
+				existingDeps = append(existingDeps, dep)
+				bundleItem.Dependencies = existingDeps
+			}
+
 
 			// Create new property object
-			prop := &api.Property{}
-			if !propType.Valid || !propValue.Valid {
-				continue
-			}
-			prop.Type = propType.String
-			prop.Value = propValue.String
+			if propType.Valid && propValue.Valid {
+				prop := &api.Property{}
+				prop.Type = propType.String
+				prop.Value = propValue.String
 
-			// Add new property to the existing list
-			existingProps := bundleItem.Properties
-			existingProps = append(existingProps, prop)
-			bundleItem.Properties = existingProps
+				// Add new property to the existing list
+				existingProps := bundleItem.Properties
+				existingProps = append(existingProps, prop)
+				bundleItem.Properties = existingProps
+			}
 		} else {
 			// Create new bundle
 			out := &api.Bundle{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -452,7 +452,7 @@ github.com/operator-framework/api/pkg/validation
 github.com/operator-framework/api/pkg/validation/errors
 github.com/operator-framework/api/pkg/validation/interfaces
 github.com/operator-framework/api/pkg/validation/internal
-# github.com/operator-framework/operator-registry v1.13.3
+# github.com/operator-framework/operator-registry v1.13.6
 github.com/operator-framework/operator-registry/pkg/api
 github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1
 github.com/operator-framework/operator-registry/pkg/client


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Introduce the new label dependency as predicate for the resolver.
Also add new function to match label dependency against operator
properties.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

**Motivation for the change:**
Add an option for operator authors to fine-tune the dependency selection in case of conflicts. The label dependency can be used as a mark/filter for the resolver to select the desirable operator during dependency resolution.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>
Require corresponding PR on registry to merge first. 
-->
