### PR TITLE
pkg/controller: Minor cleanup of catalog operator package(s)

### DIFF
--- a/pkg/controller/operators/catalog/manifests.go
+++ b/pkg/controller/operators/catalog/manifests.go
@@ -8,7 +8,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/configmap"
 	errorwrap "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/client-go/listers/core/v1"
+	corev1 "k8s.io/client-go/listers/core/v1"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
@@ -22,13 +22,13 @@ type ManifestResolver interface {
 
 // manifestResolver caches manifest from unpacked bundles (via configmaps)
 type manifestResolver struct {
-	configMapLister v1.ConfigMapLister
+	configMapLister corev1.ConfigMapLister
 	unpackedSteps   map[string][]v1alpha1.StepResource
 	namespace       string
 	logger          logrus.FieldLogger
 }
 
-func newManifestResolver(namespace string, configMapLister v1.ConfigMapLister, logger logrus.FieldLogger) *manifestResolver {
+func newManifestResolver(namespace string, configMapLister corev1.ConfigMapLister, logger logrus.FieldLogger) *manifestResolver {
 	return &manifestResolver{
 		namespace:       namespace,
 		configMapLister: configMapLister,

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apiserver/pkg/storage/names"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
@@ -1291,7 +1290,7 @@ func TestValidateExistingCRs(t *testing.T) {
 	unstructuredForFile := func(file string) *unstructured.Unstructured {
 		data, err := ioutil.ReadFile(file)
 		require.NoError(t, err)
-		dec := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
+		dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 		k8sFile := &unstructured.Unstructured{}
 		require.NoError(t, dec.Decode(k8sFile))
 		return k8sFile
@@ -1300,7 +1299,7 @@ func TestValidateExistingCRs(t *testing.T) {
 	unversionedCRDForV1beta1File := func(file string) *apiextensions.CustomResourceDefinition {
 		data, err := ioutil.ReadFile(file)
 		require.NoError(t, err)
-		dec := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
+		dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 		k8sFile := &apiextensionsv1beta1.CustomResourceDefinition{}
 		require.NoError(t, dec.Decode(k8sFile))
 		convertedCRD := &apiextensions.CustomResourceDefinition{}


### PR DESCRIPTION
- Update package import from v1 -> corev1.
- Remove duplicate, nested `!ok` conditional check.
- Flatten some conditional checks by reversing the conditional and
  exiting early.
- Remove if/else conditional structure where both are returning in the
  scope of that conditional.
- Remove any duplicate package imports.

