### PR TITLE
Bug 1899835: fix(catalog): be defensive about directly indexing catalog pods

### DIFF
--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -6,13 +6,6 @@ import (
 	"hash/fnv"
 	"time"
 
-	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
-
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -20,6 +13,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
+	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 )
 
 const (
@@ -349,9 +349,14 @@ func imageChanged(updatePod *corev1.Pod, servingPods []*corev1.Pod) bool {
 	return false
 }
 
-// imageID returns the ImageID of the primary catalog source container.
+// imageID returns the ImageID of the primary catalog source container or an empty string if the image ID isn't available yet.
 // Note: the pod must be running and the container in a ready status to return a valid ImageID.
 func imageID(pod *corev1.Pod) string {
+	if len(pod.Status.ContainerStatuses) < 1 {
+		logrus.WithField("CatalogSource", pod.GetName()).Warn("pod status unknown")
+		return ""
+	}
+
 	return pod.Status.ContainerStatuses[0].ImageID
 }
 

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -397,6 +397,19 @@ func TestGetPodImageID(t *testing.T) {
 			pod:         &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{ImageID: "xyz123"}}}},
 			result:      "xyz123",
 		},
+		{
+			description: "pod has two containers: return first",
+			pod: &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{ImageID: "xyz123"},
+				{ImageID: "abc456"},
+			}}},
+			result: "xyz123",
+		},
+		{
+			description: "pod has no status",
+			pod:         &corev1.Pod{Status: corev1.PodStatus{}},
+			result:      "",
+		},
 	}
 
 	for i, tt := range table {


### PR DESCRIPTION
Prevent index out of bound panic(s) when directly indexing catalog pod status.

