### PR TITLE
Add skips information to Operator representation

### DIFF
--- a/pkg/controller/registry/resolver/operators.go
+++ b/pkg/controller/registry/resolver/operators.go
@@ -218,6 +218,7 @@ type OperatorSurface interface {
 	Inline() bool
 	Dependencies() []*api.Dependency
 	Properties() []*api.Property
+	Skips() []string
 }
 
 type Operator struct {
@@ -230,6 +231,7 @@ type Operator struct {
 	sourceInfo   *OperatorSourceInfo
 	dependencies []*api.Dependency
 	properties   []*api.Property
+	skips        []string
 }
 
 var _ OperatorSurface = &Operator{}
@@ -307,6 +309,7 @@ func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey reg
 		sourceInfo:   sourceInfo,
 		dependencies: dependencies,
 		properties:   properties,
+		skips:        bundle.Skips,
 	}, nil
 }
 
@@ -370,6 +373,10 @@ func (o *Operator) Identifier() string {
 
 func (o *Operator) Replaces() string {
 	return o.replaces
+}
+
+func (o *Operator) Skips() []string {
+	return o.skips
 }
 
 func (o *Operator) SetReplaces(replacing string) {

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -522,7 +522,7 @@ func (r *SatResolver) sortChannel(bundles []*Operator) ([]*Operator, error) {
 
 	bundleLookup := map[string]*Operator{}
 
-	// if a replacedBy b, then replacedBy[b] = a
+	// if a replaces b, then replacedBy[b] = a
 	replacedBy := map[*Operator]*Operator{}
 	replaces := map[*Operator]*Operator{}
 
@@ -531,12 +531,16 @@ func (r *SatResolver) sortChannel(bundles []*Operator) ([]*Operator, error) {
 	}
 
 	for _, b := range bundles {
-		if b.replaces == "" {
-			continue
+		if b.replaces != "" {
+			if r, ok := bundleLookup[b.replaces]; ok {
+				replacedBy[r] = b
+				replaces[b] = r
+			}
 		}
-		if r, ok := bundleLookup[b.replaces]; ok {
-			replacedBy[r] = b
-			replaces[b] = r
+		for _, skip := range b.skips {
+			if r, ok := bundleLookup[skip]; ok {
+				replacedBy[r] = b
+			}
 		}
 	}
 


### PR DESCRIPTION
Operator object contains only `replaces` but not `skips` information
which leads to an incomplete picture of upgrade graph. Now, the
`skips` information is added to ensure we take skipped versions
into the account for upgrade graph calculation.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
