### PR TITLE
.github/workflows: Fix the release quickstart.yaml action

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -20,4 +20,24 @@ jobs:
         kubectl apply -f deploy/upstream/quickstart/crds.yaml
         kubectl wait --timeout=5m --for=condition=Established crd $(kubectl get crd --output=jsonpath='{.items[*].metadata.name}')
         kubectl apply -f deploy/upstream/quickstart/olm.yaml
-        kubectl wait --timeout=5m --for=condition=Available -n olm deploy olm-operator catalog-operator packageserver
+
+        # Note(tflannag): `kubectl wait` does not support waiting for resource creation: https://github.com/kubernetes/kubernetes/pull/87399.
+        wait_for_deployment() {
+          local deployment_name=$1
+          timeout=60
+          i=1
+          echo "Checking if the ${deployment_name} deployment is ready"
+          until kubectl -n olm get deployment ${deployment_name} -o jsonpath='{.status.conditions[?(@.status=="True")].type}' | grep "Available" 2>/dev/null; do
+              ((i++))
+              if [[ ${i} -gt ${timeout} ]]; then
+                  echo "the ${deployment_name} deployment has not become ready before the timeout period"
+                  exit 1
+              fi
+              echo "waiting for ${deployment_name} deployment to report a ready status"
+              sleep 5
+          done
+          echo "The ${deployment_name} deployment is ready"
+        }
+        wait_for_deployment catalog-operator
+        wait_for_deployment olm-operator
+        wait_for_deployment packageserver


### PR DESCRIPTION
The quickstart GH action is failing with the following error:

```
deployment.apps/olm-operator condition met
deployment.apps/catalog-operator condition met
Error from server (NotFound): deployments.apps "packageserver" not found
```

This isn't reproducible using a kindest/node:v1.19.x kind cluster, but
is consistently reproducible using the kindest/node:v1.21.1 (latest
version) kind cluster.

We can update the quickstart action to instead separate out the
PackageServer Deployment resource check outside of the OLM and Catalog
Operator Deployment resource checks as the latter creates the underlying
PackageServer CSV resources.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
