### PR TITLE
fix: use annotation on the operatorgroup to determine csv copying

### DIFF
--- a/pkg/controller/operators/olm/csvcopy/csv_copy.go
+++ b/pkg/controller/operators/olm/csvcopy/csv_copy.go
@@ -1,0 +1,31 @@
+package csvcopy
+
+import "strconv"
+
+const DisableCSVCopyAnnotation = "operatorgroup.operators.coreos.com/csv-copy"
+
+type Setting int
+
+const (
+	Disabled Setting = iota
+	Enabled
+	Spec
+)
+
+func (c Setting) String() string {
+	return [...]string{"Disabled", "Enabled", "Spec"}[c]
+}
+
+func (c *Setting) Set(value string) Setting {
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		i = 1
+	}
+	*c = Setting(i)
+	return *c
+}
+
+func New() *Setting {
+	var c Setting
+	return &c
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Enabled CSV copying behavior to be modified at runtime via an annotation on the operatorgroup

**Motivation for the change:**
Fine-grained CSV copying behavior 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
