### PR TITLE
Fix ClusterOperator selector for excluding copied CSVs.

### DIFF
--- a/pkg/controller/operators/openshift/helpers.go
+++ b/pkg/controller/operators/openshift/helpers.go
@@ -241,11 +241,7 @@ func notCopiedSelector() (labels.Selector, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	selector := labels.NewSelector()
-	selector.Add(*requirement)
-
-	return selector, nil
+	return labels.NewSelector().Add(*requirement), nil
 }
 
 func olmOperatorRelatedObjects(ctx context.Context, cli client.Client, namespace string) ([]configv1.ObjectReference, error) {

--- a/pkg/controller/operators/openshift/helpers_test.go
+++ b/pkg/controller/operators/openshift/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -599,6 +600,28 @@ func TestMaxOpenShiftVersion(t *testing.T) {
 			}
 
 			require.Equal(t, tt.expect.max, max)
+		})
+	}
+}
+
+func TestNotCopiedSelector(t *testing.T) {
+	for _, tc := range []struct {
+		Labels  labels.Set
+		Matches bool
+	}{
+		{
+			Labels:  labels.Set{operatorsv1alpha1.CopiedLabelKey: ""},
+			Matches: false,
+		},
+		{
+			Labels:  labels.Set{},
+			Matches: true,
+		},
+	} {
+		t.Run(tc.Labels.String(), func(t *testing.T) {
+			selector, err := notCopiedSelector()
+			require.NoError(t, err)
+			require.Equal(t, tc.Matches, selector.Matches(tc.Labels))
 		})
 	}
 }


### PR DESCRIPTION
The function that generated the selector had been returning a selector
that matches everything. There was no functional impact because
there's an additional client-side filter that discards objects based
on CSV.IsCopied().
