### PR TITLE
Expose errors generated while retrieving catalog content.

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -103,6 +103,10 @@ func (r *SatResolver) SolveOperators(namespaces []string, csvs []*v1alpha1.Clust
 
 	r.addInvariants(namespacedCache, installables)
 
+	if err := namespacedCache.Error(); err != nil {
+		return nil, err
+	}
+
 	input := make([]solver.Installable, 0)
 	for _, i := range installables {
 		input = append(input, i)

--- a/pkg/controller/registry/types.go
+++ b/pkg/controller/registry/types.go
@@ -33,7 +33,7 @@ func (k *CatalogKey) Virtual() bool {
 
 func NewVirtualCatalogKey(namespace string) CatalogKey {
 	return CatalogKey{
-		Name: ExistingOperatorKey,
+		Name:      ExistingOperatorKey,
 		Namespace: namespace,
 	}
 }


### PR DESCRIPTION
Failing to fetch catalog content should not silently return an empty
cache. Instead, it should fail outright with an error that indicates
which catalog(s) could not be fetched.
