### PR TITLE
add e2e environment information into DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,6 +11,16 @@
 [Docker for Mac]: https://store.docker.com/editions/community/docker-ce-desktop-mac
 [kubebuilder docs]: https://book.kubebuilder.io/quick-start.html#installation
 
+#### E2E test environments
+
+| Requirement | install docs         |
+|-------------|----------------------|
+| Minikube    | [Minikube docs]      |
+| Kind        | [Kind docs]          |
+
+[Minikube docs]: https://minikube.sigs.k8s.io/docs/start
+[Kind docs]: https://kind.sigs.k8s.io/docs/user/quick-start
+
 ### Usage
 
 #### Testing
@@ -27,6 +37,8 @@ To run the e2e tests locally:
 ```sh
 $ make e2e-local
 ```
+
+**NOTE:** Command `make e2e-local` supports Minikube and Kind environments. If you want to run the e2e tests on Minikube, you need to make sure Minikube is deployed in the local environment. If you want to run the e2e tests on Kind, you need to make sure Kind is deployed in the local environment and switch the kubeconfig to an existing Kind cluster.
 
 To run a specific e2e test locally:
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -9,6 +9,6 @@ This runs a series of tests against the Kubernetes API to verify that OLM is fun
 
 ## How to use
 
-`make e2e-local` in the root of the repository will fetch golang dependencies, start Minikube, build the appropriate images and run the tests in a fresh namespace each time.
+`make e2e-local` in the root of the repository will fetch golang dependencies, start Minikube or using an existing Kind environment, build the appropriate images and run the tests in a fresh namespace each time.
 
 Subsequent runs of the test suite do not need to go through the full setup process. Running individual tests (or the whole suite) can be accomplished by running `./test/e2e/run_e2e_local.sh [TestName]` with an optional test name.


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This PR adds Minikube and Kind to development requirements since it's needed for running e2e tests.

**Motivation for the change:**

When I follow the development document to run the e2e tests, I found Minikube or an existing Kind cluster is required.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
