### PR TITLE
fix(sub): Reset ResolutionFailed cond when error is resolved

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1246,14 +1246,8 @@ func (o *Operator) setSubsCond(subs []*v1alpha1.Subscription, condType v1alpha1.
 		cond.Reason = reason
 		cond.Message = message
 		if setTrue {
-			if cond.Status == corev1.ConditionTrue {
-				continue
-			}
 			cond.Status = corev1.ConditionTrue
 		} else {
-			if cond.Status == corev1.ConditionFalse {
-				continue
-			}
 			cond.Status = corev1.ConditionFalse
 		}
 		sub.Status.SetCondition(cond)

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1266,7 +1266,7 @@ func (o *Operator) updateSubscriptionStatuses(subs []*v1alpha1.Subscription) ([]
 
 	for _, sub := range subs {
 		wg.Add(1)
-		go func(sub v1alpha1.Subscription) {
+		go func(sub *v1alpha1.Subscription) {
 			defer wg.Done()
 
 			update := func() error {
@@ -1276,7 +1276,7 @@ func (o *Operator) updateSubscriptionStatuses(subs []*v1alpha1.Subscription) ([]
 					return err
 				}
 				latest.Status = sub.Status
-				sub = *latest
+				*sub = *latest
 				_, err = o.client.OperatorsV1alpha1().Subscriptions(sub.Namespace).UpdateStatus(context.TODO(), latest, updateOpts)
 				return err
 			}
@@ -1285,7 +1285,7 @@ func (o *Operator) updateSubscriptionStatuses(subs []*v1alpha1.Subscription) ([]
 				defer mu.Unlock()
 				errs = append(errs, err)
 			}
-		}(*sub)
+		}(sub)
 	}
 	wg.Wait()
 	return subs, utilerrors.NewAggregate(errs)

--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -155,6 +155,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -298,6 +306,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -446,6 +462,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						InstallPlanGeneration: 1,
 						LastUpdated:           now,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -599,6 +623,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -775,6 +807,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -958,6 +998,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 2,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
**Description of the change:**

In #2269, a new condition was introduced for Subscription to indicate any
dependency resolution error in it's message. However, when the case of
the error was resolved, the condition status (true) and the message
was sticking around. This PR fixes the issue, and makes sure that the
condition status is set to false, and the message and reason of the
condition are cleared off.


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
