### PR TITLE
Fix 2327: Detecting OLM existence before start to install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,6 +24,11 @@ base_url="${2:-${default_base_url}}"
 url="${base_url}/${release}"
 namespace=olm
 
+if kubectl get deployment olm-operator -n ${namespace} -o=jsonpath='{.spec}' > /dev/null 2>&1; then
+    echo "OLM is already installed in ${namespace} namespace. Exiting..."
+    exit 1
+fi
+
 kubectl apply -f "${url}/crds.yaml"
 kubectl wait --for=condition=Established -f "${url}/crds.yaml"
 kubectl apply -f "${url}/olm.yaml"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@ if [[ ${#@} -lt 1 || ${#@} -gt 2 ]]; then
     exit 1
 fi
 
-if kubectl get deployment olm-operator -n openshift-operator-lifecycle-manager -o=jsonpath='{.spec}' > /dev/null 2>&1; then
+if kubectl get deployment olm-operator -n openshift-operator-lifecycle-manager > /dev/null 2>&1; then
     echo "OLM is already installed in a different configuration. This is common if you are not running a vanilla Kubernetes cluster. Exiting..."
     exit 1
 fi
@@ -24,7 +24,7 @@ base_url="${2:-${default_base_url}}"
 url="${base_url}/${release}"
 namespace=olm
 
-if kubectl get deployment olm-operator -n ${namespace} -o=jsonpath='{.spec}' > /dev/null 2>&1; then
+if kubectl get deployment olm-operator -n ${namespace} > /dev/null 2>&1; then
     echo "OLM is already installed in ${namespace} namespace. Exiting..."
     exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Ying Mo <morningspace@yahoo.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Adding logic in `install.sh` to check if OLM has already been installed in olm namespace before going forward.

**Motivation for the change:**

This PR is aimed to fix the issue documented [here](https://github.com/operator-framework/operator-lifecycle-manager/issues/2327)

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
