### PR TITLE
test/e2e: Remove duplicate package imports

### DIFF
--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -3695,7 +3694,7 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 	Eventually(func() (bool, error) {
 		ctx.Ctx().Logf("waiting for deployment %s to delete", name)
 		_, err := c.GetDeployment(testNamespace, name)
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			ctx.Ctx().Logf("deleted %s", name)
 			return true, nil
 		}
@@ -3711,7 +3710,7 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 func csvExists(c versioned.Interface, name string) bool {
 
 	fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		return false
 	}
 	ctx.Ctx().Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
@@ -3773,7 +3772,7 @@ func createLegacyAPIResources(csv *v1alpha1.ClusterServiceVersion, desc v1alpha1
 	}
 
 	_, err = c.CreateSecret(&secret)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -3838,25 +3837,25 @@ func checkLegacyAPIResources(desc v1alpha1.APIServiceDescription, expectedIsNotF
 
 	// Attempt to create the legacy service
 	_, err := c.GetService(testNamespace, strings.Replace(apiServiceName, ".", "-", -1))
-	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret
 	_, err = c.GetSecret(testNamespace, apiServiceName+"-cert")
-	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role
 	_, err = c.GetRole(testNamespace, apiServiceName+"-cert")
-	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role binding
 	_, err = c.GetRoleBinding(testNamespace, apiServiceName+"-cert")
-	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authDelegatorClusterRoleBinding
 	_, err = c.GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
-	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authReadingRoleBinding
 	_, err = c.GetRoleBinding("kube-system", apiServiceName+"-auth-reader")
-	Expect(errors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 }

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -219,7 +218,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				log(fmt.Sprintf("Error (in %v): %v", testNamespace, fetchErr.Error()))
@@ -236,7 +235,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				log(fmt.Sprintf("Error (in %v): %v", otherNamespaceName, fetchErr.Error()))
@@ -253,7 +252,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -270,7 +269,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			createdDeployment, err := c.GetDeployment(opGroupNamespace, deploymentName)
 			if err != nil {
-				if errors.IsNotFound(err) {
+				if k8serrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -389,7 +388,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), errors.IsNotFound(err))
+		require.True(GinkgoT(), k8serrors.IsNotFound(err))
 
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			_, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(context.TODO(), operatorGroup.Name+"-edit", metav1.GetOptions{})
@@ -398,7 +397,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), errors.IsNotFound(err))
+		require.True(GinkgoT(), k8serrors.IsNotFound(err))
 
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			_, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(context.TODO(), operatorGroup.Name+"-view", metav1.GetOptions{})
@@ -407,7 +406,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), errors.IsNotFound(err))
+		require.True(GinkgoT(), k8serrors.IsNotFound(err))
 	})
 	It("role aggregation", func() {
 
@@ -1487,7 +1486,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
@@ -1520,7 +1519,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -1551,7 +1550,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, 2*pollDuration, func() (bool, error) {
 			_, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return true, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())
@@ -1967,7 +1966,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
@@ -2000,7 +1999,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -2027,7 +2026,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, 2*pollDuration, func() (bool, error) {
 			csv, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if errors.IsNotFound(fetchErr) {
+				if k8serrors.IsNotFound(fetchErr) {
 					return true, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())

--- a/test/e2e/webhook_e2e_test.go
+++ b/test/e2e/webhook_e2e_test.go
@@ -9,16 +9,15 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 
 	v1 "github.com/operator-framework/api/pkg/operators/v1"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
@@ -83,9 +82,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("The webhook is scoped to the selector", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -122,9 +121,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Creates Webhooks scoped to a single namespace", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -181,9 +180,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Reuses existing valid certs", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -210,7 +209,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 					return false
 				}
 
-				fetchedCSV.Status.Phase = v1alpha1.CSVPhasePending
+				fetchedCSV.Status.Phase = operatorsv1alpha1.CSVPhasePending
 
 				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.GetName()).UpdateStatus(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 				if err != nil {
@@ -232,9 +231,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Fails to install a CSV if multiple Webhooks share the same name", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -252,9 +251,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Fails if the webhooks intercepts all resources", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -283,9 +282,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Fails if the webhook intercepts OLM resources", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -314,9 +313,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Fails if webhook intercepts Admission Webhook resources", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -345,9 +344,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Succeeds if the webhook intercepts non Admission Webhook resources in admissionregistration group", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -377,9 +376,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Can be installed and upgraded successfully", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            "webhook.test.com",
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -444,9 +443,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("Is updated when the CAs expire", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -483,7 +482,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 				return nil
 			})).Should(Succeed())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, func(csv *v1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, csv.Name, namespace.Name, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create deployment
 				dep, err = c.GetDeployment(namespace.Name, csv.Spec.WebhookDefinitions[0].DeploymentName)
 				if err != nil {
@@ -527,9 +526,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		})
 		It("The webhook is scoped to all namespaces", func() {
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -586,9 +585,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		}).Should(Succeed())
 
 		sideEffect := admissionregistrationv1.SideEffectClassNone
-		webhook := v1alpha1.WebhookDescription{
+		webhook := operatorsv1alpha1.WebhookDescription{
 			GenerateName:            webhookName,
-			Type:                    v1alpha1.ValidatingAdmissionWebhook,
+			Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 			DeploymentName:          genName("webhook-dep-"),
 			ContainerPort:           443,
 			AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -652,17 +651,17 @@ var _ = Describe("CSVs with a Webhook", func() {
 			catSrcImage := "quay.io/olmtest/webhook-operator-index"
 
 			// Create gRPC CatalogSource
-			source := &v1alpha1.CatalogSource{
+			source := &operatorsv1alpha1.CatalogSource{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       v1alpha1.CatalogSourceKind,
-					APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+					Kind:       operatorsv1alpha1.CatalogSourceKind,
+					APIVersion: operatorsv1alpha1.CatalogSourceCRDAPIVersion,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
 					Namespace: testNamespace,
 				},
-				Spec: v1alpha1.CatalogSourceSpec{
-					SourceType: v1alpha1.SourceTypeGrpc,
+				Spec: operatorsv1alpha1.CatalogSourceSpec{
+					SourceType: operatorsv1alpha1.SourceTypeGrpc,
 					Image:      catSrcImage + ":0.0.3",
 				},
 			}
@@ -676,7 +675,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			// Create a Subscription for the webhook-operator
 			subscriptionName := genName("sub-")
-			cleanupSubscription := createSubscriptionForCatalog(crc, testNamespace, subscriptionName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
+			cleanupSubscription := createSubscriptionForCatalog(crc, testNamespace, subscriptionName, source.GetName(), packageName, channelName, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer cleanupSubscription()
 
 			// Wait for webhook-operator v2 csv to succeed
@@ -798,9 +797,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			// describe webhook
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -808,7 +807,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 				ConversionCRDs:          []string{crdA.GetName(), crdB.GetName()},
 			}
 
-			ownedCRDDescs := make([]v1alpha1.CRDDescription, 0)
+			ownedCRDDescs := make([]operatorsv1alpha1.CRDDescription, 0)
 
 			// create CSV
 			csv := createCSVWithWebhookAndCrds(namespace.GetName(), webhook, ownedCRDDescs)
@@ -860,9 +859,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			// describe webhook
 			sideEffect := admissionregistrationv1.SideEffectClassNone
-			webhook := v1alpha1.WebhookDescription{
+			webhook := operatorsv1alpha1.WebhookDescription{
 				GenerateName:            webhookName,
-				Type:                    v1alpha1.ValidatingAdmissionWebhook,
+				Type:                    operatorsv1alpha1.ValidatingAdmissionWebhook,
 				DeploymentName:          genName("webhook-dep-"),
 				ContainerPort:           443,
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
@@ -870,8 +869,8 @@ var _ = Describe("CSVs with a Webhook", func() {
 				ConversionCRDs:          []string{crdA.GetName()},
 			}
 
-			ownedCRDDescs := make([]v1alpha1.CRDDescription, 0)
-			ownedCRDDescs = append(ownedCRDDescs, v1alpha1.CRDDescription{Name: crdA.GetName(), Version: crdA.Spec.Versions[0].Name, Kind: crdA.Spec.Names.Kind})
+			ownedCRDDescs := make([]operatorsv1alpha1.CRDDescription, 0)
+			ownedCRDDescs = append(ownedCRDDescs, operatorsv1alpha1.CRDDescription{Name: crdA.GetName(), Version: crdA.Spec.Versions[0].Name, Kind: crdA.Spec.Names.Kind})
 
 			// create CSV
 			csv := createCSVWithWebhookAndCrdsAndInvalidInstallModes(namespace.GetName(), webhook, ownedCRDDescs)
@@ -924,35 +923,35 @@ func getWebhookWithGenerateName(c operatorclient.ClientInterface, generateName s
 	return nil, fmt.Errorf("NotFound")
 }
 
-func createCSVWithWebhook(namespace string, webhookDesc v1alpha1.WebhookDescription) v1alpha1.ClusterServiceVersion {
-	return v1alpha1.ClusterServiceVersion{
+func createCSVWithWebhook(namespace string, webhookDesc operatorsv1alpha1.WebhookDescription) operatorsv1alpha1.ClusterServiceVersion {
+	return operatorsv1alpha1.ClusterServiceVersion{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.ClusterServiceVersionKind,
-			APIVersion: v1alpha1.ClusterServiceVersionAPIVersion,
+			Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+			APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      genName("webhook-csv-"),
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.ClusterServiceVersionSpec{
-			WebhookDefinitions: []v1alpha1.WebhookDescription{
+		Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+			WebhookDefinitions: []operatorsv1alpha1.WebhookDescription{
 				webhookDesc,
 			},
-			InstallModes: []v1alpha1.InstallMode{
+			InstallModes: []operatorsv1alpha1.InstallMode{
 				{
-					Type:      v1alpha1.InstallModeTypeOwnNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
 					Supported: true,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeSingleNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
 					Supported: true,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeMultiNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
 					Supported: true,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeAllNamespaces,
+					Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
 					Supported: true,
 				},
 			},
@@ -961,38 +960,38 @@ func createCSVWithWebhook(namespace string, webhookDesc v1alpha1.WebhookDescript
 	}
 }
 
-func createCSVWithWebhookAndCrds(namespace string, webhookDesc v1alpha1.WebhookDescription, ownedCRDDescs []v1alpha1.CRDDescription) v1alpha1.ClusterServiceVersion {
-	return v1alpha1.ClusterServiceVersion{
+func createCSVWithWebhookAndCrds(namespace string, webhookDesc operatorsv1alpha1.WebhookDescription, ownedCRDDescs []operatorsv1alpha1.CRDDescription) operatorsv1alpha1.ClusterServiceVersion {
+	return operatorsv1alpha1.ClusterServiceVersion{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.ClusterServiceVersionKind,
-			APIVersion: v1alpha1.ClusterServiceVersionAPIVersion,
+			Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+			APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      genName("webhook-csv-"),
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.ClusterServiceVersionSpec{
-			WebhookDefinitions: []v1alpha1.WebhookDescription{
+		Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+			WebhookDefinitions: []operatorsv1alpha1.WebhookDescription{
 				webhookDesc,
 			},
-			CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+			CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
 				Owned: ownedCRDDescs,
 			},
-			InstallModes: []v1alpha1.InstallMode{
+			InstallModes: []operatorsv1alpha1.InstallMode{
 				{
-					Type:      v1alpha1.InstallModeTypeOwnNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
 					Supported: false,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeSingleNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
 					Supported: false,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeMultiNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
 					Supported: false,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeAllNamespaces,
+					Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
 					Supported: true,
 				},
 			},
@@ -1001,38 +1000,38 @@ func createCSVWithWebhookAndCrds(namespace string, webhookDesc v1alpha1.WebhookD
 	}
 }
 
-func createCSVWithWebhookAndCrdsAndInvalidInstallModes(namespace string, webhookDesc v1alpha1.WebhookDescription, ownedCRDDescs []v1alpha1.CRDDescription) v1alpha1.ClusterServiceVersion {
-	return v1alpha1.ClusterServiceVersion{
+func createCSVWithWebhookAndCrdsAndInvalidInstallModes(namespace string, webhookDesc operatorsv1alpha1.WebhookDescription, ownedCRDDescs []operatorsv1alpha1.CRDDescription) operatorsv1alpha1.ClusterServiceVersion {
+	return operatorsv1alpha1.ClusterServiceVersion{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.ClusterServiceVersionKind,
-			APIVersion: v1alpha1.ClusterServiceVersionAPIVersion,
+			Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+			APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      genName("webhook-csv-"),
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.ClusterServiceVersionSpec{
-			WebhookDefinitions: []v1alpha1.WebhookDescription{
+		Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+			WebhookDefinitions: []operatorsv1alpha1.WebhookDescription{
 				webhookDesc,
 			},
-			CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+			CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
 				Owned: ownedCRDDescs,
 			},
-			InstallModes: []v1alpha1.InstallMode{
+			InstallModes: []operatorsv1alpha1.InstallMode{
 				{
-					Type:      v1alpha1.InstallModeTypeOwnNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
 					Supported: true,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeSingleNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
 					Supported: false,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeMultiNamespace,
+					Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
 					Supported: false,
 				},
 				{
-					Type:      v1alpha1.InstallModeTypeAllNamespaces,
+					Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
 					Supported: true,
 				},
 			},


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Removes duplicate package imports for some of the test files in the e2e package.

**Motivation for the change:**
Tech debt, cleanup, etc.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
