### PR TITLE
Bug 1899588: Only re-create operator resource if it has existing components

### DIFF
--- a/pkg/controller/operators/operator_controller.go
+++ b/pkg/controller/operators/operator_controller.go
@@ -11,6 +11,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -119,6 +120,12 @@ func (r *OperatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	in := &operatorsv1.Operator{}
 	if err := r.Get(ctx, req.NamespacedName, in); err != nil {
 		if apierrors.IsNotFound(err) {
+			// If the Operator instance is not found, we're likely reconciling because
+			// of a DELETE event. Only recreate the Operator if any of its components
+			// still exist.
+			if exists, err := r.hasExistingComponents(ctx, name); err != nil || !exists {
+				return reconcile.Result{}, err
+			}
 			create = true
 			in.SetName(name)
 		} else {
@@ -217,6 +224,33 @@ func (r *OperatorReconciler) listComponents(ctx context.Context, selector labels
 	}
 
 	return componentLists, nil
+}
+
+func (r *OperatorReconciler) hasExistingComponents(ctx context.Context, name string) (bool, error) {
+	op := &operatorsv1.Operator{}
+	op.SetName(name)
+	operator := decorators.Operator{Operator: op}
+
+	selector, err := operator.ComponentSelector()
+	if err != nil {
+		return false, err
+	}
+
+	components, err := r.listComponents(ctx, selector)
+	if err != nil {
+		return false, err
+	}
+
+	for _, list := range components {
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			return false, fmt.Errorf("Unable to extract list from runtime.Object")
+		}
+		if len(items) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (r *OperatorReconciler) getLastResourceVersion(name types.NamespacedName) (string, bool) {

--- a/pkg/controller/operators/operator_controller_test.go
+++ b/pkg/controller/operators/operator_controller_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Operator Controller", func() {
 	})
 
 	Describe("operator deletion", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			Expect(k8sClient.Delete(ctx, operator)).To(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, name, operator)

--- a/pkg/controller/operators/operator_controller_test.go
+++ b/pkg/controller/operators/operator_controller_test.go
@@ -71,10 +71,8 @@ var _ = Describe("Operator Controller", func() {
 
 			AfterEach(func() {
 				for _, obj := range objs {
-					Expect(k8sClient.Get(ctx, testobj.NamespacedName(obj), obj.(client.Object))).To(Succeed())
 					Expect(k8sClient.Delete(ctx, obj.(client.Object), deleteOpts)).To(Succeed())
 				}
-				Expect(k8sClient.Get(ctx, name, operator)).To(Succeed())
 				Expect(k8sClient.Delete(ctx, operator, deleteOpts)).To(Succeed())
 			})
 
@@ -108,7 +106,6 @@ var _ = Describe("Operator Controller", func() {
 		})
 
 		AfterEach(func() {
-			Expect(k8sClient.Get(ctx, name, operator)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, operator, deleteOpts)).To(Succeed())
 		})
 
@@ -143,7 +140,6 @@ var _ = Describe("Operator Controller", func() {
 
 			AfterEach(func() {
 				for _, obj := range objs {
-					Expect(k8sClient.Get(ctx, testobj.NamespacedName(obj), obj.(client.Object))).To(Succeed())
 					Expect(k8sClient.Delete(ctx, obj.(client.Object), deleteOpts)).To(Succeed())
 				}
 			})

--- a/pkg/controller/operators/operator_controller_test.go
+++ b/pkg/controller/operators/operator_controller_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,9 +44,54 @@ var _ = Describe("Operator Controller", func() {
 		Expect(k8sClient.Create(ctx, operator)).To(Succeed())
 	})
 
-	AfterEach(func() {
-		Expect(k8sClient.Get(ctx, name, operator)).To(Succeed())
-		Expect(k8sClient.Delete(ctx, operator, deleteOpts)).To(Succeed())
+	Describe("operator deletion", func() {
+		BeforeEach(func() {
+			Expect(k8sClient.Delete(ctx, operator)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, name, operator)
+				return apierrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+		Context("with components bearing its label", func() {
+			var (
+				objs      []runtime.Object
+				namespace string
+			)
+
+			BeforeEach(func() {
+				namespace = genName("ns-")
+				objs = testobj.WithLabel(expectedKey, "",
+					testobj.WithName(namespace, &corev1.Namespace{}),
+				)
+
+				for _, obj := range objs {
+					Expect(k8sClient.Create(ctx, obj.(client.Object))).To(Succeed())
+				}
+			})
+
+			AfterEach(func() {
+				for _, obj := range objs {
+					Expect(k8sClient.Get(ctx, testobj.NamespacedName(obj), obj.(client.Object))).To(Succeed())
+					Expect(k8sClient.Delete(ctx, obj.(client.Object), deleteOpts)).To(Succeed())
+				}
+				Expect(k8sClient.Get(ctx, name, operator)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, operator, deleteOpts)).To(Succeed())
+			})
+
+			It("should re-create it", func() {
+				Eventually(func() error {
+					return k8sClient.Get(ctx, name, operator)
+				}).Should(Succeed())
+			})
+		})
+		Context("with no components bearing its label", func() {
+			It("should not re-create it", func() {
+				Consistently(func() bool {
+					err := k8sClient.Get(ctx, name, operator)
+					return apierrors.IsNotFound(err)
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
 	})
 
 	Describe("component selection", func() {
@@ -59,6 +105,11 @@ var _ = Describe("Operator Controller", func() {
 				err := k8sClient.Get(ctx, name, operator)
 				return operator.Status.Components.LabelSelector, err
 			}, timeout, interval).Should(Equal(expectedComponentLabelSelector))
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Get(ctx, name, operator)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, operator, deleteOpts)).To(Succeed())
 		})
 
 		Context("with no components bearing its label", func() {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR fixes a bug in the operator controller that causes it to
ALWAYS re-create deleted operator objects, even when no other resources
associated with that operator exist.

**Motivation for the change:**
Closes #1932

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [ ] ~Docs updated or added to `/docs`~
- [x] Commit messages sensible and descriptive


