### PR TITLE
Delete operator-lifecycle-manager.Dockerfile

### DIFF
--- a/operator-lifecycle-manager.Dockerfile
+++ b/operator-lifecycle-manager.Dockerfile
@@ -1,1 +1,0 @@
-Dockerfile


### PR DESCRIPTION
This was a temporary workaround while we split up the upstream/downstream CI promotion. Previously, we had specified the `Dockerfile` as the name for the registry CI/ART images, but when we started moving everything to the downstream monorepo, we had multiple Dockerfile(s) (e.g. operator-lifecycle-manager.Dockerfile, operator-registry.Dockerfile) and the auto-config-brancher bot was ensuring Dockerfile(s) matching that list of names was present in this repository, which they were not.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
