### PR TITLE
Preserve existing ServiceAccount owner references during installs.

### DIFF
--- a/pkg/controller/operators/catalog/step_ensurer.go
+++ b/pkg/controller/operators/catalog/step_ensurer.go
@@ -156,6 +156,7 @@ func (o *StepEnsurer) EnsureServiceAccount(namespace string, sa *corev1.ServiceA
 		return
 	}
 	sa.Secrets = preSa.Secrets
+	sa.OwnerReferences = mergedOwnerReferences(preSa.OwnerReferences, sa.OwnerReferences)
 
 	sa.SetNamespace(namespace)
 
@@ -348,4 +349,21 @@ func (o *StepEnsurer) EnsureConfigMap(namespace string, configmap *corev1.Config
 
 	status = v1alpha1.StepStatusPresent
 	return
+}
+
+func mergedOwnerReferences(in ...[]metav1.OwnerReference) []metav1.OwnerReference {
+	uniques := make(map[metav1.OwnerReference]struct{})
+	for _, refs := range in {
+		for _, ref := range refs {
+			uniques[ref] = struct{}{}
+		}
+	}
+	if len(uniques) == 0 {
+		return nil
+	}
+	merged := make([]metav1.OwnerReference, 0, len(uniques))
+	for ref := range uniques {
+		merged = append(merged, ref)
+	}
+	return merged
 }

--- a/pkg/controller/operators/catalog/step_ensurer_test.go
+++ b/pkg/controller/operators/catalog/step_ensurer_test.go
@@ -1,0 +1,190 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMergedOwnerReferences(t *testing.T) {
+	var (
+		True  bool = true
+		False bool = false
+	)
+
+	for _, tc := range []struct {
+		Name string
+		In   [][]metav1.OwnerReference
+		Out  []metav1.OwnerReference
+	}{
+		{
+			Name: "empty",
+		},
+		{
+			Name: "different uid",
+			In: [][]metav1.OwnerReference{
+				{
+					{
+						APIVersion:         "a",
+						Kind:               "b",
+						Name:               "c",
+						Controller:         &True,
+						BlockOwnerDeletion: &True,
+						UID:                "x",
+					},
+					{
+						APIVersion:         "a",
+						Kind:               "b",
+						Name:               "c",
+						Controller:         &True,
+						BlockOwnerDeletion: &True,
+						UID:                "y",
+					},
+				},
+			},
+			Out: []metav1.OwnerReference{
+				{
+					APIVersion:         "a",
+					Kind:               "b",
+					Name:               "c",
+					Controller:         &True,
+					BlockOwnerDeletion: &True,
+					UID:                "x",
+				},
+				{
+					APIVersion:         "a",
+					Kind:               "b",
+					Name:               "c",
+					Controller:         &True,
+					BlockOwnerDeletion: &True,
+					UID:                "y",
+				},
+			},
+		},
+		{
+			Name: "different controller",
+			In: [][]metav1.OwnerReference{
+				{
+					{
+						APIVersion:         "a",
+						Kind:               "b",
+						Name:               "c",
+						Controller:         &True,
+						BlockOwnerDeletion: &True,
+						UID:                "x",
+					},
+					{
+						APIVersion:         "a",
+						Kind:               "b",
+						Name:               "c",
+						Controller:         &False,
+						BlockOwnerDeletion: &True,
+						UID:                "x",
+					},
+				},
+			},
+			Out: []metav1.OwnerReference{
+				{
+					APIVersion:         "a",
+					Kind:               "b",
+					Name:               "c",
+					Controller:         &True,
+					BlockOwnerDeletion: &True,
+					UID:                "x",
+				},
+				{
+					APIVersion:         "a",
+					Kind:               "b",
+					Name:               "c",
+					Controller:         &False,
+					BlockOwnerDeletion: &True,
+					UID:                "x",
+				},
+			},
+		},
+		{
+			Name: "add owner without uid",
+			In: [][]metav1.OwnerReference{
+				{
+					{
+						APIVersion:         "a",
+						Kind:               "b",
+						Name:               "c-1",
+						Controller:         &False,
+						BlockOwnerDeletion: &False,
+						UID:                "x",
+					},
+				},
+				{
+					{
+						APIVersion:         "a",
+						Kind:               "b",
+						Name:               "c-2",
+						Controller:         &False,
+						BlockOwnerDeletion: &False,
+						UID:                "",
+					},
+				},
+			},
+			Out: []metav1.OwnerReference{
+				{
+					APIVersion:         "a",
+					Kind:               "b",
+					Name:               "c-1",
+					Controller:         &False,
+					BlockOwnerDeletion: &False,
+					UID:                "x",
+				},
+				{
+					APIVersion:         "a",
+					Kind:               "b",
+					Name:               "c-2",
+					Controller:         &False,
+					BlockOwnerDeletion: &False,
+					UID:                "",
+				},
+			},
+		},
+		{
+			Name: "duplicates combined",
+			In: [][]metav1.OwnerReference{
+				{
+					{
+						APIVersion:         "a",
+						Kind:               "b",
+						Name:               "c",
+						Controller:         &False,
+						BlockOwnerDeletion: &False,
+						UID:                "x",
+					},
+				},
+				{
+					{
+						APIVersion:         "a",
+						Kind:               "b",
+						Name:               "c",
+						Controller:         &False,
+						BlockOwnerDeletion: &False,
+						UID:                "x",
+					},
+				},
+			},
+			Out: []metav1.OwnerReference{
+				{
+					APIVersion:         "a",
+					Kind:               "b",
+					Name:               "c",
+					Controller:         &False,
+					BlockOwnerDeletion: &False,
+					UID:                "x",
+				},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.ElementsMatch(t, tc.Out, mergedOwnerReferences(tc.In...))
+		})
+	}
+}

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1514,7 +1514,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		// Check if we're not ready to install part of the replacement chain yet
 		if prev := a.isReplacing(out); prev != nil {
 			if prev.Status.Phase != v1alpha1.CSVPhaseReplacing {
-				logger.WithError(fmt.Errorf("CSV being replaced is in phase %s instead of %s", prev.Status.Phase, v1alpha1.CSVPhaseReplacing)).Debug("Unable to replace previous CSV")
+				logger.WithError(fmt.Errorf("CSV being replaced is in phase %s instead of %s", prev.Status.Phase, v1alpha1.CSVPhaseReplacing)).Warn("Unable to replace previous CSV")
 				return
 			}
 		}


### PR DESCRIPTION
A ServiceAccount requirement in a ClusterServiceVersion is considered
unsatisfied if it is not owned by the CSV _and_ it is owned by a
different CSV. During InstallPlan execution, owner references in
ServiceAccount steps replace existing owner references. As a result, a
CSV that is being replaced may transition to Failed (requirements not
met) and block replacement.
