### PR TITLE
[release-4.6] Bug 1938618: Infer package name property for unannotated CSVs, if possible.

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/blang/semver"
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
+	"github.com/operator-framework/operator-registry/pkg/api"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
 
@@ -361,6 +363,51 @@ func (r *SatResolver) getBundleInstallables(catalog registry.CatalogKey, predica
 	return ids, installables, nil
 }
 
+func (r *SatResolver) inferProperties(csv *v1alpha1.ClusterServiceVersion, subs []*v1alpha1.Subscription) ([]*api.Property, error) {
+	var properties []*api.Property
+
+	packages := make(map[string]struct{})
+	for _, sub := range subs {
+		if sub.Status.InstalledCSV != csv.Name {
+			continue
+		}
+		// Without sanity checking the Subscription spec's
+		// package against catalog contents, updates to the
+		// Subscription spec could result in a bad package
+		// inference.
+		for _, entry := range r.cache.Namespaced(sub.Namespace).Catalog(registry.CatalogKey{Namespace: sub.Spec.CatalogSourceNamespace, Name: sub.Spec.CatalogSource}).Find(And(WithCSVName(csv.Name), WithPackage(sub.Spec.Package))) {
+			if pkg := entry.Package(); pkg != "" {
+				packages[pkg] = struct{}{}
+			}
+		}
+	}
+	if l := len(packages); l != 1 {
+		r.log.Warnf("could not unambiguously infer package name for %q (found %d distinct package names)", csv.Name, l)
+		return properties, nil
+	}
+	var pkg string
+	for pkg = range packages {
+		// Assign the single key to pkg.
+	}
+	var version string // Emit empty string rather than "0.0.0" if .spec.version is zero-valued.
+	if !csv.Spec.Version.Version.Equals(semver.Version{}) {
+		version = csv.Spec.Version.String()
+	}
+	if pp, err := json.Marshal(opregistry.PackageProperty{
+		PackageName: pkg,
+		Version:     version,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to marshal inferred package property: %w", err)
+	} else {
+		properties = append(properties, &api.Property{
+			Type:  opregistry.PackageType,
+			Value: string(pp),
+		})
+	}
+
+	return properties, nil
+}
+
 func (r *SatResolver) newSnapshotForNamespace(namespace string, subs []*v1alpha1.Subscription, csvs []*v1alpha1.ClusterServiceVersion) (*CatalogSnapshot, []solver.Installable, error) {
 	installables := make([]solver.Installable, 0)
 	existingOperatorCatalog := registry.NewVirtualCatalogKey(namespace)
@@ -392,6 +439,11 @@ func (r *SatResolver) newSnapshotForNamespace(namespace string, subs []*v1alpha1
 
 		if anno, ok := csv.GetAnnotations()[projection.PropertiesAnnotationKey]; !ok {
 			csvsMissingProperties = append(csvsMissingProperties, csv)
+			if inferred, err := r.inferProperties(csv, subs); err != nil {
+				r.log.Warnf("unable to infer properties for csv %q: %w", csv.Name, err)
+			} else {
+				op.properties = append(op.properties, inferred...)
+			}
 		} else if props, err := projection.PropertyListFromPropertiesAnnotation(anno); err != nil {
 			return nil, nil, fmt.Errorf("failed to retrieve properties of csv %q: %w", csv.GetName(), err)
 		} else {

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -6,15 +6,18 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-registry/pkg/api"
-	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/operator-framework/api/pkg/lib/version"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
+	"github.com/operator-framework/operator-registry/pkg/api"
+	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 func TestSolveOperators(t *testing.T) {
@@ -1413,4 +1416,207 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 		"packageA.v6": genOperator("packageA.v6", "6.0.0", "packageA.v5", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false),
 	}
 	require.EqualValues(t, expected, operators)
+}
+
+func TestInferProperties(t *testing.T) {
+	catalog := registry.CatalogKey{Namespace: "namespace", Name: "name"}
+
+	for _, tc := range []struct {
+		Name          string
+		Cache         NamespacedOperatorCache
+		CSV           *v1alpha1.ClusterServiceVersion
+		Subscriptions []*v1alpha1.Subscription
+		Expected      []*api.Property
+	}{
+		{
+			Name: "no subscriptions infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+		},
+		{
+			Name: "one unrelated subscription infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "b",
+					},
+				},
+			},
+		},
+		{
+			Name: "one subscription with empty package field infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "two related subscriptions infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "one matching subscription infers package property",
+			Cache: NamespacedOperatorCache{
+				snapshots: map[registry.CatalogKey]*CatalogSnapshot{
+					catalog: {
+						key: catalog,
+						operators: []*Operator{
+							{
+								name: "a",
+								bundle: &api.Bundle{
+									PackageName: "x",
+								},
+							},
+						},
+					},
+				},
+			},
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          catalog.Name,
+						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":"1.2.3"}`,
+				},
+			},
+		},
+		{
+			Name: "one matching subscription without catalog entry infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "one matching subscription infers package property without csv version",
+			Cache: NamespacedOperatorCache{
+				snapshots: map[registry.CatalogKey]*CatalogSnapshot{
+					catalog: {
+						key: catalog,
+						operators: []*Operator{
+							{
+								name: "a",
+								bundle: &api.Bundle{
+									PackageName: "x",
+								},
+							},
+						},
+					},
+				},
+			},
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          catalog.Name,
+						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":""}`,
+				},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			logger, _ := test.NewNullLogger()
+			r := SatResolver{
+				log: logger,
+				cache: &FakeOperatorCache{
+					fakedNamespacedOperatorCache: tc.Cache,
+				},
+			}
+			actual, err := r.inferProperties(tc.CSV, tc.Subscriptions)
+			require.NoError(err)
+			require.Equal(tc.Expected, actual)
+		})
+	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -48,6 +48,8 @@ func TestEndToEnd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(1 * time.Minute)
 	SetDefaultEventuallyPollingInterval(1 * time.Second)
+	SetDefaultConsistentlyDuration(30 * time.Second)
+	SetDefaultConsistentlyPollingInterval(1 * time.Second)
 
 	if junitDir := os.Getenv("JUNIT_DIRECTORY"); junitDir != "" {
 		junitReporter := reporters.NewJUnitReporter(path.Join(junitDir, fmt.Sprintf("junit_e2e_%02d.xml", config.GinkgoConfig.ParallelNode)))

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -24,9 +24,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
@@ -1996,14 +1998,6 @@ var _ = Describe("Subscription", func() {
 			},
 		}
 		updateInternalCatalog(GinkgoT(), kubeClient, crClient, catalogSourceName, testNamespace, []apiextensions.CustomResourceDefinition{crd, crd2}, []v1alpha1.ClusterServiceVersion{csvA, csvB, csvNewA, csvNewB}, manifests)
-		//Eventually(func() bool {
-		//	s, err := crClient.OperatorsV1alpha1().Subscriptions(testNamespace).Get(context.Background(), subscriptionName, metav1.GetOptions{})
-		//	if err != nil {
-		//		return false
-		//	}
-		//	if s.Status.CatalogHealth
-		//
-		//}).Should(BeTrue())
 
 		_, err = fetchSubscription(crClient, testNamespace, subscriptionName, subscriptionHasInstallPlanDifferentChecker(subscription.Status.InstallPlanRef.Name))
 		require.NoError(GinkgoT(), err)
@@ -2013,6 +2007,59 @@ var _ = Describe("Subscription", func() {
 		// Ensure csvNewB is installed
 		_, err = fetchCSV(crClient, csvNewB.Name, testNamespace, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
+	})
+
+	When("an unannotated ClusterServiceVersion exists with an associated Subscription", func() {
+		var (
+			teardown func()
+		)
+
+		BeforeEach(func() {
+			teardown = func() {}
+
+			packages := []registry.PackageManifest{
+				{
+					PackageName: "package",
+					Channels: []registry.PackageChannel{
+						{Name: "channel-x", CurrentCSVName: "csv-x"},
+						{Name: "channel-y", CurrentCSVName: "csv-y"},
+					},
+					DefaultChannelName: "channel-x",
+				},
+			}
+
+			x := newCSV("csv-x", testNamespace, "", semver.MustParse("1.0.0"), nil, nil, nil)
+			y := newCSV("csv-y", testNamespace, "", semver.MustParse("1.0.0"), nil, nil, nil)
+
+			_, teardown = createInternalCatalogSource(ctx.Ctx().KubeClient(), ctx.Ctx().OperatorClient(), "test-catalog", testNamespace, packages, nil, []operatorsv1alpha1.ClusterServiceVersion{x, y})
+
+			createSubscriptionForCatalog(ctx.Ctx().OperatorClient(), testNamespace, "test-subscription-x", "test-catalog", "package", "channel-x", "", operatorsv1alpha1.ApprovalAutomatic)
+
+			Eventually(func() error {
+				var unannotated operatorsv1alpha1.ClusterServiceVersion
+				if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: "csv-x"}, &unannotated); err != nil {
+					return err
+				}
+				if _, ok := unannotated.Annotations["operatorframework.io/properties"]; !ok {
+					return nil
+				}
+				delete(unannotated.Annotations, "operatorframework.io/properties")
+				return ctx.Ctx().Client().Update(context.Background(), &unannotated)
+			}).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		It("uses inferred properties to prevent a duplicate installation from the same package ", func() {
+			createSubscriptionForCatalog(ctx.Ctx().OperatorClient(), testNamespace, "test-subscription-y", "test-catalog", "package", "channel-y", "", operatorsv1alpha1.ApprovalAutomatic)
+
+			Consistently(func() error {
+				var no operatorsv1alpha1.ClusterServiceVersion
+				return ctx.Ctx().Client().Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: "csv-y"}, &no)
+			}).ShouldNot(Succeed())
+		})
 	})
 })
 


### PR DESCRIPTION
This is a mostly-automated cherry-pick of #2033

/assign benluddy
