### PR TITLE
[release-4.6] Bug 1929335: Only re-create operator resource if it has existing components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ all: test build
 test: clean cover.out
 
 unit: kubebuilder
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(MOD_FLAGS) $(SPECIFIC_UNIT_TEST) -tags "json1" -v -race -count=1 ./pkg/...
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(MOD_FLAGS) $(SPECIFIC_UNIT_TEST) -tags "json1" -race -count=1 ./pkg/...
 
 # Ensure kubebuilder is installed before continuing
 KUBEBUILDER_ASSETS_ERR := not detected in $(KUBEBUILDER_ASSETS), to override the assets path set the KUBEBUILDER_ASSETS environment variable, for install instructions see https://book.kubebuilder.io/quick-start.html

--- a/pkg/controller/operators/operator_controller_test.go
+++ b/pkg/controller/operators/operator_controller_test.go
@@ -44,12 +44,10 @@ var _ = Describe("Operator Controller", func() {
 	})
 
 	Describe("operator deletion", func() {
+		var originalUID types.UID
 		JustBeforeEach(func() {
+			originalUID = operator.GetUID()
 			Expect(k8sClient.Delete(ctx, operator)).To(Succeed())
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, name, operator)
-				return apierrors.IsNotFound(err)
-			}, timeout, interval).Should(BeTrue())
 		})
 		Context("with components bearing its label", func() {
 			var (
@@ -76,16 +74,30 @@ var _ = Describe("Operator Controller", func() {
 			})
 
 			It("should re-create it", func() {
-				Eventually(func() error {
-					return k8sClient.Get(ctx, name, operator)
-				}).Should(Succeed())
+				// There's a race condition between this test and the controller. By the time,
+				// this function is running, we may be in one of three states.
+				//   1. The original deletion in the test setup has not yet finished, so the original
+				//      operator resource still exists.
+				//   2. The operator doesn't exist, and the controller has not yet re-created it.
+				//   3. The operator has already been deleted and re-created.
+				//
+				// To solve this problem, we simply compare the UIDs and expect to eventually see a
+				// a different UID.
+				Eventually(func() (types.UID, error) {
+					err := k8sClient.Get(ctx, name, operator)
+					return operator.GetUID(), err
+				}, timeout, interval).ShouldNot(Equal(originalUID))
 			})
 		})
 		Context("with no components bearing its label", func() {
 			It("should not re-create it", func() {
+				// We expect the operator deletion to eventually complete, and then we
+				// expect the operator to consistently never be found.
+				Eventually(func() bool {
+					return apierrors.IsNotFound(k8sClient.Get(ctx, name, operator))
+				}, timeout, interval).Should(BeTrue())
 				Consistently(func() bool {
-					err := k8sClient.Get(ctx, name, operator)
-					return apierrors.IsNotFound(err)
+					return apierrors.IsNotFound(k8sClient.Get(ctx, name, operator))
 				}, timeout, interval).Should(BeTrue())
 			})
 		})
@@ -203,5 +215,4 @@ var _ = Describe("Operator Controller", func() {
 			})
 		})
 	})
-
 })

--- a/pkg/controller/operators/operator_controller_test.go
+++ b/pkg/controller/operators/operator_controller_test.go
@@ -70,10 +70,8 @@ var _ = Describe("Operator Controller", func() {
 
 			AfterEach(func() {
 				for _, obj := range objs {
-					Expect(k8sClient.Get(ctx, testobj.NamespacedName(obj), obj)).To(Succeed())
 					Expect(k8sClient.Delete(ctx, obj, deleteOpts)).To(Succeed())
 				}
-				Expect(k8sClient.Get(ctx, name, operator)).To(Succeed())
 				Expect(k8sClient.Delete(ctx, operator, deleteOpts)).To(Succeed())
 			})
 
@@ -107,7 +105,6 @@ var _ = Describe("Operator Controller", func() {
 		})
 
 		AfterEach(func() {
-			Expect(k8sClient.Get(ctx, name, operator)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, operator, deleteOpts)).To(Succeed())
 		})
 
@@ -142,7 +139,6 @@ var _ = Describe("Operator Controller", func() {
 
 			AfterEach(func() {
 				for _, obj := range objs {
-					Expect(k8sClient.Get(ctx, testobj.NamespacedName(obj), obj)).To(Succeed())
 					Expect(k8sClient.Delete(ctx, obj, deleteOpts)).To(Succeed())
 				}
 			})

--- a/pkg/controller/operators/operator_controller_test.go
+++ b/pkg/controller/operators/operator_controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Operator Controller", func() {
 	})
 
 	Describe("operator deletion", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			Expect(k8sClient.Delete(ctx, operator)).To(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, name, operator)


### PR DESCRIPTION
This is a manual cherry-pick of #1938

/assign njhale

_(This is my best impression of the openshift-cherry-pick robot's PR message :stuck_out_tongue:)_
