### PR TITLE
Bug 1867169: Fix stale content in configmap due to stale bundle image in the node

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -106,9 +106,10 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 							},
 						},
 						{
-							Name:    "pull",
-							Image:   bundlePath,
-							Command: []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
+							Name:            "pull",
+							Image:           bundlePath,
+							ImagePullPolicy: "Always",
+							Command:         []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "bundle",

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -226,9 +226,10 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 										{
-											Name:    "pull",
-											Image:   bundlePath,
-											Command: []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
+											Name:            "pull",
+											Image:           bundlePath,
+											ImagePullPolicy: "Always",
+											Command:         []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 											VolumeMounts: []corev1.VolumeMount{
 												{
 													Name:      "bundle",
@@ -382,9 +383,10 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 										{
-											Name:    "pull",
-											Image:   bundlePath,
-											Command: []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
+											Name:            "pull",
+											Image:           bundlePath,
+											ImagePullPolicy: "Always",
+											Command:         []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 											VolumeMounts: []corev1.VolumeMount{
 												{
 													Name:      "bundle",
@@ -577,9 +579,10 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 										{
-											Name:    "pull",
-											Image:   bundlePath,
-											Command: []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
+											Name:            "pull",
+											Image:           bundlePath,
+											ImagePullPolicy: "Always",
+											Command:         []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 											VolumeMounts: []corev1.VolumeMount{
 												{
 													Name:      "bundle",


### PR DESCRIPTION
If the bundle is already present in the node, during the unpack process
the configmap may potentially use a stale bundle image. The default
setting for ImagePullPolicy is `IfNotPresent` and should be changed to
`Always`.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
