### PR TITLE
Remove spurious check for duplicate operators in resolver.

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -308,11 +308,6 @@ func (r *SatResolver) getBundleInstallables(catalog registry.CatalogKey, predica
 			bundleDependencies := make([]solver.Identifier, 0)
 			for _, dep := range sortedBundles {
 				found := namespacedCache.Catalog(dep.SourceInfo().Catalog).Find(WithCSVName(dep.Identifier()))
-				if len(found) > 1 {
-					err := fmt.Errorf("found duplicate entries for %s in %s", bundle.Identifier(), dep.sourceInfo.Catalog)
-					errs = append(errs, err)
-					continue
-				}
 				if len(found) == 0 {
 					err := fmt.Errorf("couldn't find %s in %s", bundle.Identifier(), dep.sourceInfo.Catalog)
 					errs = append(errs, err)


### PR DESCRIPTION
Resolution fails when more than one operator in a catalog share the
same name. Since the registry ListBundles endpoint returns one entry
per channel, this cardinality test is overly aggressive. The resolver
should be able to distinguish operators that share a name as long as
their channel is different (and the solver will generate an error if
its input contains duplicate identifiers).
