### PR TITLE
Specify cluster name when there is only one cluster in kind

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -17,7 +17,15 @@ docker build -f e2e.Dockerfile -t quay.io/operator-framework/olm:local -t quay.i
 docker build -f test/e2e/hang.Dockerfile -t hang:10 ./bin
 
 if [ -n "$KIND" ]; then
-  kind load docker-image quay.io/operator-framework/olm:local
-  kind load docker-image quay.io/operator-framework/olm-e2e:local
-  kind load docker-image hang:10
+  CLUSTERS=($(kind get clusters))
+
+  # kind will use the cluster named kind by default, so if there is only one cluster, specify it
+  if [[ ${#CLUSTERS[@]} == 1 ]]; then
+    KIND_FLAGS="--name ${CLUSTERS[0]}"
+    echo 'Use cluster ${CLUSTERS[0]}'
+  fi
+
+  kind load docker-image quay.io/operator-framework/olm:local ${KIND_FLAGS}
+  kind load docker-image quay.io/operator-framework/olm-e2e:local ${KIND_FLAGS}
+  kind load docker-image hang:10 ${KIND_FLAGS}
 fi


### PR DESCRIPTION
**Description of the change:**
Closes #1827 
Specify the cluster name in kind while running build-local if there is only one cluster. Otherwise it will use the default cluster name "kind".

**Motivation for the change:**
More flexibility to run OLM with kind in local

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
