### PR TITLE
Problem: Subscription config doesn't support env valueFrom.

### DIFF
--- a/pkg/controller/operators/olm/overrides/inject/inject.go
+++ b/pkg/controller/operators/olm/overrides/inject/inject.go
@@ -32,12 +32,14 @@ func mergeEnvVars(containerEnvVars []corev1.EnvVar, newEnvVars []corev1.EnvVar) 
 		existing, found := findEnvVar(containerEnvVars, newEnvVar.Name)
 		if found {
 			existing.Value = newEnvVar.Value
+			existing.ValueFrom = newEnvVar.ValueFrom
 			continue
 		}
 
 		merged = append(merged, corev1.EnvVar{
 			Name:  newEnvVar.Name,
 			Value: newEnvVar.Value,
+			ValueFrom: newEnvVar.ValueFrom,
 		})
 	}
 


### PR DESCRIPTION
This PR makes olm copy ValueFrom from envVars of subscription config.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fix https://github.com/operator-framework/operator-lifecycle-manager/issues/1946

This PR is for enabling copy `ValueFrom` from envVars of subscription config.

**Motivation for the change:**

Subscription Config can't set `ValueFrom` in the environmental variables

For example, 
```
      apiVersion: operators.coreos.com/v1alpha1
      kind: Subscription
      ...
      spec:
      ...
        config:
          env:
          - name: WATCH_NAMESPACE
            valueFrom:
              configMapKeyRef:
                name: namespace-scope
                key: namespaces

```

The `valueFrom` in `WATCH_NAMESPACE` can't be propagated to the operator deployment.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
