### PR TITLE
Bug 1884641: Regenerate downstream InstallPlan CRD manifest.

### DIFF
--- a/manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/manifests/0000_50_olm_00-installplans.crd.yaml
@@ -214,6 +214,9 @@ spec:
                       description: Path refers to the location of a bundle to pull.
                         It's typically an image reference.
                       type: string
+                    properties:
+                      description: The effective properties of the unpacked bundle.
+                      type: string
                     replaces:
                       description: Replaces is the name of the bundle to replace with
                         the one found at Path.


### PR DESCRIPTION
This is necessary for property projection to work downstream.
