### PR TITLE
fix(openshift): prevent race condition in the clusteroperator controller

### DIFF
--- a/pkg/controller/operators/openshift/clusteroperator_controller.go
+++ b/pkg/controller/operators/openshift/clusteroperator_controller.go
@@ -50,7 +50,7 @@ func NewClusterOperatorReconciler(opts ...ReconcilerOption) (*ClusterOperatorRec
 		ReconcilerConfig: config,
 		delayRequeue:     reconcile.Result{RequeueAfter: config.RequeueDelay},
 		co:               co,
-		syncTracker:      NewSyncTracker(config.SyncCh, co),
+		syncTracker:      NewSyncTracker(config.SyncCh, co.DeepCopy()),
 	}
 
 	var mutations SerialMutations

--- a/pkg/controller/operators/openshift/synctracker.go
+++ b/pkg/controller/operators/openshift/synctracker.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"sync"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
-func NewSyncTracker(syncCh <-chan error, co *ClusterOperator) *SyncTracker {
+func NewSyncTracker(syncCh <-chan error, co *configv1.ClusterOperator) *SyncTracker {
 	return &SyncTracker{
 		syncCh: syncCh,
 		events: make(chan event.GenericEvent),
@@ -22,7 +23,7 @@ type SyncTracker struct {
 	mutex  sync.RWMutex
 	once   sync.Once
 
-	co                          *ClusterOperator
+	co                          *configv1.ClusterOperator
 	totalSyncs, successfulSyncs int
 }
 

--- a/pkg/controller/operators/openshift/synctracker_test.go
+++ b/pkg/controller/operators/openshift/synctracker_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"testing/quick"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
@@ -22,7 +23,7 @@ func TestInvalidFields(t *testing.T) {
 	// Add missing fields, then try again
 	tracker.syncCh = make(chan error)
 	tracker.events = make(chan event.GenericEvent)
-	tracker.co = &ClusterOperator{}
+	tracker.co = &configv1.ClusterOperator{}
 	require.NoError(t, tracker.Start(cancelled))
 }
 
@@ -31,7 +32,7 @@ func TestSyncCount(t *testing.T) {
 		syncCh := make(chan error)
 		defer close(syncCh)
 
-		co := NewClusterOperator("operator")
+		co := NewClusterOperator("operator").DeepCopy()
 		tracker := NewSyncTracker(syncCh, co)
 
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Use a deep copy of the target ClusterOperator in SyncTracker to avoid unsafe concurrent access.

Signed-off-by: Nick Hale <njohnhale@gmail.com>

