### PR TITLE
Check registry imageID before caching operator

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -860,6 +860,13 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 		return
 	}
 
+	if !reflect.DeepEqual(catsrc.GetLabels(), out.GetLabels()) {
+		updateErr := catalogsource.UpdateSpec(logger, o.client, out)
+		if syncError == nil && updateErr != nil {
+			syncError = updateErr
+		}
+	}
+
 	if equalFunc(&catsrc.Status, &out.Status) {
 		return
 	}

--- a/pkg/lib/catalogsource/catalogsource_update.go
+++ b/pkg/lib/catalogsource/catalogsource_update.go
@@ -34,6 +34,16 @@ func UpdateStatus(logger *logrus.Entry, client versioned.Interface, catsrc *v1al
 	return nil
 }
 
+func UpdateSpec(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource) error {
+	// make the spec update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Update(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("UpdateSpec - error while updating CatalogSource spec")
+		return err
+	}
+
+	return nil
+}
+
 /* UpdateStatusWithConditions can be used to update the status conditions for the provided catalog source.
 This function will make no changes to the other status fields (those fields will be used as-is).
 If the provided conditions do not result in any status condition changes, then the API server will not be updated.
@@ -92,7 +102,12 @@ func UpdateSpecAndStatusConditions(logger *logrus.Entry, client versioned.Interf
 
 	// make the update if possible
 	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Update(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
-		logger.WithError(err).Error("UpdateSpecAndStatusConditions - unable to update CatalogSource image reference")
+		logger.WithError(err).Error("UpdateSpecAndStatusConditions - unable to update CatalogSource spec")
+		return err
+	}
+
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).UpdateStatus(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("UpdateSpecAndStatusConditions - unable to update CatalogSource status")
 		return err
 	}
 	return nil


### PR DESCRIPTION
The operator cache for resolution is synced when resolution is triggered.
While this is a necessary action to ensure fresh cache, it is not needed
if there is no chance in the catalogsource. The imageID in the registry pod
can be used as reference to see if the catalogsource is updated recently.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
