### PR TITLE
doc/design: Fix broken milestone link in the release.md

### DIFF
--- a/doc/design/release.md
+++ b/doc/design/release.md
@@ -2,7 +2,7 @@
 
 ## Step 0: Review the Release Milestone
 
-If the release you plan to create corresponds with an existing [milestone](https://github.com/operator-framework/operator-lifecycle-manager/milestone/), make sure that all features have been committed. If a feature will not be added to the release be sure to remove it from the milestone.
+If the release you plan to create corresponds with an existing [milestone](https://github.com/operator-framework/operator-lifecycle-manager/milestones/), make sure that all features have been committed. If a feature will not be added to the release be sure to remove it from the milestone.
 
 ## Step 1: Installing Requirements
 


### PR DESCRIPTION
Update the doc/design/release.md release process documentation and fix
the broken link to the OLM milestones link.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
