### PR TITLE
chore(test): Added CustomMatcher for asserting on k8 errors for better readability

### DIFF
--- a/test/e2e/bundle_e2e_test.go
+++ b/test/e2e/bundle_e2e_test.go
@@ -64,15 +64,13 @@ var _ = Describe("Installing bundles with new object types", func() {
 			err = json.Unmarshal(data, &vpaCRD)
 			Expect(err).ToNot(HaveOccurred(), "could not convert vpa crd to unstructured")
 
-			Eventually(func() error {
+			Eventually(func() bool {
 				err := ctx.Ctx().Client().Create(context.TODO(), &vpaCRD)
 				if err != nil {
-					if !k8serrors.IsAlreadyExists(err) {
-						return err
-					}
+					return k8serrors.IsAlreadyExists(err)
 				}
-				return nil
-			}).Should(Succeed())
+				return true
+			}).Should(BeTrue())
 
 			// ensure vpa crd is established and accepted on the cluster before continuing
 			Eventually(func() (bool, error) {

--- a/test/e2e/scoped_client_test.go
+++ b/test/e2e/scoped_client_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -61,7 +62,7 @@ var _ = Describe("Scoped Client", func() {
 			// lack of permission.
 			name: "ServiceAccountDoesNotHaveAnyPermission",
 			assertFunc: func(errGot error) {
-				require.True(GinkgoT(), k8serrors.IsForbidden(errGot))
+				Expect(k8serrors.IsForbidden).Should(assertOnk8Error("IsForbidden", errGot))
 			},
 		}),
 		table.Entry("ServiceAccountHasPermission", testParameter{
@@ -73,7 +74,7 @@ var _ = Describe("Scoped Client", func() {
 				return
 			},
 			assertFunc: func(errGot error) {
-				require.True(GinkgoT(), k8serrors.IsNotFound(errGot))
+				Expect(k8serrors.IsNotFound).Should(assertOnk8Error("IsNotFound", errGot))
 			},
 		}),
 	}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR is a result of discussion from [here](https://github.com/operator-framework/operator-lifecycle-manager/pull/1500#discussion_r432150730)

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
