### PR TITLE
[release-4.7] Bug 1969320: packageserver CSV: add missing properties

### DIFF
--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -9,6 +9,9 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
+  cleanup:
+    enabled: false
+  customresourcedefinitions: {}
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
   minKubeVersion: 1.11.0
@@ -80,6 +83,7 @@ spec:
                 app: packageserver
             template:
               metadata:
+                creationTimestamp: null
                 labels:
                   app: packageserver
               spec:
@@ -113,6 +117,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     ports:
                       - containerPort: 5443
+                        protocol: TCP
                     livenessProbe:
                       httpGet:
                         scheme: HTTPS


### PR DESCRIPTION
**Description of the change:**
packageserver CSV: add missing properties

**Motivation for the change:**
Some properties are unset and being set to defaults. CVO is however unware of it, so it attempts to remove the fields which are unset in the manifest files. This change would ensure CVO is not attempting to re-apply this manifest on every sync loop.

This is a cherry-pick of https://github.com/openshift/operator-framework-olm/pull/84 on `release-4.7` branch

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive