### PR TITLE
Deprecated inner channel entries cause resolution error.

### DIFF
--- a/pkg/controller/registry/resolver/cache.go
+++ b/pkg/controller/registry/resolver/cache.go
@@ -400,9 +400,6 @@ type OperatorPredicate interface {
 func (s *CatalogSnapshot) Find(p ...OperatorPredicate) []*Operator {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	if len(p) > 0 {
-		p = append(p, WithoutDeprecatedProperty())
-	}
 	return Filter(s.operators, p...)
 }
 
@@ -458,17 +455,6 @@ func WithPackage(pkg string) OperatorPredicate {
 			}
 		}
 		return o.Package() == pkg
-	})
-}
-
-func WithoutDeprecatedProperty() OperatorPredicate {
-	return OperatorPredicateFunc(func(o *Operator) bool {
-		for _, p := range o.bundle.GetProperties() {
-			if p.GetType() == opregistry.DeprecatedType {
-				return false
-			}
-		}
-		return true
 	})
 }
 


### PR DESCRIPTION
Similar to https://github.com/operator-framework/operator-lifecycle-manager/pull/2104, but this one happens because deprecated bundles are filtered out before they are returned from the catalog query layer: https://github.com/operator-framework/operator-lifecycle-manager/blob/f40e8e5a92f216aa5b84e7d7097b5221b925e43b/pkg/controller/registry/resolver/cache.go#L404