### PR TITLE
Subscription config wouldn't overwrite the resources in the operator pod if the config is empty

### DIFF
--- a/pkg/controller/operators/catalog/installplan_sync.go
+++ b/pkg/controller/operators/catalog/installplan_sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/controller/operators/olm/overrides/inject/inject.go
+++ b/pkg/controller/operators/olm/overrides/inject/inject.go
@@ -201,10 +201,28 @@ func InjectResourcesIntoDeployment(podSpec *corev1.PodSpec, resources corev1.Res
 
 	for i := range podSpec.Containers {
 		container := &podSpec.Containers[i]
-		container.Resources = resources
+		container.Resources = mergeResources(container.Resources, resources)
 	}
 
 	return nil
+}
+
+func mergeResources(containerResources, newResources corev1.ResourceRequirements) (mergedResources corev1.ResourceRequirements) {
+	mergedResources = containerResources
+	for newResourceName, newResourcesLimit := range newResources.Limits {
+		if mergedResources.Limits == nil {
+			mergedResources.Limits = make(corev1.ResourceList)
+		}
+		mergedResources.Limits[newResourceName] = newResourcesLimit
+	}
+	for newResourceName, newResourcesRequest := range newResources.Requests {
+		if mergedResources.Requests == nil {
+			mergedResources.Requests = make(corev1.ResourceList)
+		}
+		mergedResources.Requests[newResourceName] = newResourcesRequest
+	}
+
+	return
 }
 
 // InjectNodeSelectorIntoDeployment injects the provided NodeSelector

--- a/pkg/controller/operators/olm/overrides/inject/inject_test.go
+++ b/pkg/controller/operators/olm/overrides/inject/inject_test.go
@@ -677,8 +677,44 @@ func TestInjectResourcesIntoDeployment(t *testing.T) {
 		{
 			// PodSpec has one container with one resource and one resource config given
 			// Expected: Resources will be overwritten
-			// Here, overriding with empty resources
+			// Here, Resources will be overwritten
 			name: "WithDeploymentHasResources",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{
+						Resources: defaultResources,
+					},
+				},
+			},
+			resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("110m"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+			expected: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("110m"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// PodSpec has one container with one resource and one resource config given
+			// Expected: Resources won't be overwritten
+			// Here, Resources will remain since the config is empty
+			name: "WithDeploymentHasResourcesWithEmptyConfig",
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					corev1.Container{
@@ -690,7 +726,7 @@ func TestInjectResourcesIntoDeployment(t *testing.T) {
 			expected: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					corev1.Container{
-						Resources: corev1.ResourceRequirements{},
+						Resources: defaultResources,
 					},
 				},
 			},


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fix #1953 #1940

Subscription config wouldn't overwrite the resources in the operator pod if the config is empty.

**Motivation for the change:**

By default the subscription config is empty, but it will force empty the existing resource configs in the CSV.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
