### PR TITLE
(chore): add default label to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: If things aren't working as expected.
 title: ''
-labels: ''
+labels: 'kind/bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: OLM Kubernetes Slack Channel
+    url: https://kubernetes.slack.com/archives/C0181L6JYQ2
+    about: Join the "#olm-dev" channel on the kubernetes slack - it's a good place to ask OLM-related questions!
+  - name: OLM Working Group Meeting
+    url: https://docs.google.com/document/d/1Zuv-BoNFSwj10_zXPfaS9LWUQUCak2c8l48d0-AhpBw/edit?usp=sharing
+    about: The OLM working group meeting is a great place to bring up feature requests and broader community topics. 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest a feature
 title: ''
-labels: ''
+labels: 'kind/feature'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -2,7 +2,7 @@
 name: Support Question
 about: Any support questions you might have.
 title: ''
-labels: ''
+labels: 'kind/support'
 assignees: ''
 
 ---


### PR DESCRIPTION
Adds label to default issues templates and some better contact information for users. 

Note: Also sets `blank_issues_enabled: false` which will require upstream users to use a template when filing an issue. 

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
