### PR TITLE
Add OLM support for the Upgradeable OperatorCondition and Admin overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/operator-framework/api v0.3.23
+	github.com/operator-framework/api v0.3.25
 	github.com/operator-framework/operator-registry v1.13.6
 	github.com/otiai10/copy v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
-github.com/operator-framework/api v0.3.23 h1:+QiJ0m5SjfV+iMv8uzuGac+PoJFlTaMFIN8eVccUnoY=
-github.com/operator-framework/api v0.3.23/go.mod h1:GVNiB6AQucwdZz3ZFXNv9HtcLOzcFnr6O/QldzKG93g=
+github.com/operator-framework/api v0.3.25 h1:d6WgHCshCffT37okVZeL+IbGlhrsHy57xdfMnopC8rI=
+github.com/operator-framework/api v0.3.25/go.mod h1:GVNiB6AQucwdZz3ZFXNv9HtcLOzcFnr6O/QldzKG93g=
 github.com/operator-framework/operator-registry v1.13.6 h1:h/dIjQQS7uneQNRifrSz7h0xg4Xyjg6C9f6XZofbMPg=
 github.com/operator-framework/operator-registry v1.13.6/go.mod h1:YhnIzOVjRU2ZwZtzt+fjcjW8ujJaSFynBEu7QVKaSdU=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/pkg/controller/operators/olm/operatorconditions.go
+++ b/pkg/controller/operators/olm/operatorconditions.go
@@ -1,0 +1,45 @@
+package olm
+
+import (
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+func (a *Operator) isOperatorUpgradeable(csv *v1alpha1.ClusterServiceVersion) (bool, error) {
+	if csv == nil {
+		return false, fmt.Errorf("CSV is invalid")
+	}
+
+	cond, err := a.lister.OperatorsV1().OperatorConditionLister().OperatorConditions(csv.GetNamespace()).Get(csv.GetName())
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	// Check condition overrides
+	for _, override := range cond.Spec.Overrides {
+		if override.Type == operatorsv1.OperatorUpgradeable {
+			if override.Status == metav1.ConditionTrue {
+				return true, nil
+			}
+			return false, fmt.Errorf("The operator is not upgradeable: %s", override.Message)
+		}
+	}
+
+	// Check for OperatorUpgradeable condition status
+	if c := meta.FindStatusCondition(cond.Status.Conditions, operatorsv1.OperatorUpgradeable); c != nil {
+		if c.Status == metav1.ConditionFalse {
+			return false, fmt.Errorf("The operator is not upgradeable: %s", c.Message)
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/lib/operatorlister/lister.go
+++ b/pkg/lib/operatorlister/lister.go
@@ -102,8 +102,10 @@ type OperatorsV1alpha1Lister interface {
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . OperatorsV1Lister
 type OperatorsV1Lister interface {
 	RegisterOperatorGroupLister(namespace string, lister v1.OperatorGroupLister)
+	RegisterOperatorConditionLister(namespace string, lister v1.OperatorConditionLister)
 
 	OperatorGroupLister() v1.OperatorGroupLister
+	OperatorConditionLister() v1.OperatorConditionLister
 }
 
 type appsV1Lister struct {
@@ -189,12 +191,14 @@ func newOperatorsV1alpha1Lister() *operatorsV1alpha1Lister {
 }
 
 type operatorsV1Lister struct {
-	operatorGroupLister *UnionOperatorGroupLister
+	operatorGroupLister     *UnionOperatorGroupLister
+	operatorConditionLister *UnionOperatorConditionLister
 }
 
 func newOperatorsV1Lister() *operatorsV1Lister {
 	return &operatorsV1Lister{
-		operatorGroupLister: &UnionOperatorGroupLister{},
+		operatorGroupLister:     &UnionOperatorGroupLister{},
+		operatorConditionLister: &UnionOperatorConditionLister{},
 	}
 }
 

--- a/pkg/lib/operatorlister/operatorcondition.go
+++ b/pkg/lib/operatorlister/operatorcondition.go
@@ -1,0 +1,96 @@
+package operatorlister
+
+import (
+	"fmt"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1"
+)
+
+type UnionOperatorConditionLister struct {
+	opConditionListers map[string]listers.OperatorConditionLister
+	opConditionLock    sync.RWMutex
+}
+
+// List lists all OperatorConditions in the indexer.
+func (uol *UnionOperatorConditionLister) List(selector labels.Selector) (ret []*v1.OperatorCondition, err error) {
+	uol.opConditionLock.RLock()
+	defer uol.opConditionLock.RUnlock()
+
+	set := make(map[types.UID]*v1.OperatorCondition)
+	for _, cl := range uol.opConditionListers {
+		csvs, err := cl.List(selector)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, csv := range csvs {
+			set[csv.GetUID()] = csv
+		}
+	}
+
+	for _, csv := range set {
+		ret = append(ret, csv)
+	}
+
+	return
+}
+
+// OperatorConditions returns an object that can list and get OperatorConditions.
+func (uol *UnionOperatorConditionLister) OperatorConditions(namespace string) listers.OperatorConditionNamespaceLister {
+	uol.opConditionLock.RLock()
+	defer uol.opConditionLock.RUnlock()
+
+	// Check for specific namespace listers
+	if cl, ok := uol.opConditionListers[namespace]; ok {
+		return cl.OperatorConditions(namespace)
+	}
+
+	// Check for any namespace-all listers
+	if cl, ok := uol.opConditionListers[metav1.NamespaceAll]; ok {
+		return cl.OperatorConditions(namespace)
+	}
+
+	return &NullOperatorConditionNamespaceLister{}
+}
+
+func (uol *UnionOperatorConditionLister) RegisterOperatorConditionLister(namespace string, lister listers.OperatorConditionLister) {
+	uol.opConditionLock.Lock()
+	defer uol.opConditionLock.Unlock()
+
+	if uol.opConditionListers == nil {
+		uol.opConditionListers = make(map[string]listers.OperatorConditionLister)
+	}
+
+	uol.opConditionListers[namespace] = lister
+}
+
+func (l *operatorsV1Lister) RegisterOperatorConditionLister(namespace string, lister listers.OperatorConditionLister) {
+	l.operatorConditionLister.RegisterOperatorConditionLister(namespace, lister)
+}
+
+func (l *operatorsV1Lister) OperatorConditionLister() listers.OperatorConditionLister {
+	return l.operatorConditionLister
+}
+
+// NullOperatorConditionNamespaceLister is an implementation of a null OperatorConditionNamespaceLister. It is
+// used to prevent nil pointers when no OperatorConditionNamespaceLister has been registered for a given
+// namespace.
+type NullOperatorConditionNamespaceLister struct {
+	listers.OperatorConditionNamespaceLister
+}
+
+// List returns nil and an error explaining that this is a NullOperatorConditionNamespaceLister.
+func (n *NullOperatorConditionNamespaceLister) List(selector labels.Selector) (ret []*v1.OperatorCondition, err error) {
+	return nil, fmt.Errorf("cannot list OperatorConditions with a NullOperatorConditionNamespaceLister")
+}
+
+// Get returns nil and an error explaining that this is a NullOperatorConditionNamespaceLister.
+func (n *NullOperatorConditionNamespaceLister) Get(name string) (*v1.OperatorCondition, error) {
+	return nil, fmt.Errorf("cannot get OperatorCondition with a NullOperatorConditionNamespaceLister")
+}

--- a/pkg/lib/operatorlister/operatorlisterfakes/fake_operators_v1lister.go
+++ b/pkg/lib/operatorlister/operatorlisterfakes/fake_operators_v1lister.go
@@ -9,6 +9,16 @@ import (
 )
 
 type FakeOperatorsV1Lister struct {
+	OperatorConditionListerStub        func() v1.OperatorConditionLister
+	operatorConditionListerMutex       sync.RWMutex
+	operatorConditionListerArgsForCall []struct {
+	}
+	operatorConditionListerReturns struct {
+		result1 v1.OperatorConditionLister
+	}
+	operatorConditionListerReturnsOnCall map[int]struct {
+		result1 v1.OperatorConditionLister
+	}
 	OperatorGroupListerStub        func() v1.OperatorGroupLister
 	operatorGroupListerMutex       sync.RWMutex
 	operatorGroupListerArgsForCall []struct {
@@ -19,6 +29,12 @@ type FakeOperatorsV1Lister struct {
 	operatorGroupListerReturnsOnCall map[int]struct {
 		result1 v1.OperatorGroupLister
 	}
+	RegisterOperatorConditionListerStub        func(string, v1.OperatorConditionLister)
+	registerOperatorConditionListerMutex       sync.RWMutex
+	registerOperatorConditionListerArgsForCall []struct {
+		arg1 string
+		arg2 v1.OperatorConditionLister
+	}
 	RegisterOperatorGroupListerStub        func(string, v1.OperatorGroupLister)
 	registerOperatorGroupListerMutex       sync.RWMutex
 	registerOperatorGroupListerArgsForCall []struct {
@@ -27,6 +43,58 @@ type FakeOperatorsV1Lister struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeOperatorsV1Lister) OperatorConditionLister() v1.OperatorConditionLister {
+	fake.operatorConditionListerMutex.Lock()
+	ret, specificReturn := fake.operatorConditionListerReturnsOnCall[len(fake.operatorConditionListerArgsForCall)]
+	fake.operatorConditionListerArgsForCall = append(fake.operatorConditionListerArgsForCall, struct {
+	}{})
+	fake.recordInvocation("OperatorConditionLister", []interface{}{})
+	fake.operatorConditionListerMutex.Unlock()
+	if fake.OperatorConditionListerStub != nil {
+		return fake.OperatorConditionListerStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.operatorConditionListerReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeOperatorsV1Lister) OperatorConditionListerCallCount() int {
+	fake.operatorConditionListerMutex.RLock()
+	defer fake.operatorConditionListerMutex.RUnlock()
+	return len(fake.operatorConditionListerArgsForCall)
+}
+
+func (fake *FakeOperatorsV1Lister) OperatorConditionListerCalls(stub func() v1.OperatorConditionLister) {
+	fake.operatorConditionListerMutex.Lock()
+	defer fake.operatorConditionListerMutex.Unlock()
+	fake.OperatorConditionListerStub = stub
+}
+
+func (fake *FakeOperatorsV1Lister) OperatorConditionListerReturns(result1 v1.OperatorConditionLister) {
+	fake.operatorConditionListerMutex.Lock()
+	defer fake.operatorConditionListerMutex.Unlock()
+	fake.OperatorConditionListerStub = nil
+	fake.operatorConditionListerReturns = struct {
+		result1 v1.OperatorConditionLister
+	}{result1}
+}
+
+func (fake *FakeOperatorsV1Lister) OperatorConditionListerReturnsOnCall(i int, result1 v1.OperatorConditionLister) {
+	fake.operatorConditionListerMutex.Lock()
+	defer fake.operatorConditionListerMutex.Unlock()
+	fake.OperatorConditionListerStub = nil
+	if fake.operatorConditionListerReturnsOnCall == nil {
+		fake.operatorConditionListerReturnsOnCall = make(map[int]struct {
+			result1 v1.OperatorConditionLister
+		})
+	}
+	fake.operatorConditionListerReturnsOnCall[i] = struct {
+		result1 v1.OperatorConditionLister
+	}{result1}
 }
 
 func (fake *FakeOperatorsV1Lister) OperatorGroupLister() v1.OperatorGroupLister {
@@ -81,6 +149,38 @@ func (fake *FakeOperatorsV1Lister) OperatorGroupListerReturnsOnCall(i int, resul
 	}{result1}
 }
 
+func (fake *FakeOperatorsV1Lister) RegisterOperatorConditionLister(arg1 string, arg2 v1.OperatorConditionLister) {
+	fake.registerOperatorConditionListerMutex.Lock()
+	fake.registerOperatorConditionListerArgsForCall = append(fake.registerOperatorConditionListerArgsForCall, struct {
+		arg1 string
+		arg2 v1.OperatorConditionLister
+	}{arg1, arg2})
+	fake.recordInvocation("RegisterOperatorConditionLister", []interface{}{arg1, arg2})
+	fake.registerOperatorConditionListerMutex.Unlock()
+	if fake.RegisterOperatorConditionListerStub != nil {
+		fake.RegisterOperatorConditionListerStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeOperatorsV1Lister) RegisterOperatorConditionListerCallCount() int {
+	fake.registerOperatorConditionListerMutex.RLock()
+	defer fake.registerOperatorConditionListerMutex.RUnlock()
+	return len(fake.registerOperatorConditionListerArgsForCall)
+}
+
+func (fake *FakeOperatorsV1Lister) RegisterOperatorConditionListerCalls(stub func(string, v1.OperatorConditionLister)) {
+	fake.registerOperatorConditionListerMutex.Lock()
+	defer fake.registerOperatorConditionListerMutex.Unlock()
+	fake.RegisterOperatorConditionListerStub = stub
+}
+
+func (fake *FakeOperatorsV1Lister) RegisterOperatorConditionListerArgsForCall(i int) (string, v1.OperatorConditionLister) {
+	fake.registerOperatorConditionListerMutex.RLock()
+	defer fake.registerOperatorConditionListerMutex.RUnlock()
+	argsForCall := fake.registerOperatorConditionListerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
 func (fake *FakeOperatorsV1Lister) RegisterOperatorGroupLister(arg1 string, arg2 v1.OperatorGroupLister) {
 	fake.registerOperatorGroupListerMutex.Lock()
 	fake.registerOperatorGroupListerArgsForCall = append(fake.registerOperatorGroupListerArgsForCall, struct {
@@ -116,8 +216,12 @@ func (fake *FakeOperatorsV1Lister) RegisterOperatorGroupListerArgsForCall(i int)
 func (fake *FakeOperatorsV1Lister) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.operatorConditionListerMutex.RLock()
+	defer fake.operatorConditionListerMutex.RUnlock()
 	fake.operatorGroupListerMutex.RLock()
 	defer fake.operatorGroupListerMutex.RUnlock()
+	fake.registerOperatorConditionListerMutex.RLock()
+	defer fake.registerOperatorConditionListerMutex.RUnlock()
 	fake.registerOperatorGroupListerMutex.RLock()
 	defer fake.registerOperatorGroupListerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/test/e2e/operator_condition_e2e_test.go
+++ b/test/e2e/operator_condition_e2e_test.go
@@ -1,0 +1,246 @@
+package e2e
+
+import (
+	"context"
+
+	"github.com/blang/semver"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+)
+
+var _ = Describe("Operator Condition", func() {
+	AfterEach(func() {
+		TearDown(testNamespace)
+	})
+
+	It("OperatorUpgradeable condition and overrides", func() {
+		By("This test proves that an operator can upgrade successfully when" +
+			"OperatorUpgrade condition is set in OperatorCondition CR. Plus, an operator" +
+			"chooses not to use OperatorCondition, the upgrade process will proceed as" +
+			" asexpected. The overrides specification in OperatorCondition can be used to" +
+			" override the status condition. The overrides spec will remain in place until" +
+			"they are unset.")
+		c := newKubeClient()
+		crc := newCRClient()
+
+		// Create a catalog for csvA, csvB, and csvD
+		pkgA := genName("a-")
+		pkgB := genName("b-")
+		pkgD := genName("d-")
+		pkgAStable := pkgA + "-stable"
+		pkgBStable := pkgB + "-stable"
+		pkgDStable := pkgD + "-stable"
+		stableChannel := "stable"
+		strategyA := newNginxInstallStrategy(pkgAStable, nil, nil)
+		strategyB := newNginxInstallStrategy(pkgBStable, nil, nil)
+		strategyD := newNginxInstallStrategy(pkgDStable, nil, nil)
+		crd := newCRD(genName(pkgA))
+		csvA := newCSV(pkgAStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyA)
+		csvB := newCSV(pkgBStable, testNamespace, pkgAStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyB)
+		csvD := newCSV(pkgDStable, testNamespace, pkgBStable, semver.MustParse("0.3.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyD)
+
+		// Create OperatorCondition for csvA
+		opCondition := operatorsv1.OperatorCondition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pkgAStable,
+				Namespace: testNamespace,
+			},
+		}
+		_, err := crc.OperatorsV1().OperatorConditions(testNamespace).Create(context.TODO(), &opCondition, metav1.CreateOptions{})
+		require.NoError(GinkgoT(), err)
+		// Create OperatorCondition for csvB
+		opCondition = operatorsv1.OperatorCondition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pkgBStable,
+				Namespace: testNamespace,
+			},
+		}
+		_, err = crc.OperatorsV1().OperatorConditions(testNamespace).Create(context.TODO(), &opCondition, metav1.CreateOptions{})
+		require.NoError(GinkgoT(), err)
+
+		// Create the initial catalogsources
+		manifests := []registry.PackageManifest{
+			{
+				PackageName: pkgA,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: pkgAStable},
+				},
+				DefaultChannelName: stableChannel,
+			},
+		}
+
+		catalog := genName("catalog-")
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalog, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA})
+		defer cleanupCatalogSource()
+		_, err = fetchCatalogSourceOnStatus(crc, catalog, testNamespace, catalogSourceRegistryPodSynced)
+		subName := genName("sub-")
+		cleanupSub := createSubscriptionForCatalog(crc, testNamespace, subName, catalog, pkgA, stableChannel, pkgAStable, operatorsv1alpha1.ApprovalAutomatic)
+		defer cleanupSub()
+
+		// Await csvA's success
+		_, err = awaitCSV(crc, testNamespace, csvA.GetName(), csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+
+		// Get OperatorCondition for csvA
+		var cond *operatorsv1.OperatorCondition
+		Eventually(func() (bool, error) {
+			cond, err = crc.OperatorsV1().OperatorConditions(testNamespace).Get(context.TODO(), csvA.GetName(), metav1.GetOptions{})
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		}, pollInterval, pollDuration).Should(BeTrue())
+		require.NoError(GinkgoT(), err)
+
+		// Set upgradeable condition to false
+		newCond := metav1.Condition{
+			Type:               operatorsv1.OperatorUpgradeable,
+			Status:             metav1.ConditionFalse,
+			Reason:             "test",
+			Message:            "test",
+			LastTransitionTime: metav1.Now(),
+		}
+
+		meta.SetStatusCondition(&cond.Status.Conditions, newCond)
+		_, err = crc.OperatorsV1().OperatorConditions(testNamespace).UpdateStatus(context.TODO(), cond, metav1.UpdateOptions{})
+		require.NoError(GinkgoT(), err)
+
+		// Update the catalogsources
+		manifests = []registry.PackageManifest{
+			{
+				PackageName: pkgA,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: pkgBStable},
+				},
+				DefaultChannelName: stableChannel,
+			},
+		}
+
+		updateInternalCatalog(GinkgoT(), c, crc, catalog, testNamespace, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB}, manifests)
+		// Attempt to get the catalog source before creating install plan(s)
+		_, err = fetchCatalogSourceOnStatus(crc, catalog, testNamespace, catalogSourceRegistryPodSynced)
+		require.NoError(GinkgoT(), err)
+		// csvB will be in Pending phase due to csvA reports Upgradeable=False condition
+		fetchedCSV, err := fetchCSV(crc, csvB.GetName(), testNamespace, buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
+		require.NoError(GinkgoT(), err)
+		require.Equal(GinkgoT(), fetchedCSV.Status.Phase, operatorsv1alpha1.CSVPhasePending)
+
+		// Get OperatorCondition for csvA
+		Eventually(func() (bool, error) {
+			cond, err = crc.OperatorsV1().OperatorConditions(testNamespace).Get(context.TODO(), csvA.GetName(), metav1.GetOptions{})
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		}, pollInterval, pollDuration).Should(BeTrue())
+		require.NoError(GinkgoT(), err)
+
+		// Switch upgradeable condition to true
+		newCond = metav1.Condition{
+			Type:               operatorsv1.OperatorUpgradeable,
+			Status:             metav1.ConditionTrue,
+			Reason:             "test",
+			Message:            "test",
+			LastTransitionTime: metav1.Now(),
+		}
+
+		meta.SetStatusCondition(&cond.Status.Conditions, newCond)
+		_, err = crc.OperatorsV1().OperatorConditions(testNamespace).UpdateStatus(context.TODO(), cond, metav1.UpdateOptions{})
+		require.NoError(GinkgoT(), err)
+
+		// Await csvB's success
+		_, err = awaitCSV(crc, testNamespace, csvB.GetName(), csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+
+		// Get OperatorCondition for csvB
+		Eventually(func() (bool, error) {
+			cond, err = crc.OperatorsV1().OperatorConditions(testNamespace).Get(context.TODO(), csvB.GetName(), metav1.GetOptions{})
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		}, pollInterval, pollDuration).Should(BeTrue())
+		require.NoError(GinkgoT(), err)
+		// Add Condition overrides
+		cond.Spec = operatorsv1.OperatorConditionSpec{
+			Overrides: []metav1.Condition{{
+				Type:               operatorsv1.OperatorUpgradeable,
+				Status:             metav1.ConditionFalse,
+				Reason:             "test",
+				Message:            "test",
+				LastTransitionTime: metav1.Now(),
+			}},
+		}
+
+		_, err = crc.OperatorsV1().OperatorConditions(testNamespace).Update(context.TODO(), cond, metav1.UpdateOptions{})
+		require.NoError(GinkgoT(), err)
+
+		// Update the catalogsources
+		manifests = []registry.PackageManifest{
+			{
+				PackageName: pkgA,
+				Channels: []registry.PackageChannel{
+					{Name: stableChannel, CurrentCSVName: pkgDStable},
+				},
+				DefaultChannelName: stableChannel,
+			},
+		}
+
+		updateInternalCatalog(GinkgoT(), c, crc, catalog, testNamespace, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB, csvD}, manifests)
+		// Attempt to get the catalog source before creating install plan(s)
+		_, err = fetchCatalogSourceOnStatus(crc, catalog, testNamespace, catalogSourceRegistryPodSynced)
+		require.NoError(GinkgoT(), err)
+
+		// CSVD will be in Pending status due to overrides in csvB's condition
+		fetchedCSV, err = fetchCSV(crc, csvD.GetName(), testNamespace, buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
+		require.NoError(GinkgoT(), err)
+		require.Equal(GinkgoT(), fetchedCSV.Status.Phase, operatorsv1alpha1.CSVPhasePending)
+
+		// Get OperatorCondition for csvB
+		Eventually(func() (bool, error) {
+			cond, err = crc.OperatorsV1().OperatorConditions(testNamespace).Get(context.TODO(), csvB.GetName(), metav1.GetOptions{})
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		}, pollInterval, pollDuration).Should(BeTrue())
+		require.NoError(GinkgoT(), err)
+		// Set Condition overrides to True
+		cond.Spec = operatorsv1.OperatorConditionSpec{
+			Overrides: []metav1.Condition{{
+				Type:               operatorsv1.OperatorUpgradeable,
+				Status:             metav1.ConditionTrue,
+				Reason:             "test",
+				Message:            "test",
+				LastTransitionTime: metav1.Now(),
+			}},
+		}
+
+		_, err = crc.OperatorsV1().OperatorConditions(testNamespace).Update(context.TODO(), cond, metav1.UpdateOptions{})
+		require.NoError(GinkgoT(), err)
+		_, err = awaitCSV(crc, testNamespace, csvD.GetName(), csvSucceededChecker)
+		require.NoError(GinkgoT(), err)
+	})
+})

--- a/vendor/github.com/operator-framework/api/pkg/operators/v1/operatorcondition_types.go
+++ b/vendor/github.com/operator-framework/api/pkg/operators/v1/operatorcondition_types.go
@@ -4,6 +4,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// OperatorUpgradeable indicates that the operator is upgradeable
+	OperatorUpgradeable string = "OperatorUpgradeable"
+)
+
 // OperatorConditionSpec allows a cluster admin to convey information about the state of an operator to OLM, potentially overriding state reported by the operator.
 type OperatorConditionSpec struct {
 	ServiceAccounts []string           `json:"serviceAccounts,omitempty"`

--- a/vendor/github.com/operator-framework/api/pkg/operators/v1alpha1/clusterserviceversion_types.go
+++ b/vendor/github.com/operator-framework/api/pkg/operators/v1alpha1/clusterserviceversion_types.go
@@ -379,6 +379,7 @@ const (
 	CSVReasonCannotModifyStaticOperatorGroupProvidedAPIs ConditionReason = "CannotModifyStaticOperatorGroupProvidedAPIs"
 	CSVReasonDetectedClusterChange                       ConditionReason = "DetectedClusterChange"
 	CSVReasonInvalidWebhookDescription                   ConditionReason = "InvalidWebhookDescription"
+	CSVReasonOperatorConditionNotUpgradeable             ConditionReason = "OperatorConditionNotUpgradeable"
 )
 
 // HasCaResources returns true if the CSV has owned APIServices or Webhooks.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -447,7 +447,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/operator-framework/api v0.3.23
+# github.com/operator-framework/api v0.3.25
 github.com/operator-framework/api/crds
 github.com/operator-framework/api/pkg/lib/version
 github.com/operator-framework/api/pkg/manifests


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
OLM will check for OperatorCondition CR for OperatorUpgradeable status.
The pending CSV will not transition to Succeeded status until the operator
is upgradeable based on the OperatorCondition. If the operator doesn't use
OperatorCondition, the normal transition is expected.

Signed-off-by: Vu Dinh <vdinh@redhat.com>
**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
