### PR TITLE
Bug 1841175: Recreate pending installplan if deleted before approval

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -831,12 +831,6 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		return err
 	}
 
-	ips, err := o.listInstallPlansMap(namespace)
-	if err != nil {
-		logger.WithError(err).Debug("couldn't list installplan")
-		return err
-	}
-
 	// TODO: parallel
 	maxGeneration := 0
 	subscriptionUpdated := false
@@ -853,7 +847,7 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		}
 
 		// ensure the installplan reference is correct
-		sub, changedIP, err := o.ensureSubscriptionInstallPlanState(logger, sub, ips)
+		sub, changedIP, err := o.ensureSubscriptionInstallPlanState(logger, sub)
 		if err != nil {
 			logger.Debugf("error ensuring installplan state: %v", err)
 			return err
@@ -958,29 +952,9 @@ func (o *Operator) nothingToUpdate(logger *logrus.Entry, sub *v1alpha1.Subscript
 	return false
 }
 
-// checkMissingInstallPlan checks if the installplan is missing or not when
-// the subscription is in pending upgrade state
-func (o *Operator) checkMissingInstallPlan(sub *v1alpha1.Subscription, ips map[string]struct{}) (*v1alpha1.Subscription, bool, error) {
-	_, ok := ips[sub.Status.InstallPlanRef.Name]
-	if !ok && sub.Status.State == v1alpha1.SubscriptionStateUpgradePending {
-		out := sub.DeepCopy()
-		out.Status.InstallPlanRef = nil
-		out.Status.Install = nil
-		out.Status.CurrentCSV = ""
-		out.Status.State = v1alpha1.SubscriptionStateNone
-		out.Status.LastUpdated = o.now()
-		updated, err := o.client.OperatorsV1alpha1().Subscriptions(sub.GetNamespace()).UpdateStatus(context.TODO(), out, metav1.UpdateOptions{})
-		if err != nil {
-			return out, false, nil
-		}
-		return updated, true, nil
-	}
-	return sub, false, nil
-}
-
-func (o *Operator) ensureSubscriptionInstallPlanState(logger *logrus.Entry, sub *v1alpha1.Subscription, ips map[string]struct{}) (*v1alpha1.Subscription, bool, error) {
+func (o *Operator) ensureSubscriptionInstallPlanState(logger *logrus.Entry, sub *v1alpha1.Subscription) (*v1alpha1.Subscription, bool, error) {
 	if sub.Status.InstallPlanRef != nil || sub.Status.Install != nil {
-		return o.checkMissingInstallPlan(sub, ips)
+		return sub, false, nil
 	}
 
 	logger.Debug("checking for existing installplan")
@@ -2041,20 +2015,6 @@ func (o *Operator) listInstallPlans(namespace string) (ips []*v1alpha1.InstallPl
 	ips = make([]*v1alpha1.InstallPlan, 0)
 	for i := range list.Items {
 		ips = append(ips, &list.Items[i])
-	}
-
-	return
-}
-
-func (o *Operator) listInstallPlansMap(namespace string) (ips map[string]struct{}, err error) {
-	list, err := o.client.OperatorsV1alpha1().InstallPlans(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return
-	}
-
-	ips = make(map[string]struct{})
-	for i := range list.Items {
-		ips[list.Items[i].GetName()] = struct{}{}
 	}
 
 	return

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -243,7 +243,12 @@ var _ = Describe("Subscription", func() {
 		require.Equal(GinkgoT(), v1alpha1.ApprovalManual, newInstallPlan.Spec.Approval)
 		require.Equal(GinkgoT(), v1alpha1.InstallPlanPhaseRequiresApproval, newInstallPlan.Status.Phase)
 
-		newInstallPlan.Spec.Approved = true
+		// Set the InstallPlan's approved to True
+		Eventually(Apply(newInstallPlan, func(p *v1alpha1.InstallPlan) error {
+			p.Spec.Approved = true
+			return nil
+		})).Should(Succeed())
+
 		_, err = crc.OperatorsV1alpha1().InstallPlans(testNamespace).Update(context.Background(), newInstallPlan, metav1.UpdateOptions{})
 		require.NoError(GinkgoT(), err)
 

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -217,8 +217,34 @@ var _ = Describe("Subscription", func() {
 		require.Equal(GinkgoT(), v1alpha1.ApprovalManual, installPlan.Spec.Approval)
 		require.Equal(GinkgoT(), v1alpha1.InstallPlanPhaseRequiresApproval, installPlan.Status.Phase)
 
-		installPlan.Spec.Approved = true
-		_, err = crc.OperatorsV1alpha1().InstallPlans(testNamespace).Update(context.Background(), installPlan, metav1.UpdateOptions{})
+		// Delete the current installplan
+		err = crc.OperatorsV1alpha1().InstallPlans(testNamespace).Delete(context.Background(), installPlan.Name, metav1.DeleteOptions{})
+		require.NoError(GinkgoT(), err)
+
+		var ipName string
+		Eventually(func() bool {
+			fetched, err := crc.OperatorsV1alpha1().Subscriptions(testNamespace).Get(context.TODO(), "manual-subscription", metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			if fetched.Status.Install != nil {
+				ipName = fetched.Status.Install.Name
+				return fetched.Status.Install.Name != installPlan.Name
+			}
+			return false
+		}, 5*time.Minute, 10*time.Second).Should(BeTrue())
+
+		// Fetch new installplan
+		newInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, ipName, buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseRequiresApproval))
+		require.NoError(GinkgoT(), err)
+		require.NotNil(GinkgoT(), newInstallPlan)
+
+		require.NotEqual(GinkgoT(), installPlan.Name, newInstallPlan.Name, "expected new installplan recreated")
+		require.Equal(GinkgoT(), v1alpha1.ApprovalManual, newInstallPlan.Spec.Approval)
+		require.Equal(GinkgoT(), v1alpha1.InstallPlanPhaseRequiresApproval, newInstallPlan.Status.Phase)
+
+		newInstallPlan.Spec.Approved = true
+		_, err = crc.OperatorsV1alpha1().InstallPlans(testNamespace).Update(context.Background(), newInstallPlan, metav1.UpdateOptions{})
 		require.NoError(GinkgoT(), err)
 
 		subscription, err = fetchSubscription(crc, testNamespace, "manual-subscription", subscriptionStateAtLatestChecker)


### PR DESCRIPTION
At the moment, OLM will not recreate the pending-approval
installplan. The subscription will be stuck in UpgradePending forever
as a result. This PR will enable installplan recreation if it is deleted
before approval.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
