### PR TITLE
change default catalog to index image

### DIFF
--- a/deploy/chart/templates/0000_50_olm_17-upstream-operators.catalogsource.yaml
+++ b/deploy/chart/templates/0000_50_olm_17-upstream-operators.catalogsource.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.catalog_namespace }}
 spec:
   sourceType: grpc
-  image: quay.io/operator-framework/upstream-community-operators:latest
+  image: quay.io/operatorhubio/catalog:latest
   displayName: Community Operators
   publisher: OperatorHub.io
 {{- end }}


### PR DESCRIPTION
**Description of the change:**

Change the default catalog for upstream OLM to use the index image published at https://github.com/operator-framework/community-operators 
This index image contains the content of https://github.com/operator-framework/community-operators

**Motivation for the change:**

Start using index images with the default catalog source of upstream OLM on Kubernetes

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
