### PR TITLE
Handles incorrect CatalogSource interval values.

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -723,10 +723,19 @@ func (o *Operator) syncRegistryServer(logger *logrus.Entry, in *v1alpha1.Catalog
 
 	// requeue the catalog sync based on the polling interval, for accurate syncs of catalogs with polling enabled
 	if out.Spec.UpdateStrategy != nil {
-		logger.Debugf("requeuing registry server sync based on polling interval %s", out.Spec.UpdateStrategy.Interval.Duration.String())
-		resyncPeriod := reconciler.SyncRegistryUpdateInterval(out, time.Now())
-		o.catsrcQueueSet.RequeueAfter(out.GetNamespace(), out.GetName(), queueinformer.ResyncWithJitter(resyncPeriod, 0.1)())
-		return
+		if out.Spec.UpdateStrategy.RegistryPoll != nil {
+			if out.Spec.UpdateStrategy.RegistryPoll.Interval.Duration == queueinformer.DefaultResyncPeriod && out.Spec.UpdateStrategy.RegistryPoll.ParsingError != nil {
+				out.SetError(v1alpha1.CatalogSourceIntervalInvalidError, out.Spec.UpdateStrategy.RegistryPoll.ParsingError)
+				if _, err := o.client.OperatorsV1alpha1().CatalogSources(out.GetNamespace()).Update(context.TODO(), out, metav1.UpdateOptions{}); err != nil {
+					logger.Errorf("error while setting catalogsource interval - %v", err)
+					return
+				}
+			}
+			logger.Debugf("requeuing registry server sync based on polling interval %s", out.Spec.UpdateStrategy.Interval.Duration.String())
+			resyncPeriod := reconciler.SyncRegistryUpdateInterval(out, time.Now())
+			o.catsrcQueueSet.RequeueAfter(out.GetNamespace(), out.GetName(), queueinformer.ResyncWithJitter(resyncPeriod, 0.1)())
+			return
+		}
 	}
 
 	if err := o.sources.Remove(sourceKey); err != nil {

--- a/vendor/github.com/operator-framework/api/pkg/operators/v1alpha1/catalogsource_types.go
+++ b/vendor/github.com/operator-framework/api/pkg/operators/v1alpha1/catalogsource_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -10,8 +11,9 @@ import (
 )
 
 const (
-	CatalogSourceCRDAPIVersion = GroupName + "/" + GroupVersion
-	CatalogSourceKind          = "CatalogSource"
+	CatalogSourceCRDAPIVersion  = GroupName + "/" + GroupVersion
+	CatalogSourceKind           = "CatalogSource"
+	DefaultRegistryPollDuration = "15m"
 )
 
 // SourceType indicates the type of backing store for a CatalogSource
@@ -36,6 +38,8 @@ const (
 	CatalogSourceConfigMapError ConditionReason = "ConfigMapError"
 	// CatalogSourceRegistryServerError denotes when there is an issue querying the specified registry server.
 	CatalogSourceRegistryServerError ConditionReason = "RegistryServerError"
+	// CatalogSourceIntervalInvalidError denotes when the registry interval is invalid.
+	CatalogSourceIntervalInvalidError ConditionReason = "IntervalInvalidError"
 )
 
 type CatalogSourceSpec struct {
@@ -96,7 +100,8 @@ type RegistryPoll struct {
 	// Interval is used to determine the time interval between checks of the latest catalog source version.
 	// The catalog operator polls to see if a new version of the catalog source is available.
 	// If available, the latest image is pulled and gRPC traffic is directed to the latest catalog source.
-	Interval *metav1.Duration `json:"interval,omitempty"`
+	Interval     *metav1.Duration `json:"interval,omitempty"`
+	ParsingError error
 }
 
 type RegistryServiceStatus struct {
@@ -230,6 +235,29 @@ func (c *CatalogSource) Poll() bool {
 		return false
 	}
 	return true
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+func (u *UpdateStrategy) UnmarshalJSON(data []byte) (err error) {
+	var updateStrategyMap map[string]map[string]string
+	if err = json.Unmarshal(data, &updateStrategyMap); err != nil {
+		return err
+	}
+
+	registryPoll := &RegistryPoll{}
+	duration, err := time.ParseDuration(updateStrategyMap["registryPoll"]["interval"])
+	if err != nil {
+		registryPoll.ParsingError = fmt.Errorf("error parsing spec.updateStrategy.registryPoll.interval. Setting the default value of %v. Error:%v", DefaultRegistryPollDuration, err)
+		defaultTime, err := time.ParseDuration(DefaultRegistryPollDuration)
+		if err != nil {
+			return err
+		}
+		registryPoll.Interval = &metav1.Duration{Duration: defaultTime}
+	} else {
+		registryPoll.Interval = &metav1.Duration{Duration: duration}
+	}
+	u.RegistryPoll = registryPoll
+	return nil
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Handles incorrect CatalogSource interval values.

Example:

```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: ibm-operator-catalog
  namespace: openshift-marketplace
spec:
  displayName: ibm-operator-catalog 
  publisher: IBM Content
  sourceType: grpc
  image: docker.io/ibmcom/ibm-operator-catalog
  updateStrategy:
    registryPoll:
      interval: 45mError code    ################### incorrect value
```

Note:
Made changes to the UpdateStrategy unmarshal inside the vendor folder for reviews. Actual PR is here -> https://github.com/operator-framework/api/pull/142

will unhold once this and the api repo PR is lgtmed and changes from api is vendored in here.


**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
