### PR TITLE
Fix resolution error if inner entry doesn't provide a required API.

### DIFF
--- a/pkg/controller/registry/resolver/cache.go
+++ b/pkg/controller/registry/resolver/cache.go
@@ -514,6 +514,12 @@ func WithLabel(label string) OperatorPredicate {
 	})
 }
 
+func WithCatalog(key registry.CatalogKey) OperatorPredicate {
+	return OperatorPredicateFunc(func(o *Operator) bool {
+		return key.Equal(o.SourceInfo().Catalog)
+	})
+}
+
 func ProvidingAPI(api opregistry.APIKey) OperatorPredicate {
 	return OperatorPredicateFunc(func(o *Operator) bool {
 		for _, p := range o.Properties() {
@@ -608,6 +614,12 @@ func Matches(o *Operator, p ...OperatorPredicate) bool {
 func True() OperatorPredicate {
 	return OperatorPredicateFunc(func(*Operator) bool {
 		return true
+	})
+}
+
+func False() OperatorPredicate {
+	return OperatorPredicateFunc(func(*Operator) bool {
+		return false
 	})
 }
 

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -1319,6 +1319,8 @@ func genOperator(name, version, replaces, pkg, channel, catalogName, catalogName
 				Namespace: catalogNamespace,
 			},
 			DefaultChannel: defaultChannel != "" && channel == defaultChannel,
+			Package:        pkg,
+			Channel:        channel,
 		},
 		providedAPIs: providedAPIs,
 		requiredAPIs: requiredAPIs,

--- a/pkg/controller/registry/resolver/step_resolver_test.go
+++ b/pkg/controller/registry/resolver/step_resolver_test.go
@@ -855,7 +855,7 @@ func TestResolver(t *testing.T) {
 			steps, lookups, subs, err := resolver.ResolveSteps(namespace, nil)
 			if tt.out.solverError == nil {
 				if tt.out.errAssert == nil {
-					assert.Nil(t, err)
+					assert.NoError(t, err)
 				} else {
 					tt.out.errAssert(t, err)
 				}

--- a/pkg/controller/registry/resolver/util_test.go
+++ b/pkg/controller/registry/resolver/util_test.go
@@ -329,7 +329,7 @@ func bundle(name, pkg, channel, replaces string, providedCRDs, requiredCRDs, pro
 		RequiredApis: apiSetToGVK(requiredCRDs, requiredAPIServices),
 		Replaces:     replaces,
 		Dependencies: apiSetToDependencies(requiredCRDs, requiredAPIServices),
-		Properties:   append(apiSetToProperties(providedCRDs, providedAPIServices, false),
+		Properties: append(apiSetToProperties(providedCRDs, providedAPIServices, false),
 			packageNameToProperty(pkg, "0.0.0"),
 		),
 	}


### PR DESCRIPTION
For bundle-to-bundle dependencies (as opposed to
subscription-to-bundle "dependencies"), candidates were filtered first
to only those that satisfy the constraint in question, then sorted in
channel order. Since the relative order of entries within a channel is
currently determined by replaces-distance from the channel head,
sorting would fail if an entry in the middle of a channel's replaces
chain did not satisfy the constraint.

For example, assume an operator "bar" has three available versions
within a single channel: bar-1, bar-2, and bar-3. If bar-1 and bar-3
provide the API "Bar", but bar-2 does not, then resolution will fail
for any operator that requires the API "Bar", because bar-1 and bar-3
are not connected by update edges without bar-2.

Now, all (package, channel, catalog) combinations satisfying a
constraint are enumerated and sorted before filtering to only those
entries that satisfy the constraint.