### PR TITLE
Move operator caching from resolver into a new package.

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -38,6 +38,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/internal/pruning"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
+	resolvercache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clients"
 	csvutility "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/csv"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/event"
@@ -1364,7 +1365,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 	out = in.DeepCopy()
 	now := a.now()
 
-	operatorSurface, err := resolver.NewOperatorFromV1Alpha1CSV(out)
+	operatorSurface, err := resolvercache.NewOperatorFromV1Alpha1CSV(out)
 	if err != nil {
 		// If the resolver is unable to retrieve the operator info from the CSV the CSV requires changes, a syncError should not be returned.
 		logger.WithError(err).Warn("Unable to retrieve operator information from CSV")
@@ -1428,7 +1429,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 
 	groupSurface := resolver.NewOperatorGroup(operatorGroup)
 	otherGroupSurfaces := resolver.NewOperatorGroupSurfaces(otherGroups...)
-	providedAPIs := operatorSurface.ProvidedAPIs().StripPlural()
+	providedAPIs := operatorSurface.GetProvidedAPIs().StripPlural()
 
 	switch result := a.apiReconciler.Reconcile(providedAPIs, groupSurface, otherGroupSurfaces...); {
 	case operatorGroup.Spec.StaticProvidedAPIs && (result == resolver.AddAPIs || result == resolver.RemoveAPIs):

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -55,6 +55,7 @@ import (
 	olmerrors "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
+	resolvercache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/fakes"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clientfake"
 	csvutility "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/csv"
@@ -872,7 +873,7 @@ func TestTransitionCSV(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	namespace := "ns"
 
-	apiHash, err := resolver.APIKeyToGVKHash(opregistry.APIKey{Group: "g1", Version: "v1", Kind: "c1"})
+	apiHash, err := resolvercache.APIKeyToGVKHash(opregistry.APIKey{Group: "g1", Version: "v1", Kind: "c1"})
 	require.NoError(t, err)
 
 	defaultOperatorGroup := &v1.OperatorGroup{
@@ -3693,7 +3694,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 		v1alpha1.CSVPhaseNone,
 	), labels.Set{resolver.APILabelKeyPrefix + "9f4c46c37bdff8d0": "provided"})
 
-	operatorCSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{corev1.EnvVar{
+	operatorCSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{
 		Name:  "OPERATOR_CONDITION_NAME",
 		Value: operatorCSV.GetName(),
 	}}
@@ -4631,7 +4632,7 @@ func TestOperatorGroupConditions(t *testing.T) {
 			},
 			expectError: true,
 			expectedConditions: []metav1.Condition{
-				metav1.Condition{
+				{
 					Type:    v1.OperatorGroupServiceAccountCondition,
 					Status:  metav1.ConditionTrue,
 					Reason:  v1.OperatorGroupServiceAccountReason,
@@ -4674,7 +4675,7 @@ func TestOperatorGroupConditions(t *testing.T) {
 			},
 			expectError: true,
 			expectedConditions: []metav1.Condition{
-				metav1.Condition{
+				{
 					Type:    v1.MutlipleOperatorGroupCondition,
 					Status:  metav1.ConditionTrue,
 					Reason:  v1.MultipleOperatorGroupsReason,

--- a/pkg/controller/registry/resolver/cache/cache_test.go
+++ b/pkg/controller/registry/resolver/cache/cache_test.go
@@ -1,4 +1,4 @@
-package resolver
+package cache
 
 import (
 	"context"
@@ -240,9 +240,9 @@ func TestCatalogSnapshotFind(t *testing.T) {
 				return false
 			}),
 			Operators: []*Operator{
-				{name: "a"},
-				{name: "b"},
-				{name: "c"},
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
 			},
 			Expected: nil,
 		},
@@ -260,34 +260,34 @@ func TestCatalogSnapshotFind(t *testing.T) {
 				return true
 			}),
 			Operators: []*Operator{
-				{name: "a"},
-				{name: "b"},
-				{name: "c"},
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
 			},
 			Expected: []*Operator{
-				{name: "a"},
-				{name: "b"},
-				{name: "c"},
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
 			},
 		},
 		{
 			Name: "some satisfy predicate",
 			Predicate: OperatorPredicateTestFunc(func(o *Operator) bool {
-				return o.name != "a"
+				return o.Name != "a"
 			}),
 			Operators: []*Operator{
-				{name: "a"},
-				{name: "b"},
-				{name: "c"},
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
 			},
 			Expected: []*Operator{
-				{name: "b"},
-				{name: "c"},
+				{Name: "b"},
+				{Name: "c"},
 			},
 		},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
-			s := CatalogSnapshot{operators: tt.Operators}
+			s := CatalogSnapshot{Operators: tt.Operators}
 			assert.Equal(t, tt.Expected, s.Find(tt.Predicate))
 		})
 	}
@@ -314,7 +314,7 @@ func TestStripPluralRequiredAndProvidedAPIKeys(t *testing.T) {
 					Kind:    "K2",
 					Plural:  "ks2",
 				}},
-				Properties: apiSetToProperties(map[opregistry.APIKey]struct{}{
+				Properties: APISetToProperties(map[opregistry.APIKey]struct{}{
 					{
 						Group:   "g",
 						Version: "v1",
@@ -322,7 +322,7 @@ func TestStripPluralRequiredAndProvidedAPIKeys(t *testing.T) {
 						Plural:  "ks",
 					}: {},
 				}, nil, false),
-				Dependencies: apiSetToDependencies(map[opregistry.APIKey]struct{}{
+				Dependencies: APISetToDependencies(map[opregistry.APIKey]struct{}{
 					{
 						Group:   "g2",
 						Version: "v2",
@@ -340,8 +340,8 @@ func TestStripPluralRequiredAndProvidedAPIKeys(t *testing.T) {
 	result, err := AtLeast(1, nc.Find(ProvidingAPIPredicate(opregistry.APIKey{Group: "g", Version: "v1", Kind: "K"})))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(result))
-	assert.Equal(t, "K.v1.g", result[0].providedAPIs.String())
-	assert.Equal(t, "K2.v2.g2", result[0].requiredAPIs.String())
+	assert.Equal(t, "K.v1.g", result[0].ProvidedAPIs.String())
+	assert.Equal(t, "K2.v2.g2", result[0].RequiredAPIs.String())
 }
 
 func TestNamespaceOperatorCacheError(t *testing.T) {

--- a/pkg/controller/registry/resolver/cache/operators_test.go
+++ b/pkg/controller/registry/resolver/cache/operators_test.go
@@ -1,4 +1,4 @@
-package resolver
+package cache
 
 import (
 	"encoding/json"
@@ -737,7 +737,7 @@ func TestAPIMultiOwnerSet_PopAPIKey(t *testing.T) {
 			name: "OneApi/OneOwner",
 			s: map[opregistry.APIKey]OperatorSet{
 				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]OperatorSurface{
-					"owner1": &Operator{name: "op1"},
+					"owner1": &Operator{Name: "op1"},
 				},
 			},
 		},
@@ -745,8 +745,8 @@ func TestAPIMultiOwnerSet_PopAPIKey(t *testing.T) {
 			name: "OneApi/MultiOwner",
 			s: map[opregistry.APIKey]OperatorSet{
 				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]OperatorSurface{
-					"owner1": &Operator{name: "op1"},
-					"owner2": &Operator{name: "op2"},
+					"owner1": &Operator{Name: "op1"},
+					"owner2": &Operator{Name: "op2"},
 				},
 			},
 		},
@@ -754,12 +754,12 @@ func TestAPIMultiOwnerSet_PopAPIKey(t *testing.T) {
 			name: "MultipleApi/MultiOwner",
 			s: map[opregistry.APIKey]OperatorSet{
 				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]OperatorSurface{
-					"owner1": &Operator{name: "op1"},
-					"owner2": &Operator{name: "op2"},
+					"owner1": &Operator{Name: "op1"},
+					"owner2": &Operator{Name: "op2"},
 				},
 				{Group: "g2", Version: "v2", Kind: "k2", Plural: "p2"}: map[string]OperatorSurface{
-					"owner1": &Operator{name: "op1"},
-					"owner2": &Operator{name: "op2"},
+					"owner1": &Operator{Name: "op1"},
+					"owner2": &Operator{Name: "op2"},
 				},
 			},
 		},
@@ -797,41 +797,41 @@ func TestAPIMultiOwnerSet_PopAPIRequirers(t *testing.T) {
 			name: "OneApi/OneOwner",
 			s: map[opregistry.APIKey]OperatorSet{
 				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]OperatorSurface{
-					"owner1": &Operator{name: "op1"},
+					"owner1": &Operator{Name: "op1"},
 				},
 			},
 			want: map[string]OperatorSurface{
-				"owner1": &Operator{name: "op1"},
+				"owner1": &Operator{Name: "op1"},
 			},
 		},
 		{
 			name: "OneApi/MultiOwner",
 			s: map[opregistry.APIKey]OperatorSet{
 				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]OperatorSurface{
-					"owner1": &Operator{name: "op1"},
-					"owner2": &Operator{name: "op2"},
+					"owner1": &Operator{Name: "op1"},
+					"owner2": &Operator{Name: "op2"},
 				},
 			},
 			want: map[string]OperatorSurface{
-				"owner1": &Operator{name: "op1"},
-				"owner2": &Operator{name: "op2"},
+				"owner1": &Operator{Name: "op1"},
+				"owner2": &Operator{Name: "op2"},
 			},
 		},
 		{
 			name: "MultipleApi/MultiOwner",
 			s: map[opregistry.APIKey]OperatorSet{
 				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]OperatorSurface{
-					"owner1": &Operator{name: "op1"},
-					"owner2": &Operator{name: "op2"},
+					"owner1": &Operator{Name: "op1"},
+					"owner2": &Operator{Name: "op2"},
 				},
 				{Group: "g2", Version: "v2", Kind: "k2", Plural: "p2"}: map[string]OperatorSurface{
-					"owner1": &Operator{name: "op1"},
-					"owner2": &Operator{name: "op2"},
+					"owner1": &Operator{Name: "op1"},
+					"owner2": &Operator{Name: "op2"},
 				},
 			},
 			want: map[string]OperatorSurface{
-				"owner1": &Operator{name: "op1"},
-				"owner2": &Operator{name: "op2"},
+				"owner1": &Operator{Name: "op1"},
+				"owner2": &Operator{Name: "op2"},
 			},
 		},
 	}
@@ -1077,12 +1077,12 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				sourceKey: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
 			},
 			want: &Operator{
-				name:         "testBundle",
-				version:      &version.Version,
-				providedAPIs: EmptyAPISet(),
-				requiredAPIs: EmptyAPISet(),
-				bundle:       bundleNoAPIs,
-				sourceInfo: &OperatorSourceInfo{
+				Name:         "testBundle",
+				Version:      &version.Version,
+				ProvidedAPIs: EmptyAPISet(),
+				RequiredAPIs: EmptyAPISet(),
+				Bundle:       bundleNoAPIs,
+				SourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",
 					Catalog: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
@@ -1096,9 +1096,9 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				sourceKey: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
 			},
 			want: &Operator{
-				name:    "testBundle",
-				version: &version.Version,
-				providedAPIs: APISet{
+				Name:    "testBundle",
+				Version: &version.Version,
+				ProvidedAPIs: APISet{
 					opregistry.APIKey{
 						Group:   "crd.group.com",
 						Version: "v1",
@@ -1112,7 +1112,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 						Plural:  "ownedapis",
 					}: struct{}{},
 				},
-				requiredAPIs: APISet{
+				RequiredAPIs: APISet{
 					opregistry.APIKey{
 						Group:   "crd.group.com",
 						Version: "v1",
@@ -1126,7 +1126,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 						Plural:  "requiredapis",
 					}: struct{}{},
 				},
-				properties: []*api.Property{
+				Properties: []*api.Property{
 					{
 						Type:  "olm.gvk",
 						Value: "{\"group\":\"crd.group.com\",\"kind\":\"OwnedCRD\",\"version\":\"v1\"}",
@@ -1144,8 +1144,8 @@ func TestNewOperatorFromBundle(t *testing.T) {
 						Value: "{\"group\":\"apis.group.com\",\"kind\":\"RequiredAPI\",\"version\":\"v1\"}",
 					},
 				},
-				bundle: bundleWithAPIs,
-				sourceInfo: &OperatorSourceInfo{
+				Bundle: bundleWithAPIs,
+				SourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",
 					Catalog: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
@@ -1159,11 +1159,11 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				sourceKey: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
 			},
 			want: &Operator{
-				name:         "testBundle",
-				providedAPIs: EmptyAPISet(),
-				requiredAPIs: EmptyAPISet(),
-				bundle:       bundleWithAPIsUnextracted,
-				sourceInfo: &OperatorSourceInfo{
+				Name:         "testBundle",
+				ProvidedAPIs: EmptyAPISet(),
+				RequiredAPIs: EmptyAPISet(),
+				Bundle:       bundleWithAPIsUnextracted,
+				SourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",
 					Catalog: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
@@ -1178,12 +1178,12 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				defaultChannel: "testChannel",
 			},
 			want: &Operator{
-				name:         "testBundle",
-				version:      &version.Version,
-				providedAPIs: EmptyAPISet(),
-				requiredAPIs: EmptyAPISet(),
-				bundle:       bundleNoAPIs,
-				sourceInfo: &OperatorSourceInfo{
+				Name:         "testBundle",
+				Version:      &version.Version,
+				ProvidedAPIs: EmptyAPISet(),
+				RequiredAPIs: EmptyAPISet(),
+				Bundle:       bundleNoAPIs,
+				SourceInfo: &OperatorSourceInfo{
 					Package:        "testPackage",
 					Channel:        "testChannel",
 					Catalog:        registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
@@ -1198,11 +1198,11 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				sourceKey: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
 			},
 			want: &Operator{
-				name:         "testBundle",
-				version:      &version.Version,
-				providedAPIs: EmptyAPISet(),
-				requiredAPIs: EmptyAPISet(),
-				properties: []*api.Property{
+				Name:         "testBundle",
+				Version:      &version.Version,
+				ProvidedAPIs: EmptyAPISet(),
+				RequiredAPIs: EmptyAPISet(),
+				Properties: []*api.Property{
 					{
 						Type:  "olm.gvk",
 						Value: "{\"group\":\"crd.group.com\",\"kind\":\"OwnedCRD\",\"version\":\"v1\"}",
@@ -1220,8 +1220,8 @@ func TestNewOperatorFromBundle(t *testing.T) {
 						Value: "{\"group\":\"apis.group.com\",\"kind\":\"RequiredAPI\",\"version\":\"v1\"}",
 					},
 				},
-				bundle: bundleWithPropsAndDeps,
-				sourceInfo: &OperatorSourceInfo{
+				Bundle: bundleWithPropsAndDeps,
+				SourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",
 					Catalog: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
@@ -1233,8 +1233,8 @@ func TestNewOperatorFromBundle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewOperatorFromBundle(tt.args.bundle, "", tt.args.sourceKey, tt.args.defaultChannel)
 			require.Equal(t, tt.wantErr, err)
-			requirePropertiesEqual(t, tt.want.properties, got.properties)
-			tt.want.properties, got.properties = nil, nil
+			requirePropertiesEqual(t, tt.want.Properties, got.Properties)
+			tt.want.Properties, got.Properties = nil, nil
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -1264,11 +1264,11 @@ func TestNewOperatorFromCSV(t *testing.T) {
 				},
 			},
 			want: &Operator{
-				name:         "operator.v1",
-				providedAPIs: EmptyAPISet(),
-				requiredAPIs: EmptyAPISet(),
-				sourceInfo:   &ExistingOperator,
-				version:      &version.Version,
+				Name:         "operator.v1",
+				ProvidedAPIs: EmptyAPISet(),
+				RequiredAPIs: EmptyAPISet(),
+				SourceInfo:   &ExistingOperator,
+				Version:      &version.Version,
 			},
 		},
 		{
@@ -1303,12 +1303,12 @@ func TestNewOperatorFromCSV(t *testing.T) {
 				},
 			},
 			want: &Operator{
-				name: "operator.v1",
-				providedAPIs: map[opregistry.APIKey]struct{}{
+				Name: "operator.v1",
+				ProvidedAPIs: map[opregistry.APIKey]struct{}{
 					{Group: "g", Version: "v1", Kind: "APIKind", Plural: "apikinds"}: {},
 					{Group: "g", Version: "v1", Kind: "CRDKind", Plural: "crdkinds"}: {},
 				},
-				properties: []*api.Property{
+				Properties: []*api.Property{
 					{
 						Type:  "olm.gvk",
 						Value: "{\"group\":\"g\",\"kind\":\"APIKind\",\"version\":\"v1\"}",
@@ -1318,9 +1318,9 @@ func TestNewOperatorFromCSV(t *testing.T) {
 						Value: "{\"group\":\"g\",\"kind\":\"CRDKind\",\"version\":\"v1\"}",
 					},
 				},
-				requiredAPIs: EmptyAPISet(),
-				sourceInfo:   &ExistingOperator,
-				version:      &version.Version,
+				RequiredAPIs: EmptyAPISet(),
+				SourceInfo:   &ExistingOperator,
+				Version:      &version.Version,
 			},
 		},
 		{
@@ -1355,13 +1355,13 @@ func TestNewOperatorFromCSV(t *testing.T) {
 				},
 			},
 			want: &Operator{
-				name:         "operator.v1",
-				providedAPIs: EmptyAPISet(),
-				requiredAPIs: map[opregistry.APIKey]struct{}{
+				Name:         "operator.v1",
+				ProvidedAPIs: EmptyAPISet(),
+				RequiredAPIs: map[opregistry.APIKey]struct{}{
 					{Group: "g", Version: "v1", Kind: "APIKind", Plural: "apikinds"}: {},
 					{Group: "g", Version: "v1", Kind: "CRDKind", Plural: "crdkinds"}: {},
 				},
-				properties: []*api.Property{
+				Properties: []*api.Property{
 					{
 						Type:  "olm.gvk.required",
 						Value: "{\"group\":\"g\",\"kind\":\"APIKind\",\"version\":\"v1\"}",
@@ -1371,8 +1371,8 @@ func TestNewOperatorFromCSV(t *testing.T) {
 						Value: "{\"group\":\"g\",\"kind\":\"CRDKind\",\"version\":\"v1\"}",
 					},
 				},
-				sourceInfo: &ExistingOperator,
-				version:    &version.Version,
+				SourceInfo: &ExistingOperator,
+				Version:    &version.Version,
 			},
 		},
 		{
@@ -1422,16 +1422,16 @@ func TestNewOperatorFromCSV(t *testing.T) {
 				},
 			},
 			want: &Operator{
-				name: "operator.v1",
-				providedAPIs: map[opregistry.APIKey]struct{}{
+				Name: "operator.v1",
+				ProvidedAPIs: map[opregistry.APIKey]struct{}{
 					{Group: "g", Version: "v1", Kind: "APIOwnedKind", Plural: "apiownedkinds"}: {},
 					{Group: "g", Version: "v1", Kind: "CRDOwnedKind", Plural: "crdownedkinds"}: {},
 				},
-				requiredAPIs: map[opregistry.APIKey]struct{}{
+				RequiredAPIs: map[opregistry.APIKey]struct{}{
 					{Group: "g2", Version: "v1", Kind: "APIReqKind", Plural: "apireqkinds"}: {},
 					{Group: "g2", Version: "v1", Kind: "CRDReqKind", Plural: "crdreqkinds"}: {},
 				},
-				properties: []*api.Property{
+				Properties: []*api.Property{
 					{
 						Type:  "olm.gvk",
 						Value: "{\"group\":\"g\",\"kind\":\"APIOwnedKind\",\"version\":\"v1\"}",
@@ -1449,8 +1449,8 @@ func TestNewOperatorFromCSV(t *testing.T) {
 						Value: "{\"group\":\"g2\",\"kind\":\"CRDReqKind\",\"version\":\"v1\"}",
 					},
 				},
-				sourceInfo: &ExistingOperator,
-				version:    &version.Version,
+				SourceInfo: &ExistingOperator,
+				Version:    &version.Version,
 			},
 		},
 	}
@@ -1458,8 +1458,8 @@ func TestNewOperatorFromCSV(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewOperatorFromV1Alpha1CSV(tt.args.csv)
 			require.Equal(t, tt.wantErr, err)
-			requirePropertiesEqual(t, tt.want.properties, got.properties)
-			tt.want.properties, got.properties = nil, nil
+			requirePropertiesEqual(t, tt.want.Properties, got.Properties)
+			tt.want.Properties, got.Properties = nil, nil
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/controller/registry/resolver/cache/predicates.go
+++ b/pkg/controller/registry/resolver/cache/predicates.go
@@ -1,4 +1,4 @@
-package resolver
+package cache
 
 import (
 	"bytes"
@@ -24,7 +24,7 @@ func CSVNamePredicate(name string) OperatorPredicate {
 }
 
 func (c csvNamePredicate) Test(o *Operator) bool {
-	return o.Name() == string(c)
+	return o.Name == string(c)
 }
 
 func (c csvNamePredicate) String() string {
@@ -42,10 +42,10 @@ func (ch channelPredicate) Test(o *Operator) bool {
 	if string(ch) == "" {
 		return true
 	}
-	if o.Bundle() == nil {
+	if o.Bundle == nil {
 		return false
 	}
-	return o.Bundle().ChannelName == string(ch)
+	return o.Bundle.ChannelName == string(ch)
 }
 
 func (ch channelPredicate) String() string {
@@ -59,7 +59,7 @@ func PkgPredicate(pkg string) OperatorPredicate {
 }
 
 func (pkg pkgPredicate) Test(o *Operator) bool {
-	for _, p := range o.Properties() {
+	for _, p := range o.Properties {
 		if p.Type != opregistry.PackageType {
 			continue
 		}
@@ -89,7 +89,7 @@ func VersionInRangePredicate(r semver.Range, version string) OperatorPredicate {
 }
 
 func (v versionInRangePredicate) Test(o *Operator) bool {
-	for _, p := range o.Properties() {
+	for _, p := range o.Properties {
 		if p.Type != opregistry.PackageType {
 			continue
 		}
@@ -106,7 +106,7 @@ func (v versionInRangePredicate) Test(o *Operator) bool {
 			return true
 		}
 	}
-	return o.Version() != nil && v.r(*o.Version())
+	return o.Version != nil && v.r(*o.Version)
 }
 
 func (v versionInRangePredicate) String() string {
@@ -119,7 +119,7 @@ func LabelPredicate(label string) OperatorPredicate {
 	return labelPredicate(label)
 }
 func (l labelPredicate) Test(o *Operator) bool {
-	for _, p := range o.Properties() {
+	for _, p := range o.Properties {
 		if p.Type != opregistry.LabelType {
 			continue
 		}
@@ -148,7 +148,7 @@ func CatalogPredicate(key registry.CatalogKey) OperatorPredicate {
 }
 
 func (c catalogPredicate) Test(o *Operator) bool {
-	return c.key.Equal(o.SourceInfo().Catalog)
+	return c.key.Equal(o.SourceInfo.Catalog)
 }
 
 func (c catalogPredicate) String() string {
@@ -166,7 +166,7 @@ func ProvidingAPIPredicate(api opregistry.APIKey) OperatorPredicate {
 }
 
 func (g gvkPredicate) Test(o *Operator) bool {
-	for _, p := range o.Properties() {
+	for _, p := range o.Properties {
 		if p.Type != opregistry.GVKType {
 			continue
 		}
@@ -210,10 +210,10 @@ func ReplacesPredicate(replaces string) OperatorPredicate {
 }
 
 func (r replacesPredicate) Test(o *Operator) bool {
-	if o.Replaces() == string(r) {
+	if o.Replaces == string(r) {
 		return true
 	}
-	for _, s := range o.Skips() {
+	for _, s := range o.Skips {
 		if s == string(r) {
 			return true
 		}

--- a/pkg/controller/registry/resolver/cache/predicates_test.go
+++ b/pkg/controller/registry/resolver/cache/predicates_test.go
@@ -1,10 +1,20 @@
-package resolver
+package cache
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+type OperatorPredicateTestFunc func(*Operator) bool
+
+func (opf OperatorPredicateTestFunc) Test(o *Operator) bool {
+	return opf(o)
+}
+
+func (opf OperatorPredicateTestFunc) String() string {
+	return ""
+}
 
 func TestCountingPredicate(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/controller/registry/resolver/labeler_test.go
+++ b/pkg/controller/registry/resolver/labeler_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"testing"
 
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
@@ -43,8 +44,8 @@ func TestLabelSetsFor(t *testing.T) {
 		},
 		{
 			name: "OperatorSurface/Provided",
-			obj: &Operator{
-				providedAPIs: map[opregistry.APIKey]struct{}{
+			obj: &cache.Operator{
+				ProvidedAPIs: map[opregistry.APIKey]struct{}{
 					opregistry.APIKey{Group: "ghouls", Version: "v1alpha1", Kind: "Ghost", Plural: "Ghosts"}: {},
 				},
 			},
@@ -56,11 +57,11 @@ func TestLabelSetsFor(t *testing.T) {
 		},
 		{
 			name: "OperatorSurface/ProvidedAndRequired",
-			obj: &Operator{
-				providedAPIs: map[opregistry.APIKey]struct{}{
+			obj: &cache.Operator{
+				ProvidedAPIs: map[opregistry.APIKey]struct{}{
 					opregistry.APIKey{Group: "ghouls", Version: "v1alpha1", Kind: "Ghost", Plural: "Ghosts"}: {},
 				},
-				requiredAPIs: map[opregistry.APIKey]struct{}{
+				RequiredAPIs: map[opregistry.APIKey]struct{}{
 					opregistry.APIKey{Group: "ghouls", Version: "v1alpha1", Kind: "Goblin", Plural: "Goblins"}: {},
 				},
 			},

--- a/pkg/controller/registry/resolver/steps.go
+++ b/pkg/controller/registry/resolver/steps.go
@@ -17,6 +17,7 @@ import (
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 )
@@ -86,7 +87,7 @@ func NewStepResourceFromObject(obj runtime.Object, catalogSourceName, catalogSou
 	return resource, nil
 }
 
-func NewSubscriptionStepResource(namespace string, info OperatorSourceInfo) (v1alpha1.StepResource, error) {
+func NewSubscriptionStepResource(namespace string, info cache.OperatorSourceInfo) (v1alpha1.StepResource, error) {
 	return NewStepResourceFromObject(&v1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,

--- a/pkg/fakes/fake_api_intersection_reconciler.go
+++ b/pkg/fakes/fake_api_intersection_reconciler.go
@@ -5,13 +5,14 @@ import (
 	"sync"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
 type FakeAPIIntersectionReconciler struct {
-	ReconcileStub        func(resolver.APISet, resolver.OperatorGroupSurface, ...resolver.OperatorGroupSurface) resolver.APIReconciliationResult
+	ReconcileStub        func(cache.APISet, resolver.OperatorGroupSurface, ...resolver.OperatorGroupSurface) resolver.APIReconciliationResult
 	reconcileMutex       sync.RWMutex
 	reconcileArgsForCall []struct {
-		arg1 resolver.APISet
+		arg1 cache.APISet
 		arg2 resolver.OperatorGroupSurface
 		arg3 []resolver.OperatorGroupSurface
 	}
@@ -25,11 +26,11 @@ type FakeAPIIntersectionReconciler struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAPIIntersectionReconciler) Reconcile(arg1 resolver.APISet, arg2 resolver.OperatorGroupSurface, arg3 ...resolver.OperatorGroupSurface) resolver.APIReconciliationResult {
+func (fake *FakeAPIIntersectionReconciler) Reconcile(arg1 cache.APISet, arg2 resolver.OperatorGroupSurface, arg3 ...resolver.OperatorGroupSurface) resolver.APIReconciliationResult {
 	fake.reconcileMutex.Lock()
 	ret, specificReturn := fake.reconcileReturnsOnCall[len(fake.reconcileArgsForCall)]
 	fake.reconcileArgsForCall = append(fake.reconcileArgsForCall, struct {
-		arg1 resolver.APISet
+		arg1 cache.APISet
 		arg2 resolver.OperatorGroupSurface
 		arg3 []resolver.OperatorGroupSurface
 	}{arg1, arg2, arg3})
@@ -51,13 +52,13 @@ func (fake *FakeAPIIntersectionReconciler) ReconcileCallCount() int {
 	return len(fake.reconcileArgsForCall)
 }
 
-func (fake *FakeAPIIntersectionReconciler) ReconcileCalls(stub func(resolver.APISet, resolver.OperatorGroupSurface, ...resolver.OperatorGroupSurface) resolver.APIReconciliationResult) {
+func (fake *FakeAPIIntersectionReconciler) ReconcileCalls(stub func(cache.APISet, resolver.OperatorGroupSurface, ...resolver.OperatorGroupSurface) resolver.APIReconciliationResult) {
 	fake.reconcileMutex.Lock()
 	defer fake.reconcileMutex.Unlock()
 	fake.ReconcileStub = stub
 }
 
-func (fake *FakeAPIIntersectionReconciler) ReconcileArgsForCall(i int) (resolver.APISet, resolver.OperatorGroupSurface, []resolver.OperatorGroupSurface) {
+func (fake *FakeAPIIntersectionReconciler) ReconcileArgsForCall(i int) (cache.APISet, resolver.OperatorGroupSurface, []resolver.OperatorGroupSurface) {
 	fake.reconcileMutex.RLock()
 	defer fake.reconcileMutex.RUnlock()
 	argsForCall := fake.reconcileArgsForCall[i]


### PR DESCRIPTION
As part of a larger effort to extract the resolution component so that it can be shared between on- and off-cluster tools, all behavior related to caching and querying present and available operators is moving to its own package. This is a first step toward untangling the direction of inter-package dependencies that would require off-cluster tools to take a dependency on OLM itself.