### PR TITLE
Resurrect deleted metrics Service templates.

### DIFF
--- a/deploy/chart/templates/0000_50_olm_02-services.yaml
+++ b/deploy/chart/templates/0000_50_olm_02-services.yaml
@@ -1,0 +1,39 @@
+{{ if .Values.monitoring.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: olm-operator-metrics
+  namespace: {{ .Values.namespace }}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
+  labels:
+    app: olm-operator
+spec:
+  type: ClusterIP
+  ports:
+  - name: https-metrics
+    port: 8081
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    app: olm-operator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalog-operator-metrics
+  namespace: {{ .Values.namespace }}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
+  labels:
+    app: catalog-operator
+spec:
+  type: ClusterIP
+  ports:
+  - name: https-metrics
+    port: 8081
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    app: catalog-operator
+{{ end }}


### PR DESCRIPTION
The olm-operator-metrics and catalog-operator-metrics services were
deleted as part of a removal of OpenShift-specific content, but they
are still necessary when monitoring is enabled.
