### PR TITLE
set packageserver replicas to 1 for single node

### DIFF
--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -37,7 +37,7 @@ catalog:
      memory: 80Mi
 
 package:
-  replicaCount: 2
+  replicaCount: 1
   image:
     ref: quay.io/operator-framework/olm:master
     pullPolicy: Always

--- a/deploy/ocp/values.yaml
+++ b/deploy/ocp/values.yaml
@@ -62,7 +62,7 @@ catalog:
       cpu: 10m
       memory: 80Mi
 package:
-  replicaCount: 2
+  replicaCount: 1
   image:
     ref: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
     pullPolicy: IfNotPresent

--- a/deploy/upstream/quickstart/olm.yaml
+++ b/deploy/upstream/quickstart/olm.yaml
@@ -274,7 +274,7 @@ spec:
         spec:
           strategy:
             type: RollingUpdate
-          replicas: 2
+          replicas: 1
           selector:
             matchLabels:
               app: packageserver

--- a/deploy/upstream/values.yaml
+++ b/deploy/upstream/values.yaml
@@ -21,7 +21,7 @@ catalog:
   service:
     internalPort: 8080
 package:
-  replicaCount: 2
+  replicaCount: 1
   image:
     ref: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
     pullPolicy: Always

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -72,7 +72,7 @@ spec:
           spec:
             strategy:
               type: RollingUpdate
-            replicas: 2
+            replicas: 1
             selector:
               matchLabels:
                 app: packageserver


### PR DESCRIPTION
The single-node topology should allow only a single instance of the package server. The 1 replica default was to avoid fatal discovery errors for the packageserver api, which have been updated to non-fatal errors as of https://github.com/kubernetes/kubernetes/pull/73035.

Reverting the default packageserver replicas to 1