### PR TITLE
cmd/catalog: Default to the $KUBECONFIG environment variable when building client configs

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -38,7 +38,7 @@ const (
 // config flags defined globally so that they appear on the test binary as well
 var (
 	kubeConfigPath = flag.String(
-		"kubeconfig", "", "absolute path to the kubeconfig file")
+		"kubeconfig", os.Getenv("KUBECONFIG"), "absolute path to the kubeconfig file")
 
 	wakeupInterval = flag.Duration(
 		"interval", defaultWakeupInterval, "wakeup interval")


### PR DESCRIPTION
Update the catalog operator and default to the $KUBECONFIG environment
variable value when the --kubeconfig flag hasn't been provided. This
mirrors the same way that the olm operator (e.g. controller-runtime is
handling this check under-the-hood) behaves.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
