### PR TITLE
Require valid client certificate for profiling endpoints.

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -10,7 +9,6 @@ import (
 	"time"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -18,10 +16,9 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/filemonitor"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/profile"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/server"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/signals"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
 	olmversion "github.com/operator-framework/operator-lifecycle-manager/pkg/version"
@@ -67,8 +64,9 @@ var (
 	tlsCertPath = flag.String(
 		"tls-cert", "", "Path to use for certificate key (requires tls-key)")
 
-	profiling = flag.Bool(
-		"profiling", false, "serve profiling data (on port 8080)")
+	profiling = flag.Bool("profiling", false, "deprecated")
+
+	clientCAPath = flag.String("client-ca", "", "path to watch for client ca bundle")
 
 	installPlanTimeout  = flag.Duration("install-plan-retry-timeout", 1*time.Minute, "time since first attempt at which plan execution errors are considered fatal")
 	bundleUnpackTimeout = flag.Duration("bundle-unpack-timeout", 10*time.Minute, "The time limit for bundle unpacking, after which InstallPlan execution is considered to have failed. 0 is considered as having no timeout.")
@@ -106,59 +104,16 @@ func main() {
 		*catalogNamespace = catalogNamespaceEnvVarValue
 	}
 
-	var useTLS bool
-	if *tlsCertPath != "" && *tlsKeyPath == "" || *tlsCertPath == "" && *tlsKeyPath != "" {
-		logger.Warn("both --tls-key and --tls-crt must be provided for TLS to be enabled, falling back to non-https")
-	} else if *tlsCertPath == "" && *tlsKeyPath == "" {
-		logger.Info("TLS keys not set, using non-https for metrics")
-	} else {
-		logger.Info("TLS keys set, using https for metrics")
-		useTLS = true
+	listenAndServe, err := server.GetListenAndServeFunc(logger, tlsCertPath, tlsKeyPath, clientCAPath)
+	if err != nil {
+		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
 	}
 
-	// Serve a health check.
-	healthMux := http.NewServeMux()
-	healthMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	// Serve profiling if enabled
-	if *profiling {
-		logger.Infof("profiling enabled")
-		profile.RegisterHandlers(healthMux)
-	}
-
-	go http.ListenAndServe(":8080", healthMux)
-
-	metricsMux := http.NewServeMux()
-	metricsMux.Handle("/metrics", promhttp.Handler())
-	if useTLS {
-		tlsGetCertFn, err := filemonitor.OLMGetCertRotationFn(logger, *tlsCertPath, *tlsKeyPath)
-		if err != nil {
-			logger.Errorf("Certificate monitoring for metrics (https) failed: %v", err)
+	go func() {
+		if err := listenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error(err)
 		}
-
-		go func() {
-			httpsServer := &http.Server{
-				Addr:    ":8081",
-				Handler: metricsMux,
-				TLSConfig: &tls.Config{
-					GetCertificate: tlsGetCertFn,
-				},
-			}
-			err := httpsServer.ListenAndServeTLS("", "")
-			if err != nil {
-				logger.Errorf("Metrics (https) serving failed: %v", err)
-			}
-		}()
-	} else {
-		go func() {
-			err := http.ListenAndServe(":8081", metricsMux)
-			if err != nil {
-				logger.Errorf("Metrics (http) serving failed: %v", err)
-			}
-		}()
-	}
+	}()
 
 	// create a config client for operator status
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigPath)

--- a/deploy/chart/templates/0000_50_olm_02-services.yaml
+++ b/deploy/chart/templates/0000_50_olm_02-services.yaml
@@ -12,9 +12,9 @@ spec:
   type: ClusterIP
   ports:
   - name: https-metrics
-    port: 8081
+    port: {{ .Values.olm.service.externalPort }}
     protocol: TCP
-    targetPort: metrics
+    targetPort: {{ .Values.olm.service.internalPort }}
   selector:
     app: olm-operator
 ---
@@ -31,9 +31,9 @@ spec:
   type: ClusterIP
   ports:
   - name: https-metrics
-    port: 8081
+    port: {{ .Values.catalog.service.externalPort }}
     protocol: TCP
-    targetPort: metrics
+    targetPort: {{ .Values.catalog.service.internalPort }}
   selector:
     app: catalog-operator
 {{ end }}

--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -18,8 +18,34 @@ spec:
         app: olm-operator
     spec:
       serviceAccountName: olm-operator-serviceaccount
+      {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
+      volumes: 
+      {{- end }}
+      {{- if .Values.olm.tlsSecret }}
+      - name: srv-cert
+        secret:
+          secretName: {{ .Values.olm.tlsSecret }}
+      {{- end }}
+      {{- if .Values.olm.clientCASecret }}
+      - name: profile-collector-cert
+        secret:
+          secretName: {{ .Values.olm.clientCASecret }}
+      {{- end }}
       containers:
         - name: olm-operator
+          {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
+          volumeMounts:
+          {{- end }}
+          {{- if .Values.olm.tlsSecret }}
+          - name: srv-cert
+            mountPath: "/srv-cert"
+            readOnly: true
+          {{- end }}
+          {{- if .Values.olm.clientCASecret }}
+          - name: profile-collector-cert
+            mountPath: "/profile-collector-cert"
+            readOnly: true
+          {{- end }}
           command:
           - /bin/olm
           args:
@@ -43,29 +69,30 @@ spec:
           - --writePackageServerStatusName
           - {{ .Values.writePackageServerStatusName }}
           {{- end }}
-          {{- if .Values.olm.tlsCertPath }}
+         {{- if .Values.olm.tlsSecret }}
           - --tls-cert
-          - {{ .Values.olm.tlsCertPath }}
-          {{- end }}
-          {{- if .Values.olm.tlsKeyPath }}
+          - /srv-cert/tls.crt
           - --tls-key
-          - {{ .Values.olm.tlsKeyPath }}
+          - /srv-cert/tls.key
+          {{- end }}
+          {{- if .Values.olm.clientCASecret }}
+          - --client-ca
+          - /profile-collector-cert/tls.crt
           {{- end }}
           image: {{ .Values.olm.image.ref }}
           imagePullPolicy: {{ .Values.olm.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.olm.service.internalPort }}
-            - containerPort: 8081
-              name: metrics
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.olm.service.internalPort }}
+              scheme: {{ if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}HTTPS{{ else }}HTTP{{end}}
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.olm.service.internalPort }}
+              scheme: {{ if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}HTTPS{{ else }}HTTP{{end}}
           terminationMessagePolicy: FallbackToLogsOnError
           env:
           - name: OPERATOR_NAMESPACE

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -18,8 +18,34 @@ spec:
         app: catalog-operator
     spec:
       serviceAccountName: olm-operator-serviceaccount
+      {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
+      volumes: 
+      {{- end }}
+      {{- if .Values.catalog.tlsSecret }}
+      - name: srv-cert
+        secret:
+          secretName: {{ .Values.catalog.tlsSecret }}
+      {{- end }}
+      {{- if .Values.catalog.clientCASecret }}
+      - name: profile-collector-cert
+        secret:
+          secretName: {{ .Values.catalog.clientCASecret }}
+      {{- end }}
       containers:
         - name: catalog-operator
+          {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
+          volumeMounts:
+          {{- end }}
+          {{- if .Values.catalog.tlsSecret }}
+          - name: srv-cert
+            mountPath: "/srv-cert"
+            readOnly: true
+          {{- end }}
+          {{- if .Values.catalog.clientCASecret }}
+          - name: profile-collector-cert
+            mountPath: "/profile-collector-cert"
+            readOnly: true
+          {{- end }}
           command:
           - /bin/catalog
           args:
@@ -37,29 +63,30 @@ spec:
           - -writeStatusName
           - {{ .Values.writeStatusNameCatalog }}
           {{- end }}
-          {{- if .Values.olm.tlsCertPath }}
-          - -tls-cert
-          - {{ .Values.olm.tlsCertPath }}
+          {{- if .Values.catalog.tlsSecret }}
+          - --tls-cert
+          - /srv-cert/tls.crt
+          - --tls-key
+          - /srv-cert/tls.key
           {{- end }}
-          {{- if .Values.olm.tlsKeyPath }}
-          - -tls-key
-          - {{ .Values.olm.tlsKeyPath }}
+          {{- if .Values.catalog.clientCASecret }}
+          - --client-ca
+          - /profile-collector-cert/tls.crt
           {{- end }}
           image: {{ .Values.catalog.image.ref }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.catalog.service.internalPort }}
-            - containerPort: 8081
-              name: metrics
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.catalog.service.internalPort }}
+              scheme: {{ if and .Values.catalog.tlsKeyPath .Values.catalog.tlsCertPath }}HTTPS{{ else }}HTTP{{end}}
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.catalog.service.internalPort }}
+              scheme: {{ if and .Values.catalog.tlsKeyPath .Values.catalog.tlsCertPath }}HTTPS{{ else }}HTTP{{end}}
           terminationMessagePolicy: FallbackToLogsOnError
           {{- if .Values.catalog.resources }}
           resources:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -14,6 +14,9 @@ olm:
     pullPolicy: Always
   service:
     internalPort: 8080
+    externalPort: metrics
+  # tlsSecret: olm-operator-serving-cert
+  # clientCASecret: pprof-serving-cert
   nodeSelector:
     kubernetes.io/os: linux
   resources:
@@ -29,6 +32,9 @@ catalog:
     pullPolicy: Always
   service:
     internalPort: 8080
+    externalPort: metrics
+  # tlsSecret: catalog-operator-serving-cert
+  # clientCASecret: pprof-serving-cert
   nodeSelector:
     kubernetes.io/os: linux
   resources:

--- a/pkg/lib/filemonitor/cabundle_updater.go
+++ b/pkg/lib/filemonitor/cabundle_updater.go
@@ -1,0 +1,60 @@
+package filemonitor
+
+import (
+	"crypto/x509"
+	"io/ioutil"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+)
+
+type certPoolStore struct {
+	mutex        sync.RWMutex
+	certpool     *x509.CertPool
+	clientCAPath string
+}
+
+func NewCertPoolStore(clientCAPath string) (*certPoolStore, error) {
+	pem, err := ioutil.ReadFile(clientCAPath)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(pem)
+
+	return &certPoolStore{
+		mutex:        sync.RWMutex{},
+		certpool:     pool,
+		clientCAPath: clientCAPath,
+	}, nil
+}
+
+func (c *certPoolStore) storeCABundle(clientCAPath string) error {
+	pem, err := ioutil.ReadFile(clientCAPath)
+	if err == nil {
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(pem)
+		c.certpool = pool
+	}
+	return err
+}
+
+func (c *certPoolStore) HandleCABundleUpdate(logger logrus.FieldLogger, event fsnotify.Event) {
+	switch op := event.Op; op {
+	case fsnotify.Create:
+		logger.Debugf("got fs event for %v", event.Name)
+
+		if err := c.storeCABundle(c.clientCAPath); err != nil {
+			logger.Debugf("unable to reload ca bundle: %v", err)
+		} else {
+			logger.Debugf("successfully reload ca bundle: %v", err)
+		}
+	}
+}
+
+func (c *certPoolStore) GetCertPool() *x509.CertPool {
+	return c.certpool
+}

--- a/pkg/lib/filemonitor/cert_updater.go
+++ b/pkg/lib/filemonitor/cert_updater.go
@@ -1,43 +1,38 @@
 package filemonitor
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
-	"path/filepath"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 )
 
-type keystore struct {
+type certStore struct {
 	mutex      sync.RWMutex
 	cert       *tls.Certificate
 	tlsCrtPath string
 	tlsKeyPath string
 }
 
-type getCertFn = func(*tls.ClientHelloInfo) (*tls.Certificate, error)
-
-// NewKeystore returns a store for storing the certificate data and the ability to retrieve it safely
-func NewKeystore(tlsCrt, tlsKey string) *keystore {
+// NewCertStore returns a store for storing the certificate data and the ability to retrieve it safely
+func NewCertStore(tlsCrt, tlsKey string) (*certStore, error) {
 	cert, err := tls.LoadX509KeyPair(tlsCrt, tlsKey)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return &keystore{
+	return &certStore{
 		mutex:      sync.RWMutex{},
 		cert:       &cert,
 		tlsCrtPath: tlsCrt,
 		tlsKeyPath: tlsKey,
-	}
+	}, nil
 }
 
 // HandleFilesystemUpdate is intended to be used as the OnUpdateFn for a watcher
 // and expects the certificate files to be in the same directory.
-func (k *keystore) HandleFilesystemUpdate(logger *logrus.Logger, event fsnotify.Event) {
+func (k *certStore) HandleFilesystemUpdate(logger logrus.FieldLogger, event fsnotify.Event) {
 	switch op := event.Op; op {
 	case fsnotify.Create:
 		logger.Debugf("got fs event for %v", event.Name)
@@ -57,7 +52,7 @@ func (k *keystore) HandleFilesystemUpdate(logger *logrus.Logger, event fsnotify.
 	}
 }
 
-func (k *keystore) storeCertificate(tlsCrt, tlsKey string) error {
+func (k *certStore) storeCertificate(tlsCrt, tlsKey string) error {
 	cert, err := tls.LoadX509KeyPair(tlsCrt, tlsKey)
 	if err == nil {
 		k.mutex.Lock()
@@ -67,24 +62,8 @@ func (k *keystore) storeCertificate(tlsCrt, tlsKey string) error {
 	return err
 }
 
-func (k *keystore) GetCertificate(h *tls.ClientHelloInfo) (*tls.Certificate, error) {
+func (k *certStore) GetCertificate() *tls.Certificate {
 	k.mutex.RLock()
 	defer k.mutex.RUnlock()
-	return k.cert, nil
-}
-
-// OLMGetCertRotationFn is a convenience function for OLM use only, but serves as an example for monitoring file system events
-func OLMGetCertRotationFn(logger *logrus.Logger, tlsCertPath, tlsKeyPath string) (getCertFn, error) {
-	if filepath.Dir(tlsCertPath) != filepath.Dir(tlsKeyPath) {
-		return nil, fmt.Errorf("certificates expected to be in same directory %v vs %v", tlsCertPath, tlsKeyPath)
-	}
-
-	keystore := NewKeystore(tlsCertPath, tlsKeyPath)
-	watcher, err := NewWatch(logger, []string{filepath.Dir(tlsCertPath)}, keystore.HandleFilesystemUpdate)
-	if err != nil {
-		return nil, err
-	}
-	watcher.Run(context.Background())
-
-	return keystore.GetCertificate, nil
+	return k.cert
 }

--- a/pkg/lib/filemonitor/watcher.go
+++ b/pkg/lib/filemonitor/watcher.go
@@ -10,12 +10,12 @@ import (
 type watcher struct {
 	notify       *fsnotify.Watcher
 	pathsToWatch []string
-	logger       *logrus.Logger
-	onUpdateFn   func(*logrus.Logger, fsnotify.Event)
+	logger       logrus.FieldLogger
+	onUpdateFn   func(logrus.FieldLogger, fsnotify.Event)
 }
 
 // NewWatch sets up monitoring on a slice of paths and will execute the update function to process each event
-func NewWatch(logger *logrus.Logger, pathsToWatch []string, onUpdateFn func(*logrus.Logger, fsnotify.Event)) (*watcher, error) {
+func NewWatch(logger logrus.FieldLogger, pathsToWatch []string, onUpdateFn func(logrus.FieldLogger, fsnotify.Event)) (*watcher, error) {
 	notify, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err

--- a/pkg/lib/server/server.go
+++ b/pkg/lib/server/server.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/filemonitor"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/profile"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+)
+
+func GetListenAndServeFunc(logger *logrus.Logger, tlsCertPath, tlsKeyPath, clientCAPath *string) (func() error, error) {
+	mux := http.NewServeMux()
+	profile.RegisterHandlers(mux)
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	s := http.Server{
+		Handler: mux,
+		Addr:    ":8080",
+	}
+	listenAndServe := s.ListenAndServe
+
+	if *tlsCertPath != "" && *tlsKeyPath != "" {
+		logger.Info("TLS keys set, using https for metrics")
+
+		certStore, err := filemonitor.NewCertStore(*tlsCertPath, *tlsKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("Certificate monitoring for metrics (https) failed: %v", err)
+		}
+
+		csw, err := filemonitor.NewWatch(logger, []string{filepath.Dir(*tlsCertPath), filepath.Dir(*tlsKeyPath)}, certStore.HandleFilesystemUpdate)
+		if err != nil {
+			return nil, fmt.Errorf("error creating cert file watcher: %v", err)
+		}
+		csw.Run(context.Background())
+		certPoolStore, err := filemonitor.NewCertPoolStore(*clientCAPath)
+		cpsw, err := filemonitor.NewWatch(logger, []string{filepath.Dir(*clientCAPath)}, certPoolStore.HandleCABundleUpdate)
+		if err != nil {
+			return nil, fmt.Errorf("error creating cert file watcher: %v", err)
+		}
+		cpsw.Run(context.Background())
+
+		s.Addr = ":8443"
+		s.TLSConfig = &tls.Config{
+			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				return certStore.GetCertificate(), nil
+			},
+			GetConfigForClient: func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+				var certs []tls.Certificate
+				if cert := certStore.GetCertificate(); cert != nil {
+					certs = append(certs, *cert)
+				}
+				return &tls.Config{
+					Certificates: certs,
+					ClientCAs:    certPoolStore.GetCertPool(),
+					ClientAuth:   tls.VerifyClientCertIfGiven,
+				}, nil
+			},
+		}
+
+		listenAndServe = func() error {
+			return s.ListenAndServeTLS("", "")
+		}
+	} else if *tlsCertPath != "" || *tlsKeyPath != "" {
+		return nil, fmt.Errorf("both --tls-key and --tls-crt must be provided for TLS to be enabled")
+	} else {
+		logger.Info("TLS keys not set, using non-https for metrics")
+	}
+	return listenAndServe, nil
+}

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Install Plan", func() {
 
 		BeforeEach(func() {
 			counter = 0
-			for _, metric := range getMetricsFromPod(ctx.Ctx().KubeClient(), getPodWithLabel(ctx.Ctx().KubeClient(), "app=catalog-operator"), "8081") {
+			for _, metric := range getMetricsFromPod(ctx.Ctx().KubeClient(), getPodWithLabel(ctx.Ctx().KubeClient(), "app=catalog-operator"), "8080") {
 				if metric.Family == "installplan_warnings_total" {
 					counter = metric.Value
 				}
@@ -189,7 +189,7 @@ var _ = Describe("Install Plan", func() {
 
 		It("increments a metric counting the warning", func() {
 			Eventually(func() []Metric {
-				return getMetricsFromPod(ctx.Ctx().KubeClient(), getPodWithLabel(ctx.Ctx().KubeClient(), "app=catalog-operator"), "8081")
+				return getMetricsFromPod(ctx.Ctx().KubeClient(), getPodWithLabel(ctx.Ctx().KubeClient(), "app=catalog-operator"), "8080")
 			}).Should(ContainElement(LikeMetric(
 				WithFamily("installplan_warnings_total"),
 				WithValueGreaterThan(counter),

--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 
 			It("generates csv_abnormal metric for OLM pod", func() {
 
-				Expect(getMetricsFromPod(c, getPodWithLabel(c, "app=olm-operator"), "8081")).To(And(
+				Expect(getMetricsFromPod(c, getPodWithLabel(c, "app=olm-operator"), "8080")).To(And(
 					ContainElement(LikeMetric(
 						WithFamily("csv_abnormal"),
 						WithName(failingCSV.Name),
@@ -108,7 +108,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 
 				It("deletes its associated CSV metrics", func() {
 					// Verify that when the csv has been deleted, it deletes the corresponding CSV metrics
-					Expect(getMetricsFromPod(c, getPodWithLabel(c, "app=olm-operator"), "8081")).ToNot(And(
+					Expect(getMetricsFromPod(c, getPodWithLabel(c, "app=olm-operator"), "8080")).ToNot(And(
 						ContainElement(LikeMetric(WithFamily("csv_abnormal"), WithName(failingCSV.Name))),
 						ContainElement(LikeMetric(WithFamily("csv_succeeded"), WithName(failingCSV.Name))),
 					))
@@ -138,7 +138,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 
 				// Verify metrics have been emitted for subscription
 				Eventually(func() []Metric {
-					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 				}).Should(ContainElement(LikeMetric(
 					WithFamily("subscription_sync_total"),
 					WithName("metric-subscription-for-create"),
@@ -153,7 +153,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 				// Verify metrics have been emitted for dependency resolution
 				Eventually(func() bool {
 					return Eventually(func() []Metric {
-						return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+						return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 					}).Should(ContainElement(LikeMetric(
 						WithFamily("olm_resolution_duration_seconds"),
 						WithLabel("outcome", "failed"),
@@ -168,7 +168,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 			BeforeEach(func() {
 				subscriptionCleanup, subscription = createSubscription(GinkgoT(), crc, testNamespace, "metric-subscription-for-update", testPackageName, stableChannel, v1alpha1.ApprovalManual)
 				Eventually(func() []Metric {
-					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 				}).Should(ContainElement(LikeMetric(WithFamily("subscription_sync_total"), WithLabel("name", "metric-subscription-for-update"))))
 				Eventually(func() error {
 					s, err := crc.OperatorsV1alpha1().Subscriptions(subscription.GetNamespace()).Get(context.TODO(), subscription.GetName(), metav1.GetOptions{})
@@ -189,7 +189,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 
 			It("deletes the old Subscription metric and emits the new metric", func() {
 				Eventually(func() []Metric {
-					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 				}).Should(And(
 					Not(ContainElement(LikeMetric(
 						WithFamily("subscription_sync_total"),
@@ -223,7 +223,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 
 				It("deletes the old subscription metric and emits the new metric(there is only one metric for the subscription)", func() {
 					Eventually(func() []Metric {
-						return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+						return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 					}).Should(And(
 						Not(ContainElement(LikeMetric(
 							WithFamily("subscription_sync_total"),
@@ -253,7 +253,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 			BeforeEach(func() {
 				subscriptionCleanup, subscription = createSubscription(GinkgoT(), crc, testNamespace, "metric-subscription-for-delete", testPackageName, stableChannel, v1alpha1.ApprovalManual)
 				Eventually(func() []Metric {
-					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 				}).Should(ContainElement(LikeMetric(WithFamily("subscription_sync_total"), WithLabel("name", "metric-subscription-for-delete"))))
 				if subscriptionCleanup != nil {
 					subscriptionCleanup()
@@ -269,7 +269,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 
 			It("deletes the Subscription metric", func() {
 				Eventually(func() []Metric {
-					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 				}).ShouldNot(ContainElement(LikeMetric(WithFamily("subscription_sync_total"), WithName("metric-subscription-for-delete"))))
 			})
 		})
@@ -312,7 +312,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 			})
 			It("emits metrics for the catalogSource", func() {
 				Eventually(func() []Metric {
-					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 				}).Should(And(
 					ContainElement(LikeMetric(
 						WithFamily("catalog_source_count"),
@@ -332,7 +332,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 				})
 				It("deletes the metrics for the CatalogSource", func() {
 					Eventually(func() []Metric {
-						return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+						return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 					}).Should(And(
 						Not(ContainElement(LikeMetric(
 							WithFamily("catalogsource_ready"),
@@ -356,7 +356,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 			})
 			It("emits metrics for the CatlogSource with a Value greater than 0", func() {
 				Eventually(func() []Metric {
-					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 				}).Should(And(
 					ContainElement(LikeMetric(
 						WithFamily("catalogsource_ready"),
@@ -366,7 +366,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 					)),
 				))
 				Consistently(func() []Metric {
-					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8081")
+					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"), "8080")
 				}, "3m").Should(And(
 					ContainElement(LikeMetric(
 						WithFamily("catalogsource_ready"),


### PR DESCRIPTION
One HTTP server is used for healthz, metrics, and profiling.

TLS can still be enabled via flags, but it now applies to all three
APIs since there is a single HTTP server per operator process.

The -profiling flag is deprecated and does nothing. The profiling APIs
are now always enabled, but they refuse to serve clients that do not
present a verifiable certificate (see the new flag -client-ca). This
effectively disables the profiling APIs when served over HTTP.
