### PR TITLE
Bug 1929904: Infer package name property for unannotated CSVs, if possible.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ all: test build
 test: clean cover.out
 
 unit: kubebuilder
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(MOD_FLAGS) $(SPECIFIC_UNIT_TEST) -tags "json1" -v -race -count=1 ./pkg/...
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(MOD_FLAGS) $(SPECIFIC_UNIT_TEST) -tags "json1" -race -count=1 ./pkg/...
 
 # Ensure kubebuilder is installed before continuing
 KUBEBUILDER_ASSETS_ERR := not detected in $(KUBEBUILDER_ASSETS), to override the assets path set the KUBEBUILDER_ASSETS environment variable, for install instructions see https://book.kubebuilder.io/quick-start.html

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
+	"github.com/operator-framework/operator-registry/pkg/api"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
 
@@ -361,6 +363,51 @@ func (r *SatResolver) getBundleInstallables(catalog registry.CatalogKey, predica
 	return ids, installables, nil
 }
 
+func (r *SatResolver) inferProperties(csv *v1alpha1.ClusterServiceVersion, subs []*v1alpha1.Subscription) ([]*api.Property, error) {
+	var properties []*api.Property
+
+	packages := make(map[string]struct{})
+	for _, sub := range subs {
+		if sub.Status.InstalledCSV != csv.Name {
+			continue
+		}
+		// Without sanity checking the Subscription spec's
+		// package against catalog contents, updates to the
+		// Subscription spec could result in a bad package
+		// inference.
+		for _, entry := range r.cache.Namespaced(sub.Namespace).Catalog(registry.CatalogKey{Namespace: sub.Spec.CatalogSourceNamespace, Name: sub.Spec.CatalogSource}).Find(And(WithCSVName(csv.Name), WithPackage(sub.Spec.Package))) {
+			if pkg := entry.Package(); pkg != "" {
+				packages[pkg] = struct{}{}
+			}
+		}
+	}
+	if l := len(packages); l != 1 {
+		r.log.Warnf("could not unambiguously infer package name for %q (found %d distinct package names)", csv.Name, l)
+		return properties, nil
+	}
+	var pkg string
+	for pkg = range packages {
+		// Assign the single key to pkg.
+	}
+	var version string // Emit empty string rather than "0.0.0" if .spec.version is zero-valued.
+	if !csv.Spec.Version.Version.Equals(semver.Version{}) {
+		version = csv.Spec.Version.String()
+	}
+	if pp, err := json.Marshal(opregistry.PackageProperty{
+		PackageName: pkg,
+		Version:     version,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to marshal inferred package property: %w", err)
+	} else {
+		properties = append(properties, &api.Property{
+			Type:  opregistry.PackageType,
+			Value: string(pp),
+		})
+	}
+
+	return properties, nil
+}
+
 func (r *SatResolver) newSnapshotForNamespace(namespace string, subs []*v1alpha1.Subscription, csvs []*v1alpha1.ClusterServiceVersion) (*CatalogSnapshot, []solver.Installable, error) {
 	installables := make([]solver.Installable, 0)
 	existingOperatorCatalog := registry.NewVirtualCatalogKey(namespace)
@@ -392,6 +439,11 @@ func (r *SatResolver) newSnapshotForNamespace(namespace string, subs []*v1alpha1
 
 		if anno, ok := csv.GetAnnotations()[projection.PropertiesAnnotationKey]; !ok {
 			csvsMissingProperties = append(csvsMissingProperties, csv)
+			if inferred, err := r.inferProperties(csv, subs); err != nil {
+				r.log.Warnf("unable to infer properties for csv %q: %w", csv.Name, err)
+			} else {
+				op.properties = append(op.properties, inferred...)
+			}
 		} else if props, err := projection.PropertyListFromPropertiesAnnotation(anno); err != nil {
 			return nil, nil, fmt.Errorf("failed to retrieve properties of csv %q: %w", csv.GetName(), err)
 		} else {

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -6,15 +6,18 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-registry/pkg/api"
-	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/operator-framework/api/pkg/lib/version"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
+	"github.com/operator-framework/operator-registry/pkg/api"
+	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 func TestSolveOperators(t *testing.T) {
@@ -1413,4 +1416,207 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 		"packageA.v6": genOperator("packageA.v6", "6.0.0", "packageA.v5", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false),
 	}
 	require.EqualValues(t, expected, operators)
+}
+
+func TestInferProperties(t *testing.T) {
+	catalog := registry.CatalogKey{Namespace: "namespace", Name: "name"}
+
+	for _, tc := range []struct {
+		Name          string
+		Cache         NamespacedOperatorCache
+		CSV           *v1alpha1.ClusterServiceVersion
+		Subscriptions []*v1alpha1.Subscription
+		Expected      []*api.Property
+	}{
+		{
+			Name: "no subscriptions infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+		},
+		{
+			Name: "one unrelated subscription infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "b",
+					},
+				},
+			},
+		},
+		{
+			Name: "one subscription with empty package field infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "two related subscriptions infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "one matching subscription infers package property",
+			Cache: NamespacedOperatorCache{
+				snapshots: map[registry.CatalogKey]*CatalogSnapshot{
+					catalog: {
+						key: catalog,
+						operators: []*Operator{
+							{
+								name: "a",
+								bundle: &api.Bundle{
+									PackageName: "x",
+								},
+							},
+						},
+					},
+				},
+			},
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          catalog.Name,
+						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":"1.2.3"}`,
+				},
+			},
+		},
+		{
+			Name: "one matching subscription without catalog entry infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "one matching subscription infers package property without csv version",
+			Cache: NamespacedOperatorCache{
+				snapshots: map[registry.CatalogKey]*CatalogSnapshot{
+					catalog: {
+						key: catalog,
+						operators: []*Operator{
+							{
+								name: "a",
+								bundle: &api.Bundle{
+									PackageName: "x",
+								},
+							},
+						},
+					},
+				},
+			},
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          catalog.Name,
+						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":""}`,
+				},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			logger, _ := test.NewNullLogger()
+			r := SatResolver{
+				log: logger,
+				cache: &FakeOperatorCache{
+					fakedNamespacedOperatorCache: tc.Cache,
+				},
+			}
+			actual, err := r.inferProperties(tc.CSV, tc.Subscriptions)
+			require.NoError(err)
+			require.Equal(tc.Expected, actual)
+		})
+	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -48,6 +48,8 @@ func TestEndToEnd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(1 * time.Minute)
 	SetDefaultEventuallyPollingInterval(1 * time.Second)
+	SetDefaultConsistentlyDuration(30 * time.Second)
+	SetDefaultConsistentlyPollingInterval(1 * time.Second)
 
 	if junitDir := os.Getenv("JUNIT_DIRECTORY"); junitDir != "" {
 		junitReporter := reporters.NewJUnitReporter(path.Join(junitDir, fmt.Sprintf("junit_e2e_%02d.xml", config.GinkgoConfig.ParallelNode)))


### PR DESCRIPTION
Backport of #1993 to release-4.7.
