### PR TITLE
Bug 1856526: check API discovery before attempting to install a CR in a bundle.

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -27,12 +27,13 @@ import (
 )
 
 const (
-	catalogNamespaceEnvVarName  = "GLOBAL_CATALOG_NAMESPACE"
-	defaultWakeupInterval       = 15 * time.Minute
-	defaultCatalogNamespace     = "openshift-operator-lifecycle-manager"
-	defaultConfigMapServerImage = "quay.io/operatorframework/configmap-operator-registry:latest"
-	defaultUtilImage            = "quay.io/operator-framework/olm:latest"
-	defaultOperatorName         = ""
+	catalogNamespaceEnvVarName    = "GLOBAL_CATALOG_NAMESPACE"
+	defaultWakeupInterval         = 15 * time.Minute
+	defaultCatalogNamespace       = "openshift-operator-lifecycle-manager"
+	defaultConfigMapServerImage   = "quay.io/operatorframework/configmap-operator-registry:latest"
+	defaultUtilImage              = "quay.io/operator-framework/olm:latest"
+	defaultOperatorName           = ""
+	defaultDynamicResourceTimeout = 2 * time.Minute
 )
 
 // config flags defined globally so that they appear on the test binary as well
@@ -68,6 +69,9 @@ var (
 
 	profiling = flag.Bool(
 		"profiling", false, "serve profiling data (on port 8080)")
+
+	dynamicResourceTimeout = flag.Duration(
+		"dynamicResourceTimeout", defaultDynamicResourceTimeout, "timeout to discover required CRDs on the api-server when installing CRs")
 )
 
 func init() {
@@ -172,7 +176,7 @@ func main() {
 	}
 
 	// Create a new instance of the operator.
-	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *utilImage, *catalogNamespace)
+	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *utilImage, *catalogNamespace, *dynamicResourceTimeout)
 	if err != nil {
 		log.Panicf("error configuring operator: %s", err.Error())
 	}

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -590,8 +590,7 @@ func TestExecutePlan(t *testing.T) {
 				case *unstructured.Unstructured:
 					// Get the resource from the GVK
 					gvk := o.GroupVersionKind()
-					var r metav1.APIResource
-					r, err = op.apiresourceFromGVK(gvk)
+					r, err := op.apiresourceFromGVK(gvk)
 					require.NoError(t, err)
 
 					gvr := schema.GroupVersionResource{

--- a/test/e2e/bundle_e2e_test.go
+++ b/test/e2e/bundle_e2e_test.go
@@ -3,18 +3,18 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
-	"github.com/ghodss/yaml"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
+	"github.com/ghodss/yaml"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
@@ -163,6 +163,142 @@ var _ = Describe("Installing bundles with new object types", func() {
 				}
 				return err
 			}).Should(Succeed())
+		})
+	})
+
+	When("A bundle is installed with a CR that is associated with a provided CRD", func() {
+		By("including the VPA CRD in the CSV")
+		const (
+			packageName = "busybox"
+			channelName = "alpha"
+			subName     = "test-subscription"
+			vpaName     = "busybox-vpa"
+			vpaGroup    = "autoscaling.k8s.io"
+			vpaVersion  = "v1"
+			vpaResource = "verticalpodautoscalers"
+		)
+
+		BeforeEach(func() {
+			const (
+				sourceName = "test-catalog"
+				imageName  = "quay.io/olmtest/single-bundle-index:vpa-race"
+			)
+			var installPlanRef string
+			// create catalog source
+			source := &v1alpha1.CatalogSource{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       v1alpha1.CatalogSourceKind,
+					APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{"olm.catalogSource": sourceName},
+				},
+				Spec: v1alpha1.CatalogSourceSpec{
+					SourceType: v1alpha1.SourceTypeGrpc,
+					Image:      imageName,
+				},
+			}
+
+			source, err := operatorClient.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(context.TODO(), source, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred(), "could not create catalog source")
+
+			// Create a Subscription for package
+			_ = createSubscriptionForCatalog(operatorClient, source.GetNamespace(), subName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
+
+			// Wait for the Subscription to succeed
+			sub, err := fetchSubscription(operatorClient, testNamespace, subName, subscriptionStateAtLatestChecker)
+			Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
+
+			installPlanRef = sub.Status.InstallPlanRef.Name
+
+			// Wait for the installplan to complete (5 minute timeout)
+			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+			Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
+
+			ctx.Ctx().Logf("install plan %s completed", installPlanRef)
+		})
+
+		It("should create the additional bundle objects in the correct order: by first installing the CRD then the CR", func() {
+			var vpaGVR = schema.GroupVersionResource{
+				Group:    vpaGroup,
+				Version:  vpaVersion,
+				Resource: vpaResource,
+			}
+
+			// confirm extra bundle objects are installed
+			Eventually(func() error {
+				_, err := dynamicClient.Resource(vpaGVR).Namespace(testNamespace).Get(context.TODO(), vpaName, metav1.GetOptions{})
+				return err
+			}).Should(Succeed(), "expected no error finding vpa object associated with csv")
+		})
+
+		AfterEach(func() {
+			By("Deleting the VPA CRD")
+			vpaCRDName := fmt.Sprint(vpaResource, ".", vpaGroup)
+			Eventually(func() error {
+				err := ctx.Ctx().KubeClient().ApiextensionsInterface().ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), vpaCRDName, metav1.DeleteOptions{})
+				if k8serrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}).Should(Succeed())
+		})
+	})
+
+	When("A bundle is installed with a CR that has no associated CRD", func() {
+		By("the API not becoming available on the api-server")
+		const (
+			packageName = "busybox"
+			channelName = "alpha"
+			subName     = "test-subscription"
+		)
+		var installPlanRef string
+
+		BeforeEach(func() {
+			const (
+				sourceName = "test-catalog"
+				imageName  = "quay.io/olmtest/single-bundle-index:missing-crd"
+			)
+			// create catalog source
+			source := &v1alpha1.CatalogSource{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       v1alpha1.CatalogSourceKind,
+					APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{"olm.catalogSource": sourceName},
+				},
+				Spec: v1alpha1.CatalogSourceSpec{
+					SourceType: v1alpha1.SourceTypeGrpc,
+					Image:      imageName,
+				},
+			}
+
+			source, err := operatorClient.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(context.TODO(), source, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred(), "could not create catalog source")
+
+			// Create a Subscription for package
+			_ = createSubscriptionForCatalog(operatorClient, source.GetNamespace(), subName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
+
+			// Wait for the Subscription to succeed
+			sub, err := fetchSubscription(operatorClient, testNamespace, subName, subscriptionStateAtLatestChecker)
+			Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
+			installPlanRef = sub.Status.InstallPlanRef.Name
+
+		})
+
+		It("should fail the installplan after the timeout is exceeded", func() {
+			// Wait for the installplan to fail (2 minute timeout)
+			Eventually(func() bool {
+				ip, err := fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete, v1alpha1.InstallPlanPhaseFailed))
+				Expect(err).ToNot(HaveOccurred(), "error fetching failed install plan")
+				return ip.Status.Phase == v1alpha1.InstallPlanPhaseFailed
+			}).Should(BeTrue())
+			ctx.Ctx().Logf("install plan %s failed", installPlanRef)
 		})
 	})
 })


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Support for the gardener feature allowed packaging VPAs in the bundle. If the VPA CRD is not installed in the cluster, the CRD could be included in the bundle. 

Since this is the first time OLM allows a CRD and CR related to that CRD be installed simultaneously, a race condition in the InstallPlan occurs. The CRD is installed first, but if it takes a while to be established and accepted then the CR creation will fail. This fix ensures that the CR will not be created before the corresponding CRD is available via discovery. 

Also adds a unit test to the new resolver to check that an operator can satisfy its own dependencies. 

**Motivation for the change:**
This race affects gardener objects as well as prometheus objects 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
