### PR TITLE
(fix)registry: fix configmap registry server liveness probe timeouts

### DIFF
--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -101,7 +101,7 @@ func (s *configMapCatalogSourceDecorator) Service() *v1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
-	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 2)
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -139,6 +139,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 							},
 						},
 						InitialDelaySeconds: livenessDelay,
+						TimeoutSeconds:      5,
 					},
 					Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

In #1378, the readiness probe initial delay and timeout were bumped
to account for node resource constraints during pod startup. This
PR bumps the liveness probe delay and timeout values too, to account
for scenarios where node resources continue to be overloaded causing
the liveness probe to fail temporarily.

**Motivation for the change:**

Failing readiness/liveness probe fires prometheus alerts for
CatalogSources backed by configmap registry servers.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
