### PR TITLE
[release-4.5] Bug 1862407: fix(resolver): be smarter about the way downgrades are attempted

### DIFF
--- a/pkg/controller/registry/resolver/evolver_test.go
+++ b/pkg/controller/registry/resolver/evolver_test.go
@@ -451,6 +451,28 @@ func TestNamespaceGenerationEvolver(t *testing.T) {
 				NewFakeOperatorSurface("depender.v1", "depender", "channel", "", "catsrc", "", nil,[]opregistry.APIKey{{"g", "v", "k", "ks"}}, nil, nil),
 			),
 		},
+		{
+			name: "NoProviderInUpdateSet",
+			fields: fields{
+				querier: NewFakeSourceQuerier(map[CatalogKey][]*api.Bundle{
+					CatalogKey{"catsrc", "catsrc-namespace"}: {
+						bundle("original", "o", "c", "", APISet{opregistry.APIKey{"g", "v", "k", "ks"}: {}},  EmptyAPISet(), EmptyAPISet(), EmptyAPISet()),
+						bundle("original.v2", "o", "c", "original", EmptyAPISet(), EmptyAPISet(), EmptyAPISet(), EmptyAPISet()),
+						bundle("depender", "depender", "channel", "", EmptyAPISet(),  APISet{opregistry.APIKey{"g", "v", "k", "ks"}: {}}, EmptyAPISet(), EmptyAPISet()),
+						bundle("depender.v2", "depender", "channel", "depender", EmptyAPISet(), APISet{opregistry.APIKey{"g", "v", "k", "ks"}: {}}, EmptyAPISet(), EmptyAPISet()),
+					},
+				}),
+				gen: NewGenerationFromOperators(
+					NewFakeOperatorSurface("original", "o", "c", "", "catsrc", "", []opregistry.APIKey{{"g", "v", "k", "ks"}}, nil, nil, nil),
+					NewFakeOperatorSurface("depender", "depender", "channel", "", "catsrc", "", nil, []opregistry.APIKey{{"g", "v", "k", "ks"}}, nil, nil),
+				),
+			},
+			args: args{},
+			wantGen: NewGenerationFromOperators(
+				NewFakeOperatorSurface("original", "o", "c", "", "catsrc", "",  []opregistry.APIKey{{"g", "v", "k", "ks"}},nil, nil, nil),
+				NewFakeOperatorSurface("depender.v2", "depender", "channel", "depender", "catsrc", "", nil, []opregistry.APIKey{{"g", "v", "k", "ks"}}, nil, nil),
+			),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
"downgrade" here refers to downgrading potential updates back to what
has already been installed.

this fixes issues where OLM would otherwise not have been able to
determine a safe set of operators to update to - the case where, after
tentative updates to the current generation, there are required apis
missing from the set.

the previous algorithm solves this by downgrading the updates that
require the missing apis, which has the potential to downgrade back
to the initial set of operators.

in the case where the api was provided by some operator in the previous
generation, it would be possible to not downgrade all requirers, but
rather downgrade the operator that previously provided the api.

this commit implements an exhaustive search of potential downgrades for
a generation, and uses one without missing required apis if one is found

if none is found, the old behavior takes place, and the set may still
contract back to what is currently installed.

the new resolver avoids this issue entirely, so to avoid complicating
the implementation a limit of 64 updated operators per generation has
been added.

the implementation uses a bitmask to select either the old or new
operator from the set. finding all possible combinations of old/new
versions is then a simple integer count from 0 to the max.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
