### PR TITLE
Bug 1952576: csv_succeeded metric not present

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1115,10 +1115,11 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 			} else {
 				syncError = fmt.Errorf("error transitioning ClusterServiceVersion: %s and error updating CSV status: %s", syncError, updateErr)
 			}
-		} else {
-			metrics.EmitCSVMetric(clusterServiceVersion, outCSV)
 		}
 	}
+
+	// always emit csv metrics
+	metrics.EmitCSVMetric(clusterServiceVersion, outCSV)
 
 	operatorGroup := a.operatorGroupFromAnnotations(logger, clusterServiceVersion)
 	if operatorGroup == nil {


### PR DESCRIPTION
`csv_succeeded` metric is lost between pod restarts.
This is because this metric is only emitted when CSV.Status is changed.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Emit `csv_succeeded`/`csv_abnormal` metric during every CSV sync loop.

**Motivation for the change:**
`csv_succeeded` metric is lost between pod restarts.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
