### PR TITLE
add further console customization types

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -2438,6 +2438,9 @@ const (
 	PriorityClassKind         = "PriorityClass"
 	VerticalPodAutoscalerKind = "VerticalPodAutoscaler"
 	ConsoleYAMLSampleKind     = "ConsoleYAMLSample"
+	ConsoleQuickStartKind     = "ConsoleQuickStart"
+	ConsoleCLIDownloadKind    = "ConsoleCLIDownload"
+	ConsoleLinkKind           = "ConsoleLink"
 )
 
 var supportedKinds = map[string]struct{}{
@@ -2447,6 +2450,9 @@ var supportedKinds = map[string]struct{}{
 	PriorityClassKind:         {},
 	VerticalPodAutoscalerKind: {},
 	ConsoleYAMLSampleKind:     {},
+	ConsoleQuickStartKind:     {},
+	ConsoleCLIDownloadKind:    {},
+	ConsoleLinkKind:           {},
 }
 
 // isSupported returns true if OLM supports this type of CustomResource.


### PR DESCRIPTION
Signed-off-by: Daniel Messer <dmesser@redhat.com>

**Description of the change:**
Allow Operators to ship customization extensions for graphical consoles

**Motivation for the change:**
- Enabling https://github.com/operator-framework/operator-registry/pull/743
- Make it easier to get started with operator provided services by guiding users with quick starts, CLI download links or links to standalone consoles in graphical console for Kubernetes

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
