### PR TITLE
Bug 1905850: Fix operatorcondition role verbs

### DIFF
--- a/pkg/controller/operators/operatorcondition_controller.go
+++ b/pkg/controller/operators/operatorcondition_controller.go
@@ -115,7 +115,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRole(operatorCondit
 				ResourceNames: []string{operatorCondition.GetName()},
 			},
 			{
-				Verbs:         []string{"get,update,patch"},
+				Verbs:         []string{"get", "update", "patch"},
 				APIGroups:     []string{"operators.coreos.com"},
 				Resources:     []string{"operatorconditions/status"},
 				ResourceNames: []string{operatorCondition.GetName()},

--- a/pkg/controller/operators/operatorcondition_controller_test.go
+++ b/pkg/controller/operators/operatorcondition_controller_test.go
@@ -106,7 +106,7 @@ var _ = Describe("OperatorCondition", func() {
 						ResourceNames: []string{namespacedName.Name},
 					},
 					{
-						Verbs:         []string{"get,update,patch"},
+						Verbs:         []string{"get", "update", "patch"},
 						APIGroups:     []string{"operators.coreos.com"},
 						Resources:     []string{"operatorconditions/status"},
 						ResourceNames: []string{namespacedName.Name},


### PR DESCRIPTION
Problem: The role created to allow operators to modify its
OperatorCondition/status resource currently contains a string matching
"get,patch,update" instead of an array of strings consisting of "get",
"patch", and "update".

Solution: Update the verbs defined for the role to match the expected
array.
