### PR TITLE
Bug 1870453: Should not compare the digest if cannot the new update pod's imageID

### DIFF
--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -292,7 +292,10 @@ func (c *GrpcRegistryReconciler) createUpdatePod(source grpcCatalogSourceDecorat
 // checkUpdatePodDigest checks update pod to get Image ID and see if it matches the serving (live) pod ImageID
 func imageChanged(updatePod *corev1.Pod, servingPods []*corev1.Pod) bool {
 	updatedCatalogSourcePodImageID := imageID(updatePod)
-
+	if updatedCatalogSourcePodImageID == "" {
+		logrus.WithField("CatalogSource", updatePod.GetName()).Warn("pod status unknown, cannot get the pod's imageID")
+		return false
+	}
 	for _, servingPod := range servingPods {
 		servingCatalogSourcePodImageID := imageID(servingPod)
 		if updatedCatalogSourcePodImageID != servingCatalogSourcePodImageID {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

During the CatalogSource pods polling, OLM compare the digest of the update pod and the current served pods. But, OLM cannot get the imageID of the update pod once it's created. But, OLM still compare the digest, it leads to unnecessary updates operations. As follows:

```console
 330 time="2020-08-19T05:28:57Z" level=warning msg="pod status unknown" CatalogSource=qe-app-registry-v5xz4
 331 time="2020-08-19T05:28:57Z" level=info msg="ImageID " CatalogSource=qe-app-registry-v5xz4
 332 time="2020-08-19T05:28:57Z" level=info msg="Update Pod ImageID " CatalogSource=qe-app-registry-v5xz4
```

**Motivation for the change:**
When the imageID of the update pod is empty, don't run the updates operations.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
