### PR TITLE
.github/workflows: Avoid running the e2e-tests workflow on doc-only PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
   pull_request:
+    paths:
+      - '**'
+      - '!doc/**'
 jobs:
   run-e2e-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the e2e-tests.yml github workflow and avoid running that action
on PRs that only change the doc directory.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
