### PR TITLE
Simplify deployment status check to reduce flapping.

### DIFF
--- a/pkg/controller/install/status_viewer.go
+++ b/pkg/controller/install/status_viewer.go
@@ -1,7 +1,5 @@
 package install
 
-// See kubernetes/pkg/kubectl/rollout_status.go
-
 import (
 	"fmt"
 
@@ -15,29 +13,26 @@ const TimedOutReason = "ProgressDeadlineExceeded"
 func DeploymentStatus(deployment *appsv1.Deployment) (string, bool, error) {
 	if deployment.Generation <= deployment.Status.ObservedGeneration {
 		// check if deployment has timed out
-		cond := getDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)
-		if cond != nil && cond.Reason == TimedOutReason {
+		progressing := getDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)
+		if progressing != nil && progressing.Reason == TimedOutReason {
 			return "", false, fmt.Errorf("deployment %q exceeded its progress deadline", deployment.Name)
 		}
-		// not all replicas are up yet
-		if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-			return fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas have been updated...\n", deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas), false, nil
-		}
-		// waiting for old replicas to be cleaned up
+
 		if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-			return fmt.Sprintf("Waiting for rollout to finish: %d old replicas are pending termination...\n", deployment.Status.Replicas-deployment.Status.UpdatedReplicas), false, nil
+			return fmt.Sprintf("deployment %q waiting for %d outdated replica(s) to be terminated", deployment.Name, deployment.Status.Replicas-deployment.Status.UpdatedReplicas), false, nil
 		}
-		if c := getDeploymentCondition(deployment.Status, appsv1.DeploymentAvailable); c == nil || c.Status != corev1.ConditionTrue {
-			msg := fmt.Sprintf("deployment %q missing condition %q", deployment.Name, appsv1.DeploymentAvailable)
-			if c != nil {
-				msg = fmt.Sprintf("deployment %q not available: %s", deployment.Name, c.Message)
+
+		if available := getDeploymentCondition(deployment.Status, appsv1.DeploymentAvailable); available == nil || available.Status != corev1.ConditionTrue {
+			msg := fmt.Sprintf("missing condition %q", appsv1.DeploymentAvailable)
+			if available != nil {
+				msg = available.Message
 			}
-			return fmt.Sprintf("Waiting for rollout to finish: %s\n", msg), false, nil
+			return fmt.Sprintf("deployment %q not available: %s", deployment.Name, msg), false, nil
 		}
-		// deployment is finished
-		return fmt.Sprintf("deployment %q successfully rolled out\n", deployment.Name), true, nil
+
+		return fmt.Sprintf("deployment %q is up-to-date and available", deployment.Name), true, nil
 	}
-	return fmt.Sprintf("Waiting for deployment spec update to be observed...\n"), false, nil
+	return fmt.Sprintf("waiting for spec update of deployment %q to be observed...", deployment.Name), false, nil
 }
 
 func getDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {


### PR DESCRIPTION
The deployment status logic (originally based on kubectl's rollout
status) can impact its ClusterServiceVersion's status (e.g. by sending
it to Failed/ComponentUnhealthy or triggering reinstallation). If
these ClusterServiceVersion status updates are generated when no
changes have been made to the Deployment spec and when the Deployment
itself has condition Available: True, then the usefulness of
ClusterServiceVersion statuses as a signal is reduced.

This patch changes the deployment status logic so that it is
considered "done" when a) there are no replicas from earlier
generations, and b) the Deployment has condition Available: true.
