### PR TITLE
Bug 1909992: Allow private bundle images within private indexes

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -113,6 +113,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 							Namespace: "ns-a",
 							Name:      "src-a",
 						},
+						Spec: operatorsv1alpha1.CatalogSourceSpec{
+							Secrets: []string{"my-secret"},
+						},
 					},
 				},
 			},
@@ -193,7 +196,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 									Name: pathHash,
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: corev1.RestartPolicyOnFailure,
+									RestartPolicy:    corev1.RestartPolicyOnFailure,
+									ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-secret"}},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",


### PR DESCRIPTION
In #1878, the secrets passed in `spec.secrets` field of a catalogsource
were attached to the catsrc's corresponding SA that was used by the registry
pod, thereby having access to the secrets. This allowed for pulling of
private index images. However, the job that unpacks the bundle images did
not have access to the secrets, and as a result private bundle image included
in the catsrc were not installable using the secrets.
This PR attaches the secrets from the catsrc to the job that unpacks the bundles,
thereby allowing the inclusion of private bundle images within index from private
indexes.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
