### PR TITLE
Bug 1945261: Fix inconsistent dependency candidate order.

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -324,15 +324,7 @@ func (r *SatResolver) getBundleInstallables(catalog registry.CatalogKey, predica
 				continue
 			}
 			bundleDependencies := make([]solver.Identifier, 0)
-			for _, dep := range sortedBundles {
-				found := namespacedCache.Catalog(dep.SourceInfo().Catalog).Find(WithCSVName(dep.Identifier()))
-				if len(found) == 0 {
-					err := fmt.Errorf("couldn't find %s in %s", bundle.Identifier(), dep.sourceInfo.Catalog)
-					errs = append(errs, err)
-					r.log.Warnf("cache consistency error: %s not found in %s", bundle.Identifier(), dep.sourceInfo.Catalog)
-					continue
-				}
-				b := found[0]
+			for _, b := range sortedBundles {
 				src := b.SourceInfo()
 				if src == nil {
 					err := fmt.Errorf("unable to resolve the source of bundle %s, invalid cache", bundle.Identifier())


### PR DESCRIPTION
After bundle dependency candidates are sorted, a second query is made
to the catalog cache. This query filters by CSV name alone, so it's
ambiguous when the same CSV name appears in multiple channels (or
packages). The query appears to be redundant, so it has been removed.
