### PR TITLE
Add managed label to configmap to reduce cache size

### DIFF
--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -902,7 +902,7 @@ func TestSyncCatalogSources(t *testing.T) {
 				&corev1.ConfigMap{},
 			},
 			expectedStatus: nil,
-			expectedError:  errors.New("failed to get catalog config map cool-configmap: configmap \"cool-configmap\" not found"),
+			expectedError:  errors.New("failed to get catalog config map cool-configmap: configmaps \"cool-configmap\" not found"),
 		},
 		{
 			testName:      "CatalogSourceWithGrpcImage",


### PR DESCRIPTION
Using managed label to filter relevant configmaps in the cluster
to reduce the configmap cache size.

For catalogsource configmaps, they are created by users and there are
no prexisting labels, there are extra API calls initially to add
the label to migrate those configmaps to the catalog cache.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
