### PR TITLE
Bug 1869523: Fix nodeSelector subscription config override

### DIFF
--- a/pkg/controller/operators/olm/overrides/inject.go
+++ b/pkg/controller/operators/olm/overrides/inject.go
@@ -217,6 +217,9 @@ func InjectNodeSelectorIntoDeployment(podSpec *corev1.PodSpec, nodeSelector map[
 		return errors.New("no pod spec provided")
 	}
 
-	podSpec.NodeSelector = nodeSelector
+	if nodeSelector != nil {
+		podSpec.NodeSelector = nodeSelector
+	}
+
 	return nil
 }

--- a/pkg/controller/operators/olm/overrides/inject_test.go
+++ b/pkg/controller/operators/olm/overrides/inject_test.go
@@ -746,6 +746,30 @@ func TestInjectNodeSelectorIntoDeployment(t *testing.T) {
 				NodeSelector: map[string]string{"foo": "bar"},
 			},
 		},
+		{
+			// Existing PodSpec is left alone if nodeSelector is nil
+			// Expected: PodSpec is not changed
+			name: "WithNilNodeSelector",
+			podSpec: &corev1.PodSpec{
+				NodeSelector: defaultNodeSelector,
+			},
+			nodeSelector: nil,
+			expected: &corev1.PodSpec{
+				NodeSelector: defaultNodeSelector,
+			},
+		},
+		{
+			// Existing PodSpec is set to an empty map if the nodeSelector is an empty map
+			// Expected: PodSpec nodeSelector is set to an empty map
+			name: "WithEmptyNodeSelector",
+			podSpec: &corev1.PodSpec{
+				NodeSelector: defaultNodeSelector,
+			},
+			nodeSelector: map[string]string{},
+			expected: &corev1.PodSpec{
+				NodeSelector: map[string]string{},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Problem: Empty nodeSelector overrides defined in the subscription are
overwriting existing nodeSelectors in the CSV when empty / not set.

Solution: Only override the nodeSelectors defined in the CSV when the
provided nodeSelector list is not nil.