### PR TITLE
Bug 1903034:  Reduce log noise from OLM

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -169,7 +169,7 @@ func main() {
 		}()
 	}
 
-	mgr, err := Manager(ctx)
+	mgr, err := Manager(ctx, *debug)
 	if err != nil {
 		logger.WithError(err).Fatalf("error configuring controller manager")
 	}

--- a/cmd/olm/manager.go
+++ b/cmd/olm/manager.go
@@ -12,8 +12,8 @@ import (
 
 var log = ctrl.Log.WithName("manager")
 
-func Manager(ctx context.Context) (ctrl.Manager, error) {
-	ctrl.SetLogger(zap.Logger(true))
+func Manager(ctx context.Context, debug bool) (ctrl.Manager, error) {
+	ctrl.SetLogger(zap.Logger(debug))
 	setupLog := log.WithName("setup").V(4)
 
 	// Setup a Manager

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -555,7 +555,7 @@ func (a *Operator) syncAPIService(obj interface{}) (syncError error) {
 		"id":         queueinformer.NewLoopID(),
 		"apiService": apiService.GetName(),
 	})
-	logger.Info("syncing APIService")
+	logger.Debug("syncing APIService")
 
 	if name, ns, ok := ownerutil.GetOwnerByKindLabel(apiService, v1alpha1.ClusterServiceVersionKind); ok {
 		_, err := a.lister.CoreV1().NamespaceLister().Get(ns)
@@ -1281,7 +1281,7 @@ func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logg
 			}
 			return nil, nil
 		}
-		logger.Info("csv in operatorgroup")
+		logger.Debug("csv in operatorgroup")
 		return operatorGroup, nil
 	default:
 		err = fmt.Errorf("csv created in namespace with multiple operatorgroups, can't pick one automatically")


### PR DESCRIPTION
Problem: OLM produce a lot of noise in its logs while printing debug
logs. Additionally, a few info logs could better be classified as debug
logs and are contributing to the noise as well.

Solution: Ensure that controllers created by OLM are not printing debug
level logs and reclassify a few info logs as debug logs.
