### PR TITLE
Use metadata-only watches when possible for Operator component APIs.

### DIFF
--- a/cmd/olm/manager.go
+++ b/cmd/olm/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
@@ -34,6 +35,9 @@ func Manager(ctx context.Context, debug bool) (ctrl.Manager, error) {
 	setupLog := ctrl.Log.WithName("setup").V(1)
 
 	scheme := runtime.NewScheme()
+	if err := metav1.AddMetaToScheme(scheme); err != nil {
+		return nil, err
+	}
 	if err := operators.AddToScheme(scheme); err != nil {
 		// ctrl.NewManager needs the Scheme to be populated
 		// up-front so that the NewCache implementation we

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,9 @@ replace (
 	// controller runtime
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200331152225-585af27e34fd // release-4.5
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 // release-4.5
+	// Patch for a race condition involving metadata-only
+	// informers until it can be resolved upstream:
+	sigs.k8s.io/controller-runtime v0.9.2 => github.com/benluddy/controller-runtime v0.9.3-0.20210720171926-9bcb99bd9bd3
 
 	// pinned because no tag supports 1.18 yet
 	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benluddy/controller-runtime v0.9.3-0.20210720171926-9bcb99bd9bd3 h1:XnmeUOSdoo764dm67j2pKUNU7MqzB6a303w4ML2EhB4=
+github.com/benluddy/controller-runtime v0.9.3-0.20210720171926-9bcb99bd9bd3/go.mod h1:TxzMCHyEUpaeuOiZx/bIdc2T81vfs/aKdvJt9wuu0zk=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -1724,8 +1726,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.20 h1:jLWvYcn/9pCws
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.20/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/controller-runtime v0.8.0/go.mod h1:v9Lbj5oX443uR7GXYY46E0EE2o7k2YxQ58GxVNeXSW4=
 sigs.k8s.io/controller-runtime v0.9.0/go.mod h1:TgkfvrhhEw3PlI0BRL/5xM+89y3/yc0ZDfdbTl84si8=
-sigs.k8s.io/controller-runtime v0.9.2 h1:MnCAsopQno6+hI9SgJHKddzXpmv2wtouZz6931Eax+Q=
-sigs.k8s.io/controller-runtime v0.9.2/go.mod h1:TxzMCHyEUpaeuOiZx/bIdc2T81vfs/aKdvJt9wuu0zk=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/controller-tools v0.6.0/go.mod h1:baRMVPrctU77F+rfAuH2uPqW93k6yQnZA2dhUOr7ihc=
 sigs.k8s.io/controller-tools v0.6.1 h1:nODRx2YrSNcaGd+90+CVC9SGEG6ygHlz3nSJmweR5as=

--- a/pkg/controller/operators/adoption_controller.go
+++ b/pkg/controller/operators/adoption_controller.go
@@ -19,6 +19,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -68,17 +69,17 @@ func (r *AdoptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &appsv1.Deployment{}}, enqueueCSV).
 		Watches(&source.Kind{Type: &corev1.Namespace{}}, enqueueCSV).
 		Watches(&source.Kind{Type: &corev1.Service{}}, enqueueCSV).
-		Watches(&source.Kind{Type: &corev1.ServiceAccount{}}, enqueueCSV).
-		Watches(&source.Kind{Type: &corev1.Secret{}}, enqueueCSV).
-		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, enqueueCSV).
-		Watches(&source.Kind{Type: &rbacv1.Role{}}, enqueueCSV).
-		Watches(&source.Kind{Type: &rbacv1.RoleBinding{}}, enqueueCSV).
-		Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, enqueueCSV).
-		Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, enqueueCSV).
 		Watches(&source.Kind{Type: &apiextensionsv1.CustomResourceDefinition{}}, enqueueProviders).
 		Watches(&source.Kind{Type: &apiregistrationv1.APIService{}}, enqueueCSV).
 		Watches(&source.Kind{Type: &operatorsv1alpha1.Subscription{}}, enqueueCSV).
 		Watches(&source.Kind{Type: &operatorsv2.OperatorCondition{}}, enqueueCSV).
+		Watches(&source.Kind{Type: &corev1.Secret{}}, enqueueCSV, builder.OnlyMetadata).
+		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, enqueueCSV, builder.OnlyMetadata).
+		Watches(&source.Kind{Type: &corev1.ServiceAccount{}}, enqueueCSV, builder.OnlyMetadata).
+		Watches(&source.Kind{Type: &rbacv1.Role{}}, enqueueCSV, builder.OnlyMetadata).
+		Watches(&source.Kind{Type: &rbacv1.RoleBinding{}}, enqueueCSV, builder.OnlyMetadata).
+		Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, enqueueCSV, builder.OnlyMetadata).
+		Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, enqueueCSV, builder.OnlyMetadata).
 		Complete(reconcile.Func(r.ReconcileClusterServiceVersion))
 	if err != nil {
 		return err
@@ -350,24 +351,7 @@ func (r *AdoptionReconciler) disownFromAll(ctx context.Context, component runtim
 func (r *AdoptionReconciler) adoptees(ctx context.Context, operator decorators.Operator, csv *operatorsv1alpha1.ClusterServiceVersion) ([]runtime.Object, error) {
 	// Note: We need to figure out how to dynamically add new list types here (or some equivalent) in
 	// order to support operators composed of custom resources.
-	componentLists := []runtime.Object{
-		&appsv1.DeploymentList{},
-		&corev1.ServiceList{},
-		&corev1.NamespaceList{},
-		&corev1.ServiceAccountList{},
-		&corev1.SecretList{},
-		&corev1.ConfigMapList{},
-		&rbacv1.RoleList{},
-		&rbacv1.RoleBindingList{},
-		&rbacv1.ClusterRoleList{},
-		&rbacv1.ClusterRoleBindingList{},
-		&apiregistrationv1.APIServiceList{},
-		&apiextensionsv1.CustomResourceDefinitionList{},
-		&operatorsv1alpha1.SubscriptionList{},
-		&operatorsv1alpha1.InstallPlanList{},
-		&operatorsv1alpha1.ClusterServiceVersionList{},
-		&operatorsv2.OperatorConditionList{},
-	}
+	componentLists := componentLists()
 
 	// Only resources that aren't already labelled are adoption candidates
 	selector, err := operator.NonComponentSelector()
@@ -403,7 +387,8 @@ func (r *AdoptionReconciler) adoptees(ctx context.Context, operator decorators.O
 
 	// Pick up owned CRDs
 	for _, provided := range csv.Spec.CustomResourceDefinitions.Owned {
-		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd := &metav1.PartialObjectMetadata{}
+		crd.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
 		if err := r.Get(ctx, types.NamespacedName{Name: provided.Name}, crd); err != nil {
 			if !apierrors.IsNotFound(err) {
 				// Inform requeue on transient error

--- a/pkg/controller/operators/components.go
+++ b/pkg/controller/operators/components.go
@@ -1,0 +1,70 @@
+package operators
+
+import (
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv2 "github.com/operator-framework/api/pkg/operators/v2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+func componentLists() []runtime.Object {
+	return []runtime.Object{
+		&appsv1.DeploymentList{},
+		&corev1.ServiceList{},
+		&corev1.NamespaceList{},
+		&apiregistrationv1.APIServiceList{},
+		&apiextensionsv1.CustomResourceDefinitionList{},
+		&operatorsv1alpha1.SubscriptionList{},
+		&operatorsv1alpha1.InstallPlanList{},
+		&operatorsv1alpha1.ClusterServiceVersionList{},
+		&operatorsv2.OperatorConditionList{},
+
+		&metav1.PartialObjectMetadataList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "SecretList",
+			},
+		},
+		&metav1.PartialObjectMetadataList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "ConfigMapList",
+			},
+		},
+		&metav1.PartialObjectMetadataList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "ServiceAccountList",
+			},
+		},
+		&metav1.PartialObjectMetadataList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+				Kind:       "RoleList",
+			},
+		},
+		&metav1.PartialObjectMetadataList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+				Kind:       "RoleBindingList",
+			},
+		},
+		&metav1.PartialObjectMetadataList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+				Kind:       "ClusterRoleList",
+			},
+		},
+		&metav1.PartialObjectMetadataList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+				Kind:       "ClusterRoleBindingList",
+			},
+		},
+	}
+}

--- a/pkg/controller/operators/decorators/operator.go
+++ b/pkg/controller/operators/decorators/operator.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/reference"
 
@@ -343,6 +344,10 @@ func NewComponent(component runtime.Object, scheme *runtime.Scheme) (*Component,
 	u := &unstructured.Unstructured{}
 	if err := scheme.Convert(component, u, nil); err != nil {
 		return nil, err
+	}
+	// GVK may have been lost from PartialObjectMetadata during conversion.
+	if gvk := component.GetObjectKind().GroupVersionKind(); gvk != schema.EmptyObjectKind.GroupVersionKind() {
+		u.SetGroupVersionKind(gvk)
 	}
 
 	c := &Component{

--- a/pkg/controller/operators/decorators/operator_test.go
+++ b/pkg/controller/operators/decorators/operator_test.go
@@ -88,6 +88,7 @@ func TestAddComponents(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, k8sscheme.AddToScheme(scheme))
 	require.NoError(t, operatorsv1alpha1.AddToScheme(scheme))
+	require.NoError(t, metav1.AddMetaToScheme(scheme))
 
 	type fields struct {
 		operator *operatorsv1.Operator

--- a/pkg/controller/operators/suite_test.go
+++ b/pkg/controller/operators/suite_test.go
@@ -105,8 +105,8 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).ToNot(BeNil())
 
 	By("Setting up a controller manager")
-	err = AddToScheme(scheme)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(metav1.AddMetaToScheme(scheme)).To(Succeed())
+	Expect(AddToScheme(scheme)).To(Succeed())
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress: "0", // Prevents conflicts with other test suites that might bind metrics
 		Scheme:             scheme,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1589,7 +1589,7 @@ k8s.io/utils/trace
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.20
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/controller-runtime v0.9.2
+# sigs.k8s.io/controller-runtime v0.9.2 => github.com/benluddy/controller-runtime v0.9.3-0.20210720171926-9bcb99bd9bd3
 ## explicit
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder


### PR DESCRIPTION
The Operator adoption controller reads metadata.ownerReferences and
metadata.labels to adopt Operator components, and the Operator
controller itself maintains a list of component references in
status.components.refs. For APIs without a status.conditions field,
these references are equivalent to v1 ObjectReferences, and can be
constructed using only the component's metadata. For APIs that do have
a status.conditions field, the references are augmented with that
information.
