### PR TITLE
fix(openshift): block upgrades on invalid max properties

### DIFF
--- a/pkg/controller/operators/openshift/helpers_test.go
+++ b/pkg/controller/operators/openshift/helpers_test.go
@@ -394,12 +394,20 @@ func TestIncompatibleOperators(t *testing.T) {
 				},
 			},
 			expect: expect{
-				err: true,
+				err: false,
 				incompatible: skews{
 					{
 						name:                "beech",
 						namespace:           "default",
 						maxOpenShiftVersion: "1.0.0",
+					},
+					{
+						name:      "chestnut",
+						namespace: "default",
+						err: fmt.Errorf(`Failed to parse "bad_version" as semver: %w`, func() error {
+							_, err := semver.ParseTolerant("bad_version")
+							return err
+						}()),
 					},
 				},
 			},
@@ -429,7 +437,7 @@ func TestIncompatibleOperators(t *testing.T) {
 				},
 			},
 			expect: expect{
-				err:          false,
+				err:          true,
 				incompatible: nil,
 			},
 		},
@@ -501,35 +509,13 @@ func TestMaxOpenShiftVersion(t *testing.T) {
 			description: "Nothing",
 			in:          []string{`""`},
 			expect: expect{
-				err: false,
-				max: nil,
-			},
-		},
-		{
-			description: "Nothing/Mixed",
-			in: []string{
-				`""`,
-				`"1.0.0"`,
-			},
-			expect: expect{
-				err: false,
-				max: mustParse("1.0.0"),
-			},
-		},
-		{
-			description: "Garbage",
-			in:          []string{`"bad_version"`},
-			expect: expect{
 				err: true,
 				max: nil,
 			},
 		},
 		{
-			description: "Garbage/Mixed",
-			in: []string{
-				`"bad_version"`,
-				`"1.0.0"`,
-			},
+			description: "Garbage",
+			in:          []string{`"bad_version"`},
 			expect: expect{
 				err: true,
 				max: nil,
@@ -548,40 +534,6 @@ func TestMaxOpenShiftVersion(t *testing.T) {
 			in: []string{
 				`"1.0.0"`,
 				`"2.0.0"`,
-			},
-			expect: expect{
-				err: false,
-				max: mustParse("2.0.0"),
-			},
-		},
-		{
-			description: "Duplicates",
-			in: []string{
-				`"1.0.0"`,
-				`"1.0.0"`,
-			},
-			expect: expect{
-				err: false,
-				max: mustParse("1.0.0"),
-			},
-		},
-		{
-			description: "Duplicates/NonMax",
-			in: []string{
-				`"1.0.0"`,
-				`"1.0.0"`,
-				`"2.0.0"`,
-			},
-			expect: expect{
-				err: false,
-				max: mustParse("2.0.0"),
-			},
-		},
-		{
-			description: "Ambiguous",
-			in: []string{
-				`"1.0.0"`,
-				`"1.0.0+1"`,
 			},
 			expect: expect{
 				err: true,


### PR DESCRIPTION
~~Fail open when olm.maxOpenShiftVersion properties have invalid
values. This means that all invalid values are logged but are ultimately
ignored when determining cluster upgradeability.~~

Block OpenShift upgrades while:

- olm.maxOpenShiftVersion properties have invalid values
- cluster information is unavailable; e.g. the desired version of the cluster is undefined
- an installed operator has declared more than one olm.MaxOpenShiftVersion
  property

See https://bugzilla.redhat.com/show_bug.cgi?id=1986753 for motivation.

