### PR TITLE
Use docker driver for minikube installation test.

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -28,8 +28,8 @@ jobs:
         curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
         chmod +x minikube
         sudo mv minikube /bin/
-        minikube config set vm-driver none
-        sudo make run-local # vm-driver=none requires root
+        minikube config set vm-driver docker
+        make run-local
   run-local-kind:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Something changed (either in a new minikube version or the runner bump
to Ubuntu 20) and minikube isn't honoring the vm-driver=none
config. I'm guessing that it has something to do with running `minikube start`
with sudo but `minikube config` without. This test now uses the
newer docker driver in an effort to sidestep the issue completely.
