### PR TITLE
Bug 1915473: Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/0000_50_olm_00-catalogsources.crd.yaml
+++ b/manifests/0000_50_olm_00-catalogsources.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: catalogsources.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: clusterserviceversions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/manifests/0000_50_olm_00-installplans.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: installplans.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
@@ -16,5 +17,6 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/scc: "anyuid"

--- a/manifests/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorconditions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operatorconditions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorgroups.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operatorgroups.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-operators.crd.yaml
+++ b/manifests/0000_50_olm_00-operators.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operators.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-subscriptions.crd.yaml
+++ b/manifests/0000_50_olm_00-subscriptions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: subscriptions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -12,6 +13,7 @@ metadata:
   name: system:controller:operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -25,6 +27,7 @@ metadata:
   name: olm-operator-binding-openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/0000_50_olm_02-services.yaml
+++ b/manifests/0000_50_olm_02-services.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     app: olm-operator
 spec:
@@ -26,6 +27,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     app: catalog-operator
 spec:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   strategy:
     type: RollingUpdate

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   strategy:
     type: RollingUpdate

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["subscriptions"]
@@ -27,6 +28,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]

--- a/manifests/0000_50_olm_13-operatorgroup-default.yaml
+++ b/manifests/0000_50_olm_13-operatorgroup-default.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operators
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -13,6 +14,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   targetNamespaces:
     - openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.

--- a/manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/manifests/0000_50_olm_99-operatorstatus.yaml
@@ -4,6 +4,7 @@ metadata:
   name: operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator
@@ -15,6 +16,7 @@ metadata:
   name: operator-lifecycle-manager-catalog
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator
@@ -26,6 +28,7 @@ metadata:
   name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator

--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups:
       - ""
@@ -24,6 +25,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -42,6 +44,7 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -73,6 +76,7 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   jobLabel: k8s-app
   endpoints:

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -8,6 +8,7 @@ metadata:
     role: alert-rules
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   groups:
     - name: olm.failing_operators.rules

--- a/scripts/add_release_annotation.sh
+++ b/scripts/add_release_annotation.sh
@@ -9,4 +9,5 @@ yq=$2
 
 for f in $chartdir/*.yaml; do
    $yq w -d'*' --inplace --style=double $f 'metadata.annotations['include.release.openshift.io/self-managed-high-availability']' true
+   $yq w -d'*' --inplace --style=double $f 'metadata.annotations['include.release.openshift.io/single-node-developer']' true
 done


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->