### PR TITLE
Remove unnecessary ENV directives from base.Dockerfile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LOCAL_NAMESPACE := "olm"
 export GO111MODULE=on
 CONTROLLER_GEN := go run $(MOD_FLAGS) ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 YQ_INTERNAL := go run $(MOD_FLAGS) ./vendor/github.com/mikefarah/yq/v2/
-KUBEBUILDER_ASSETS := $(or $(or $(KUBEBUILDER_ASSETS),$(dir $(shell command -v kubebuilder))), /usr/local/kubebuilder/bin)
+KUBEBUILDER_ASSETS := $(or $(or $(KUBEBUILDER_ASSETS),$(dir $(shell command -v kubebuilder))),/usr/local/kubebuilder/bin)
 export KUBEBUILDER_ASSETS
 
 # ART builds are performed in dist-git, with content (but not commits) copied 

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -10,6 +10,3 @@ RUN yum install -y skopeo && \
     mv /tmp/kubebuilder_2.3.1_${OS}_${ARCH}/ /usr/local/kubebuilder && \
     export PATH=$PATH:/usr/local/kubebuilder/bin && \
     echo "Kubebuilder installation complete!"
-
-ENV PATH=$PATH:/usr/local/kubebuilder/bin
-ENV KUBEBUILDER_ASSETS=/usr/local/kubebuilder/bin


### PR DESCRIPTION
The addition of a hardcoded default for KUBEBUILDER_ASSETS in the
Makefile should make it unnecessary to also put the kubebuilder
binaries in PATH.
