### PR TITLE
fix(og): Fix missing MultiOperatorGroups condition in some cases

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -15,7 +15,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extinf "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -878,41 +877,6 @@ func (a *Operator) syncNamespace(obj interface{}) error {
 	if err != nil {
 		logger.WithError(err).Warn("lister failed")
 		return err
-	}
-
-	// Query OG in this namespace
-	groups, err := a.lister.OperatorsV1().OperatorGroupLister().OperatorGroups(namespace.GetName()).List(labels.Everything())
-	if err != nil {
-		logger.WithError(err).Warn("failed to list OperatorGroups in the namespace")
-		return err
-	}
-
-	// Check if there is a stale multiple OG condition and clear it if existed.
-	if len(groups) == 1 {
-		og := groups[0]
-		if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
-			meta.RemoveStatusCondition(&og.Status.Conditions, v1.MutlipleOperatorGroupCondition)
-			_, err = a.client.OperatorsV1().OperatorGroups(namespace.GetName()).UpdateStatus(context.TODO(), og, metav1.UpdateOptions{})
-			if err != nil {
-				logger.Warnf("fail to upgrade operator group status og=%s with condition %+v: %s", og.GetName(), c, err.Error())
-			}
-		}
-	} else if len(groups) > 1 {
-		// Add to all OG's status conditions to indicate they're multiple OGs in the
-		// same namespace which is not allowed.
-		cond := metav1.Condition{
-			Type:    v1.MutlipleOperatorGroupCondition,
-			Status:  metav1.ConditionTrue,
-			Reason:  v1.MultipleOperatorGroupsReason,
-			Message: "Multiple OperatorGroup found in the same namespace",
-		}
-		for _, og := range groups {
-			meta.SetStatusCondition(&og.Status.Conditions, cond)
-			_, err = a.client.OperatorsV1().OperatorGroups(namespace.GetName()).UpdateStatus(context.TODO(), og, metav1.UpdateOptions{})
-			if err != nil {
-				logger.Warnf("fail to upgrade operator group status og=%s with condition %+v: %s", og.GetName(), cond, err.Error())
-			}
-		}
 	}
 
 	for _, group := range operatorGroupList {

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -4543,11 +4543,6 @@ func TestOperatorGroupConditions(t *testing.T) {
 	clockFake := utilclock.NewFakeClock(time.Date(2006, time.January, 2, 15, 4, 5, 0, time.FixedZone("MST", -7*3600)))
 
 	operatorNamespace := "operator-ns"
-	opNamespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: operatorNamespace,
-		},
-	}
 	serviceAccount := serviceAccount("sa", operatorNamespace)
 
 	type initial struct {
@@ -4665,7 +4660,7 @@ func TestOperatorGroupConditions(t *testing.T) {
 							UID:       "cdc9643e-7c52-4f7c-ae75-28ccb6aec97d",
 						},
 						Spec: v1.OperatorGroupSpec{
-							TargetNamespaces: []string{operatorNamespace},
+							TargetNamespaces: []string{operatorNamespace, "some-namespace"},
 						},
 					},
 				},
@@ -4719,20 +4714,6 @@ func TestOperatorGroupConditions(t *testing.T) {
 			if !tt.expectError {
 				require.NoError(t, err)
 			}
-
-			// wait on operator group updated status to be in the cache
-			err = wait.PollImmediate(1*time.Millisecond, 5*time.Second, func() (bool, error) {
-				og, err := op.lister.OperatorsV1().OperatorGroupLister().OperatorGroups(tt.initial.operatorGroup.GetNamespace()).Get(tt.initial.operatorGroup.GetName())
-				if err != nil || og == nil {
-					return false, err
-				}
-				return true, nil
-			})
-			require.NoError(t, err)
-
-			// sync namespace
-			err = op.syncNamespace(opNamespace)
-			require.NoError(t, err)
 
 			operatorGroup, err := op.client.OperatorsV1().OperatorGroups(tt.initial.operatorGroup.GetNamespace()).Get(context.TODO(), tt.initial.operatorGroup.GetName(), metav1.GetOptions{})
 			require.NoError(t, err)


### PR DESCRIPTION
In some special cases, the MultiOperatorGroups condition is missing
even though there are multiple OGs in the same namespace. The process
of adding this condition happens during syncNamespace which sometimes
doesn't happen if syncOperatorGroups fails prematurely due to other
errors. Moving the MultiOperatorGroups condition to syncOperatorGroups
to ensure it will be run everytime.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
