### PR TITLE
Wrap catalog update test with retry logic

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -1068,8 +1068,11 @@ var _ = Describe("Catalog represents a store of bundles which OLM can use to ins
 
 		source.SetAnnotations(map[string]string{catalogsource.CatalogImageTemplateAnnotation: fmt.Sprintf("quay.io/olmtest/catsrc-update-test:%s.%s.%s", catalogsource.TemplKubeMajorV, catalogsource.TemplKubeMinorV, catalogsource.TemplKubePatchV)})
 
-		source, err = crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Update(context.TODO(), source, metav1.UpdateOptions{})
-		Expect(err).ShouldNot(HaveOccurred(), "error updating catalog source with template annotation")
+		// Update the catalog image
+		Eventually(func() error {
+			source, err = crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Update(context.TODO(), source, metav1.UpdateOptions{})
+			return err
+		}).Should(Succeed())
 
 		// wait for status condition to show up
 		Eventually(func() (bool, error) {


### PR DESCRIPTION
Fix CI inconsistency by adding retries during catalog e2e test `adding catalog template adjusts image used`. This test inconsistently fails due to apiserver cache invalidation responses