### PR TITLE
Bug 1917537: Fix time comparison in CSV reconcile loop

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1097,7 +1097,7 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 	}
 
 	// status changed, update CSV
-	if !(outCSV.Status.LastUpdateTime == clusterServiceVersion.Status.LastUpdateTime &&
+	if !(outCSV.Status.LastUpdateTime.Equal(clusterServiceVersion.Status.LastUpdateTime) &&
 		outCSV.Status.Phase == clusterServiceVersion.Status.Phase &&
 		outCSV.Status.Reason == clusterServiceVersion.Status.Reason &&
 		outCSV.Status.Message == clusterServiceVersion.Status.Message) {


### PR DESCRIPTION
**Description of the change:**
Fix the comparison check for `csv.status.LastUpdateTime` in the CSV reconcile from `==` to [Time.Equal()](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Time.Equal).

**Motivation for the change:**
See the following bug for background on the reconcile hotloop: https://bugzilla.redhat.com/show_bug.cgi?id=1917537

After installing an operator on an openshift `4.6.z` cluster (e.g `4.6.13`) the OLM operator can get into a loop where the CSV object is being continuously being reconciled and updated roughly every second.
```
time="2021-01-26T19:55:44Z" level=info msg="checking ocs-operator.v4.6.1"
2021-01-26T19:55:44.512Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "operator", "request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:44.513Z	DEBUG	controllers.operator	reconciling operator	{"request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:44.513Z	DEBUG	controllers.operator	Operator is already up-to-date	{"request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:44.513Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "operator", "request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:44.514Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "clusterserviceversion", "request": "openshift-storage/ocs-operator.v4.6.1"}
2021-01-26T19:55:45.634Z	DEBUG	controllers.operator	reconciling operator	{"request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:45.635Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "subscription", "request": "openshift-storage/ocs-operator"}
time="2021-01-26T19:55:45Z" level=info msg="csv in operatorgroup" csv=ocs-operator.v4.6.1 id=zuP7V namespace=openshift-storage opgroup=openshift-storage-dvlsm phase=Succeeded
time="2021-01-26T19:55:45Z" level=info msg="checking ocs-operator.v4.6.1"
2021-01-26T19:55:45.666Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "clusterserviceversion", "request": "openshift-storage/ocs-operator.v4.6.1"}
2021-01-26T19:55:45.678Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "operator", "request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:45.680Z	DEBUG	controllers.operator	reconciling operator	{"request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:45.680Z	DEBUG	controllers.operator	Operator is already up-to-date	{"request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:45.680Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "operator", "request": "/ocs-operator.openshift-storage"}
2021-01-26T19:55:46.848Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "subscription", "request": "openshift-storage/ocs-operator"}
2021-01-26T19:55:46.848Z	DEBUG	controllers.operator	reconciling operator	{"request": "/ocs-operator.openshift-storage"}
time="2021-01-26T19:55:46Z" level=info msg="csv in operatorgroup" csv=ocs-operator.v4.6.1 id=zykOJ namespace=openshift-storage opgroup=openshift-storage-dvlsm phase=Succeeded
time="2021-01-26T19:55:46Z" level=info msg="checking ocs-operator.v4.6.1"
...
```
This results in increased CPU usage and requests to the APIserver.
![Pre-fix-usage](https://user-images.githubusercontent.com/6660644/105895217-1842de00-5fca-11eb-9bb8-2b32ba2635e5.png)

While it's unclear how the operator gets into this reconcile hotloop when installing certain operators (OCS, ACM) and not others (etcd, cert-manager), the comparison check `outCSV.Status.LastUpdateTime == clusterServiceVersion.Status.LastUpdateTime` is incorrect as it always results `false` since the values being compared are `*metav1.Time` pointer addresses. 

This results in the OLM operator always updating the CSV object with no real status change and triggering another reconcile event.

With the proposed fix the reconcile hotloop does go away since the CSV is no longer being updated when there are no status changes. 
![Screen Shot 2021-01-26 at 11 33 20 AM](https://user-images.githubusercontent.com/6660644/105896828-31e52500-5fcc-11eb-91e3-a19c97e1a0a1.png)


**TODO:**
- Unknown how OLM gets into the reconcile loop or why it doesn't occur on a 4.7.z cluster
- Figure out a unit or e2e test to cover this case

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
