### PR TITLE
.github/workflows: Add the unit and verify workflows

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,25 @@
+name: unit
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**'
+      - '!doc/**'
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+      - name: Install Kubebuilder
+        run: |
+          os=$(go env GOOS)
+          arch=$(go env GOARCH)
+          curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+          sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+      - name: Run unit tests
+        run: make unit

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,25 @@
+name: verify
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**'
+      - '!doc/**'
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+
+        # Note(tflannag): We need to explicitly setup the GOPATH as the generate-internal-groups.sh
+        # codegen script still relies on $GOPATH being set and will return an error otherwise.
+        # The setup-go action does not set this value for us: https://github.com/actions/setup-go/issues/14.
+      - name: Run the verify target
+        run: |
+          export GOPATH=$(go env GOPATH)
+          make verify


### PR DESCRIPTION
Introduce two additional GH action workflows that match the existing
prow-based unit/verify jobs, with the intention of migrating off prow
entirely for master/4.8+ branch(es).

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
