### PR TITLE
Update catalog deployment template

### DIFF
--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -81,12 +81,12 @@ spec:
             httpGet:
               path: /healthz
               port: {{ .Values.catalog.service.internalPort }}
-              scheme: {{ if and .Values.catalog.tlsKeyPath .Values.catalog.tlsCertPath }}HTTPS{{ else }}HTTP{{end}}
+              scheme: {{ if .Values.catalog.tlsSecret }}HTTPS{{ else }}HTTP{{end}}
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.catalog.service.internalPort }}
-              scheme: {{ if and .Values.catalog.tlsKeyPath .Values.catalog.tlsCertPath }}HTTPS{{ else }}HTTP{{end}}
+              scheme: {{ if .Values.catalog.tlsSecret }}HTTPS{{ else }}HTTP{{end}}
           terminationMessagePolicy: FallbackToLogsOnError
           {{- if .Values.catalog.resources }}
           resources:


### PR DESCRIPTION
The catalog deployment template only sets the
readiness and liveness probes to HTTPS Scheme if the
values.catalog.tlsKeyPath and values.catalog.tlsCertPath
configurations are provided. These values should be set
when the values.catalog.tlsSecret or
values.catalog.clientCASecret configurations are set as
it is done in the olm deployment template.
