### PR TITLE
Bug 1921953: Infer package name property for unannotated CSVs, if possible.

### DIFF
--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -6,15 +6,18 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-registry/pkg/api"
-	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/operator-framework/api/pkg/lib/version"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
+	"github.com/operator-framework/operator-registry/pkg/api"
+	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 func TestSolveOperators(t *testing.T) {
@@ -1455,4 +1458,207 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 		"packageB.v2": opB2,
 	}
 	require.EqualValues(t, expected, operators)
+}
+
+func TestInferProperties(t *testing.T) {
+	catalog := registry.CatalogKey{Namespace: "namespace", Name: "name"}
+
+	for _, tc := range []struct {
+		Name          string
+		Cache         NamespacedOperatorCache
+		CSV           *v1alpha1.ClusterServiceVersion
+		Subscriptions []*v1alpha1.Subscription
+		Expected      []*api.Property
+	}{
+		{
+			Name: "no subscriptions infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+		},
+		{
+			Name: "one unrelated subscription infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "b",
+					},
+				},
+			},
+		},
+		{
+			Name: "one subscription with empty package field infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "two related subscriptions infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "one matching subscription infers package property",
+			Cache: NamespacedOperatorCache{
+				snapshots: map[registry.CatalogKey]*CatalogSnapshot{
+					catalog: {
+						key: catalog,
+						operators: []*Operator{
+							{
+								name: "a",
+								bundle: &api.Bundle{
+									PackageName: "x",
+								},
+							},
+						},
+					},
+				},
+			},
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          catalog.Name,
+						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":"1.2.3"}`,
+				},
+			},
+		},
+		{
+			Name: "one matching subscription without catalog entry infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "one matching subscription infers package property without csv version",
+			Cache: NamespacedOperatorCache{
+				snapshots: map[registry.CatalogKey]*CatalogSnapshot{
+					catalog: {
+						key: catalog,
+						operators: []*Operator{
+							{
+								name: "a",
+								bundle: &api.Bundle{
+									PackageName: "x",
+								},
+							},
+						},
+					},
+				},
+			},
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          catalog.Name,
+						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":""}`,
+				},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			logger, _ := test.NewNullLogger()
+			r := SatResolver{
+				log: logger,
+				cache: &FakeOperatorCache{
+					fakedNamespacedOperatorCache: tc.Cache,
+				},
+			}
+			actual, err := r.inferProperties(tc.CSV, tc.Subscriptions)
+			require.NoError(err)
+			require.Equal(tc.Expected, actual)
+		})
+	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -48,6 +48,8 @@ func TestEndToEnd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(1 * time.Minute)
 	SetDefaultEventuallyPollingInterval(1 * time.Second)
+	SetDefaultConsistentlyDuration(30 * time.Second)
+	SetDefaultConsistentlyPollingInterval(1 * time.Second)
 
 	if junitDir := os.Getenv("JUNIT_DIRECTORY"); junitDir != "" {
 		junitReporter := reporters.NewJUnitReporter(path.Join(junitDir, fmt.Sprintf("junit_e2e_%02d.xml", config.GinkgoConfig.ParallelNode)))

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -24,9 +24,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
@@ -1999,14 +2001,6 @@ var _ = Describe("Subscription", func() {
 			},
 		}
 		updateInternalCatalog(GinkgoT(), kubeClient, crClient, catalogSourceName, testNamespace, []apiextensions.CustomResourceDefinition{crd, crd2}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvNewA, csvNewB}, manifests)
-		//Eventually(func() bool {
-		//	s, err := crClient.OperatorsV1alpha1().Subscriptions(testNamespace).Get(context.Background(), subscriptionName, metav1.GetOptions{})
-		//	if err != nil {
-		//		return false
-		//	}
-		//	if s.Status.CatalogHealth
-		//
-		//}).Should(BeTrue())
 
 		_, err = fetchSubscription(crClient, testNamespace, subscriptionName, subscriptionHasInstallPlanDifferentChecker(subscription.Status.InstallPlanRef.Name))
 		require.NoError(GinkgoT(), err)
@@ -2016,6 +2010,59 @@ var _ = Describe("Subscription", func() {
 		// Ensure csvNewB is installed
 		_, err = fetchCSV(crClient, csvNewB.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
+	})
+
+	When("an unannotated ClusterServiceVersion exists with an associated Subscription", func() {
+		var (
+			teardown func()
+		)
+
+		BeforeEach(func() {
+			teardown = func() {}
+
+			packages := []registry.PackageManifest{
+				{
+					PackageName: "package",
+					Channels: []registry.PackageChannel{
+						{Name: "channel-x", CurrentCSVName: "csv-x"},
+						{Name: "channel-y", CurrentCSVName: "csv-y"},
+					},
+					DefaultChannelName: "channel-x",
+				},
+			}
+
+			x := newCSV("csv-x", testNamespace, "", semver.MustParse("1.0.0"), nil, nil, nil)
+			y := newCSV("csv-y", testNamespace, "", semver.MustParse("1.0.0"), nil, nil, nil)
+
+			_, teardown = createInternalCatalogSource(ctx.Ctx().KubeClient(), ctx.Ctx().OperatorClient(), "test-catalog", testNamespace, packages, nil, []operatorsv1alpha1.ClusterServiceVersion{x, y})
+
+			createSubscriptionForCatalog(ctx.Ctx().OperatorClient(), testNamespace, "test-subscription-x", "test-catalog", "package", "channel-x", "", operatorsv1alpha1.ApprovalAutomatic)
+
+			Eventually(func() error {
+				var unannotated operatorsv1alpha1.ClusterServiceVersion
+				if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: "csv-x"}, &unannotated); err != nil {
+					return err
+				}
+				if _, ok := unannotated.Annotations["operatorframework.io/properties"]; !ok {
+					return nil
+				}
+				delete(unannotated.Annotations, "operatorframework.io/properties")
+				return ctx.Ctx().Client().Update(context.Background(), &unannotated)
+			}).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		FIt("uses inferred properties to prevent a duplicate installation from the same package ", func() {
+			createSubscriptionForCatalog(ctx.Ctx().OperatorClient(), testNamespace, "test-subscription-y", "test-catalog", "package", "channel-y", "", operatorsv1alpha1.ApprovalAutomatic)
+
+			Consistently(func() error {
+				var no operatorsv1alpha1.ClusterServiceVersion
+				return ctx.Ctx().Client().Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: "csv-y"}, &no)
+			}).ShouldNot(Succeed())
+		})
 	})
 })
 


### PR DESCRIPTION
Rebase of #1993

**Description of the change:**
If a CSV is missing the properties annotation, but it is referenced in
a Subscription's .status.installedCSV and is available in the same
Subscription's referenced catalog, then the CSV can be treated as
though it has a package annotation.

**Motivation for the change:**
If an operator has been installed on a cluster prior to when OLM projected package information onto the CSV, and has since updated to a version that does, OLM will not see that a CSV belongs to a particular package and may attempt to install an operator from the same package again to satisfy a dependency.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
