### PR TITLE
Added resource 'operator' to aggregated clusterrole

### DIFF
--- a/deploy/chart/templates/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/deploy/chart/templates/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
   resources: ["subscriptions"]
   verbs: ["create", "update", "patch", "delete"]
 - apiGroups: ["operators.coreos.com"]
-  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operators"]
   verbs: ["delete"]
 ---
 kind: ClusterRole
@@ -25,7 +25,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups: ["operators.coreos.com"]
-  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups", "operators"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["packages.operators.coreos.com"]
   resources: ["packagemanifests", "packagemanifests/icon"]


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Added the CRD `operators` to `0000_50_olm_09-aggregated.clusterrole.yaml`

**Motivation for the change:**
Missing declaration for the CRD `operators` in aggregated clusterrole.

The CRD is: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/deploy/chart/crds/0000_50_olm_00-operators.crd.yaml

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
