### PR TITLE
fix environment variable merging from subscription.config

### DIFF
--- a/pkg/controller/operators/olm/overrides/inject/inject_test.go
+++ b/pkg/controller/operators/olm/overrides/inject/inject_test.go
@@ -3,10 +3,11 @@ package inject_test
 import (
 	"testing"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides/inject"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides/inject"
 )
 
 var (
@@ -387,6 +388,10 @@ func TestInjectEnvIntoDeployment(t *testing.T) {
 			},
 			envVar: []corev1.EnvVar{
 				corev1.EnvVar{
+					Name:  "extra",
+					Value: "extra_value",
+				},
+				corev1.EnvVar{
 					Name:  "foo",
 					Value: "new_foo_value",
 				},
@@ -406,6 +411,10 @@ func TestInjectEnvIntoDeployment(t *testing.T) {
 							corev1.EnvVar{
 								Name:  "bar",
 								Value: "new_bar_value",
+							},
+							corev1.EnvVar{
+								Name:  "extra",
+								Value: "extra_value",
 							},
 						},
 					},


### PR DESCRIPTION
**Description of the change:**
OLM's subscription.config environment variable merge algorithm is broken because it only overrides environment variables listed in the CSV if they are listed first in the subscription.config overrides. This PR fixes that problem.
 
**Motivation for the change:**
Fixes a bug in the way OLM merges environment variable overrides

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
