### PR TITLE
[release-4.6] Bug 1922919: Fix zero-delay resyncs for certain registry update policies.

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -640,7 +640,7 @@ func (o *Operator) syncRegistryServer(logger *logrus.Entry, in *v1alpha1.Catalog
 	// requeue the catalog sync based on the polling interval, for accurate syncs of catalogs with polling enabled
 	if out.Spec.UpdateStrategy != nil {
 		logger.Debugf("requeuing registry server sync based on polling interval %s", out.Spec.UpdateStrategy.Interval.Duration.String())
-		resyncPeriod := reconciler.SyncRegistryUpdateInterval(out)
+		resyncPeriod := reconciler.SyncRegistryUpdateInterval(out, time.Now())
 		o.catsrcQueueSet.RequeueAfter(out.GetNamespace(), out.GetName(), queueinformer.ResyncWithJitter(resyncPeriod, 0.1)())
 		return
 	}

--- a/pkg/controller/registry/reconciler/grpc_polling.go
+++ b/pkg/controller/registry/reconciler/grpc_polling.go
@@ -12,7 +12,7 @@ import (
 // SyncRegistryUpdateInterval returns a duration to use when requeuing the catalog source for reconciliation.
 // This ensures that the catalog is being synced on the correct time interval based on its spec.
 // Note: this function assumes the catalog has an update strategy set.
-func SyncRegistryUpdateInterval(source *v1alpha1.CatalogSource) time.Duration {
+func SyncRegistryUpdateInterval(source *v1alpha1.CatalogSource, now time.Time) time.Duration {
 	pollingInterval := source.Spec.UpdateStrategy.Interval.Duration
 	latestPoll := source.Status.LatestImageRegistryPoll
 	creationTimestamp := source.CreationTimestamp.Time
@@ -22,19 +22,21 @@ func SyncRegistryUpdateInterval(source *v1alpha1.CatalogSource) time.Duration {
 		return pollingInterval
 	}
 	// Resync based on the delta between the default sync and the actual last poll if the interval is greater than the default
-	return defaultOr(latestPoll, pollingInterval, creationTimestamp)
+	return defaultOr(latestPoll, pollingInterval, creationTimestamp, now)
 }
 
-// defaultOr returns either the default resync period or the modulus of the polling interval and the default.
+// defaultOr returns either the default resync period or the time remaining until the next poll is due, whichever is smaller.
 // For example, if the polling interval is 40 minutes, OLM will sync after ~30 minutes and see that the next sync
-// for this catalog should be sooner than the default (15 minutes) and return 10 minutes (40 % 15).
-func defaultOr(latestPoll *metav1.Time, pollingInterval time.Duration, creationTimestamp time.Time) time.Duration {
+// for this catalog should be in 10 minutes, sooner than the default 15 minutes, and return 10 minutes.
+func defaultOr(latestPoll *metav1.Time, pollingInterval time.Duration, creationTimestamp time.Time, now time.Time) time.Duration {
 	if latestPoll.IsZero() {
 		latestPoll = &metav1.Time{Time: creationTimestamp}
 	}
+
+	remaining := latestPoll.Add(pollingInterval).Sub(now)
 	// sync ahead of the default interval in the case where now + default sync is after the last sync plus the interval
-	if time.Now().Add(queueinformer.DefaultResyncPeriod).After(latestPoll.Add(pollingInterval)) {
-		return (pollingInterval % queueinformer.DefaultResyncPeriod).Round(time.Minute)
+	if remaining < queueinformer.DefaultResyncPeriod {
+		return remaining
 	}
 	// return the default sync period otherwise: the next sync cycle will check again
 	return queueinformer.DefaultResyncPeriod


### PR DESCRIPTION
If the registry update polling interval is greater than and a multiple
of the operator's default resync period (15m), and there are fewer
than 15 minutes remaining until the next poll is due, the
catalog-operator will continuously resync its associated CatalogSource
until the next poll time is reached. This is not beneficial to update
polling and can generate excessive load that negatively impacts useful
work on the cluster.
