### PR TITLE
Emit CSV metric on startup

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -171,6 +171,11 @@ func main() {
 	op.Run(ctx)
 	<-op.Ready()
 
+	// Emit CSV metric
+	if err = op.EnsureCSVMetric(); err != nil {
+		logger.WithError(err).Fatalf("error emitting metrics for existing CSV")
+	}
+
 	if *writeStatusName != "" {
 		reconciler, err := openshift.NewClusterOperatorReconciler(
 			openshift.WithClient(mgr.GetClient()),

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -655,6 +655,23 @@ func (a *Operator) RegisterCSVWatchNotification(csvNotification csvutility.Watch
 	a.csvNotification = csvNotification
 }
 
+func (a *Operator) EnsureCSVMetric() error {
+	csvs, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, csv := range csvs {
+		logger := a.logger.WithFields(logrus.Fields{
+			"name":      csv.GetName(),
+			"namespace": csv.GetNamespace(),
+			"self":      csv.GetSelfLink(),
+		})
+		logger.Debug("emitting metrics for existing CSV")
+		metrics.EmitCSVMetric(csv, csv)
+	}
+	return nil
+}
+
 func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 	metaObj, ok := obj.(metav1.Object)
 	if !ok {


### PR DESCRIPTION
`csv_succeeded` metric is lost between pod restarts.
This is because this metric is only emitted when CSV.Status is changed.
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Emit `csv_succeeded`/`csv_abnormal` metric during OLM startup

**Motivation for the change:**
csv_succeeded metric is lost between pod restarts.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
