### PR TITLE
Bug 1857877: check the service account owner in the requirement

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -432,7 +432,7 @@ func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersi
 			strategyDetailsDeployment.ClusterPermissions = append(strategyDetailsDeployment.ClusterPermissions, p)
 		}
 		strategyDetailsDeployment.Permissions = nil
-		permMet, _, err := a.permissionStatus(strategyDetailsDeployment, ruleChecker, corev1.NamespaceAll, csv.GetNamespace())
+		permMet, _, err := a.permissionStatus(strategyDetailsDeployment, ruleChecker, corev1.NamespaceAll, csv)
 		if err != nil {
 			return err
 		}
@@ -669,7 +669,7 @@ func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, o
 	}
 	for _, ns := range targetNamespaces {
 		// create roles/rolebindings for each target namespace
-		permMet, _, err := a.permissionStatus(strategyDetailsDeployment, ruleChecker, ns, csv.GetNamespace())
+		permMet, _, err := a.permissionStatus(strategyDetailsDeployment, ruleChecker, ns, csv)
 		if err != nil {
 			logger.WithError(err).Debug("permission status")
 			return err

--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -273,7 +273,7 @@ func (a *Operator) permissionStatus(strategyDetailsDeployment *v1alpha1.Strategy
 			}
 
 			// Check if the ServiceAccount is owned by CSV
-			if !ownerutil.IsOwnedBy(sa, csv) {
+			if len(sa.GetOwnerReferences()) != 0 && !ownerutil.IsOwnedBy(sa, csv) {
 				met = false
 				status.Status = v1alpha1.RequirementStatusReasonPresentNotSatisfied
 				status.Message = "Service account is not owned by this ClusterServiceVersion"

--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/coreos/go-semver/semver"
+	"github.com/sirupsen/logrus"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	olmErrors "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 )
 

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -1399,7 +1399,7 @@ var _ = Describe("Operator Group", func() {
 				Name: role.GetName(),
 			},
 		}
-		createdServiceAccount, err := c.CreateServiceAccount(serviceAccount)
+		_, err = c.CreateServiceAccount(serviceAccount)
 		require.NoError(GinkgoT(), err)
 		defer func() {
 			c.DeleteServiceAccount(serviceAccount.GetNamespace(), serviceAccount.GetName(), metav1.NewDeleteOptions(0))
@@ -1423,12 +1423,6 @@ var _ = Describe("Operator Group", func() {
 		// Use the It spec name as label after stripping whitespaces
 		aCSV.Labels = map[string]string{"label": strings.Replace(CurrentGinkgoTestDescription().TestText, " ", "", -1)}
 		createdCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Create(context.TODO(), &aCSV, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
-
-		ownerutil.AddNonBlockingOwner(createdServiceAccount, createdCSV)
-		err = ownerutil.AddOwnerLabels(createdServiceAccount, createdCSV)
-		require.NoError(GinkgoT(), err)
-		_, err = c.UpdateServiceAccount(createdServiceAccount)
 		require.NoError(GinkgoT(), err)
 
 		err = ownerutil.AddOwnerLabels(createdRole, createdCSV)

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -1399,7 +1399,7 @@ var _ = Describe("Operator Group", func() {
 				Name: role.GetName(),
 			},
 		}
-		_, err = c.CreateServiceAccount(serviceAccount)
+		createdServiceAccount, err := c.CreateServiceAccount(serviceAccount)
 		require.NoError(GinkgoT(), err)
 		defer func() {
 			c.DeleteServiceAccount(serviceAccount.GetNamespace(), serviceAccount.GetName(), metav1.NewDeleteOptions(0))
@@ -1423,6 +1423,12 @@ var _ = Describe("Operator Group", func() {
 		// Use the It spec name as label after stripping whitespaces
 		aCSV.Labels = map[string]string{"label": strings.Replace(CurrentGinkgoTestDescription().TestText, " ", "", -1)}
 		createdCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Create(context.TODO(), &aCSV, metav1.CreateOptions{})
+		require.NoError(GinkgoT(), err)
+
+		ownerutil.AddNonBlockingOwner(createdServiceAccount, createdCSV)
+		err = ownerutil.AddOwnerLabels(createdServiceAccount, createdCSV)
+		require.NoError(GinkgoT(), err)
+		_, err = c.UpdateServiceAccount(createdServiceAccount)
 		require.NoError(GinkgoT(), err)
 
 		err = ownerutil.AddOwnerLabels(createdRole, createdCSV)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This PR is to check the owner of the service account when OLM controller checks the requirements

Closes #1879 
**Motivation for the change:**

This PR is for fixing this issue https://github.com/operator-framework/operator-lifecycle-manager/issues/1879.

This can help to avoid the issue that during the upgrade, the service account is deleted together with the old CSV.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
