### PR TITLE
Bug 1935909: Allow non-CSV-owned ServiceAccounts to satisfy CSV requirements.

### DIFF
--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -272,17 +272,8 @@ func (a *Operator) permissionStatus(strategyDetailsDeployment *v1alpha1.Strategy
 			// Check SA's ownership
 			if ownerutil.IsOwnedByKind(sa, v1alpha1.ClusterServiceVersionKind) && !ownerutil.IsOwnedBy(sa, csv) {
 				met = false
-				status.Status = v1alpha1.RequirementStatusReasonNotPresent
-				status.Message = "Service account is stale"
-				statusesSet[saName] = status
-				continue
-			}
-
-			// Check if the ServiceAccount is owned by CSV
-			if len(sa.GetOwnerReferences()) != 0 && !ownerutil.IsOwnedBy(sa, csv) {
-				met = false
 				status.Status = v1alpha1.RequirementStatusReasonPresentNotSatisfied
-				status.Message = "Service account is not owned by this ClusterServiceVersion"
+				status.Message = "Service account is owned by another ClusterServiceVersion"
 				statusesSet[saName] = status
 				continue
 			}


### PR DESCRIPTION
The existing check, intended to prevent a race condition that could
occur during CSV upgrades, marks a ServiceAccount as NotPresent when
it has at least one owner but is not owned by the current CSV. It's
expected for the ServiceAccount "default" not to be have an
ownerreference to a CSV, so the check can be relaxed to only consider
owners of kind ClusterServiceVersion.

This also combines two ServiceAccount checks that were independently
added to address the same race condition into a single check.
