### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/scripts/add_release_annotation.sh
+++ b/scripts/add_release_annotation.sh
@@ -9,4 +9,5 @@ yq=$2
 
 for f in $chartdir/*.yaml; do
    $yq w --inplace $f 'metadata.annotations['include.release.openshift.io/self-managed-high-availability']' true
+   $yq w --inplace $f 'metadata.annotations['include.release.openshift.io/single-node-production-edge']' true
 done


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.