### PR TITLE
Fix typo in docs

### DIFF
--- a/doc/design/channel-naming.md
+++ b/doc/design/channel-naming.md
@@ -27,7 +27,7 @@ In the diagram above you can see the following:
   
   - A catalog index named “redhat:v4.6”, this catalog is built by a cluster administrator typically
   - There are 2 operator packages found in the catalog, myoperator and otheroperator.
-  - The myoperator has 3 bundles (1.0.0, 1.0.1, 1.0.2).  Versions 1.0.1 and 1.0.1 are in multiple channels (fast, stable).  Whereas version 1.0.2 is only in the fast channel. 
+  - The myoperator has 3 bundles (1.0.0, 1.0.1, 1.0.2).  Versions 1.0.0 and 1.0.1 are in multiple channels (fast, stable).  Whereas version 1.0.2 is only in the fast channel.
   - The otheroperator has 2 bundles specifying 2 different channels (preview, stable).  Version 1.4.0 specifies it is within 2 channels, stable and preview.
 
 


### PR DESCRIPTION
Fixes a typo in `channel-naming.md` docs

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [X] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
