### PR TITLE
Bug 1907792: Change the OperatorUpgradeable condition to Upgradeable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/operator-framework/api v0.5.0
+	github.com/operator-framework/api v0.5.1
 	github.com/operator-framework/operator-registry v1.13.6
 	github.com/otiai10/copy v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -818,8 +818,8 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
-github.com/operator-framework/api v0.5.0 h1:pzlFOIyrbqoW5Fx6EgJNaEa2sipwPGhNhFxIwu9V6CY=
-github.com/operator-framework/api v0.5.0/go.mod h1:A4VYTXGHHutXy4VrVvr3voBkObOaCaKaGF2dn5i0Fnw=
+github.com/operator-framework/api v0.5.1 h1:3CVLatTCtgV+f/kPh36op7ZFRBPWro2SZDlQkE9Y4+w=
+github.com/operator-framework/api v0.5.1/go.mod h1:A4VYTXGHHutXy4VrVvr3voBkObOaCaKaGF2dn5i0Fnw=
 github.com/operator-framework/operator-registry v1.13.6 h1:h/dIjQQS7uneQNRifrSz7h0xg4Xyjg6C9f6XZofbMPg=
 github.com/operator-framework/operator-registry v1.13.6/go.mod h1:YhnIzOVjRU2ZwZtzt+fjcjW8ujJaSFynBEu7QVKaSdU=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/pkg/controller/operators/olm/operatorconditions.go
+++ b/pkg/controller/operators/olm/operatorconditions.go
@@ -26,7 +26,7 @@ func (a *Operator) isOperatorUpgradeable(csv *v1alpha1.ClusterServiceVersion) (b
 
 	// Check condition overrides
 	for _, override := range cond.Spec.Overrides {
-		if override.Type == operatorsv1.OperatorUpgradeable {
+		if override.Type == operatorsv1.Upgradeable {
 			if override.Status == metav1.ConditionTrue {
 				return true, nil
 			}
@@ -35,7 +35,7 @@ func (a *Operator) isOperatorUpgradeable(csv *v1alpha1.ClusterServiceVersion) (b
 	}
 
 	// Check for OperatorUpgradeable condition status
-	if c := meta.FindStatusCondition(cond.Status.Conditions, operatorsv1.OperatorUpgradeable); c != nil {
+	if c := meta.FindStatusCondition(cond.Status.Conditions, operatorsv1.Upgradeable); c != nil {
 		if c.Status == metav1.ConditionFalse {
 			return false, fmt.Errorf("The operator is not upgradeable: %s", c.Message)
 		}

--- a/test/e2e/operator_condition_e2e_test.go
+++ b/test/e2e/operator_condition_e2e_test.go
@@ -22,9 +22,9 @@ var _ = Describe("Operator Condition", func() {
 		TearDown(testNamespace)
 	})
 
-	It("OperatorUpgradeable condition and overrides", func() {
+	It("OperatorCondition Upgradeable type and overrides", func() {
 		By("This test proves that an operator can upgrade successfully when" +
-			"OperatorUpgrade condition is set in OperatorCondition CR. Plus, an operator" +
+			"Upgrade condition type is set in OperatorCondition CR. Plus, an operator" +
 			"chooses not to use OperatorCondition, the upgrade process will proceed as" +
 			" asexpected. The overrides specification in OperatorCondition can be used to" +
 			" override the status condition. The overrides spec will remain in place until" +
@@ -93,7 +93,7 @@ var _ = Describe("Operator Condition", func() {
 		// Get the OperatorCondition for csvA and report that it is not upgradeable
 		var cond *operatorsv1.OperatorCondition
 		upgradeableFalseCondition := metav1.Condition{
-			Type:               operatorsv1.OperatorUpgradeable,
+			Type:               operatorsv1.Upgradeable,
 			Status:             metav1.ConditionFalse,
 			Reason:             "test",
 			Message:            "test",
@@ -134,7 +134,7 @@ var _ = Describe("Operator Condition", func() {
 
 		// Get the OperatorCondition for csvA and report that it is upgradeable, unblocking csvB
 		upgradeableTrueCondition := metav1.Condition{
-			Type:               operatorsv1.OperatorUpgradeable,
+			Type:               operatorsv1.Upgradeable,
 			Status:             metav1.ConditionTrue,
 			Reason:             "test",
 			Message:            "test",
@@ -195,7 +195,7 @@ var _ = Describe("Operator Condition", func() {
 			// Set Condition overrides to True
 			cond.Spec = operatorsv1.OperatorConditionSpec{
 				Overrides: []metav1.Condition{{
-					Type:               operatorsv1.OperatorUpgradeable,
+					Type:               operatorsv1.Upgradeable,
 					Status:             metav1.ConditionTrue,
 					Reason:             "test",
 					Message:            "test",

--- a/vendor/github.com/operator-framework/api/pkg/operators/v1/operatorcondition_types.go
+++ b/vendor/github.com/operator-framework/api/pkg/operators/v1/operatorcondition_types.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	// OperatorUpgradeable indicates that the operator is upgradeable
-	OperatorUpgradeable string = "OperatorUpgradeable"
+	// Upgradeable indicates that the operator is upgradeable
+	Upgradeable string = "Upgradeable"
 )
 
 // OperatorConditionSpec allows a cluster admin to convey information about the state of an operator to OLM, potentially overriding state reported by the operator.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -439,7 +439,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/operator-framework/api v0.5.0
+# github.com/operator-framework/api v0.5.1
 github.com/operator-framework/api/crds
 github.com/operator-framework/api/pkg/lib/version
 github.com/operator-framework/api/pkg/manifests


### PR DESCRIPTION
The original design intends to use the name `Upgradeable` only.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Gate operator upgrade on the "Upgradeable" OperatorCondition status type instead of "OperatorUpgradeable".

**Motivation for the change:**

The [OperatorConditions enhancement](https://github.com/operator-framework/enhancements/blob/master/enhancements/operator-conditions.md#example-upgradeable-condition) indicates that OLM gates upgrades on a status condition type of "Upgradeable", not "OperatorUpgradeable".

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
