### PR TITLE
Bug 1913132: Create CSV Deployments with OpCond EnvVar

### DIFF
--- a/pkg/controller/operators/olm/overrides/initializer.go
+++ b/pkg/controller/operators/olm/overrides/initializer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides/inject"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/proxy"
@@ -67,27 +68,27 @@ func (d *DeploymentInitializer) initialize(ownerCSV ownerutil.Owner, deployment 
 	}
 
 	podSpec := &deployment.Spec.Template.Spec
-	if err := InjectEnvIntoDeployment(podSpec, merged); err != nil {
+	if err := inject.InjectEnvIntoDeployment(podSpec, merged); err != nil {
 		return fmt.Errorf("failed to inject proxy env variable(s) into deployment spec name=%s - %v", deployment.Name, err)
 	}
 
-	if err = InjectVolumesIntoDeployment(podSpec, volumeOverrides); err != nil {
+	if err = inject.InjectVolumesIntoDeployment(podSpec, volumeOverrides); err != nil {
 		return fmt.Errorf("failed to inject volume(s) into deployment spec name=%s - %v", deployment.Name, err)
 	}
 
-	if err = InjectVolumeMountsIntoDeployment(podSpec, volumeMountOverrides); err != nil {
+	if err = inject.InjectVolumeMountsIntoDeployment(podSpec, volumeMountOverrides); err != nil {
 		return fmt.Errorf("failed to inject volumeMounts(s) into deployment spec name=%s - %v", deployment.Name, err)
 	}
 
-	if err = InjectTolerationsIntoDeployment(podSpec, tolerationOverrides); err != nil {
+	if err = inject.InjectTolerationsIntoDeployment(podSpec, tolerationOverrides); err != nil {
 		return fmt.Errorf("failed to inject toleration(s) into deployment spec name=%s - %v", deployment.Name, err)
 	}
 
-	if err = InjectResourcesIntoDeployment(podSpec, resourcesOverride); err != nil {
+	if err = inject.InjectResourcesIntoDeployment(podSpec, resourcesOverride); err != nil {
 		return fmt.Errorf("failed to inject resources into deployment spec name=%s - %v", deployment.Name, err)
 	}
 
-	if err = InjectNodeSelectorIntoDeployment(podSpec, nodeSelectorOverride); err != nil {
+	if err = inject.InjectNodeSelectorIntoDeployment(podSpec, nodeSelectorOverride); err != nil {
 		return fmt.Errorf("failed to inject nodeSelector into deployment spec name=%s - %v", deployment.Name, err)
 	}
 

--- a/pkg/controller/operators/olm/overrides/inject/inject.go
+++ b/pkg/controller/operators/olm/overrides/inject/inject.go
@@ -1,4 +1,4 @@
-package overrides
+package inject
 
 import (
 	"errors"

--- a/pkg/controller/operators/olm/overrides/inject/inject_test.go
+++ b/pkg/controller/operators/olm/overrides/inject/inject_test.go
@@ -1,9 +1,9 @@
-package overrides_test
+package inject_test
 
 import (
 	"testing"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides/inject"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -196,7 +196,7 @@ func TestInjectVolumeMountIntoDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides.InjectVolumeMountsIntoDeployment(tt.podSpec, tt.volumeMounts)
+			inject.InjectVolumeMountsIntoDeployment(tt.podSpec, tt.volumeMounts)
 
 			podSpecWant := tt.expected
 			podSpecGot := tt.podSpec
@@ -298,7 +298,7 @@ func TestInjectVolumeIntoDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides.InjectVolumesIntoDeployment(tt.podSpec, tt.volumes)
+			inject.InjectVolumesIntoDeployment(tt.podSpec, tt.volumes)
 
 			podSpecWant := tt.expected
 			podSpecGot := tt.podSpec
@@ -511,7 +511,7 @@ func TestInjectEnvIntoDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides.InjectEnvIntoDeployment(tt.podSpec, tt.envVar)
+			inject.InjectEnvIntoDeployment(tt.podSpec, tt.envVar)
 
 			podSpecWant := tt.expected
 			podSpecGot := tt.podSpec
@@ -617,7 +617,7 @@ func TestInjectTolerationsIntoDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides.InjectTolerationsIntoDeployment(tt.podSpec, tt.tolerations)
+			inject.InjectTolerationsIntoDeployment(tt.podSpec, tt.tolerations)
 
 			podSpecWant := tt.expected
 			podSpecGot := tt.podSpec
@@ -699,7 +699,7 @@ func TestInjectResourcesIntoDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides.InjectResourcesIntoDeployment(tt.podSpec, tt.resources)
+			inject.InjectResourcesIntoDeployment(tt.podSpec, tt.resources)
 
 			podSpecWant := tt.expected
 			podSpecGot := tt.podSpec
@@ -774,7 +774,7 @@ func TestInjectNodeSelectorIntoDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides.InjectNodeSelectorIntoDeployment(tt.podSpec, tt.nodeSelector)
+			inject.InjectNodeSelectorIntoDeployment(tt.podSpec, tt.nodeSelector)
 
 			podSpecWant := tt.expected
 			podSpecGot := tt.podSpec


### PR DESCRIPTION
Problem: The OLM controller creates deployments defined in the CSV
without including the OPERATOR_CONDITION_NAME environment variable. The
OperatorCondition reconciller then immediately injects said environment
variable into the deployment.

Solution: Update the OLM controller to create the deployment with the
OPERATOR_CONDITION_NAME environment variable.
