### PR TITLE
Bug 1873030: Make a subscription without at least one candidate fail resolution.

### DIFF
--- a/pkg/controller/registry/resolver/installabletypes.go
+++ b/pkg/controller/registry/resolver/installabletypes.go
@@ -28,6 +28,10 @@ func (i *BundleInstallable) MakeProhibited() {
 	i.constraints = append(i.constraints, solver.Prohibited())
 }
 
+func (i *BundleInstallable) AddConflict(id solver.Identifier) {
+	i.constraints = append(i.constraints, solver.Conflict(id))
+}
+
 func (i *BundleInstallable) AddDependency(dependencies []solver.Identifier) {
 	i.constraints = append(i.constraints, solver.Dependency(dependencies...))
 }
@@ -47,9 +51,13 @@ func (i *BundleInstallable) BundleSourceInfo() (string, string, registry.Catalog
 	return csvName, channel, catalog, nil
 }
 
+func bundleId(bundle, channel string, catalog registry.CatalogKey) solver.Identifier {
+	return solver.Identifier(fmt.Sprintf("%s/%s/%s", catalog.String(), channel, bundle))
+}
+
 func NewBundleInstallable(bundle, channel string, catalog registry.CatalogKey, constraints ...solver.Constraint) BundleInstallable {
 	return BundleInstallable{
-		identifier:  solver.Identifier(fmt.Sprintf("%s/%s/%s", catalog.String(), channel, bundle)),
+		identifier:  bundleId(bundle, channel, catalog),
 		constraints: constraints,
 	}
 }
@@ -75,7 +83,5 @@ func (r SubscriptionInstallable) Constraints() []solver.Constraint {
 }
 
 func (r *SubscriptionInstallable) AddDependency(dependencies []solver.Identifier) {
-	if len(dependencies) > 0 {
-		r.constraints = append(r.constraints, solver.Dependency(dependencies...))
-	}
+	r.constraints = append(r.constraints, solver.Dependency(dependencies...))
 }

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -13,6 +13,7 @@ import (
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
 )
 
 func TestSolveOperators(t *testing.T) {
@@ -225,9 +226,6 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 		"packageC.v1.0.1": genOperator("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
 		"packageD.v1.0.1": genOperator("packageD.v1.0.1", "1.0.1", "packageD.v1.0.0", "packageD", "alpha", "community", "olm", nil, nil, nil, "", false),
 	}
-	for _, o := range operators {
-		t.Logf("%#v", o)
-	}
 	for k := range expected {
 		require.NotNil(t, operators[k])
 		assert.EqualValues(t, k, operators[k].Identifier())
@@ -335,7 +333,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 				},
 				operators: []*Operator{
 					genOperator("packageA.v1", "0.0.1", "packageA.v1", "packageA", "alpha", "community", namespace, nil,
-						nil, opToAddVersionDeps, "",false),
+						nil, opToAddVersionDeps, "", false),
 				},
 			},
 			registry.CatalogKey{
@@ -348,7 +346,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 				},
 				operators: []*Operator{
 					genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
-						namespace, nil, nil, nil, "",false),
+						namespace, nil, nil, nil, "", false),
 				},
 			},
 			registry.CatalogKey{
@@ -362,7 +360,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 				priority: catalogSourcePriority(100),
 				operators: []*Operator{
 					genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "high-priority-operator",
-						namespace, nil, nil, nil, "",false),
+						namespace, nil, nil, nil, "", false),
 				},
 			},
 		},
@@ -377,9 +375,9 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	assert.NoError(t, err)
 	expected := OperatorSet{
 		"packageA.v1": genOperator("packageA.v1", "0.0.1", "packageA.v1", "packageA", "alpha", "community", "olm",
-			nil, nil, opToAddVersionDeps, "",false),
+			nil, nil, opToAddVersionDeps, "", false),
 		"packageB.v1": genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "high-priority-operator", "olm",
-			nil, nil, nil, "",false),
+			nil, nil, nil, "", false),
 	}
 	assert.Equal(t, 2, len(operators))
 	for k, e := range expected {
@@ -398,7 +396,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 		priority: catalogSourcePriority(100),
 		operators: []*Operator{
 			genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
-				namespace, nil, nil, nil, "",false),
+				namespace, nil, nil, nil, "", false),
 		},
 	}
 
@@ -410,9 +408,9 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	assert.NoError(t, err)
 	expected = OperatorSet{
 		"packageA.v1": genOperator("packageA.v1", "0.0.1", "packageA.v1", "packageA", "alpha", "community", "olm",
-			nil, nil, opToAddVersionDeps, "",false),
+			nil, nil, opToAddVersionDeps, "", false),
 		"packageB.v1": genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator", "olm",
-			nil, nil, nil, "",false),
+			nil, nil, nil, "", false),
 	}
 	assert.Equal(t, 2, len(operators))
 	for k, e := range expected {
@@ -430,9 +428,9 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 		},
 		operators: []*Operator{
 			genOperator("packageA.v1", "0.0.1", "packageA.v1", "packageA", "alpha", "community", namespace, nil,
-				nil, opToAddVersionDeps, "",false),
+				nil, opToAddVersionDeps, "", false),
 			genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community",
-				namespace, nil, nil, nil, "",false),
+				namespace, nil, nil, nil, "", false),
 		},
 	}
 
@@ -444,9 +442,9 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	assert.NoError(t, err)
 	expected = OperatorSet{
 		"packageA.v1": genOperator("packageA.v1", "0.0.1", "packageA.v1", "packageA", "alpha", "community", "olm",
-			nil, nil, opToAddVersionDeps, "",false),
+			nil, nil, opToAddVersionDeps, "", false),
 		"packageB.v1": genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community", "olm",
-			nil, nil, nil, "",false),
+			nil, nil, nil, "", false),
 	}
 	assert.Equal(t, 2, len(operators))
 	for k, e := range expected {
@@ -486,7 +484,7 @@ func TestSolveOperators_WithDependencies(t *testing.T) {
 					Name:      "community",
 				},
 				operators: []*Operator{
-					genOperator("packageA.v1.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
@@ -518,13 +516,15 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	community := registry.CatalogKey{"community", namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	csvs := []*v1alpha1.ClusterServiceVersion{csv}
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
-	subs := []*v1alpha1.Subscription{sub, newSub}
+	csvs := []*v1alpha1.ClusterServiceVersion{
+		existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", nil, nil, nil, nil),
+	}
+	subs := []*v1alpha1.Subscription{
+		existingSub(namespace, "packageA.v1", "packageA", "alpha", community),
+		newSub(namespace, "packageB", "alpha", community),
+	}
 
 	deps := []*api.Dependency{
 		{
@@ -535,14 +535,8 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 
 	fakeNamespacedOperatorCache := NamespacedOperatorCache{
 		snapshots: map[registry.CatalogKey]*CatalogSnapshot{
-			registry.CatalogKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				key: registry.CatalogKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
+			community: {
+				key: community,
 				operators: []*Operator{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
@@ -558,12 +552,12 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(operators))
 
 	expected := OperatorSet{
 		"packageB.v1": genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 		"packageC.v1": genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, Provides, nil, "", false),
 	}
+	assert.Equal(t, len(expected), len(operators))
 	for k := range expected {
 		require.NotNil(t, operators[k])
 		assert.EqualValues(t, k, operators[k].Identifier())
@@ -760,17 +754,17 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 }
 
 func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
-	APISet := APISet{opregistry.APIKey{"g", "v", "k", "ks"}: struct{}{}}
-	Provides := APISet
+	const namespace = "olm"
 
-	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
-
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	csvs := []*v1alpha1.ClusterServiceVersion{csv}
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
-	subs := []*v1alpha1.Subscription{sub, newSub}
+	Provides := APISet{opregistry.APIKey{Group: "g", Version: "v", Kind: "k", Plural: "ks"}: struct{}{}}
+	community := registry.CatalogKey{Name: "community", Namespace: namespace}
+	csvs := []*v1alpha1.ClusterServiceVersion{
+		existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil),
+	}
+	subs := []*v1alpha1.Subscription{
+		existingSub(namespace, "packageA.v1", "packageA", "alpha", community),
+		newSub(namespace, "packageB", "alpha", community),
+	}
 
 	opToAddVersionDeps := []*api.Dependency{
 		{
@@ -787,21 +781,15 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 
 	fakeNamespacedOperatorCache := NamespacedOperatorCache{
 		snapshots: map[registry.CatalogKey]*CatalogSnapshot{
-			registry.CatalogKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				key: registry.CatalogKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
+			community: {
+				key: community,
 				operators: []*Operator{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, unsatisfiableVersionDeps, "", false),
 				},
 			},
-			registry.CatalogKey{
+			{
 				Namespace: "olm",
 				Name:      "certified",
 			}: {
@@ -824,12 +812,11 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(operators))
-
 	expected := OperatorSet{
-		"packageB.v1": genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "certified", "olm", nil, nil, opToAddVersionDeps, "", false),
+		"packageB.v1": genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 		"packageC.v1": genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "certified", "olm", nil, nil, nil, "", false),
 	}
+	assert.Equal(t, len(expected), len(operators))
 	for k := range expected {
 		require.NotNil(t, operators[k])
 		assert.EqualValues(t, k, operators[k].Identifier())
@@ -1044,11 +1031,10 @@ func TestSolveOperators_SubscriptionlessOperatorsSatisfyDependencies(t *testing.
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(operators))
 	expected := OperatorSet{
-		"packageA.v1":     stripBundle(genOperator("packageA.v1", "", "", "packageA", "alpha", "@existing", catalog.Namespace, nil, Provides, nil, "", false)),
 		"packageB.v1.0.1": genOperator("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", catalog.Name, catalog.Namespace, Provides, nil, apiSetToDependencies(Provides, nil), "", false),
 	}
+	assert.Equal(t, len(expected), len(operators))
 	for k := range expected {
 		require.NotNil(t, operators[k])
 		assert.EqualValues(t, k, operators[k].Identifier())
@@ -1193,7 +1179,7 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 				},
 			},
 			// nothing new to do here
-			expected: nil,
+			expected: OperatorSet{},
 		},
 		{
 			// will have two existing subs after resolving once
@@ -1207,12 +1193,12 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
 					genOperator("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
 					genOperator("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
-					genOperator("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "stable", false),
+					genOperator("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "packageB", "stable", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "stable", false),
 				},
 			},
 			expected: OperatorSet{
 				"opA.v1.0.1": genOperator("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
-				"opB.v1.0.1": genOperator("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "stable", false),
+				"opB.v1.0.1": genOperator("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "packageB", "stable", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "stable", false),
 			},
 		},
 	}
@@ -1230,19 +1216,22 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 		}
 		csvs := make([]*v1alpha1.ClusterServiceVersion, 0)
 		for _, o := range operators {
-			csvs = append(csvs, existingOperator(namespace, o.Identifier(), o.Bundle().PackageName, o.Bundle().ChannelName, o.Replaces(), o.ProvidedAPIs(), o.RequiredAPIs(), nil, nil))
+			var pkg, channel string
+			if b := o.Bundle(); b != nil {
+				pkg = b.PackageName
+				channel = b.ChannelName
+			}
+			csvs = append(csvs, existingOperator(namespace, o.Identifier(), pkg, channel, o.Replaces(), o.ProvidedAPIs(), o.RequiredAPIs(), nil, nil))
 		}
 
-		o, err := satResolver.SolveOperators([]string{"olm"}, csvs, p.subs)
-		if p.expected != nil {
-			assert.NoError(t, err)
-			operators = o
-		}
+		var err error
+		operators, err = satResolver.SolveOperators([]string{"olm"}, csvs, p.subs)
+		assert.NoError(t, err)
 		for k := range p.expected {
-			require.NotNil(t, o[k])
-			assert.EqualValues(t, k, o[k].Identifier())
+			require.NotNil(t, operators[k])
+			assert.EqualValues(t, k, operators[k].Identifier())
 		}
-		assert.Equal(t, len(p.expected), len(o))
+		assert.Equal(t, len(p.expected), len(operators))
 	}
 }
 
@@ -1301,31 +1290,19 @@ func stripBundle(o *Operator) *Operator {
 }
 
 func TestSolveOperators_WithoutDeprecated(t *testing.T) {
-	APISet := APISet{opregistry.APIKey{"g", "v", "k", "ks"}: struct{}{}}
-	Provides := APISet
-
 	namespace := "olm"
 	catalog := registry.CatalogKey{"community", namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	csvs := []*v1alpha1.ClusterServiceVersion{csv}
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
-	subs := []*v1alpha1.Subscription{sub, newSub}
+	subs := []*v1alpha1.Subscription{
+		newSub(namespace, "packageA", "alpha", catalog),
+	}
 
 	fakeNamespacedOperatorCache := NamespacedOperatorCache{
 		snapshots: map[registry.CatalogKey]*CatalogSnapshot{
-			registry.CatalogKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				key: registry.CatalogKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
+			catalog: {
+				key: catalog,
 				operators: []*Operator{
-					genOperator("packageA.v2", "0.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", true),
-					genOperator("packageB.v1", "1.0.1", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genOperator("packageA.v1", "0.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", true),
 				},
 			},
 		},
@@ -1335,11 +1312,7 @@ func TestSolveOperators_WithoutDeprecated(t *testing.T) {
 		log:   logrus.New(),
 	}
 
-	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
-	assert.NoError(t, err)
-
-	expected := OperatorSet{
-		"packageB.v1": genOperator("packageB.v1", "1.0.1", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
-	}
-	require.EqualValues(t, expected, operators)
+	operators, err := satResolver.SolveOperators([]string{"olm"}, nil, subs)
+	assert.Empty(t, operators)
+	assert.IsType(t, solver.NotSatisfiable{}, err)
 }

--- a/pkg/controller/registry/resolver/step_resolver.go
+++ b/pkg/controller/registry/resolver/step_resolver.go
@@ -74,9 +74,9 @@ func (r *OperatorStepResolver) ResolveSteps(namespace string, _ SourceQuerier) (
 	// TODO: build this index ahead of time
 	// omit copied csvs from generation - they indicate that apis are provided to the namespace, not by the namespace
 	var csvs []*v1alpha1.ClusterServiceVersion
-	for _, c := range allCSVs {
-		if !c.IsCopied() {
-			csvs = append(csvs, c)
+	for i := range allCSVs {
+		if !allCSVs[i].IsCopied() {
+			csvs = append(csvs, allCSVs[i])
 		}
 	}
 


### PR DESCRIPTION
In order to allow subscriptions to be satisfied by an
already-installed CSV, those operators that are already associated
with a subscription are now a part of the resolution constraint
system. As a result, already-installed operators can appear in
resolution output.
