### PR TITLE
Use amd64 for local linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,15 +84,15 @@ build-coverage: build_cmd=test -c -covermode=count -coverpkg ./pkg/controller/..
 build-coverage: clean $(CMDS)
 
 build-linux: build_cmd=build
-build-linux: arch_flags=GOOS=linux GOARCH=386
+build-linux: arch_flags=GOOS=linux GOARCH=amd64
 build-linux: clean $(CMDS)
 
 build-wait: clean bin/wait
 
 bin/wait:
-	GOOS=linux GOARCH=386 go build $(MOD_FLAGS) -o $@ $(PKG)/test/e2e/wait
+	GOOS=linux GOARCH=amd64 go build $(MOD_FLAGS) -o $@ $(PKG)/test/e2e/wait
 
-build-util-linux: arch_flags=GOOS=linux GOARCH=386
+build-util-linux: arch_flags=GOOS=linux GOARCH=amd64
 build-util-linux: build-util
 
 build-util: bin/cpb

--- a/x.mk
+++ b/x.mk
@@ -21,7 +21,7 @@ bin/e2e-local.test: FORCE test/e2e/assets/chart/zz_chart.go
 	$(GO) test -c -tags kind,helm -o $@ ./test/e2e
 
 test/e2e-local.image.tar: export GOOS=linux
-test/e2e-local.image.tar: export GOARCH=386
+test/e2e-local.image.tar: export GOARCH=amd64
 test/e2e-local.image.tar: e2e.Dockerfile bin/wait bin/cpb $(CMDS)
 	docker build -t quay.io/operator-framework/olm:local -f $< bin
 	docker save -o $@ quay.io/operator-framework/olm:local


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Changes local linux builds (for kind/etc) to use amd64 instead of 386

**Motivation for the change:**
Avoid https://github.com/kubernetes/kubernetes/issues/97685

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
