### PR TITLE
Bug 1989712: Fix for resolution error on channels with deprecated inner entries.

### DIFF
--- a/pkg/controller/registry/resolver/cache.go
+++ b/pkg/controller/registry/resolver/cache.go
@@ -392,9 +392,6 @@ type OperatorPredicate func(*Operator) bool
 func (s *CatalogSnapshot) Find(p ...OperatorPredicate) []*Operator {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	if len(p) > 0 {
-		p = append(p, WithoutDeprecatedProperty())
-	}
 	return Filter(s.operators, p...)
 }
 
@@ -450,17 +447,6 @@ func WithPackage(pkg string) OperatorPredicate {
 			}
 		}
 		return o.Package() == pkg
-	}
-}
-
-func WithoutDeprecatedProperty() OperatorPredicate {
-	return func(o *Operator) bool {
-		for _, p := range o.bundle.GetProperties() {
-			if p.GetType() == opregistry.DeprecatedType {
-				return false
-			}
-		}
-		return true
 	}
 }
 

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -294,19 +294,17 @@ func (r *SatResolver) getBundleInstallables(catalog registry.CatalogKey, predica
 		bundle := bundleStack[len(bundleStack)-1]
 		bundleStack = bundleStack[:len(bundleStack)-1]
 
-		bundleSource := bundle.SourceInfo()
-		if bundleSource == nil {
-			err := fmt.Errorf("unable to resolve the source of bundle %s, invalid cache", bundle.Identifier())
-			errs = append(errs, err)
-			continue
-		}
-
 		if b, ok := visited[bundle]; ok {
 			installables[b.identifier] = b
 			continue
 		}
 
-		bundleInstallable := NewBundleInstallable(bundle.Identifier(), bundle.Channel(), bundleSource.Catalog)
+		bundleInstallable, err := NewBundleInstallableFromOperator(bundle)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
 		visited[bundle] = &bundleInstallable
 
 		dependencyPredicates, err := bundle.DependencyPredicates()
@@ -348,14 +346,11 @@ func (r *SatResolver) getBundleInstallables(catalog registry.CatalogKey, predica
 			// (after sorting) to remove all bundles that
 			// don't satisfy the dependency.
 			for _, b := range Filter(sortedBundles, d) {
-				src := b.SourceInfo()
-				if src == nil {
-					err := fmt.Errorf("unable to resolve the source of bundle %s, invalid cache", bundle.Identifier())
+				i, err := NewBundleInstallableFromOperator(b)
+				if err != nil {
 					errs = append(errs, err)
 					continue
 				}
-
-				i := NewBundleInstallable(b.Identifier(), b.Channel(), src.Catalog)
 				installables[i.Identifier()] = &i
 				bundleDependencies = append(bundleDependencies, i.Identifier())
 				bundleStack = append(bundleStack, b)


### PR DESCRIPTION
Resolution would fail with an error in the presence of channels
containing more than two entries with a deprecated inner
entry (e.g. V1 -> V2 -> V3, with deprecated V2). This was due to
special handling that filtered out deprecated bundles at the cache
query layer. A channel's complete replaces-chain must be returned from
cache queries in order to correctly determine the relative order
between entries in the channel.
