### PR TITLE
Bug 1939294: Avoid setting metadata.GracePeriodSeconds to zero seconds

### DIFF
--- a/pkg/api/wrappers/deployment_install_client.go
+++ b/pkg/api/wrappers/deployment_install_client.go
@@ -3,6 +3,7 @@ package wrappers
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -102,7 +103,8 @@ func (c *InstallStrategyDeploymentClientForNamespace) CreateDeployment(deploymen
 
 func (c *InstallStrategyDeploymentClientForNamespace) DeleteDeployment(name string) error {
 	foregroundDelete := metav1.DeletePropagationForeground // cascading delete
-	immediate := int64(0)
+	// Note(tflannag): See https://bugzilla.redhat.com/show_bug.cgi?id=1939294.
+	immediate := int64(1)
 	immediateForegroundDelete := &metav1.DeleteOptions{GracePeriodSeconds: &immediate, PropagationPolicy: &foregroundDelete}
 	return c.opClient.DeleteDeployment(c.Namespace, name, immediateForegroundDelete)
 }

--- a/pkg/controller/operators/suite_test.go
+++ b/pkg/controller/operators/suite_test.go
@@ -49,7 +49,7 @@ var (
 	ctx       context.Context
 
 	scheme            = runtime.NewScheme()
-	gracePeriod int64 = 0
+	gracePeriod int64 = 1
 	propagation       = metav1.DeletePropagationForeground
 	deleteOpts        = &client.DeleteOptions{
 		GracePeriodSeconds: &gracePeriod,

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -354,7 +354,7 @@ func (c *ConfigMapRegistryReconciler) ensurePod(source configMapCatalogSourceDec
 			return nil
 		}
 		for _, p := range currentPods {
-			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(pod.GetNamespace()).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(0)); err != nil {
+			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(pod.GetNamespace()).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil {
 				return errors.Wrapf(err, "error deleting old pod: %s", p.GetName())
 			}
 		}

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -226,7 +226,7 @@ func (c *GrpcRegistryReconciler) ensurePod(source grpcCatalogSourceDecorator, sa
 			return nil
 		}
 		for _, p := range currentLivePods {
-			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(source.GetNamespace()).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(0)); err != nil {
+			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(source.GetNamespace()).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil {
 				return errors.Wrapf(err, "error deleting old pod: %s", p.GetName())
 			}
 		}
@@ -307,6 +307,7 @@ func (c *GrpcRegistryReconciler) ensureService(source grpcCatalogSourceDecorator
 		if !overwrite && ServiceHashMatch(svc, service) {
 			return nil
 		}
+		// TODO(tflannag): Do we care about force deleting services?
 		if err := c.OpClient.DeleteService(service.GetNamespace(), service.GetName(), metav1.NewDeleteOptions(0)); err != nil {
 			return err
 		}
@@ -402,7 +403,7 @@ func imageID(pod *corev1.Pod) string {
 
 func (c *GrpcRegistryReconciler) removePods(pods []*corev1.Pod, namespace string) error {
 	for _, p := range pods {
-		err := c.OpClient.KubernetesInterface().CoreV1().Pods(namespace).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(0))
+		err := c.OpClient.KubernetesInterface().CoreV1().Pods(namespace).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1))
 		if err != nil {
 			return errors.Wrapf(err, "error deleting pod: %s", p.GetName())
 		}

--- a/test/rh-operators/operator_util.go
+++ b/test/rh-operators/operator_util.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/operator-framework/api/pkg/operators/v1"
+	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
@@ -26,7 +26,7 @@ var (
 	pollDuration        = 20 * time.Minute
 	terminationDuration = 5 * time.Minute
 
-	immediate             = int64(0)
+	immediate             = int64(1)
 	immediateDeleteOption = &metav1.DeleteOptions{GracePeriodSeconds: &immediate}
 )
 


### PR DESCRIPTION
Update any references where we set the metadata.GracePeriodSeconds field
to zero seconds. If we need a Pod to be deleted as quick as possible,
use a single second.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
