### PR TITLE
Update extractMessage

### DIFF
--- a/pkg/controller/operators/catalog/subscription/state.go
+++ b/pkg/controller/operators/catalog/subscription/state.go
@@ -511,23 +511,22 @@ func (i *installPlanReferencedState) CheckInstallPlanStatus(now *metav1.Time, cl
 }
 
 func extractMessage(status *v1alpha1.InstallPlanStatus) string {
-	str := ""
-	if len(status.BundleLookups) > 0 {
-		var b bytes.Buffer
-		for _, lookup := range status.BundleLookups {
-			if cond := lookup.GetCondition(v1alpha1.BundleLookupPending); cond.Status != corev1.ConditionUnknown {
-				b.WriteString(cond.Message)
-				b.WriteString(".")
+	if cond := status.GetCondition(v1alpha1.InstallPlanInstalled); cond.Status != corev1.ConditionUnknown && cond.Message != "" {
+		return cond.Message
+	}
+
+	var b bytes.Buffer
+	for _, lookup := range status.BundleLookups {
+		if cond := lookup.GetCondition(v1alpha1.BundleLookupPending); cond.Status != corev1.ConditionUnknown && cond.Message != "" {
+			if b.Len() != 0 {
+				b.WriteString(" ")
 			}
-		}
-		str = b.String()
-	}
-	if cond := status.GetCondition(v1alpha1.InstallPlanInstalled); cond.Status != corev1.ConditionUnknown {
-		if cond.Message != "" {
-			str = cond.Message
+			b.WriteString(cond.Message)
+			b.WriteString(".")
 		}
 	}
-	return str
+
+	return b.String()
 }
 
 type installPlanKnownState struct {


### PR DESCRIPTION
When building the subscription condition message,
check if the status of the InstallPlan is available
before iterating through bundle lookup conditions.
