### PR TITLE
add CatalogSource info for event

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -207,11 +207,11 @@ func (r *SatResolver) getSubscriptionInstallables(sub *v1alpha1.Subscription, cu
 		case nall == 0:
 			si = NewInvalidSubscriptionInstallable(sub.GetName(), fmt.Sprintf("no operators found from catalog %s in namespace %s referenced by subscription %s", sub.Spec.CatalogSource, sub.Spec.CatalogSourceNamespace, sub.GetName()))
 		case npkg == 0:
-			si = NewInvalidSubscriptionInstallable(sub.GetName(), fmt.Sprintf("no operators found in package %s in the catalog referenced by subscription %s", sub.Spec.Package, sub.GetName()))
+			si = NewInvalidSubscriptionInstallable(sub.GetName(), fmt.Sprintf("no operators found in package %s in the catalog %s referenced by subscription %s", sub.Spec.Package, sub.Spec.CatalogSource, sub.GetName()))
 		case nch == 0:
-			si = NewInvalidSubscriptionInstallable(sub.GetName(), fmt.Sprintf("no operators found in channel %s of package %s in the catalog referenced by subscription %s", sub.Spec.Channel, sub.Spec.Package, sub.GetName()))
+			si = NewInvalidSubscriptionInstallable(sub.GetName(), fmt.Sprintf("no operators found in channel %s of package %s in the catalog %s referenced by subscription %s", sub.Spec.Channel, sub.Spec.Package, sub.Spec.CatalogSource, sub.GetName()))
 		case ncsv == 0:
-			si = NewInvalidSubscriptionInstallable(sub.GetName(), fmt.Sprintf("no operators found with name %s in channel %s of package %s in the catalog referenced by subscription %s", sub.Spec.StartingCSV, sub.Spec.Channel, sub.Spec.Package, sub.GetName()))
+			si = NewInvalidSubscriptionInstallable(sub.GetName(), fmt.Sprintf("no operators found with name %s in channel %s of package %s in the catalog %s referenced by subscription %s", sub.Spec.StartingCSV, sub.Spec.Channel, sub.Spec.Package, sub.Spec.CatalogSource, sub.GetName()))
 		}
 
 		if si != nil {

--- a/pkg/controller/registry/resolver/step_resolver_test.go
+++ b/pkg/controller/registry/resolver/step_resolver_test.go
@@ -126,7 +126,7 @@ func TestResolver(t *testing.T) {
 					},
 					{
 						Installable: NewSubscriptionInstallable("a", nil),
-						Constraint:  PrettyConstraint(solver.Dependency(), "no operators found in package a in the catalog referenced by subscription a-alpha"),
+						Constraint:  PrettyConstraint(solver.Dependency(), fmt.Sprintf("no operators found in package a in the catalog %s referenced by subscription a-alpha", catalog.Name)),
 					},
 				},
 			},
@@ -149,7 +149,7 @@ func TestResolver(t *testing.T) {
 					},
 					{
 						Installable: NewSubscriptionInstallable("a", nil),
-						Constraint:  PrettyConstraint(solver.Dependency(), "no operators found in channel alpha of package a in the catalog referenced by subscription a-alpha"),
+						Constraint:  PrettyConstraint(solver.Dependency(), fmt.Sprintf("no operators found in channel alpha of package a in the catalog %s referenced by subscription a-alpha", catalog.Name)),
 					},
 				},
 			},
@@ -172,7 +172,7 @@ func TestResolver(t *testing.T) {
 					},
 					{
 						Installable: NewSubscriptionInstallable("a", nil),
-						Constraint:  PrettyConstraint(solver.Dependency(), "no operators found with name notfound in channel alpha of package a in the catalog referenced by subscription a-alpha"),
+						Constraint:  PrettyConstraint(solver.Dependency(), fmt.Sprintf("no operators found with name notfound in channel alpha of package a in the catalog %s referenced by subscription a-alpha", catalog.Name)),
 					},
 				},
 			},


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add `CatalogSource` info

**Motivation for the change:**
The users don't need to check the subscription for checking the `CatalogSource` info.
Current:
```yaml
no operators found with name etcdoperator.v0.9.3 in channel singlenamespace-alpha of package etcd in the catalog referenced by subscription wrong-test2, subscription wrong-test2 exists
```
**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
