### PR TITLE
Updating operator-lifecycle-manager builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 ENV GO111MODULE auto
 ENV GOPATH /go
@@ -23,7 +23,7 @@ COPY go.sum go.sum
 RUN CGO_ENABLED=1 make build
 RUN make build-util
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 ADD manifests/ /manifests
 LABEL io.openshift.release.operator=true


### PR DESCRIPTION
Updating operator-lifecycle-manager builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/operator-lifecycle-manager.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.