### PR TITLE
Bug1906056: fix(resolver): Allow skipped versions to be installed initially

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -97,6 +97,7 @@ func (r *SatResolver) SolveOperators(namespaces []string, csvs []*v1alpha1.Clust
 
 		// if no operator is installed and we have a startingCSV, filter for it
 		if current == nil && len(sub.Spec.StartingCSV) > 0 {
+			predicates = append(predicates, WithCSVName(sub.Spec.StartingCSV))
 			channelFilter = append(channelFilter, WithCSVName(sub.Spec.StartingCSV))
 			startingCSVs[sub.Spec.StartingCSV] = struct{}{}
 		}

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -1354,14 +1354,14 @@ func TestSolveOperators_WithoutDeprecated(t *testing.T) {
 	assert.IsType(t, solver.NotSatisfiable{}, err)
 }
 
-func TestSolveOperators_WithSkips(t *testing.T) {
+func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 	APISet := APISet{opregistry.APIKey{"g", "v", "k", "ks"}: struct{}{}}
 	Provides := APISet
 
 	namespace := "olm"
 	catalog := registry.CatalogKey{"community", namespace}
 
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	newSub := newSub(namespace, "packageB", "alpha", catalog, withStartingCSV("packageB.v1"))
 	subs := []*v1alpha1.Subscription{newSub}
 
 	opToAddVersionDeps := []*api.Dependency{
@@ -1372,6 +1372,8 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 	}
 
 	opB := genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false)
+	opB2 := genOperator("packageB.v2", "2.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false)
+	opB2.skips = []string{"packageB.v1"}
 	op1 := genOperator("packageA.v1", "1.0.0", "", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
 	op2 := genOperator("packageA.v2", "2.0.0", "packageA.v1", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
 	op3 := genOperator("packageA.v3", "3.0.0", "packageA.v2", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
@@ -1392,7 +1394,7 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 					Name:      "community",
 				},
 				operators: []*Operator{
-					opB, op1, op2, op3, op4, op5, op6,
+					opB, opB2, op1, op2, op3, op4, op5, op6,
 				},
 			},
 		},
@@ -1404,10 +1406,50 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, nil, subs)
 	assert.NoError(t, err)
-
+	opB.SourceInfo().StartingCSV = "packageB.v1"
 	expected := OperatorSet{
-		"packageB.v1": genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
-		"packageA.v6": genOperator("packageA.v6", "6.0.0", "packageA.v5", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false),
+		"packageB.v1": opB,
+		"packageA.v6": op6,
+	}
+	require.EqualValues(t, expected, operators)
+}
+
+func TestSolveOperators_WithSkips(t *testing.T) {
+	namespace := "olm"
+	catalog := registry.CatalogKey{"community", namespace}
+
+	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	subs := []*v1alpha1.Subscription{newSub}
+
+	opB := genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false)
+	opB2 := genOperator("packageB.v2", "2.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false)
+	opB2.skips = []string{"packageB.v1"}
+
+	fakeNamespacedOperatorCache := NamespacedOperatorCache{
+		snapshots: map[registry.CatalogKey]*CatalogSnapshot{
+			registry.CatalogKey{
+				Namespace: "olm",
+				Name:      "community",
+			}: {
+				key: registry.CatalogKey{
+					Namespace: "olm",
+					Name:      "community",
+				},
+				operators: []*Operator{
+					opB, opB2,
+				},
+			},
+		},
+	}
+	satResolver := SatResolver{
+		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
+		log:   logrus.New(),
+	}
+
+	operators, err := satResolver.SolveOperators([]string{"olm"}, nil, subs)
+	assert.NoError(t, err)
+	expected := OperatorSet{
+		"packageB.v2": opB2,
 	}
 	require.EqualValues(t, expected, operators)
 }


### PR DESCRIPTION
Currently, the resolver will filter all skipped versions so they
cannot be installed under any conditions. This behavior is a slight
change from the older resolver which allows the skipped versions to
be installed if they are chosen in `startingCSV`.

With this change, the resolver will allow skipped versions to be
installed if specified in `startingCSV` during the initial
installation.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
