### PR TITLE
fix(catalog): Reduce namespace resync in resolution failure

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -893,7 +893,7 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		// given not-satisfiable error is terminal and most likely require intervention
 		// from users/admins. Resyncing the namespace again is unlikely to resolve
 		// not-satisfiable error
-		if errors.Is(err, solver.NotSatisfiable{}) {
+		if _, ok := err.(solver.NotSatisfiable); ok {
 			logger.WithError(err).Debug("resolution failed")
 			return nil
 		}


### PR DESCRIPTION
Every resolution error will trigger namespace resync up to 8 times.
This sometimes leads to excessive resync even though the problem
is persistent.

NotSatisfiable error from resolver is often terminal and require
further manual intervetion. This type of error usually won't get
resolved by retrying resolution. As a result, if catalog encounters
this error, it should move on and doesn't force immediate resync.
The resync will happen naturally later when the default resync is
triggered.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
