### PR TITLE
README: Remove reference to subscribing to channels through the tectonic UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Operators can behave like managed service providers. Their user interface on the
 - [kubectl][kubectl_tool] version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
 
-## Getting Started 
+## Getting Started
 
 Check the [Getting Started][olm-getting-started] section.
 
@@ -61,7 +61,7 @@ Use the admin console to interact with and visualize the resources managed by OL
 Ensure `kubectl` is pointing at a cluster and run:
 
 ```shell
-$ make run-console-local
+make run-console-local
 ```
 
 Then visit `http://localhost:9000` to view the console.
@@ -73,9 +73,6 @@ Have an awesome Operator you want to share? Checkout the [publishing docs](https
 ## Subscribe to a Package and Channel
 
 Cloud Services can be installed from the catalog by subscribing to a channel in the corresponding package.
-
-**Subscription detail view:**
-![screenshot_20180628_165240](https://user-images.githubusercontent.com/11700385/42060125-c3cde42c-7af3-11e8-87ec-e5910a554902.png)
 
 ## Kubernetes-native Applications
 
@@ -96,7 +93,7 @@ Learn more about the components used by OLM by reading about the [architecture] 
 
 ## CustomResourceDefinitions
 
-OLM standardizes interactions with operators by requiring that the interface to an operator be via the Kubernetes API. Because we expect users to define the interfaces to their applications, OLM currently uses CRDs to define the Kubernetes API interactions.  
+OLM standardizes interactions with operators by requiring that the interface to an operator be via the Kubernetes API. Because we expect users to define the interfaces to their applications, OLM currently uses CRDs to define the Kubernetes API interactions.
 
 Examples: [EtcdCluster CRD](https://github.com/operator-framework/community-operators/blob/master/community-operators/etcd/0.9.4/etcdclusters.etcd.database.coreos.com.crd.yaml), [EtcdBackup CRD](https://github.com/operator-framework/community-operators/blob/master/community-operators/etcd/0.9.4/etcdbackups.etcd.database.coreos.com.crd.yaml)
 
@@ -112,9 +109,9 @@ To minimize the effort required to run an application on kubernetes, OLM handles
 
 This is achieved through additional metadata on the application definition. Each operator must define:
 
- - The CRDs that it is responsible for managing. 
+ - The CRDs that it is responsible for managing.
    - e.g., the etcd operator manages `EtcdCluster`.
- - The CRDs that it depends on. 
+ - The CRDs that it depends on.
    - e.g., the vault operator depends on `EtcdCluster`, because Vault is backed by etcd.
 
 Basic dependency resolution is then possible by finding, for each “required” CRD, the corresponding operator that manages it and installing it as well. Dependency resolution can be further constrained by the way a user interacts with catalogs.
@@ -126,7 +123,8 @@ Dependency resolution is driven through the `(Group, Version, Kind)` of CRDs. Th
 There is no way to express a dependency on a particular version of an operator (e.g. `etcd-operator v0.9.0`) or application instance (e.g. `etcd v3.2.1`). This encourages application authors to depend on the interface and not the implementation.
 
 ## Discovery, Catalogs, and Automated Upgrades
-OLM has the concept of catalogs, which are repositories of application definitions and CRDs. 	
+
+OLM has the concept of catalogs, which are repositories of application definitions and CRDs.
 
 Catalogs contain a set of Packages, which map “channels” to a particular application definition. Channels allow package authors to write different upgrade paths for different users (e.g. alpha vs. stable).
 
@@ -155,7 +153,7 @@ Catalogs are served internally over a grpc interface to OLM from [operator-regis
 
 ## Samples
 
-To explore any operator samples using the OLM, see the [https://operatorhub.io/](https://operatorhub.io/) and its resources in [Community Operators](https://github.com/operator-framework/community-operators/tree/master/upstream-community-operators). 
+To explore any operator samples using the OLM, see the [https://operatorhub.io/](https://operatorhub.io/) and its resources in [Community Operators](https://github.com/operator-framework/community-operators/tree/master/upstream-community-operators).
 
 ## Community and how to get involved
 


### PR DESCRIPTION
Update the README.md and remove the section around subscribing to
channels through the tectonic UI.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
