### PR TITLE
Fix test for detecting a previous OLM install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,10 +14,11 @@ if [[ ${#@} -lt 1 || ${#@} -gt 2 ]]; then
     exit 1
 fi
 
-if kubectl get deployment olm-operator -n openshift-operator-lifecycle-manager -o=jsonpath='{.spec}' > /dev/null 2>&1; then
+kubectl get deployment olm-operator -n openshift-operator-lifecycle-manager -o=jsonpath='{.spec}' > /dev/null 2>&1 \
+&& {
     echo "OLM is already installed in a different configuration. This is common if you are not running a vanilla Kubernetes cluster. Exiting..."
     exit 1
-fi
+}
 
 release="$1"
 base_url="${2:-${default_base_url}}"


### PR DESCRIPTION
**Description of the change:**

Fix `install.sh` test for detecting a previous OLM install

**Motivation for the change:**

Fix bug https://github.com/operator-framework/operator-lifecycle-manager/issues/2217

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
