### PR TITLE
add detailed logs

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -673,7 +673,7 @@ func (r *SatResolver) sortChannel(bundles []*Operator) ([]*Operator, error) {
 		for _, v := range headCandidates {
 			names = append(names, v.Identifier())
 		}
-		return nil, fmt.Errorf("found multiple channel heads: %v, please check the `replaces`/`skipRange` fields of the operator bundles", names)
+		return nil, fmt.Errorf("found multiple channel heads: %v, please check the `replaces`/`skipRange` fields of the operator bundles. bundleLookup:%v, replacedBy:%v", names, bundleLookup, replacedBy)
 
 	} else if len(headCandidates) < 1 {
 		return nil, fmt.Errorf("head of channel not found")


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Hi, 

We got the below errors during the test. 
```console
E0716 04:13:36.828509       1 queueinformer_operator.go:290] sync {"update" "x923s"} failed: found multiple channel heads: [amqstreams.v1.6.2 amqstreams.v1.7.2], please check the `replaces`/`skipRange` fields of the operator bundles.
```
But, I cannot locate the root cause based on the current `error logs`. And, I checked all related CSV files manually, seems good. So, it's better to output the related `map` content so that the user can locate where is wrong. 
```console
[cloud-user@preserve-olm-env cpaas]$ podman cp rhv1.7.1:/manifests/ rhv1.7.1
[cloud-user@preserve-olm-env cpaas]$ cat rhv1.7.1/bundle.clusterserviceversion.yaml |grep replaces
  replaces: amqstreams.v1.7.0
[cloud-user@preserve-olm-env cpaas]$ cat rhv1.7.2/bundle.clusterserviceversion.yaml |grep replaces
  replaces: amqstreams.v1.7.1
[cloud-user@preserve-olm-env cpaas]$ cat rhv1.7.0/bundle.clusterserviceversion.yaml |grep replaces
  replaces: amqstreams.v1.6.3
[cloud-user@preserve-olm-env cpaas]$ cat rhv1.6.3/amq-streams.v1.6.3.clusterserviceversion.yaml |grep replaces
  replaces: amqstreams.v1.6.2
[cloud-user@preserve-olm-env cpaas]$ cat rhv1.6.2/amq-streams.v1.6.2.clusterserviceversion.yaml |grep replaces
  replaces: amqstreams.v1.6.1
[cloud-user@preserve-olm-env cpaas]$ cat rhv1.6.2/amq-streams.v1.6.2.clusterserviceversion.yaml |grep "amqstreams.v1.6.2"
  name: amqstreams.v1.6.2
```

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
