### PR TITLE
Drop inline manifests from resolver cache.

### DIFF
--- a/pkg/controller/registry/resolver/operators.go
+++ b/pkg/controller/registry/resolver/operators.go
@@ -303,7 +303,7 @@ func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey reg
 		return op, nil
 	}
 
-	return &Operator{
+	o := &Operator{
 		name:         bundle.CsvName,
 		replaces:     bundle.Replaces,
 		version:      version,
@@ -313,7 +313,18 @@ func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey reg
 		sourceInfo:   sourceInfo,
 		properties:   properties,
 		skips:        bundle.Skips,
-	}, nil
+	}
+
+	if !o.Inline() {
+		// TODO: Extract any necessary information from the Bundle
+		// up-front and remove the bundle field altogether. For now,
+		// take the easy opportunity to save heap space by discarding
+		// two of the worst offenders.
+		bundle.CsvJson = ""
+		bundle.Object = nil
+	}
+
+	return o, nil
 }
 
 func NewOperatorFromV1Alpha1CSV(csv *v1alpha1.ClusterServiceVersion) (*Operator, error) {


### PR DESCRIPTION
For cached catalog entries whose content is ultimately installed from
a referenced bundle image, any additional inlined manifests are bloat
in the resolver cache and can be removed. Ultimately, no bundle
references should be held by resolver cache entries, but the CsvJson
and Object bundle fields can be zeroed out now for an immediate heap
size reduction.
