### PR TITLE
Copy all CatalogSource annotations to its Pod

### DIFF
--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -1424,7 +1424,7 @@ func toManifest(t *testing.T, obj runtime.Object) string {
 }
 
 func pod(s v1alpha1.CatalogSource) *corev1.Pod {
-	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetName(), s.GetLabels(), 5, 10)
+	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetName(), s.GetLabels(), s.GetAnnotations(), 5, 10)
 	ownerutil.AddOwner(pod, &s, false, false)
 	return pod
 }

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -58,6 +58,11 @@ func (s *configMapCatalogSourceDecorator) Labels() map[string]string {
 	return labels
 }
 
+func (s *configMapCatalogSourceDecorator) Annotations() map[string]string {
+	// TODO: Maybe something better than just a copy of all annotations would be to have a specific 'podMetadata' section in the CatalogSource?
+	return s.GetAnnotations()
+}
+
 func (s *configMapCatalogSourceDecorator) ConfigMapChanges(configMap *v1.ConfigMap) bool {
 	if s.Status.ConfigMapResource == nil {
 		return true
@@ -95,7 +100,7 @@ func (s *configMapCatalogSourceDecorator) Service() *v1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
-	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), 5, 2)
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 2)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -62,6 +62,11 @@ func (s *grpcCatalogSourceDecorator) Labels() map[string]string {
 	}
 }
 
+func (s *grpcCatalogSourceDecorator) Annotations() map[string]string {
+	// TODO: Maybe something better than just a copy of all annotations would be to have a specific 'podMetadata' section in the CatalogSource?
+	return s.GetAnnotations()
+}
+
 func (s *grpcCatalogSourceDecorator) Service() *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -115,7 +120,7 @@ func (s *grpcCatalogSourceDecorator) ServiceAccount() *corev1.ServiceAccount {
 }
 
 func (s *grpcCatalogSourceDecorator) Pod(saName string) *corev1.Pod {
-	pod := Pod(s.CatalogSource, "registry-server", s.Spec.Image, saName, s.Labels(), 5, 10)
+	pod := Pod(s.CatalogSource, "registry-server", s.Spec.Image, saName, s.Labels(), s.Annotations(), 5, 10)
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)
 	return pod
 }

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -91,7 +91,7 @@ func NewRegistryReconcilerFactory(lister operatorlister.OperatorLister, opClient
 	}
 }
 
-func Pod(source *v1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, readinessDelay int32, livenessDelay int32) *v1.Pod {
+func Pod(source *v1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *v1.Pod {
 	// Ensure the catalog image is always pulled if the image is not based on a digest, measured by whether an "@" is included.
 	// See https://github.com/docker/distribution/blob/master/reference/reference.go for more info.
 	// This means recreating non-digest based catalog pods will result in the latest version of the catalog content being delivered on-cluster.
@@ -107,6 +107,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 			GenerateName: source.GetName() + "-",
 			Namespace:    source.GetNamespace(),
 			Labels:       labels,
+			Annotations:  annotations,
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -19,7 +19,7 @@ func TestPodNodeSelector(t *testing.T) {
 	key := "kubernetes.io/os"
 	value := "linux"
 
-	gotCatSrcPod := Pod(catsrc, "hello", "busybox", "", map[string]string{}, int32(0), int32(0))
+	gotCatSrcPod := Pod(catsrc, "hello", "busybox", "", map[string]string{}, map[string]string{}, int32(0), int32(0))
 	gotCatSrcPodSelector := gotCatSrcPod.Spec.NodeSelector
 
 	if gotCatSrcPodSelector[key] != value {
@@ -67,7 +67,7 @@ func TestPullPolicy(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		p := Pod(source, "catalog", tt.image, "", nil, int32(0), int32(0))
+		p := Pod(source, "catalog", tt.image, "", nil, nil, int32(0), int32(0))
 		policy := p.Spec.Containers[0].ImagePullPolicy
 		if policy != tt.policy {
 			t.Fatalf("expected pull policy %s for image  %s", tt.policy, tt.image)


### PR DESCRIPTION
**Description of the change:**

Plumbs a mechanism that copies all annotations from the
CatalogSource directly into the corresponding Pod's metadata.

**Motivation for the change:**

This is needed in order to facilitate adding annotations to the pods created by a
CatalogSource; in particular the workload partitioning annotations required for Single Node Openshift as outlined in https://github.com/openshift/enhancements/pull/703

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive