### PR TITLE
don't return an error if the singleton rbac doesn't exist

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -485,8 +485,14 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 					Resources: []string{"namespaces"},
 				}),
 			}
-			if _, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
-				return err
+			// TODO: this should do something smarter if the cluster role already exists
+			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
+				// if the CR already exists, but the label is correct, the cache is just behind
+				if k8serrors.IsAlreadyExists(err) && ownerutil.IsOwnedByLabel(cr, csv) {
+					continue
+				} else {
+					return err
+				}
 			}
 			a.logger.Debug("created cluster role")
 		}
@@ -519,8 +525,14 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 					Name:     r.RoleRef.Name,
 				},
 			}
-			if _, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
-				return err
+			// TODO: this should do something smarter if the cluster role binding already exists
+			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
+				// if the CR already exists, but the label is correct, the cache is just behind
+				if k8serrors.IsAlreadyExists(err) && ownerutil.IsOwnedByLabel(crb, csv) {
+					continue
+				} else {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Doesn't return an error from `ensureSingletonRBAC` if we can detect that the cache is just a bit behind

**Motivation for the change:**
Fixes https://github.com/operator-framework/operator-lifecycle-manager/issues/2091

prior to this change, I could reproduce with:
```
$ go test ./pkg/controller/operators/olm/... -v -run ^TestSyncOperatorGroups$ -count 10
```
after this change, I couldn't reproduce with:
```
$ go test ./pkg/controller/operators/olm/... -v -run ^TestSyncOperatorGroups$ -count 100
```

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
