### PR TITLE
Bug 1870367: gracefully handling bad catalog image when polling 

### DIFF
--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -219,7 +219,15 @@ func (c *GrpcRegistryReconciler) ensureUpdatePod(source grpcCatalogSourceDecorat
 	}
 
 	// check if update pod is ready - if not requeue the sync
+	// if update pod failed (potentially due to a bad catalog image) delete it
 	for _, p := range currentUpdatePods {
+		fail, err := c.podFailed(p)
+		if err != nil {
+			return err
+		}
+		if fail {
+			return fmt.Errorf("update pod %s in a %s state: deleted update pod", p.GetName(), p.Status.Phase)
+		}
 		if !podReady(p) {
 			return UpdateNotReadyErr{catalogName: source.GetName(), podName: p.GetName()}
 		}
@@ -358,4 +366,17 @@ func swapLabels(pod *corev1.Pod, labelKey, updateKey string) *corev1.Pod {
 	pod.Labels[CatalogSourceLabelKey] = labelKey
 	pod.Labels[CatalogSourceUpdateKey] = updateKey
 	return pod
+}
+
+// podFailed checks whether the pod status is in a failed or unknown state, and deletes the pod if so.
+func (c *GrpcRegistryReconciler) podFailed(pod *corev1.Pod) (bool, error) {
+	if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodUnknown {
+		logrus.WithField("UpdatePod", pod.GetName()).Info("catalog polling result: update pod %s failed to start", pod.GetName())
+		err := c.removePods([]*corev1.Pod{pod}, pod.GetNamespace())
+		if err != nil {
+			return true, errors.Wrapf(err, "error deleting failed catalog polling pod: %s", pod.GetName())
+		}
+		return true, nil
+	}
+	return false, nil
 }

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -375,11 +375,6 @@ func TestGetPodImageID(t *testing.T) {
 		result      string
 	}{
 		{
-			description: "no pod status: return nothing",
-			pod:         &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{}}},
-			result:      "",
-		},
-		{
 			description: "pod has status: return status",
 			pod:         &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{ImageID: "xyz123"}}}},
 			result:      "xyz123",
@@ -387,7 +382,7 @@ func TestGetPodImageID(t *testing.T) {
 	}
 
 	for i, tt := range table {
-		require.Equal(t, tt.result, getPodImageID(tt.pod), table[i].description)
+		require.Equal(t, tt.result, imageID(tt.pod), table[i].description)
 	}
 }
 
@@ -405,7 +400,7 @@ func TestUpdatePodByDigest(t *testing.T) {
 			result:      false,
 		},
 		{
-			description: "pod image ids do not match:  updated image on the registry: return true",
+			description: "pod image ids do not match: update on the registry: return true",
 			updatePod:   &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{ImageID: "abc456"}}}},
 			servingPods: []*corev1.Pod{{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{ImageID: "xyz123"}}}}},
 			result:      true,
@@ -413,6 +408,6 @@ func TestUpdatePodByDigest(t *testing.T) {
 	}
 
 	for i, tt := range table {
-		require.Equal(t, tt.result, updatePodByDigest(tt.updatePod, tt.servingPods), table[i].description)
+		require.Equal(t, tt.result, imageChanged(tt.updatePod, tt.servingPods), table[i].description)
 	}
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updates to the catalog polling code ensure that only 1 update pod is running on the cluster. When it becomes ready, we check the imageID against the running catalog imageID to see if an update occured.

In the case where a bad catalog source image is pushed, the container would never come up ready, and the check would fail. Since we only allow 1 update pod, this would break the upgrade logic. 

**Motivation for the change:**
A bad catalog image break the updated polling logic by continually requeuing the catalog. 

Dependent on #1723 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
