### PR TITLE
doc/design: Add a version prefix to the release tag in release.md

### DIFF
--- a/doc/design/release.md
+++ b/doc/design/release.md
@@ -37,10 +37,10 @@ If git `push` is disabled on `upstream` repository in your fork, then clone this
 
 ```bash
 # 0.11.0 is the bumped version.
-git tag -a 0.11.0 -m "Version 0.11.0"
+git tag -a v0.18.0 -m "Version 0.18.0"
 
-# origin points to operator-framework/operator-lifecycle-manager
-git push origin 0.11.0
+# origin remote points to operator-framework/operator-lifecycle-manager
+git push origin v0.18.0
 ```
 
 * Confirm that new images have been built here: <https://quay.io/repository/operator-framework/olm?tab=builds>.


### PR DESCRIPTION
Update the doc/design/release.md documentation and ensure the git
release tag that's produced is prefixed with `v` so Go dependency
resolution works.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
