### PR TITLE
Do not adopt copied CSVs

### DIFF
--- a/pkg/controller/operators/operatorcondition_controller_test.go
+++ b/pkg/controller/operators/operatorcondition_controller_test.go
@@ -250,7 +250,7 @@ var _ = Describe("OperatorCondition", func() {
 					}
 					Expect(k8sClient.Create(ctx, operatorCondition)).To(Succeed())
 				})
-				It("does not injected the OperatorCondition name into the deployment's Environment Variables", func() {
+				It("does not inject the OperatorCondition name into the deployment's Environment Variables", func() {
 					deployment := &appsv1.Deployment{}
 					Consistently(func() error {
 						err := k8sClient.Get(ctx, types.NamespacedName{Name: operatorCondition.Spec.Deployments[0], Namespace: namespace.GetName()}, deployment)


### PR DESCRIPTION
**Description of the change:**
- Disowns any adopted copied CSVs if they exist in the cluster
- Prevents adoption of copied CSVs in the future

**Motivation for the change:**
Copied CSVs can show up in the component list of an Operator if:

- Component adoption happens before the copy
- A namespace is added to the operatorgroup's set after the real csv has been adopted

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
