### PR TITLE
Bug 1877835: update catalog image pull policy

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"testing"
@@ -24,5 +25,52 @@ func TestPodNodeSelector(t *testing.T) {
 	if gotCatSrcPodSelector[key] != value {
 		t.Errorf("expected %s value for node selector key %s, received %s value instead", value, key,
 			gotCatSrcPodSelector[key])
+	}
+}
+
+func TestPullPolicy(t *testing.T) {
+	var table = []struct {
+		image  string
+		policy corev1.PullPolicy
+	}{
+		{
+			image:  "quay.io/operator-framework/olm@sha256:b9d011c0fbfb65b387904f8fafc47ee1a9479d28d395473341288ee126ed993b",
+			policy: corev1.PullIfNotPresent,
+		},
+		{
+			image:  "gcc@sha256:06a6f170d7fff592e44b089c0d2e68d870573eb9a23d9c66d4b6ea11f8fad18b",
+			policy: corev1.PullIfNotPresent,
+		},
+		{
+			image:  "myimage:1.0",
+			policy: corev1.PullAlways,
+		},
+		{
+			image:  "busybox",
+			policy: corev1.PullAlways,
+		},
+		{
+			image:  "gcc@sha256:06a6f170d7fff592e44b089c0d2e68",
+			policy: corev1.PullIfNotPresent,
+		},
+		{
+			image:  "hello@md5:b1946ac92492d2347c6235b4d2611184",
+			policy: corev1.PullIfNotPresent,
+		},
+	}
+
+	source := &v1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-ns",
+		},
+	}
+
+	for _, tt := range table {
+		p := Pod(source, "catalog", tt.image, nil, int32(0), int32(0))
+		policy := p.Spec.Containers[0].ImagePullPolicy
+		if policy != tt.policy {
+			t.Fatalf("expected pull policy %s for image  %s", tt.policy, tt.image)
+		}
 	}
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Set catalog image pull policy to Always when the image is not digest-based

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
