### PR TITLE
Indicate invalid OperatorGroup on InstallPlan status

### DIFF
--- a/doc/design/architecture.md
+++ b/doc/design/architecture.md
@@ -93,10 +93,10 @@ The OLM Operator will then pickup the installation and carry it through to compl
 ### InstallPlan Control Loop
 
 ```
-None --> Planning +------>------->------> Installing --> Complete
-                  |                       ^
-                  v                       |
-                  +--> RequiresApproval --+
+None --> Planning +------>------->------> Installing +---> Complete
+                  |                       ^          |
+                  v                       |          v
+                  +--> RequiresApproval --+          Failed
 ```
 
 | Phase            | Description                                                                                    |
@@ -106,6 +106,7 @@ None --> Planning +------>------->------> Installing --> Complete
 | RequiresApproval | occurs when using manual approval, will not transition phase until `approved` field is true    |
 | Installing       | resolved resources in the InstallPlan `Status` block are being created                      |
 | Complete         | all resolved resources in the `Status` block exist                                             |
+| Failed           | occurs when resources fail to install or there is an invalid OperatorGroup                     |
 
 ### Subscription Control Loop
 

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1346,20 +1346,19 @@ func (o *Operator) syncInstallPlans(obj interface{}) (syncError error) {
 		}
 
 		// Mark the InstallPlan as failed for a fatal Operator Group related error
-		ipFailError := fmt.Errorf("attenuated service account query failed - %v", err)
-		logger.Infof("InstallPlan failed: %v", ipFailError)
-
+		logger.Infof("attenuated service account query failed - %v", err)
+		ipFailError := fmt.Errorf("invalid operator group - %v", err)
 		now := o.now()
 		out := plan.DeepCopy()
 		out.Status.SetCondition(v1alpha1.ConditionFailed(v1alpha1.InstallPlanInstalled,
 			v1alpha1.InstallPlanReasonInstallCheckFailed, ipFailError.Error(), &now))
 		out.Status.Phase = v1alpha1.InstallPlanPhaseFailed
 
-		logger.Info("Transitioning InstallPlan to failed")
+		logger.Info("transitioning InstallPlan to failed")
 		if _, err := o.client.OperatorsV1alpha1().InstallPlans(plan.GetNamespace()).UpdateStatus(context.TODO(), out, metav1.UpdateOptions{}); err != nil {
 			updateErr := errors.New("error updating InstallPlan status: " + err.Error())
 			logger = logger.WithField("updateError", updateErr)
-			logger.Info("error transitioning InstallPlan to failed")
+			logger.Errorf("error transitioning InstallPlan to failed")
 
 			// retry sync with error to update InstallPlan status
 			syncError = fmt.Errorf("InstallPlan failed: %s and error updating InstallPlan status as failed: %s", ipFailError, updateErr)

--- a/pkg/lib/scoped/error.go
+++ b/pkg/lib/scoped/error.go
@@ -1,0 +1,30 @@
+package scoped
+
+// operatorGroupError is an error type returned by the service account querier when
+// there is an invalid operatorGroup (zero groups, multiple groups, non-existent service account)
+type operatorGroupError struct {
+	s string
+}
+
+func NewOperatorGroupError(s string) error {
+	return operatorGroupError{s: s}
+}
+
+func (e operatorGroupError) Error() string {
+	return e.s
+}
+
+func (e operatorGroupError) IsOperatorGroupError() bool {
+	return true
+}
+
+// IsOperatorGroupError checks if an error is an operator group error
+// This lets us classify multiple errors as operatorGroupError without
+// defining and checking all the specific error value types
+func IsOperatorGroupError(err error) bool {
+	type operatorGroupError interface {
+		IsOperatorGroupError() bool
+	}
+	ogErr, ok := err.(operatorGroupError)
+	return ok && ogErr.IsOperatorGroupError()
+}

--- a/pkg/lib/scoped/querier.go
+++ b/pkg/lib/scoped/querier.go
@@ -55,7 +55,7 @@ func queryServiceAccountFromNamespace(logger *logrus.Entry, crclient versioned.I
 	}
 
 	if len(list.Items) == 0 {
-		err = fmt.Errorf("no operator group found that is managing this namespace")
+		err = NewOperatorGroupError("no operator group found that is managing this namespace")
 		return
 	}
 
@@ -70,12 +70,12 @@ func queryServiceAccountFromNamespace(logger *logrus.Entry, crclient versioned.I
 	}
 
 	if len(groups) == 0 {
-		err = fmt.Errorf("no operator group found that is managing this namespace")
+		err = NewOperatorGroupError("no operator group found that is managing this namespace")
 		return
 	}
 
 	if len(groups) > 1 {
-		err = fmt.Errorf("more than one operator group(s) are managing this namespace count=%d", len(groups))
+		err = NewOperatorGroupError(fmt.Sprintf("more than one operator group(s) are managing this namespace count=%d", len(groups)))
 		return
 	}
 
@@ -86,7 +86,7 @@ func queryServiceAccountFromNamespace(logger *logrus.Entry, crclient versioned.I
 	}
 
 	if !group.HasServiceAccountSynced() {
-		err = fmt.Errorf("please make sure the service account exists. sa=%s operatorgroup=%s/%s", group.Spec.ServiceAccountName, group.GetNamespace(), group.GetName())
+		err = NewOperatorGroupError(fmt.Sprintf("please make sure the service account exists. sa=%s operatorgroup=%s/%s", group.Spec.ServiceAccountName, group.GetNamespace(), group.GetName()))
 		return
 	}
 

--- a/pkg/lib/scoped/querier_test.go
+++ b/pkg/lib/scoped/querier_test.go
@@ -149,7 +149,7 @@ func TestUserDefinedServiceAccountQuerier(t *testing.T) {
 			}
 			gotReference, err := f.NamespaceQuerier(tt.namespace)()
 			if tt.wantErr {
-				require.Equal(t, tt.err, err)
+				require.Equal(t, tt.err.Error(), err.Error())
 			} else {
 				require.Nil(t, tt.err)
 			}

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -2673,6 +2673,7 @@ var _ = Describe("Install Plan", func() {
 		ip := newInstallPlanWithDummySteps(installPlanName, ns.GetName(), operatorsv1alpha1.InstallPlanPhaseNone)
 		outIP, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Create(context.TODO(), ip, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		Expect(outIP).NotTo(BeNil())
 
 		// The status gets ignored on create so we need to update it else the InstallPlan sync ignores
 		// InstallPlans without any steps or bundle lookups
@@ -2682,6 +2683,7 @@ var _ = Describe("Install Plan", func() {
 
 		fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseFailed))
 		Expect(err).NotTo(HaveOccurred())
+		Expect(fetchedInstallPlan).NotTo(BeNil())
 		ctx.Ctx().Logf(fmt.Sprintf("Install plan %s fetched with phase %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
 		ctx.Ctx().Logf(fmt.Sprintf("Install plan %s fetched with conditions %+v", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Conditions))
 	})
@@ -2699,7 +2701,8 @@ var _ = Describe("Install Plan", func() {
 		Expect(err).NotTo(HaveOccurred())
 		deleteOpts := &metav1.DeleteOptions{}
 		defer func() {
-			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), *deleteOpts))
+			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), *deleteOpts)
+			Expect(err).ToNot(HaveOccurred())
 		}()
 
 		// Create 2 operatorgroups in the same namespace
@@ -2728,6 +2731,7 @@ var _ = Describe("Install Plan", func() {
 		ip := newInstallPlanWithDummySteps(installPlanName, ns.GetName(), operatorsv1alpha1.InstallPlanPhaseNone)
 		outIP, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Create(context.TODO(), ip, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		Expect(outIP).NotTo(BeNil())
 
 		// The status gets ignored on create so we need to update it else the InstallPlan sync ignores
 		// InstallPlans without any steps or bundle lookups
@@ -2736,7 +2740,8 @@ var _ = Describe("Install Plan", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseFailed))
-		require.NoError(GinkgoT(), err)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fetchedInstallPlan).NotTo(BeNil())
 		ctx.Ctx().Logf(fmt.Sprintf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
 		ctx.Ctx().Logf(fmt.Sprintf("Install plan %s fetched with conditions %+v", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Conditions))
 	})
@@ -2754,7 +2759,8 @@ var _ = Describe("Install Plan", func() {
 		Expect(err).NotTo(HaveOccurred())
 		deleteOpts := &metav1.DeleteOptions{}
 		defer func() {
-			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), *deleteOpts))
+			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), *deleteOpts)
+			Expect(err).ToNot(HaveOccurred())
 		}()
 
 		// OperatorGroup with serviceaccount specified
@@ -2769,6 +2775,7 @@ var _ = Describe("Install Plan", func() {
 		}
 		og, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
+		Expect(og).NotTo(BeNil())
 
 		// Update OperatorGroup status with namespace but no service account reference
 		now := metav1.Now()
@@ -2784,6 +2791,7 @@ var _ = Describe("Install Plan", func() {
 		ip := newInstallPlanWithDummySteps(installPlanName, ns.GetName(), operatorsv1alpha1.InstallPlanPhaseNone)
 		outIP, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Create(context.TODO(), ip, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		Expect(outIP).NotTo(BeNil())
 
 		// The status gets ignored on create so we need to update it else the InstallPlan sync ignores
 		// InstallPlans without any steps or bundle lookups
@@ -2793,6 +2801,7 @@ var _ = Describe("Install Plan", func() {
 
 		fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseFailed))
 		Expect(err).NotTo(HaveOccurred())
+		Expect(fetchedInstallPlan).NotTo(BeNil())
 		ctx.Ctx().Logf(fmt.Sprintf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
 		ctx.Ctx().Logf(fmt.Sprintf("Install plan %s fetched with conditions %+v", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Conditions))
 	})


### PR DESCRIPTION
**Description of the change:**
The InstallPlan reconciler/sync will now update the InstallPlan phase as `Failed` along with a status condition message
if it sees an invalid OperatorGroup.
An invalid OperatorGroup is one of:
- No OperatorGroups in the InstallPlan's namespace
- Multiple OperatorGroups in the InstallPlan's namespace
- An incorrect or non-existent ServiceAccount name specified on the OperatorGroup

**Motivation for the change:**
Previously an InstallPlan would stay in the `Installing` phase indefinitely if the installplan sync encountered an invalid OperatorGroup.
With this change, the failure is more readily apparent and the InstallPlan status condition is also propagated to the Subscription's status condition.

```Yaml
apiVersion: operators.coreos.com/v1alpha1
kind: InstallPlan
status:
  conditions:
    - lastTransitionTime: '2021-04-06T01:10:01Z'
      lastUpdateTime: '2021-04-06T01:10:01Z'
      message: >-
        invalid operator group - no operator group found that
        is managing this namespace
      reason: InstallCheckFailed
      status: 'False'
      type: Installed
  phase: Failed
```

```Yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
...
status:
  ...
  conditions:
    ...
    - lastTransitionTime: '2021-04-06T01:29:16Z'
      reason: InstallCheckFailed
      status: 'True'
      type: InstallPlanFailed
```

See feature request: https://issues.redhat.com/browse/OLM-2116


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive

