### PR TITLE
Minor updates in the template of PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,9 @@ Note: Make sure your branch is rebased to the latest upstream master.
 
 **Reviewer Checklist**
 - [ ] Implementation matches the proposed design, or proposal is updated to match implementation
-- [ ] Sufficient unit test coverage 
+- [ ] Sufficient unit test coverage
 - [ ] Sufficient end-to-end test coverage
-- [ ] Docs updated or added to `/docs` 
+- [ ] Docs updated or added to `/doc`
 - [ ] Commit messages sensible and descriptive
 
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Update the `/docs` to `/doc`

**Motivation for the change:**

When I create a PR, I found there is no `/docs` directory in the repo.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
