### PR TITLE
Bug 1905299: fix(olm): Verify ServiceAccount ownership before installing deployment

### DIFF
--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -269,6 +269,14 @@ func (a *Operator) permissionStatus(strategyDetailsDeployment *v1alpha1.Strategy
 				statusesSet[saName] = status
 				continue
 			}
+			// Check SA's ownership
+			if ownerutil.IsOwnedByKind(sa, v1alpha1.ClusterServiceVersionKind) && !ownerutil.IsOwnedBy(sa, csv) {
+				met = false
+				status.Status = v1alpha1.RequirementStatusReasonNotPresent
+				status.Message = "Service account is stale"
+				statusesSet[saName] = status
+				continue
+			}
 
 			// Check if the ServiceAccount is owned by CSV
 			if len(sa.GetOwnerReferences()) != 0 && !ownerutil.IsOwnedBy(sa, csv) {


### PR DESCRIPTION
Currently, there is a timing during upgrade, the new SA is not yet being
created but the deployment is successfully updated and the new pod
is coming up using the old SA. As a result, the pod fails to succeed
due to permission failure.

When CSV is in Pending state, a permission and requirement check list
is performed. A check for SA ownership is added to that check list
to verify if new SA is in place before moving CSV to Installing state.
If new SA is not yet in place, CSV can continue to be Pending which
will prevent the deployment to be created/updated.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
