### PR TITLE
Bug 1881584: fix check from previous polling implementation

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -613,8 +613,8 @@ func (o *Operator) syncRegistryServer(logger *logrus.Entry, in *v1alpha1.Catalog
 	if healthy && in.Status.RegistryServiceStatus != nil {
 		logger.Debug("registry state good")
 		continueSync = true
-		// Check if registryService is ready for polling update
-		if !out.Update() {
+		// return here if catalog does not have polling enabled
+		if !out.Poll() {
 			return
 		}
 	}

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -313,7 +313,7 @@ var _ = Describe("Catalog", func() {
 
 		stableChannel := "stable"
 
-		dependentCRD := newCRD( genName("ins-"))
+		dependentCRD := newCRD(genName("ins-"))
 		mainCSV := newCSV(mainPackageStable, testNamespace, "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
 		dependentCSV := newCSV(dependentPackageStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
@@ -556,7 +556,7 @@ var _ = Describe("Catalog", func() {
 
 		// Wait for a new registry pod to be created
 		notUID := func(pods *corev1.PodList) bool {
-			uids := make([]string,0)
+			uids := make([]string, 0)
 			for _, pod := range pods.Items {
 				uids = append(uids, string(pod.GetUID()))
 				if pod.GetUID() == uid {
@@ -620,7 +620,7 @@ var _ = Describe("Catalog", func() {
 
 		// Wait for a new registry pod to be created
 		notUID := func(pods *corev1.PodList) bool {
-			uids := make([]string,0)
+			uids := make([]string, 0)
 			for _, pod := range pods.Items {
 				uids = append(uids, string(pod.GetUID()))
 				if pod.GetUID() == uid {
@@ -983,6 +983,77 @@ var _ = Describe("Catalog", func() {
 		csv, err = fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), "busybox-dependency.v1.0.0", csv.Spec.Replaces)
+	})
+	It("registry polls on the correct interval", func() {
+		// Create a catalog source with polling enabled
+		// Confirm the following
+		//   a) the new update pod is spun up roughly in line with the registry polling interval
+		//   b) the update pod is removed quickly when the image is found to not have changed
+		// This is more of a behavioral test that ensures the feature is working as designed.
+
+		c := newKubeClient()
+		crc := newCRClient()
+
+		sourceName := genName("catalog-")
+		source := &v1alpha1.CatalogSource{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       v1alpha1.CatalogSourceKind,
+				APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sourceName,
+				Namespace: testNamespace,
+				Labels:    map[string]string{"olm.catalogSource": sourceName},
+			},
+			Spec: v1alpha1.CatalogSourceSpec{
+				SourceType: v1alpha1.SourceTypeGrpc,
+				Image:      "quay.io/olmtest/catsrc-update-test:new",
+				UpdateStrategy: &v1alpha1.UpdateStrategy{
+					RegistryPoll: &v1alpha1.RegistryPoll{
+						Interval: &metav1.Duration{Duration: 45 * time.Second},
+					},
+				},
+			},
+		}
+
+		source, err := crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(context.TODO(), source, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		// wait for new catalog source pod to be created and report ready
+		selector := labels.SelectorFromSet(map[string]string{"olm.catalogSource": source.GetName()})
+		singlePod := podCount(1)
+		catalogPods, err := awaitPods(GinkgoT(), c, source.GetNamespace(), selector.String(), singlePod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(catalogPods).ToNot(BeNil())
+
+		Eventually(func() (bool, error) {
+			podList, err := c.KubernetesInterface().CoreV1().Pods(source.GetNamespace()).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+			if err != nil {
+				return false, err
+			}
+
+			for _, p := range podList.Items {
+				if podReady(&p) {
+					return true, nil
+				}
+				return false, nil
+			}
+
+			return false, nil
+		}).Should(BeTrue())
+
+		// Wait roughly the polling interval for update pod to show up
+		updateSelector := labels.SelectorFromSet(map[string]string{"catalogsource.operators.coreos.com/update": source.GetName()})
+		updatePods, err := awaitPodsWithInterval(GinkgoT(), c, source.GetNamespace(), updateSelector.String(), 5*time.Second, 2*time.Minute, singlePod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updatePods).ToNot(BeNil())
+		Expect(updatePods.Items).To(HaveLen(1))
+
+		// No update to image: update pod should be deleted quickly
+		noPod := podCount(0)
+		updatePods, err = awaitPodsWithInterval(GinkgoT(), c, source.GetNamespace(), updateSelector.String(), 1*time.Second, 30*time.Second, noPod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updatePods.Items).To(HaveLen(0))
 	})
 })
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Improvements to the update polling cycle were made in 
* https://bugzilla.redhat.com/show_bug.cgi?id=1866444 
* https://bugzilla.redhat.com/show_bug.cgi?id=1867802

but we still saw a) update pods hanging around and b) short polling intervals not working as expected

This is due to the leftover update check that was in the previous implementation of the polling (before the bugfixes above went in). That code caused the sync to still occur according to the default 15 minute sync cycle. 

Removing that extra check results in the expected behavior: catalogs with short update intervals (for example 1 minute) get deleted/recreated roughly every minute, and only 1 catalog pod is long-lived. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
