### PR TITLE
Don't cache copied CSVs in the controller-runtime-based controllers.

### DIFF
--- a/cmd/olm/manager.go
+++ b/cmd/olm/manager.go
@@ -2,30 +2,57 @@ package main
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/labels"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/feature"
 )
 
+var (
+	copiedLabelDoesNotExist labels.Selector
+)
+
+func init() {
+	requirement, err := labels.NewRequirement(operatorsv1alpha1.CopiedLabelKey, selection.DoesNotExist, nil)
+	if err != nil {
+		panic(err)
+	}
+	copiedLabelDoesNotExist = labels.NewSelector().Add(*requirement)
+}
+
 func Manager(ctx context.Context, debug bool) (ctrl.Manager, error) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(debug)))
 	setupLog := ctrl.Log.WithName("setup").V(1)
 
-	// Setup a Manager
+	scheme := runtime.NewScheme()
+	if err := operators.AddToScheme(scheme); err != nil {
+		// ctrl.NewManager needs the Scheme to be populated
+		// up-front so that the NewCache implementation we
+		// provide can configure custom cache behavior on
+		// non-core types.
+		return nil, err
+	}
+
 	setupLog.Info("configuring manager")
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:             scheme,
 		MetricsBindAddress: "0", // TODO(njhale): Enable metrics on non-conflicting port (not 8080)
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
 				&corev1.Secret{}: {
 					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&operatorsv1alpha1.ClusterServiceVersion{}: {
+					Label: copiedLabelDoesNotExist,
 				},
 			},
 		}),


### PR DESCRIPTION
Only the main controller (i.e., the controller responsible for
reconciling ClusterServiceVersions) needs to watch copied
ClusterServiceVersions. The OperatorCondition and Operator controllers
-- which coincidentally maintain separate caches -- are not interested
in copied CSVs, so all copied CSVs can be excluded via from their
cache using a label selector.
