### PR TITLE
Bug 1952238: Report catalog pod termination logs to catalog operator on exit

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -143,7 +143,8 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 							v1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 					},
-					ImagePullPolicy: pullPolicy,
+					ImagePullPolicy:          pullPolicy,
+					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			NodeSelector: map[string]string{


### PR DESCRIPTION
**Description of the change:**

This PR sets the terminationMessagePolicy for the registry container in the
catalog pod as FallBackToLogsOnError to report back termination logs from a
catalog pod to the catalog operator

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive

