### PR TITLE
Update getMetricsFromPort to infer port number

### DIFF
--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -83,6 +83,7 @@ spec:
           imagePullPolicy: {{ .Values.olm.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.olm.service.internalPort }}
+              name: metrics
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -76,7 +76,8 @@ spec:
           image: {{ .Values.catalog.image.ref }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.catalog.service.internalPort }}
+            - containerPort: {{ .Values.olm.service.internalPort }}
+              name: metrics
           livenessProbe:
             httpGet:
               path: /healthz

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Install Plan", func() {
 
 		BeforeEach(func() {
 			counter = 0
-			for _, metric := range getMetricsFromPod(ctx.Ctx().KubeClient(), getPodWithLabel(ctx.Ctx().KubeClient(), "app=catalog-operator"), "8080") {
+			for _, metric := range getMetricsFromPod(ctx.Ctx().KubeClient(), getPodWithLabel(ctx.Ctx().KubeClient(), "app=catalog-operator")) {
 				if metric.Family == "installplan_warnings_total" {
 					counter = metric.Value
 				}
@@ -182,7 +182,7 @@ var _ = Describe("Install Plan", func() {
 
 		It("increments a metric counting the warning", func() {
 			Eventually(func() []Metric {
-				return getMetricsFromPod(ctx.Ctx().KubeClient(), getPodWithLabel(ctx.Ctx().KubeClient(), "app=catalog-operator"), "8080")
+				return getMetricsFromPod(ctx.Ctx().KubeClient(), getPodWithLabel(ctx.Ctx().KubeClient(), "app=catalog-operator"))
 			}).Should(ContainElement(LikeMetric(
 				WithFamily("installplan_warnings_total"),
 				WithValueGreaterThan(counter),


### PR DESCRIPTION
Problem: The getMetricsFromPod function assumes that metrics are exposed
on port 8080. This function fails to retrieve metrics from the olm or
catalog operator when the port is changed.

Solution: Name the port in each of the deployments and update the
getMetricsFromPod function to infer the port number from the
deployments.
