### PR TITLE
Don't create default ServiceAccounts

### DIFF
--- a/pkg/controller/registry/resolver/step_resolver_test.go
+++ b/pkg/controller/registry/resolver/step_resolver_test.go
@@ -831,6 +831,19 @@ func TestNamespaceResolverRBAC(t *testing.T) {
 		},
 	}
 	bundle := bundleWithPermissions("a.v1", "a", "alpha", "", nil, nil, nil, nil, simplePermissions, simplePermissions)
+	defaultServiceAccountPermissions := []v1alpha1.StrategyDeploymentPermissions{
+		{
+			ServiceAccountName: "default",
+			Rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list"},
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+				},
+			},
+		},
+	}
+	bundleWithDefaultServiceAccount := bundleWithPermissions("a.v1", "a", "alpha", "", nil, nil, nil, nil, defaultServiceAccountPermissions, defaultServiceAccountPermissions)
 	type out struct {
 		steps [][]*v1alpha1.Step
 		subs  []*v1alpha1.Subscription
@@ -851,6 +864,21 @@ func TestNamespaceResolverRBAC(t *testing.T) {
 			out: out{
 				steps: [][]*v1alpha1.Step{
 					bundleSteps(bundle, namespace, "", catalog),
+				},
+				subs: []*v1alpha1.Subscription{
+					updatedSub(namespace, "a.v1", "", "a", "alpha", catalog),
+				},
+			},
+		},
+		{
+			name: "don't create default service accounts",
+			clusterState: []runtime.Object{
+				newSub(namespace, "a", "alpha", catalog),
+			},
+			bundlesInCatalog: []*api.Bundle{bundleWithDefaultServiceAccount},
+			out: out{
+				steps: [][]*v1alpha1.Step{
+					withoutResourceKind("ServiceAccount", bundleSteps(bundleWithDefaultServiceAccount, namespace, "", catalog)),
 				},
 				subs: []*v1alpha1.Subscription{
 					updatedSub(namespace, "a.v1", "", "a", "alpha", catalog),
@@ -1026,6 +1054,18 @@ func bundleSteps(bundle *api.Bundle, ns, replaces string, catalog registry.Catal
 		})
 	}
 	return steps
+}
+
+func withoutResourceKind(kind string, steps []*v1alpha1.Step) []*v1alpha1.Step {
+	filtered := make([]*v1alpha1.Step, 0)
+
+	for i, s := range steps {
+		if s.Resource.Kind != kind {
+			filtered = append(filtered, steps[i])
+		}
+	}
+
+	return filtered
 }
 
 func subSteps(namespace, operatorName, pkgName, channelName string, catalog registry.CatalogKey) []*v1alpha1.Step {

--- a/pkg/controller/registry/resolver/steps.go
+++ b/pkg/controller/registry/resolver/steps.go
@@ -190,11 +190,13 @@ func NewServiceAccountStepResources(csv *v1alpha1.ClusterServiceVersion, catalog
 	}
 
 	for _, perms := range operatorPermissions {
-		step, err := NewStepResourceFromObject(perms.ServiceAccount, catalogSourceName, catalogSourceNamespace)
-		if err != nil {
-			return nil, err
+		if perms.ServiceAccount.Name != "default" {
+			step, err := NewStepResourceFromObject(perms.ServiceAccount, catalogSourceName, catalogSourceNamespace)
+			if err != nil {
+				return nil, err
+			}
+			rbacSteps = append(rbacSteps, step)
 		}
-		rbacSteps = append(rbacSteps, step)
 		for _, role := range perms.Roles {
 			step, err := NewStepResourceFromObject(role, catalogSourceName, catalogSourceNamespace)
 			if err != nil {


### PR DESCRIPTION
**Description of the change:**

Don't create steps to create ServiceAccounts named "default" in install plans.

[According to the k8s docs](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#serviceaccount-controller) the ServiceAccount controller is responsible for creating these.

**Motivation for the change:**

Re-creating the "default" service account may remove privileges or pull secrets granted to it before the operator was installed.

In our case these are pull secrets that are needed for fetching the controller image.

Closes #1752
Closes #1820

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
