### PR TITLE
Set labels for the operator Deployment created via the ClusterServiceVersion

### DIFF
--- a/doc/design/building-your-csv.md
+++ b/doc/design/building-your-csv.md
@@ -314,6 +314,8 @@ Ensure that the `serviceAccountName` used in the `deployment` spec matches one o
 
 Multiple Roles should be described to reduce the scope of any actions needed containers that the Operator may run on the cluster. For example, if you have a component that generates a TLS Secret upon start up, a Role that allows `create` but not `list` on Secrets is more secure than using a single all-powerful Service Account.
 
+It is also possible to set custom labels for Deployment in addition to the system labels set by the OLM. This labels should be present in the `labels` fields of the `deployments` section.  
+
 Here’s a full example:
 
 ```yaml
@@ -321,6 +323,9 @@ Here’s a full example:
     spec:
       deployments:
         - name: example-operator
+          labels:
+            application: example-operator
+            technology: general
           spec:
             replicas: 1
             selector:

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1798,6 +1799,78 @@ var _ = Describe("ClusterServiceVersion", func() {
 		Expect(annotations["foo1"]).Should(Equal("bar1"))
 		Expect(annotations["foo2"]).Should(Equal("bar2"))
 		Expect(annotations["foo3"]).Should(Equal("bar3"))
+	})
+	It("Set labels for the Deployment created via the ClusterServiceVersion", func() {
+		// Create a StrategyDetailsDeployment that defines labels for Deployment inside
+		nginxName := genName("nginx-")
+		strategy := v1alpha1.StrategyDetailsDeployment{
+			DeploymentSpecs: []v1alpha1.StrategyDeploymentSpec{
+				{
+					Name: genName("dep-"),
+					Spec: newNginxDeployment(nginxName),
+					Label: k8slabels.Set{
+						"application":      "nginx",
+						"application.type": "proxy",
+					},
+				},
+			},
+		}
+
+		csv := v1alpha1.ClusterServiceVersion{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       v1alpha1.ClusterServiceVersionKind,
+				APIVersion: v1alpha1.ClusterServiceVersionAPIVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: genName("csv"),
+			},
+			Spec: v1alpha1.ClusterServiceVersionSpec{
+				MinKubeVersion: "0.0.0",
+				InstallModes: []v1alpha1.InstallMode{
+					{
+						Type:      v1alpha1.InstallModeTypeOwnNamespace,
+						Supported: true,
+					},
+					{
+						Type:      v1alpha1.InstallModeTypeSingleNamespace,
+						Supported: true,
+					},
+					{
+						Type:      v1alpha1.InstallModeTypeMultiNamespace,
+						Supported: true,
+					},
+					{
+						Type:      v1alpha1.InstallModeTypeAllNamespaces,
+						Supported: true,
+					},
+				},
+				InstallStrategy: v1alpha1.NamedInstallStrategy{
+					StrategyName: v1alpha1.InstallStrategyNameDeployment,
+					StrategySpec: strategy,
+				},
+			},
+		}
+
+		// Create the CSV and make sure to clean it up
+		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
+		Expect(err).ShouldNot(HaveOccurred())
+		defer cleanupCSV()
+
+		// Wait for current CSV to succeed
+		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Should have created deployment
+		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(dep).ShouldNot(BeNil())
+
+		// Make sure that the deployment labels are correct
+		labels := dep.GetLabels()
+		Expect(labels["olm.owner"]).Should(Equal(csv.GetName()))
+		Expect(labels["olm.owner.namespace"]).Should(Equal(testNamespace))
+		Expect(labels["application"]).Should(Equal("nginx"))
+		Expect(labels["application.type"]).Should(Equal("proxy"))
 	})
 	It("update same deployment name", func() {
 


### PR DESCRIPTION
**Description of the change:**
With this changes is possible to set custom labels for Deployment in addition to the system labels set by the OLM. This labels should be present in the `labels` fields of the `deployments` section.  

**Motivation for the change:**
Would like the ability to set labels for the operator Deployment created via the ClusterServiceVersion.
Only owner labels are set by OLM, and the operator Deployment is limited to setting the DeploymentSpec, with no ability to set any metadata such as labels.
Custom operator deployment labels is very desirable feature, for example when we need to lookup operator deployment from the operator code itself and the name of this deployment could be change potentially and we don't want to change the logic every update. Only custom CSV based labels could help in this case.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


Closes #1522