### PR TITLE
Use client.Object for methods in the adoption and operator controllers

### DIFF
--- a/pkg/controller/operators/adoption_controller.go
+++ b/pkg/controller/operators/adoption_controller.go
@@ -262,7 +262,7 @@ func (r *AdoptionReconciler) adoptComponents(ctx context.Context, csv *operators
 func (r *AdoptionReconciler) adopt(ctx context.Context, operator *decorators.Operator, component client.Object) error {
 	if err := r.Get(ctx, types.NamespacedName{Namespace: component.GetNamespace(), Name: component.GetName()}, component); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.log.V(1).Info("not found", "component", cObj)
+			r.log.V(1).Info("not found", "component", component)
 			err = nil
 		}
 

--- a/pkg/controller/operators/catalog/installplan_sync.go
+++ b/pkg/controller/operators/catalog/installplan_sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/controller/operators/decorators/operator.go
+++ b/pkg/controller/operators/decorators/operator.go
@@ -66,7 +66,7 @@ type OperatorFactory interface {
 	// An error is returned if the decorator cannot be instantiated.
 	NewOperator(external *operatorsv1.Operator) (*Operator, error)
 
-	// NewPackageOperator returns an Operator decorator for a package and installs namespace.
+	// NewPackageOperator returns an Operator decorator for a package and install namespace.
 	NewPackageOperator(pkg, namespace string) (*Operator, error)
 }
 

--- a/pkg/controller/operators/decorators/operator_test.go
+++ b/pkg/controller/operators/decorators/operator_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -93,7 +94,7 @@ func TestAddComponents(t *testing.T) {
 		operator *operatorsv1.Operator
 	}
 	type args struct {
-		components []runtime.Object
+		components []client.Object
 	}
 	type results struct {
 		operator *operatorsv1.Operator
@@ -117,8 +118,8 @@ func TestAddComponents(t *testing.T) {
 				}(),
 			},
 			args: args{
-				components: []runtime.Object{
-					func() runtime.Object {
+				components: []client.Object{
+					func() client.Object {
 						namespace := &corev1.Namespace{}
 						namespace.SetName("atlantic")
 						namespace.SetLabels(map[string]string{
@@ -127,7 +128,7 @@ func TestAddComponents(t *testing.T) {
 
 						return namespace
 					}(),
-					func() runtime.Object {
+					func() client.Object {
 						pod := &corev1.Pod{}
 						pod.SetNamespace("atlantic")
 						pod.SetName("puffin")
@@ -143,7 +144,7 @@ func TestAddComponents(t *testing.T) {
 
 						return pod
 					}(),
-					func() runtime.Object {
+					func() client.Object {
 						csv := &operatorsv1alpha1.ClusterServiceVersion{}
 						csv.SetNamespace("atlantic")
 						csv.SetName("puffin")

--- a/pkg/controller/operators/olm/operatorgroup_test.go
+++ b/pkg/controller/operators/olm/operatorgroup_test.go
@@ -229,8 +229,8 @@ func TestCopyToNamespace(t *testing.T) {
 						},
 					},
 					Status: v1alpha1.ClusterServiceVersionStatus{
-						Message:        "The operator is running in foo but is managing this namespace",
-						Reason:         v1alpha1.CSVReasonCopied,
+						Message: "The operator is running in foo but is managing this namespace",
+						Reason:  v1alpha1.CSVReasonCopied,
 					},
 				}),
 			},

--- a/pkg/controller/operators/operator_controller.go
+++ b/pkg/controller/operators/operator_controller.go
@@ -185,18 +185,20 @@ func (r *OperatorReconciler) updateComponents(ctx context.Context, operator *dec
 		return err
 	}
 
-	components, err := r.listComponents(ctx, selector)
+	componentLists, err := r.listComponents(ctx, selector)
 	if err != nil {
 		return err
 	}
 
+	components := flatten(componentLists)
+
 	return operator.SetComponents(components...)
 }
 
-func (r *OperatorReconciler) listComponents(ctx context.Context, selector labels.Selector) ([]runtime.Object, error) {
+func (r *OperatorReconciler) listComponents(ctx context.Context, selector labels.Selector) ([]client.ObjectList, error) {
 	// Note: We need to figure out how to dynamically add new list types here (or some equivalent) in
 	// order to support operators composed of custom resources.
-	componentLists := []runtime.Object{
+	componentLists := []client.ObjectList{
 		&appsv1.DeploymentList{},
 		&corev1.NamespaceList{},
 		&corev1.ServiceAccountList{},

--- a/pkg/controller/operators/operator_controller.go
+++ b/pkg/controller/operators/operator_controller.go
@@ -190,7 +190,10 @@ func (r *OperatorReconciler) updateComponents(ctx context.Context, operator *dec
 		return err
 	}
 
-	components := flatten(componentLists)
+	components, err := flatten(componentLists)
+	if err != nil {
+		return err
+	}
 
 	return operator.SetComponents(components...)
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

Fix #1917

**Description of the change:**

This PR is for fixing issue #1917.

- The `runtime.Object` in the adoption and operator controllers are replaced to `client.Object` and `client.ObjectList`. 

- Function `flatten` is updated to extract `client.ObjectList` slice to `client.Object` slice.

- The object flatten logic is removed from `func (o *Operator) AddComponents`, components are going to be flattened before they are passed to `AddComponents`.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
