### PR TITLE
Don't cache secrets not managed by olm

### DIFF
--- a/pkg/controller/install/certresources_test.go
+++ b/pkg/controller/install/certresources_test.go
@@ -12,7 +12,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/wrappers"
@@ -182,6 +184,7 @@ func TestInstallCertRequirementsForDeployment(t *testing.T) {
 						Name:        "test-service-cert",
 						Namespace:   namespace,
 						Annotations: map[string]string{OLMCAHashAnnotationKey: caHash},
+						Labels:      map[string]string{OLMManagedLabelKey: OLMManagedLabelValue},
 					},
 					Data: map[string][]byte{
 						"tls.crt":   certPEM,
@@ -405,6 +408,7 @@ func TestInstallCertRequirementsForDeployment(t *testing.T) {
 						Name:        "test-service-cert",
 						Namespace:   namespace,
 						Annotations: map[string]string{OLMCAHashAnnotationKey: caHash},
+						Labels:      map[string]string{OLMManagedLabelKey: OLMManagedLabelValue},
 					},
 					Data: map[string][]byte{
 						"tls.crt":   certPEM,
@@ -542,6 +546,241 @@ func TestInstallCertRequirementsForDeployment(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{OLMCAHashAnnotationKey: caHash},
+					},
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "test-sa",
+						Volumes: []corev1.Volume{
+							{
+								Name: "apiservice-cert",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "test-service-cert",
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "tls.crt",
+												Path: "apiserver.crt",
+											},
+											{
+												Key:  "tls.key",
+												Path: "apiserver.key",
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "webhook-cert",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "test-service-cert",
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "tls.crt",
+												Path: "tls.crt",
+											},
+											{
+												Key:  "tls.key",
+												Path: "tls.key",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "labels an unlabelled secret if present",
+			mockExternal: func(mockOpClient *operatorclientmocks.MockClientInterface, fakeLister *operatorlisterfakes.FakeOperatorLister, namespace string, args args) {
+				mockOpClient.EXPECT().DeleteService(namespace, "test-service", &metav1.DeleteOptions{}).Return(nil)
+				service := corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-service",
+						OwnerReferences: []metav1.OwnerReference{
+							ownerutil.NonBlockingOwner(&v1alpha1.ClusterServiceVersion{}),
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports:    args.ports,
+						Selector: selector(t, "test=label").MatchLabels,
+					},
+				}
+				mockOpClient.EXPECT().CreateService(&service).Return(&service, nil)
+
+				hosts := []string{
+					fmt.Sprintf("%s.%s", service.GetName(), namespace),
+					fmt.Sprintf("%s.%s.svc", service.GetName(), namespace),
+				}
+				servingPair, err := certGenerator.Generate(args.rotateAt, Organization, args.ca, hosts)
+				require.NoError(t, err)
+
+				// Create Secret for serving cert
+				certPEM, privPEM, err := servingPair.ToPEM()
+				require.NoError(t, err)
+
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-service-cert",
+						Namespace:   namespace,
+						Annotations: map[string]string{OLMCAHashAnnotationKey: caHash},
+						Labels:      map[string]string{OLMManagedLabelKey: OLMManagedLabelValue},
+						OwnerReferences: []metav1.OwnerReference{
+							ownerutil.NonBlockingOwner(&v1alpha1.ClusterServiceVersion{}),
+						},
+					},
+					Data: map[string][]byte{
+						"tls.crt":   certPEM,
+						"tls.key":   privPEM,
+						OLMCAPEMKey: caPEM,
+					},
+					Type: corev1.SecretTypeTLS,
+				}
+				// secret already exists, but without label
+				mockOpClient.EXPECT().CreateSecret(secret).Return(nil, errors.NewAlreadyExists(schema.GroupResource{
+					Group:    "",
+					Resource: "secrets",
+				}, "test-service-cert"))
+
+				// update secret with label
+				mockOpClient.EXPECT().UpdateSecret(secret).Return(secret, nil)
+
+				secretRole := &rbacv1.Role{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secret.GetName(),
+						Namespace: namespace,
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:         []string{"get"},
+							APIGroups:     []string{""},
+							Resources:     []string{"secrets"},
+							ResourceNames: []string{secret.GetName()},
+						},
+					},
+				}
+				mockOpClient.EXPECT().UpdateRole(secretRole).Return(secretRole, nil)
+
+				roleBinding := &rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secret.GetName(),
+						Namespace: namespace,
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind:      "ServiceAccount",
+							APIGroup:  "",
+							Name:      "test-sa",
+							Namespace: namespace,
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "Role",
+						Name:     secretRole.GetName(),
+					},
+				}
+				mockOpClient.EXPECT().UpdateRoleBinding(roleBinding).Return(roleBinding, nil)
+
+				authDelegatorClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: service.GetName() + "-system:auth-delegator",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind:      "ServiceAccount",
+							APIGroup:  "",
+							Name:      "test-sa",
+							Namespace: namespace,
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "ClusterRole",
+						Name:     "system:auth-delegator",
+					},
+				}
+
+				mockOpClient.EXPECT().UpdateClusterRoleBinding(authDelegatorClusterRoleBinding).Return(authDelegatorClusterRoleBinding, nil)
+
+				authReaderRoleBinding := &rbacv1.RoleBinding{
+					Subjects: []rbacv1.Subject{
+						{
+							Kind:      "ServiceAccount",
+							APIGroup:  "",
+							Name:      args.depSpec.Template.Spec.ServiceAccountName,
+							Namespace: namespace,
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "Role",
+						Name:     "extension-apiserver-authentication-reader",
+					},
+				}
+				authReaderRoleBinding.SetName(service.GetName() + "-auth-reader")
+				authReaderRoleBinding.SetNamespace(KubeSystem)
+
+				mockOpClient.EXPECT().UpdateRoleBinding(authReaderRoleBinding).Return(authReaderRoleBinding, nil)
+			},
+			state: fakeState{
+				existingService: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							ownerutil.NonBlockingOwner(&v1alpha1.ClusterServiceVersion{}),
+						},
+					},
+				},
+				// unlabelled secret won't be in cache
+				getSecretError: errors.NewNotFound(schema.GroupResource{
+					Group:    "",
+					Resource: "Secret",
+				}, "nope"),
+				existingRole: &rbacv1.Role{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+				existingRoleBinding: &rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+				existingClusterRoleBinding: &rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+			},
+			fields: fields{
+				owner:                  &v1alpha1.ClusterServiceVersion{},
+				previousStrategy:       nil,
+				templateAnnotations:    nil,
+				initializers:           nil,
+				apiServiceDescriptions: []certResource{},
+				webhookDescriptions:    []certResource{},
+			},
+			args: args{
+				deploymentName: "test",
+				ca:             ca,
+				rotateAt:       time.Now().Add(time.Hour),
+				ports:          []corev1.ServicePort{},
+				depSpec: appsv1.DeploymentSpec{
+					Selector: selector(t, "test=label"),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							ServiceAccountName: "test-sa",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.DeploymentSpec{
+				Selector: selector(t, "test=label"),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"foo":                  "bar",
+							OLMCAHashAnnotationKey: caHash},
 					},
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "test-sa",

--- a/pkg/controller/operators/olm/apiservices.go
+++ b/pkg/controller/operators/olm/apiservices.go
@@ -110,7 +110,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 		secretName := install.SecretName(serviceName)
 		secret, err := a.lister.CoreV1().SecretLister().Secrets(csv.GetNamespace()).Get(secretName)
 		if err != nil {
-			logger.WithField("secret", secretName).Warnf("could not retrieve generated Secret")
+			logger.WithField("secret", secretName).Warnf("could not retrieve generated Secret: %v", err)
 			errs = append(errs, err)
 			continue
 		}

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -303,7 +303,9 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		}
 
 		// Register Secret QueueInformer
-		secretInformer := k8sInformerFactory.Core().V1().Secrets()
+		secretInformer := informers.NewSharedInformerFactoryWithOptions(op.opClient.KubernetesInterface(), config.resyncPeriod(), informers.WithNamespace(namespace), informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}).String()
+		})).Core().V1().Secrets()
 		op.lister.CoreV1().RegisterSecretLister(namespace, secretInformer.Lister())
 		secretQueueInformer, err := queueinformer.NewQueueInformer(
 			ctx,

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -1460,9 +1460,9 @@ func TestTransitionCSV(t *testing.T) {
 					deployment("a1", namespace, "sa", addAnnotations(defaultTemplateAnnotations, map[string]string{
 						install.OLMCAHashAnnotationKey: validCAHash,
 					})),
-					withAnnotations(keyPairToTLSSecret("a1-service-cert", namespace, signedServingPair(time.Now().Add(24*time.Hour), validCA, []string{"a1-service.ns", "a1-service.ns.svc"})), map[string]string{
+					withLabels(withAnnotations(keyPairToTLSSecret("a1-service-cert", namespace, signedServingPair(time.Now().Add(24*time.Hour), validCA, []string{"a1-service.ns", "a1-service.ns.svc"})), map[string]string{
 						install.OLMCAHashAnnotationKey: validCAHash,
-					}),
+					}), map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
 					service("a1-service", namespace, "a1", 80),
 					serviceAccount("sa", namespace),
 					role("a1-service-cert", namespace, []rbacv1.PolicyRule{


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Omits secrets that aren't owned by olm (via label-selector in cache)

**Motivation for the change:**

Before:
<img width="444" alt="Screen Shot 2021-04-26 at 5 15 13 PM" src="https://user-images.githubusercontent.com/58055/116153074-c4bd5a80-a6b4-11eb-9274-0e287472473a.png">

After: 
<img width="432" alt="Screen Shot 2021-04-26 at 5 27 12 PM" src="https://user-images.githubusercontent.com/58055/116153113-d272e000-a6b4-11eb-80e0-57f16d26c694.png">


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
