### PR TITLE
fix: improve stalebot configuration for github issue tracking

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
@@ -7,11 +7,19 @@ exemptLabels:
   - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: lifecycle/stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+  any recent activity. It will be closed in 7 days if no further activity occurs. Thank you
+  for your contribution.
+
+  For more help on your issue, check out the olm-dev channel on the kubernetes slack [1] and the OLM Dev Working Group [2]
+  [1] https://kubernetes.slack.com/archives/C0181L6JYQ2
+  [2] https://github.com/operator-framework/community#operator-lifecycle-manager-wg
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been automatically closed because it has not had
+  any recent activity. Thank you for your contribution.
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
Signed-off-by: Daniel Sover <dsover@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

- Change the label of a stale issue from `wontfix` to `lifecycle/stale` so hopefully this does not conflict with the openshift-ci-robot as we have currently. See any older issue for an example. 
- Close issues 7 days after the stale label has been applied if no further activity occurs
- Bump the stale label application from 60 days to 90 days
- Add more helptext when the stale label is applied providing upstream resources
- Limit bot to issues only (PR backlog is currently manageable and PRs should not be automatically closed) 

**Motivation for the change:**
Manage the github issues backlog better and ensure issues that are actively affecting the community get more visibility. See https://github.com/probot/stale#is-closing-stale-issues-really-a-good-idea for more. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
