### PR TITLE
fix(openshift): handle unquoted short max versions

### DIFF
--- a/pkg/controller/operators/openshift/helpers.go
+++ b/pkg/controller/operators/openshift/helpers.go
@@ -2,7 +2,6 @@ package openshift
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -190,12 +189,7 @@ func maxOpenShiftVersion(csv *operatorsv1alpha1.ClusterServiceVersion) (*semver.
 			continue
 		}
 
-		var value string
-		if err := json.Unmarshal([]byte(property.Value), &value); err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
+		value := strings.Trim(property.Value, "\"")
 		if value == "" {
 			continue
 		}
@@ -203,6 +197,7 @@ func maxOpenShiftVersion(csv *operatorsv1alpha1.ClusterServiceVersion) (*semver.
 		version, err := semver.ParseTolerant(value)
 		if err != nil {
 			errs = append(errs, err)
+			continue
 		}
 
 		if max == nil {

--- a/pkg/controller/registry/resolver/projection/properties_test.go
+++ b/pkg/controller/registry/resolver/projection/properties_test.go
@@ -54,6 +54,16 @@ func TestPropertiesAnnotationFromPropertyList(t *testing.T) {
 			},
 			expected: `{"properties":[{"type":"string","value":"hello"},{"type":"number","value":5},{"type":"array","value":[1,"two",3,"four"]},{"type":"object","value":{"hello":{"worl":"d"}}}]}`,
 		},
+		{
+			name: "unquoted string",
+			properties: []*api.Property{
+				{
+					Type:  "version",
+					Value: "4.8",
+				},
+			},
+			expected: `{"properties":[{"type":"version","value":4.8}]}`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := projection.PropertiesAnnotationFromPropertyList(tc.properties)
@@ -120,9 +130,20 @@ func TestPropertyListFromPropertiesAnnotation(t *testing.T) {
 				{
 					Type:  "array",
 					Value: `[1,"two",3,"four"]`,
-				}, {
+				},
+				{
 					Type:  "object",
 					Value: `{"hello":{"worl":"d"}}`,
+				},
+			},
+		},
+		{
+			name:       "unquoted string values",
+			annotation: `{"properties":[{"type": "version","value": 4.8}]}`,
+			expected: []*api.Property{
+				{
+					Type:  "version",
+					Value: "4.8",
 				},
 			},
 		},


### PR DESCRIPTION
## Description

Add special handling for version shorthand commonly used in pipelines for Red Hat operator catalogs. 

Allows unquoted short versions to be used when specifying an operator's OpenShift compatibility; e.g. olm.maxOpenShiftVersion: 4.8. Without this, OLM will only recognize quoted, fully qualified, maxOpenShiftVersion properties; e.g. olm.maxOpenShiftVersion: "4.8.0".

## Motivation

Under my direction, Red Hat catalog pipeline maintainers have already notified bundle authors of, built automation around, and updated catalog content using this shorthand. Given this, supporting the shorthand will save these clients the effort and confusion required to switch to a fully qualified version.
 