### PR TITLE
Enable debug messgaes via klog

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -15,6 +16,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/klog"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm"
@@ -81,6 +84,10 @@ func main() {
 	// Get exit signal context
 	ctx, cancel := context.WithCancel(signals.Context())
 	defer cancel()
+
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+
 	pflag.Parse()
 
 	// Parse the command-line flags.
@@ -107,6 +114,8 @@ func main() {
 	logger := logrus.New()
 	if *debug {
 		logger.SetLevel(logrus.DebugLevel)
+		klogVerbosity := klogFlags.Lookup("v")
+		klogVerbosity.Value.Set("99")
 	}
 	logger.Infof("log level %s", logger.Level)
 


### PR DESCRIPTION
**Description of the change:**

At present any libraries using klog do not log debug messages when
the `--debug` flag is set. This change chains klog to `--debug` flag
and enables debugging of all dependencies that use klog, e.g. various
packages under `pkg/lib/operatorclient` and `pkg/lib/kubernetes`.

**Motivation for the change:**

I was faced with a challenge while trying to undetstand what is wrong
with CSV object  that I have setup and I kept getting unsatisfied RBAC
dependencies. I have looked at the code and found the following log
message:

https://github.com/operator-framework/operator-lifecycle-manager/blob/0e65642458a1e44e77bd5509dceee3a41da35b76/pkg/lib/kubernetes/plugin/pkg/auth/authorizer/rbac/rbac.go#L118

However, having looked at how `klog` is initialised, I learnt that the
log level cannot be controlled in any way, so I had to make this
change and I hope it will be useful to others.

**Reviewer Checklist**

- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive