### PR TITLE
Add tracing to the resolver

### DIFF
--- a/pkg/controller/registry/resolver/cache_test.go
+++ b/pkg/controller/registry/resolver/cache_test.go
@@ -222,7 +222,7 @@ func TestCatalogSnapshotExpired(t *testing.T) {
 func TestCatalogSnapshotFind(t *testing.T) {
 	type tc struct {
 		Name      string
-		Predicate func(*Operator) bool
+		Predicate Predicate
 		Operators []*Operator
 		Expected  []*Operator
 	}
@@ -230,8 +230,11 @@ func TestCatalogSnapshotFind(t *testing.T) {
 	for _, tt := range []tc{
 		{
 			Name: "nothing satisfies predicate",
-			Predicate: func(*Operator) bool {
-				return false
+			Predicate: &OperatorPredicate{
+				f: func(o *Operator) bool {
+					return false
+				},
+				desc: "nothing",
 			},
 			Operators: []*Operator{
 				{name: "a"},
@@ -242,16 +245,22 @@ func TestCatalogSnapshotFind(t *testing.T) {
 		},
 		{
 			Name: "no operators in snapshot",
-			Predicate: func(*Operator) bool {
-				return true
+			Predicate: &OperatorPredicate{
+				f: func(o *Operator) bool {
+					return true
+				},
+				desc: "everything",
 			},
 			Operators: nil,
 			Expected:  nil,
 		},
 		{
 			Name: "everything satisfies predicate",
-			Predicate: func(*Operator) bool {
-				return true
+			Predicate: &OperatorPredicate{
+				f: func(o *Operator) bool {
+					return true
+				},
+				desc: "everything",
 			},
 			Operators: []*Operator{
 				{name: "a"},
@@ -266,8 +275,11 @@ func TestCatalogSnapshotFind(t *testing.T) {
 		},
 		{
 			Name: "some satisfy predicate",
-			Predicate: func(o *Operator) bool {
-				return o.name != "a"
+			Predicate: &OperatorPredicate{
+				f: func(o *Operator) bool {
+					return o.name != "a"
+				},
+				desc: "not a",
 			},
 			Operators: []*Operator{
 				{name: "a"},

--- a/pkg/controller/registry/resolver/operators.go
+++ b/pkg/controller/registry/resolver/operators.go
@@ -258,7 +258,7 @@ func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey reg
 
 	// legacy support - if the api doesn't contain properties/dependencies, build them from required/provided apis
 	properties := bundle.Properties
-	if properties == nil || len(properties) == 0{
+	if properties == nil || len(properties) == 0 {
 		properties, err = apisToProperties(provided)
 		if err != nil {
 			return nil, err
@@ -296,8 +296,6 @@ func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey reg
 		op.bundle = bundle
 		return op, nil
 	}
-
-
 
 	return &Operator{
 		name:         bundle.CsvName,
@@ -416,10 +414,10 @@ func (o *Operator) Properties() []*api.Property {
 	return o.properties
 }
 
-func (o *Operator) DependencyPredicates() (predicates []OperatorPredicate, err error) {
-	predicates = make([]OperatorPredicate, 0)
+func (o *Operator) DependencyPredicates() (predicates []Predicate, err error) {
+	predicates = make([]Predicate, 0)
 	for _, d := range o.Dependencies() {
-		var p OperatorPredicate
+		var p Predicate
 		if d == nil || d.Type == "" {
 			continue
 		}
@@ -434,7 +432,7 @@ func (o *Operator) DependencyPredicates() (predicates []OperatorPredicate, err e
 
 // TODO: this should go in its own dependency/predicate builder package
 // TODO: can we make this more extensible, i.e. via cue
-func PredicateForDependency(dependency *api.Dependency) (OperatorPredicate, error) {
+func PredicateForDependency(dependency *api.Dependency) (Predicate, error) {
 	p, ok := predicates[dependency.Type]
 	if !ok {
 		return nil, fmt.Errorf("no predicate for dependency type %s", dependency.Type)
@@ -442,12 +440,12 @@ func PredicateForDependency(dependency *api.Dependency) (OperatorPredicate, erro
 	return p(dependency.Value)
 }
 
-var predicates = map[string]func(string) (OperatorPredicate, error){
+var predicates = map[string]func(string) (Predicate, error){
 	opregistry.GVKType:     predicateForGVKDependency,
 	opregistry.PackageType: predicateForPackageDependency,
 }
 
-func predicateForGVKDependency(value string) (OperatorPredicate, error) {
+func predicateForGVKDependency(value string) (Predicate, error) {
 	var gvk opregistry.GVKDependency
 	if err := json.Unmarshal([]byte(value), &gvk); err != nil {
 		return nil, err
@@ -459,7 +457,7 @@ func predicateForGVKDependency(value string) (OperatorPredicate, error) {
 	}), nil
 }
 
-func predicateForPackageDependency(value string) (OperatorPredicate, error) {
+func predicateForPackageDependency(value string) (Predicate, error) {
 	var pkg opregistry.PackageDependency
 	if err := json.Unmarshal([]byte(value), &pkg); err != nil {
 		return nil, err
@@ -469,7 +467,7 @@ func predicateForPackageDependency(value string) (OperatorPredicate, error) {
 		return nil, err
 	}
 
-	return And(WithPackage(pkg.PackageName), WithVersionInRange(ver)), nil
+	return And(WithPackage(pkg.PackageName), WithVersionInRange(ver, pkg.Version)), nil
 }
 
 func apisToDependencies(apis APISet) (out []*api.Dependency, err error) {

--- a/pkg/controller/registry/resolver/step_resolver.go
+++ b/pkg/controller/registry/resolver/step_resolver.go
@@ -96,6 +96,7 @@ func (r *OperatorStepResolver) ResolveSteps(namespace string, _ SourceQuerier) (
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	r.log.WithField("operators", operators).Debug("got operators")
 
 	// if there's no error, we were able to satisfy all constraints in the subscription set, so we calculate what
 	// changes to persist to the cluster and write them out as `steps`
@@ -115,6 +116,11 @@ func (r *OperatorStepResolver) ResolveSteps(namespace string, _ SourceQuerier) (
 		sourceInfo.DefaultChannel = false
 		_, isAdded := add[sourceInfo]
 		existingSubscription, subExists := subMap[sourceInfo]
+
+		r.log.Debugf("source: %#v", sourceInfo)
+		r.log.Debugf("already exists: %v %v", subExists, existingSubscription)
+		r.log.Debugf("isAdded: %v", isAdded)
+
 
 		// subscription exists and is up to date
 		if subExists && existingSubscription.Status.CurrentCSV == op.Identifier() && !isAdded {
@@ -180,6 +186,7 @@ func (r *OperatorStepResolver) ResolveSteps(namespace string, _ SourceQuerier) (
 
 	// Order Steps
 	steps = v1alpha1.OrderSteps(steps)
+	r.log.WithField("steps", steps).Debug("final")
 	return steps, bundleLookups, updatedSubs, nil
 }
 

--- a/vendor/github.com/operator-framework/operator-registry/pkg/client/client.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/client/client.go
@@ -54,6 +54,7 @@ func (it *BundleIterator) Next() *api.Bundle {
 	}
 	if err != nil {
 		it.error = err
+		return nil
 	}
 	return next
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
/hold

Adds lots of extra logging + tracing for cache queries.

**Motivation for the change:**
For now, using this to debug test flakes. 

It would be nice to come up with a good way to control when / if these are generated. It's likely too chatty to keep on all the time. I also don't love this abstraction, just threw it together to help debug something last week.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
