### PR TITLE
[release-4.7] Bug 1969320: remove spec.cleanup from ClusterServiceVersion

### DIFF
--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -9,8 +9,6 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
-  cleanup:
-    enabled: false
   customresourcedefinitions: {}
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.


### PR DESCRIPTION
spec.cleanup is not declared in CRD for 4.7, so it makes CVO hotloop

Followup for #2192, as https://bugzilla.redhat.com/show_bug.cgi?id=1969320 failed QE