### PR TITLE
Fix OperatorGroup Documentation Example

### DIFF
--- a/doc/design/operatorgroups.md
+++ b/doc/design/operatorgroups.md
@@ -45,7 +45,8 @@ metadata:
   namespace: my-namespace
 spec:
   selector:
-    cool.io/prod: "true"
+    matchLabels:
+      cool.io/prod: "true"
 ```
 
 or by explicitly naming target namespaces with the `spec.targetNamespaces` field:


### PR DESCRIPTION
This commit fixes an example OperatorGroup in developer documentation
that had an incorrect spec.