### PR TITLE
Bug 1866444: remove duplicate catalog source pod when polling

### DIFF
--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -375,11 +375,6 @@ func TestGetPodImageID(t *testing.T) {
 		result      string
 	}{
 		{
-			description: "no pod status: return nothing",
-			pod:         &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{}}},
-			result:      "",
-		},
-		{
 			description: "pod has status: return status",
 			pod:         &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{ImageID: "xyz123"}}}},
 			result:      "xyz123",
@@ -387,7 +382,7 @@ func TestGetPodImageID(t *testing.T) {
 	}
 
 	for i, tt := range table {
-		require.Equal(t, tt.result, getPodImageID(tt.pod), table[i].description)
+		require.Equal(t, tt.result, imageID(tt.pod), table[i].description)
 	}
 }
 
@@ -405,7 +400,7 @@ func TestUpdatePodByDigest(t *testing.T) {
 			result:      false,
 		},
 		{
-			description: "pod image ids do not match:  updated image on the registry: return true",
+			description: "pod image ids do not match: update on the registry: return true",
 			updatePod:   &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{ImageID: "abc456"}}}},
 			servingPods: []*corev1.Pod{{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{ImageID: "xyz123"}}}}},
 			result:      true,
@@ -413,6 +408,6 @@ func TestUpdatePodByDigest(t *testing.T) {
 	}
 
 	for i, tt := range table {
-		require.Equal(t, tt.result, updatePodByDigest(tt.updatePod, tt.servingPods), table[i].description)
+		require.Equal(t, tt.result, imageChanged(tt.updatePod, tt.servingPods), table[i].description)
 	}
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR modifies the `ensureUpdatePod()` portion of the catalog syncing loop to always delete an update pod in the case where polling is enabled. Either:

- The update pod has a different digest than the serving pod, in which case we delete the old serving pod immediately
OR
- The update pod has the same digest as the serving pod, in which case we immediately delete the update pod

This requires requeueing the catalog source sync until the update pod becomes running on the cluster to obtain the imageID of the running container in the pod. 

The result is that two catalog source pods are seen on the cluster for only a minimal amount of time. 

May require a rebase on #1624 

**Motivation for the change:**
Having two catalog pods on the cluster for one OLM sync cycle was considered bad UX

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
