### PR TITLE
.github/workflows: Bump the docker/build-push-action to the v2 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     - name: Check out the repo
       uses: actions/checkout@v2
     - name: Build the container image
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
-        repository: operator-framework/olm
-        dockerfile: ./Dockerfile
+        context: .
+        file: Dockerfile
         push: false


### PR DESCRIPTION
Update the test-scripts.yml workflow and replace the
docker/build-push-action to use the v2 version.

These changes were made by following their upgrade from v1 to v2 guide:
- https://github.com/docker/build-push-action/blob/master/UPGRADE.md.

We only use this action currently to ensure that builds are successful
and don't push (or test against) the newly build container image.

Fixes #2144

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
