### PR TITLE
Dockerfile: Avoid hardcoding the kubebuilder version in the build root image

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,12 +1,12 @@
 # Dockerfile to bootstrap build and test in openshift-ci
-
 FROM openshift/origin-release:golang-1.15
 
+ARG KUBEBUILDER_RELEASE=2.3.1
 # Install test dependencies
 RUN yum install -y skopeo && \
     export OS=$(go env GOOS) && \
     export ARCH=$(go env GOARCH) && \
-    curl -L "https://go.kubebuilder.io/dl/2.3.1/${OS}/${ARCH}" | tar -xz -C /tmp/ && \
-    mv /tmp/kubebuilder_2.3.1_${OS}_${ARCH}/ /usr/local/kubebuilder && \
+    curl -L "https://go.kubebuilder.io/dl/${KUBEBUILDER_RELEASE}/${OS}/${ARCH}" | tar -xz -C /tmp/ && \
+    mv /tmp/kubebuilder_${KUBEBUILDER_RELEASE}_${OS}_${ARCH}/ /usr/local/kubebuilder && \
     export PATH=$PATH:/usr/local/kubebuilder/bin && \
     echo "Kubebuilder installation complete!"


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the build root Dockerfile and add an argument for the kubebuilder version, and avoid hardcoding the version when curling that binary into $PATH.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
