### PR TITLE
Bug 1860035: Fix SubscriptionConfig NodeSelector field

### DIFF
--- a/doc/design/subscription-config.md
+++ b/doc/design/subscription-config.md
@@ -16,7 +16,7 @@ The `env` field defines a list of [Environment Variables](https://kubernetes.io/
 
 Increase log verbosity on an Operator's container that utilizes the `ARGS` variable:
 
-```
+```yaml
 kind: Subscription
 metadata:
   name: prometheus
@@ -39,7 +39,7 @@ The `envFrom` field defines a [list of sources to populate Environment Variables
 
 Inject a license key residing in a Secret to unlock Operator features:
 
-```
+```yaml
 kind: Subscription
 metadata:
   name: my-operator
@@ -68,7 +68,7 @@ The `volumeMounts` field defines a list of [VolumeMounts](https://kubernetes.io/
 
 Mount a ConfigMap as a Volume that contains configuration information that can change default Operator behavior. Modifications to the content of the ConfigMap should appear within the container's VolumeMount.
 
-```
+```yaml
 kind: Subscription
 metadata:
   name: my-operator
@@ -95,7 +95,7 @@ The `tolerations` field defines a list of [Tolerations](https://kubernetes.io/do
 
 Inject toleration to tolerate all taints.
 
-```
+```yaml
 kind: Subscription
 metadata:
   name: my-operator
@@ -117,7 +117,7 @@ The `resources` field defines [Resource Constraints](https://kubernetes.io/docs/
 
 Inject a request of 0.25 cpu and 64 MiB of memory, and a limit of 0.5 cpu and 128MiB of memory in each container.
 
-```
+```yaml
 kind: Subscription
 metadata:
   name: my-operator
@@ -132,4 +132,24 @@ spec:
       limits:
         memory: "128Mi"
         cpu: "500m"
+```
+
+### NodeSelector
+
+The `nodeSelector` field defines a [NodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for the Pod created by OLM.
+
+#### Example
+
+Inject `nodeSelector` key-values pairs.
+
+```yaml
+kind: Subscription
+metadata:
+  name: my-operator
+spec:
+  package: etcd
+  channel: alpha
+  config:
+    nodeSelector:
+      foo: bar
 ```

--- a/pkg/controller/operators/olm/overrides/config.go
+++ b/pkg/controller/operators/olm/overrides/config.go
@@ -16,7 +16,7 @@ type operatorConfig struct {
 	logger *logrus.Logger
 }
 
-func (o *operatorConfig) GetConfigOverrides(ownerCSV ownerutil.Owner) (envVarOverrides []corev1.EnvVar, volumeOverrides []corev1.Volume, volumeMountOverrides []corev1.VolumeMount, tolerationOverrides []corev1.Toleration, resourcesOverride corev1.ResourceRequirements, err error) {
+func (o *operatorConfig) GetConfigOverrides(ownerCSV ownerutil.Owner) (envVarOverrides []corev1.EnvVar, volumeOverrides []corev1.Volume, volumeMountOverrides []corev1.VolumeMount, tolerationOverrides []corev1.Toleration, resourcesOverride corev1.ResourceRequirements, nodeSelectorOverride map[string]string, err error) {
 	list, listErr := o.lister.OperatorsV1alpha1().SubscriptionLister().Subscriptions(ownerCSV.GetNamespace()).List(labels.Everything())
 	if listErr != nil {
 		err = fmt.Errorf("failed to list subscription namespace=%s - %v", ownerCSV.GetNamespace(), listErr)
@@ -34,6 +34,7 @@ func (o *operatorConfig) GetConfigOverrides(ownerCSV ownerutil.Owner) (envVarOve
 	volumeMountOverrides = owner.Spec.Config.VolumeMounts
 	tolerationOverrides = owner.Spec.Config.Tolerations
 	resourcesOverride = owner.Spec.Config.Resources
+	nodeSelectorOverride = owner.Spec.Config.NodeSelector
 
 	return
 }

--- a/pkg/controller/operators/olm/overrides/initializer.go
+++ b/pkg/controller/operators/olm/overrides/initializer.go
@@ -44,7 +44,7 @@ func (d *DeploymentInitializer) initialize(ownerCSV ownerutil.Owner, deployment 
 	var envVarOverrides, proxyEnvVar, merged []corev1.EnvVar
 	var err error
 
-	envVarOverrides, volumeOverrides, volumeMountOverrides, tolerationOverrides, resourcesOverride, err := d.config.GetConfigOverrides(ownerCSV)
+	envVarOverrides, volumeOverrides, volumeMountOverrides, tolerationOverrides, resourcesOverride, nodeSelectorOverride, err := d.config.GetConfigOverrides(ownerCSV)
 	if err != nil {
 		err = fmt.Errorf("failed to get subscription pod configuration - %v", err)
 		return err
@@ -85,6 +85,10 @@ func (d *DeploymentInitializer) initialize(ownerCSV ownerutil.Owner, deployment 
 
 	if err = InjectResourcesIntoDeployment(podSpec, resourcesOverride); err != nil {
 		return fmt.Errorf("failed to inject resources into deployment spec name=%s - %v", deployment.Name, err)
+	}
+
+	if err = InjectNodeSelectorIntoDeployment(podSpec, nodeSelectorOverride); err != nil {
+		return fmt.Errorf("failed to inject nodeSelector into deployment spec name=%s - %v", deployment.Name, err)
 	}
 
 	return nil

--- a/pkg/controller/operators/olm/overrides/inject.go
+++ b/pkg/controller/operators/olm/overrides/inject.go
@@ -206,3 +206,17 @@ func InjectResourcesIntoDeployment(podSpec *corev1.PodSpec, resources corev1.Res
 
 	return nil
 }
+
+// InjectNodeSelectorIntoDeployment injects the provided NodeSelector
+// into the container(s) of the given PodSpec.
+//
+// If any Container in PodSpec already defines a NodeSelector it will
+// be overwritten.
+func InjectNodeSelectorIntoDeployment(podSpec *corev1.PodSpec, nodeSelector map[string]string) error {
+	if podSpec == nil {
+		return errors.New("no pod spec provided")
+	}
+
+	podSpec.NodeSelector = nodeSelector
+	return nil
+}


### PR DESCRIPTION
Problem: OLM's Subscription CRD allows cluster admins to set
nodeSelectors on Operators they deploy. Currently this API is exposed
but performs no action.

Solution: Wire the NodeSelector specified in the SubscriptionConfig into
the pods deployed when installing the operator.
