### PR TITLE
Reduce resolver dependencies on operator-registry and operator-lifecycle-manager.

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -55,6 +55,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/grpc"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
+	resolvercache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clients"
@@ -463,7 +464,7 @@ func (o *Operator) syncSourceState(state grpc.SourceState) {
 
 	switch state.State {
 	case connectivity.Ready:
-		o.resolver.Expire(state.Key)
+		o.resolver.Expire(resolvercache.SourceKey(state.Key))
 		if o.namespace == state.Key.Namespace {
 			namespaces, err := index.CatalogSubscriberNamespaces(o.catalogSubscriberIndexer,
 				state.Key.Name, state.Key.Namespace)

--- a/pkg/controller/registry/resolver/cache/cache.go
+++ b/pkg/controller/registry/resolver/cache/cache.go
@@ -2,24 +2,20 @@ package cache
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
-	"github.com/operator-framework/operator-registry/pkg/api"
-	"github.com/operator-framework/operator-registry/pkg/client"
-	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 )
 
-const ExistingOperatorKey = "@existing"
+const existingOperatorKey = "@existing"
 
 type SourceKey struct {
 	Name      string
@@ -40,42 +36,36 @@ func (k *SourceKey) Equal(compare SourceKey) bool {
 
 // Virtual indicates if this is a "virtual" catalog representing the currently installed operators in a namespace
 func (k *SourceKey) Virtual() bool {
-	return k.Name == ExistingOperatorKey && k.Namespace != ""
+	return k.Name == existingOperatorKey && k.Namespace != ""
 }
 
 func NewVirtualSourceKey(namespace string) SourceKey {
 	return SourceKey{
-		Name:      ExistingOperatorKey,
+		Name:      existingOperatorKey,
 		Namespace: namespace,
 	}
 }
 
-type RegistryClientProvider interface {
-	ClientsForNamespaces(namespaces ...string) map[registry.CatalogKey]client.Interface
+type Source interface {
+	Snapshot(context.Context) (*Snapshot, error)
 }
 
 type SourceProvider interface {
-	// TODO: Spun off from the old RegistryClientProvider in order
-	// to phase out the dependency on registry.CatalogKey. Subject
-	// to further change as the registry client dependency is also
-	// removed.
-	ClientsForNamespaces(namespaces ...string) map[SourceKey]client.Interface
+	// TODO: namespaces parameter is an artifact of SourceStore
+	Sources(namespaces ...string) map[SourceKey]Source
 }
 
-type DefaultRegistryClientProvider struct {
-	s RegistryClientProvider
-}
+type StaticSourceProvider map[SourceKey]Source
 
-func SourceProviderFromRegistryClientProvider(store RegistryClientProvider) *DefaultRegistryClientProvider {
-	return &DefaultRegistryClientProvider{
-		s: store,
-	}
-}
-
-func (rcp *DefaultRegistryClientProvider) ClientsForNamespaces(namespaces ...string) map[SourceKey]client.Interface {
-	result := make(map[SourceKey]client.Interface)
-	for key, client := range rcp.s.ClientsForNamespaces(namespaces...) {
-		result[SourceKey(key)] = client
+func (p StaticSourceProvider) Sources(namespaces ...string) map[SourceKey]Source {
+	result := make(map[SourceKey]Source)
+	for key, source := range p {
+		for _, namespace := range namespaces {
+			if key.Namespace == namespace {
+				result[key] = source
+				break
+			}
+		}
 	}
 	return result
 }
@@ -85,46 +75,67 @@ type OperatorCacheProvider interface {
 	Expire(catalog SourceKey)
 }
 
-type OperatorCache struct {
-	logger       logrus.FieldLogger
-	rcp          SourceProvider
+type Cache struct {
+	logger       logrus.StdLogger
+	sp           SourceProvider
 	catsrcLister v1alpha1.CatalogSourceLister
-	snapshots    map[SourceKey]*CatalogSnapshot
+	snapshots    map[SourceKey]*snapshotHeader
 	ttl          time.Duration
 	sem          chan struct{}
 	m            sync.RWMutex
 }
 
-const defaultCatalogSourcePriority int = 0
-
 type catalogSourcePriority int
 
-var _ OperatorCacheProvider = &OperatorCache{}
+var _ OperatorCacheProvider = &Cache{}
 
-func NewOperatorCache(rcp SourceProvider, log logrus.FieldLogger, catsrcLister v1alpha1.CatalogSourceLister) *OperatorCache {
+type Option func(*Cache)
+
+func WithLogger(logger logrus.StdLogger) Option {
+	return func(c *Cache) {
+		c.logger = logger
+	}
+}
+
+func WithCatalogSourceLister(catalogSourceLister v1alpha1.CatalogSourceLister) Option {
+	return func(c *Cache) {
+		c.catsrcLister = catalogSourceLister
+	}
+}
+
+func New(sp SourceProvider, options ...Option) *Cache {
 	const (
 		MaxConcurrentSnapshotUpdates = 4
 	)
 
-	return &OperatorCache{
-		logger:       log,
-		rcp:          rcp,
-		catsrcLister: catsrcLister,
-		snapshots:    make(map[SourceKey]*CatalogSnapshot),
+	cache := Cache{
+		logger: func() logrus.StdLogger {
+			logger := logrus.New()
+			logger.SetOutput(io.Discard)
+			return logger
+		}(),
+		sp:           sp,
+		catsrcLister: operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister(),
+		snapshots:    make(map[SourceKey]*snapshotHeader),
 		ttl:          5 * time.Minute,
 		sem:          make(chan struct{}, MaxConcurrentSnapshotUpdates),
 	}
+
+	for _, opt := range options {
+		opt(&cache)
+	}
+
+	return &cache
 }
 
 type NamespacedOperatorCache struct {
-	Namespaces []string
-	existing   *SourceKey
-	Snapshots  map[SourceKey]*CatalogSnapshot
+	existing  *SourceKey
+	snapshots map[SourceKey]*snapshotHeader
 }
 
 func (c *NamespacedOperatorCache) Error() error {
 	var errs []error
-	for key, snapshot := range c.Snapshots {
+	for key, snapshot := range c.snapshots {
 		snapshot.m.Lock()
 		err := snapshot.err
 		snapshot.m.Unlock()
@@ -135,7 +146,7 @@ func (c *NamespacedOperatorCache) Error() error {
 	return errors.NewAggregate(errs)
 }
 
-func (c *OperatorCache) Expire(catalog SourceKey) {
+func (c *Cache) Expire(catalog SourceKey) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	s, ok := c.snapshots[catalog]
@@ -145,31 +156,30 @@ func (c *OperatorCache) Expire(catalog SourceKey) {
 	s.expiry = time.Unix(0, 0)
 }
 
-func (c *OperatorCache) Namespaced(namespaces ...string) MultiCatalogOperatorFinder {
+func (c *Cache) Namespaced(namespaces ...string) MultiCatalogOperatorFinder {
 	const (
 		CachePopulateTimeout = time.Minute
 	)
 
 	now := time.Now()
-	clients := c.rcp.ClientsForNamespaces(namespaces...)
+	sources := c.sp.Sources(namespaces...)
 
 	result := NamespacedOperatorCache{
-		Namespaces: namespaces,
-		Snapshots:  make(map[SourceKey]*CatalogSnapshot),
+		snapshots: make(map[SourceKey]*snapshotHeader),
 	}
 
 	var misses []SourceKey
 	func() {
 		c.m.RLock()
 		defer c.m.RUnlock()
-		for key := range clients {
+		for key := range sources {
 			snapshot, ok := c.snapshots[key]
 			if ok {
 				func() {
 					snapshot.m.RLock()
 					defer snapshot.m.RUnlock()
-					if !snapshot.Expired(now) && snapshot.Operators != nil && len(snapshot.Operators) > 0 {
-						result.Snapshots[key] = snapshot
+					if snapshot.Valid(now) {
+						result.snapshots[key] = snapshot
 					} else {
 						misses = append(misses, key)
 					}
@@ -191,7 +201,7 @@ func (c *OperatorCache) Namespaced(namespaces ...string) MultiCatalogOperatorFin
 	// Take the opportunity to clear expired snapshots while holding the lock.
 	var expired []SourceKey
 	for key, snapshot := range c.snapshots {
-		if snapshot.Expired(now) {
+		if !snapshot.Valid(now) {
 			snapshot.Cancel()
 			expired = append(expired, key)
 		}
@@ -203,8 +213,8 @@ func (c *OperatorCache) Namespaced(namespaces ...string) MultiCatalogOperatorFin
 	// Check for any snapshots that were populated while waiting to acquire the lock.
 	var found int
 	for i := range misses {
-		if snapshot, ok := c.snapshots[misses[i]]; ok && !snapshot.Expired(now) && snapshot.Operators != nil && len(snapshot.Operators) > 0 {
-			result.Snapshots[misses[i]] = snapshot
+		if hdr, ok := c.snapshots[misses[i]]; ok && hdr.Valid(now) {
+			result.snapshots[misses[i]] = hdr
 			misses[found], misses[i] = misses[i], misses[found]
 			found++
 		}
@@ -214,101 +224,30 @@ func (c *OperatorCache) Namespaced(namespaces ...string) MultiCatalogOperatorFin
 	for _, miss := range misses {
 		ctx, cancel := context.WithTimeout(context.Background(), CachePopulateTimeout)
 
-		catsrcPriority := defaultCatalogSourcePriority
-		// Ignoring error and treat catsrc priority as 0 if not found.
-		catsrc, err := c.catsrcLister.CatalogSources(miss.Namespace).Get(miss.Name)
-		if err == nil {
-			catsrcPriority = catsrc.Spec.Priority
+		hdr := snapshotHeader{
+			key:    miss,
+			expiry: now.Add(c.ttl),
+			pop:    cancel,
 		}
 
-		s := CatalogSnapshot{
-			logger:   c.logger.WithField("catalog", miss),
-			Key:      miss,
-			expiry:   now.Add(c.ttl),
-			pop:      cancel,
-			Priority: catalogSourcePriority(catsrcPriority),
+		// Ignoring error and treat catsrc priority as 0 if not found.
+		if catsrc, _ := c.catsrcLister.CatalogSources(miss.Namespace).Get(miss.Name); catsrc != nil {
+			hdr.priority = catsrc.Spec.Priority
 		}
-		s.m.Lock()
-		c.snapshots[miss] = &s
-		result.Snapshots[miss] = &s
-		go c.populate(ctx, &s, clients[miss])
+
+		hdr.m.Lock()
+		c.snapshots[miss] = &hdr
+		result.snapshots[miss] = &hdr
+
+		go func(ctx context.Context, hdr *snapshotHeader, source Source) {
+			defer hdr.m.Unlock()
+			c.sem <- struct{}{}
+			defer func() { <-c.sem }()
+			hdr.snapshot, hdr.err = source.Snapshot(ctx)
+		}(ctx, &hdr, sources[miss])
 	}
 
 	return &result
-}
-
-func (c *OperatorCache) populate(ctx context.Context, snapshot *CatalogSnapshot, registry client.Interface) {
-	defer snapshot.m.Unlock()
-	defer func() {
-		// Don't cache an errorred snapshot.
-		if snapshot.err != nil {
-			snapshot.expiry = time.Time{}
-		}
-	}()
-
-	c.sem <- struct{}{}
-	defer func() { <-c.sem }()
-
-	// Fetching default channels this way makes many round trips
-	// -- may need to either add a new API to fetch all at once,
-	// or embed the information into Bundle.
-	defaultChannels := make(map[string]string)
-
-	it, err := registry.ListBundles(ctx)
-	if err != nil {
-		snapshot.logger.Errorf("failed to list bundles: %s", err.Error())
-		snapshot.err = err
-		return
-	}
-	c.logger.WithField("catalog", snapshot.Key.String()).Debug("updating cache")
-	var operators []*Operator
-	for b := it.Next(); b != nil; b = it.Next() {
-		defaultChannel, ok := defaultChannels[b.PackageName]
-		if !ok {
-			if p, err := registry.GetPackage(ctx, b.PackageName); err != nil {
-				snapshot.logger.Warnf("failed to retrieve default channel for bundle, continuing: %v", err)
-				continue
-			} else {
-				defaultChannels[b.PackageName] = p.DefaultChannelName
-				defaultChannel = p.DefaultChannelName
-			}
-		}
-		o, err := NewOperatorFromBundle(b, "", snapshot.Key, defaultChannel)
-		if err != nil {
-			snapshot.logger.Warnf("failed to construct operator from bundle, continuing: %v", err)
-			continue
-		}
-		o.ProvidedAPIs = o.ProvidedAPIs.StripPlural()
-		o.RequiredAPIs = o.RequiredAPIs.StripPlural()
-		o.Replaces = b.Replaces
-		EnsurePackageProperty(o, b.PackageName, b.Version)
-		operators = append(operators, o)
-	}
-	if err := it.Error(); err != nil {
-		snapshot.logger.Warnf("error encountered while listing bundles: %s", err.Error())
-		snapshot.err = err
-	}
-	snapshot.Operators = operators
-}
-
-func EnsurePackageProperty(o *Operator, name, version string) {
-	for _, p := range o.Properties {
-		if p.Type == opregistry.PackageType {
-			return
-		}
-	}
-	prop := opregistry.PackageProperty{
-		PackageName: name,
-		Version:     version,
-	}
-	bytes, err := json.Marshal(prop)
-	if err != nil {
-		return
-	}
-	o.Properties = append(o.Properties, &api.Property{
-		Type:  opregistry.PackageType,
-		Value: string(bytes),
-	})
 }
 
 func (c *NamespacedOperatorCache) Catalog(k SourceKey) OperatorFinder {
@@ -316,18 +255,18 @@ func (c *NamespacedOperatorCache) Catalog(k SourceKey) OperatorFinder {
 	if k.Empty() {
 		return c
 	}
-	if snapshot, ok := c.Snapshots[k]; ok {
+	if snapshot, ok := c.snapshots[k]; ok {
 		return snapshot
 	}
 	return EmptyOperatorFinder{}
 }
 
-func (c *NamespacedOperatorCache) FindPreferred(preferred *SourceKey, p ...OperatorPredicate) []*Operator {
+func (c *NamespacedOperatorCache) FindPreferred(preferred *SourceKey, preferredNamespace string, p ...OperatorPredicate) []*Operator {
 	var result []*Operator
 	if preferred != nil && preferred.Empty() {
 		preferred = nil
 	}
-	sorted := NewSortableSnapshots(c.existing, preferred, c.Namespaces, c.Snapshots)
+	sorted := newSortableSnapshots(c.existing, preferred, preferredNamespace, c.snapshots)
 	sort.Sort(sorted)
 	for _, snapshot := range sorted.snapshots {
 		result = append(result, snapshot.Find(p...)...)
@@ -335,65 +274,71 @@ func (c *NamespacedOperatorCache) FindPreferred(preferred *SourceKey, p ...Opera
 	return result
 }
 
-func (c *NamespacedOperatorCache) WithExistingOperators(snapshot *CatalogSnapshot) MultiCatalogOperatorFinder {
+func (c *NamespacedOperatorCache) WithExistingOperators(snapshot *Snapshot, namespace string) MultiCatalogOperatorFinder {
+	key := NewVirtualSourceKey(namespace)
 	o := &NamespacedOperatorCache{
-		Namespaces: c.Namespaces,
-		existing:   &snapshot.Key,
-		Snapshots:  c.Snapshots,
+		existing: &key,
+		snapshots: map[SourceKey]*snapshotHeader{
+			key: {
+				key:      key,
+				snapshot: snapshot,
+			},
+		},
 	}
-	o.Snapshots[snapshot.Key] = snapshot
+	for k, v := range c.snapshots {
+		o.snapshots[k] = v
+	}
 	return o
 }
 
 func (c *NamespacedOperatorCache) Find(p ...OperatorPredicate) []*Operator {
-	return c.FindPreferred(nil, p...)
+	return c.FindPreferred(nil, "", p...)
 }
 
-type CatalogSnapshot struct {
-	logger    logrus.FieldLogger
-	Key       SourceKey
-	expiry    time.Time
-	Operators []*Operator
-	m         sync.RWMutex
-	pop       context.CancelFunc
-	Priority  catalogSourcePriority
-	err       error
+type Snapshot struct {
+	Entries []*Operator
 }
 
-func (s *CatalogSnapshot) Cancel() {
-	s.pop()
+var _ Source = &Snapshot{}
+
+func (s *Snapshot) Snapshot(context.Context) (*Snapshot, error) {
+	return s, nil
 }
 
-func (s *CatalogSnapshot) Expired(at time.Time) bool {
-	return !at.Before(s.expiry)
+type snapshotHeader struct {
+	snapshot *Snapshot
+
+	key      SourceKey
+	expiry   time.Time
+	m        sync.RWMutex
+	pop      context.CancelFunc
+	err      error
+	priority int
 }
 
-// NewRunningOperatorSnapshot creates a CatalogSnapshot that represents a set of existing installed operators
-// in the cluster.
-func NewRunningOperatorSnapshot(logger logrus.FieldLogger, key SourceKey, o []*Operator) *CatalogSnapshot {
-	return &CatalogSnapshot{
-		logger:    logger,
-		Key:       key,
-		Operators: o,
-	}
+func (hdr *snapshotHeader) Cancel() {
+	hdr.pop()
 }
 
-type SortableSnapshots struct {
-	snapshots  []*CatalogSnapshot
-	namespaces map[string]int
-	preferred  *SourceKey
-	existing   *SourceKey
+func (hdr *snapshotHeader) Valid(at time.Time) bool {
+	hdr.m.RLock()
+	defer hdr.m.RUnlock()
+	return hdr.snapshot != nil && hdr.err == nil && at.Before(hdr.expiry)
 }
 
-func NewSortableSnapshots(existing, preferred *SourceKey, namespaces []string, snapshots map[SourceKey]*CatalogSnapshot) SortableSnapshots {
-	sorted := SortableSnapshots{
-		existing:   existing,
-		preferred:  preferred,
-		snapshots:  make([]*CatalogSnapshot, 0),
-		namespaces: make(map[string]int, 0),
-	}
-	for i, n := range namespaces {
-		sorted.namespaces[n] = i
+type sortableSnapshots struct {
+	snapshots          []*snapshotHeader
+	preferredNamespace string
+	preferred          *SourceKey
+	existing           *SourceKey
+}
+
+func newSortableSnapshots(existing, preferred *SourceKey, preferredNamespace string, snapshots map[SourceKey]*snapshotHeader) sortableSnapshots {
+	sorted := sortableSnapshots{
+		existing:           existing,
+		preferred:          preferred,
+		snapshots:          make([]*snapshotHeader, 0),
+		preferredNamespace: preferredNamespace,
 	}
 	for _, s := range snapshots {
 		sorted.snapshots = append(sorted.snapshots, s)
@@ -401,60 +346,69 @@ func NewSortableSnapshots(existing, preferred *SourceKey, namespaces []string, s
 	return sorted
 }
 
-var _ sort.Interface = SortableSnapshots{}
+var _ sort.Interface = sortableSnapshots{}
 
 // Len is the number of elements in the collection.
-func (s SortableSnapshots) Len() int {
+func (s sortableSnapshots) Len() int {
 	return len(s.snapshots)
 }
 
 // Less reports whether the element with
 // index i should sort before the element with index j.
-func (s SortableSnapshots) Less(i, j int) bool {
+func (s sortableSnapshots) Less(i, j int) bool {
 	// existing operators are preferred over catalog operators
 	if s.existing != nil &&
-		s.snapshots[i].Key.Name == s.existing.Name &&
-		s.snapshots[i].Key.Namespace == s.existing.Namespace {
+		s.snapshots[i].key.Name == s.existing.Name &&
+		s.snapshots[i].key.Namespace == s.existing.Namespace {
 		return true
 	}
 	if s.existing != nil &&
-		s.snapshots[j].Key.Name == s.existing.Name &&
-		s.snapshots[j].Key.Namespace == s.existing.Namespace {
+		s.snapshots[j].key.Name == s.existing.Name &&
+		s.snapshots[j].key.Namespace == s.existing.Namespace {
 		return false
 	}
 
 	// preferred catalog is less than all other catalogs
 	if s.preferred != nil &&
-		s.snapshots[i].Key.Name == s.preferred.Name &&
-		s.snapshots[i].Key.Namespace == s.preferred.Namespace {
+		s.snapshots[i].key.Name == s.preferred.Name &&
+		s.snapshots[i].key.Namespace == s.preferred.Namespace {
 		return true
 	}
 	if s.preferred != nil &&
-		s.snapshots[j].Key.Name == s.preferred.Name &&
-		s.snapshots[j].Key.Namespace == s.preferred.Namespace {
+		s.snapshots[j].key.Name == s.preferred.Name &&
+		s.snapshots[j].key.Namespace == s.preferred.Namespace {
 		return false
 	}
 
 	// the rest are sorted first on priority, namespace and then by name
-	if s.snapshots[i].Priority != s.snapshots[j].Priority {
-		return s.snapshots[i].Priority > s.snapshots[j].Priority
-	}
-	if s.snapshots[i].Key.Namespace != s.snapshots[j].Key.Namespace {
-		return s.namespaces[s.snapshots[i].Key.Namespace] < s.namespaces[s.snapshots[j].Key.Namespace]
+	if s.snapshots[i].priority != s.snapshots[j].priority {
+		return s.snapshots[i].priority > s.snapshots[j].priority
 	}
 
-	return s.snapshots[i].Key.Name < s.snapshots[j].Key.Name
+	if s.snapshots[i].key.Namespace != s.snapshots[j].key.Namespace {
+		if s.snapshots[i].key.Namespace == s.preferredNamespace {
+			return true
+		}
+		if s.snapshots[j].key.Namespace == s.preferredNamespace {
+			return false
+		}
+	}
+
+	return s.snapshots[i].key.Name < s.snapshots[j].key.Name
 }
 
 // Swap swaps the elements with indexes i and j.
-func (s SortableSnapshots) Swap(i, j int) {
+func (s sortableSnapshots) Swap(i, j int) {
 	s.snapshots[i], s.snapshots[j] = s.snapshots[j], s.snapshots[i]
 }
 
-func (s *CatalogSnapshot) Find(p ...OperatorPredicate) []*Operator {
+func (s *snapshotHeader) Find(p ...OperatorPredicate) []*Operator {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	return Filter(s.Operators, p...)
+	if s.snapshot == nil {
+		return nil
+	}
+	return Filter(s.snapshot.Entries, p...)
 }
 
 type OperatorFinder interface {
@@ -463,8 +417,8 @@ type OperatorFinder interface {
 
 type MultiCatalogOperatorFinder interface {
 	Catalog(SourceKey) OperatorFinder
-	FindPreferred(*SourceKey, ...OperatorPredicate) []*Operator
-	WithExistingOperators(*CatalogSnapshot) MultiCatalogOperatorFinder
+	FindPreferred(preferred *SourceKey, preferredNamespace string, predicates ...OperatorPredicate) []*Operator
+	WithExistingOperators(snapshot *Snapshot, namespace string) MultiCatalogOperatorFinder
 	Error() error
 	OperatorFinder
 }

--- a/pkg/controller/registry/resolver/cache/cache_test.go
+++ b/pkg/controller/registry/resolver/cache/cache_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/client"
@@ -77,9 +76,9 @@ func (s *RegistryClientStub) Close() error {
 	return nil
 }
 
-type RegistryClientProviderStub map[registry.CatalogKey]client.Interface
+type RegistryClientProviderStub map[SourceKey]client.Interface
 
-func (s RegistryClientProviderStub) ClientsForNamespaces(namespaces ...string) map[registry.CatalogKey]client.Interface {
+func (s RegistryClientProviderStub) ClientsForNamespaces(namespaces ...string) map[SourceKey]client.Interface {
 	return s
 }
 
@@ -89,10 +88,10 @@ func TestOperatorCacheConcurrency(t *testing.T) {
 	)
 	rcp := RegistryClientProviderStub{}
 	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
-	var keys []registry.CatalogKey
+	var keys []SourceKey
 	for i := 0; i < 128; i++ {
 		for j := 0; j < 8; j++ {
-			key := registry.CatalogKey{Namespace: strconv.Itoa(i), Name: strconv.Itoa(j)}
+			key := SourceKey{Namespace: strconv.Itoa(i), Name: strconv.Itoa(j)}
 			keys = append(keys, key)
 			rcp[key] = &RegistryClientStub{
 				BundleIterator: client.NewBundleIterator(&BundleStreamStub{
@@ -145,7 +144,7 @@ func TestOperatorCacheConcurrency(t *testing.T) {
 func TestOperatorCacheExpiration(t *testing.T) {
 	rcp := RegistryClientProviderStub{}
 	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
-	key := registry.CatalogKey{Namespace: "dummynamespace", Name: "dummyname"}
+	key := SourceKey{Namespace: "dummynamespace", Name: "dummyname"}
 	rcp[key] = &RegistryClientStub{
 		BundleIterator: client.NewBundleIterator(&BundleStreamStub{
 			Bundles: []*api.Bundle{{
@@ -169,7 +168,7 @@ func TestOperatorCacheExpiration(t *testing.T) {
 func TestOperatorCacheReuse(t *testing.T) {
 	rcp := RegistryClientProviderStub{}
 	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
-	key := registry.CatalogKey{Namespace: "dummynamespace", Name: "dummyname"}
+	key := SourceKey{Namespace: "dummynamespace", Name: "dummyname"}
 	rcp[key] = &RegistryClientStub{
 		BundleIterator: client.NewBundleIterator(&BundleStreamStub{
 			Bundles: []*api.Bundle{{
@@ -297,7 +296,7 @@ func TestCatalogSnapshotFind(t *testing.T) {
 func TestStripPluralRequiredAndProvidedAPIKeys(t *testing.T) {
 	rcp := RegistryClientProviderStub{}
 	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
-	key := registry.CatalogKey{Namespace: "testnamespace", Name: "testname"}
+	key := SourceKey{Namespace: "testnamespace", Name: "testname"}
 	rcp[key] = &RegistryClientStub{
 		BundleIterator: client.NewBundleIterator(&BundleStreamStub{
 			Bundles: []*api.Bundle{{
@@ -347,7 +346,7 @@ func TestStripPluralRequiredAndProvidedAPIKeys(t *testing.T) {
 func TestNamespaceOperatorCacheError(t *testing.T) {
 	rcp := RegistryClientProviderStub{}
 	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
-	key := registry.CatalogKey{Namespace: "dummynamespace", Name: "dummyname"}
+	key := SourceKey{Namespace: "dummynamespace", Name: "dummyname"}
 	rcp[key] = &RegistryClientStub{
 		ListBundlesError: errors.New("testing"),
 	}

--- a/pkg/controller/registry/resolver/cache/cache_test.go
+++ b/pkg/controller/registry/resolver/cache/cache_test.go
@@ -4,112 +4,37 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"math/rand"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 	"github.com/operator-framework/operator-registry/pkg/api"
-	"github.com/operator-framework/operator-registry/pkg/client"
-	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
-
-type BundleStreamStub struct {
-	Bundles []*api.Bundle
-}
-
-func (s *BundleStreamStub) Recv() (*api.Bundle, error) {
-	if len(s.Bundles) == 0 {
-		return nil, io.EOF
-	}
-	b := s.Bundles[0]
-	s.Bundles = s.Bundles[1:]
-	return b, nil
-}
-
-type RegistryClientStub struct {
-	BundleIterator *client.BundleIterator
-
-	ListBundlesError error
-}
-
-func (s *RegistryClientStub) Get() (client.Interface, error) {
-	return s, nil
-}
-
-func (s *RegistryClientStub) GetBundle(ctx context.Context, packageName, channelName, csvName string) (*api.Bundle, error) {
-	return nil, nil
-}
-
-func (s *RegistryClientStub) GetBundleInPackageChannel(ctx context.Context, packageName, channelName string) (*api.Bundle, error) {
-	return nil, nil
-}
-
-func (s *RegistryClientStub) GetReplacementBundleInPackageChannel(ctx context.Context, currentName, packageName, channelName string) (*api.Bundle, error) {
-	return nil, nil
-}
-
-func (s *RegistryClientStub) GetBundleThatProvides(ctx context.Context, group, version, kind string) (*api.Bundle, error) {
-	return nil, nil
-}
-
-func (s *RegistryClientStub) ListBundles(ctx context.Context) (*client.BundleIterator, error) {
-	return s.BundleIterator, s.ListBundlesError
-}
-
-func (s *RegistryClientStub) GetPackage(ctx context.Context, packageName string) (*api.Package, error) {
-	return &api.Package{Name: packageName}, nil
-}
-
-func (s *RegistryClientStub) HealthCheck(ctx context.Context, reconnectTimeout time.Duration) (bool, error) {
-	return false, nil
-}
-
-func (s *RegistryClientStub) Close() error {
-	return nil
-}
-
-type RegistryClientProviderStub map[SourceKey]client.Interface
-
-func (s RegistryClientProviderStub) ClientsForNamespaces(namespaces ...string) map[SourceKey]client.Interface {
-	return s
-}
 
 func TestOperatorCacheConcurrency(t *testing.T) {
 	const (
 		NWorkers = 64
 	)
-	rcp := RegistryClientProviderStub{}
-	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
+
+	sp := make(StaticSourceProvider)
 	var keys []SourceKey
 	for i := 0; i < 128; i++ {
 		for j := 0; j < 8; j++ {
 			key := SourceKey{Namespace: strconv.Itoa(i), Name: strconv.Itoa(j)}
 			keys = append(keys, key)
-			rcp[key] = &RegistryClientStub{
-				BundleIterator: client.NewBundleIterator(&BundleStreamStub{
-					Bundles: []*api.Bundle{{
-						CsvName: fmt.Sprintf("%s/%s", key.Namespace, key.Name),
-						ProvidedApis: []*api.GroupVersionKind{{
-							Group:   "g",
-							Version: "v1",
-							Kind:    "K",
-							Plural:  "ks",
-						}},
-					}},
-				}),
+			sp[key] = &Snapshot{
+				Entries: []*Operator{
+					{Name: fmt.Sprintf("%s/%s", key.Namespace, key.Name)},
+				},
 			}
 		}
 	}
 
-	c := NewOperatorCache(rcp, logrus.New(), catsrcLister)
+	c := New(sp)
 
 	errs := make(chan error)
 	for w := 0; w < NWorkers; w++ {
@@ -142,56 +67,52 @@ func TestOperatorCacheConcurrency(t *testing.T) {
 }
 
 func TestOperatorCacheExpiration(t *testing.T) {
-	rcp := RegistryClientProviderStub{}
-	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
 	key := SourceKey{Namespace: "dummynamespace", Name: "dummyname"}
-	rcp[key] = &RegistryClientStub{
-		BundleIterator: client.NewBundleIterator(&BundleStreamStub{
-			Bundles: []*api.Bundle{{
-				CsvName: "csvname",
-				ProvidedApis: []*api.GroupVersionKind{{
-					Group:   "g",
-					Version: "v1",
-					Kind:    "K",
-					Plural:  "ks",
-				}},
-			}},
-		}),
-	}
-
-	c := NewOperatorCache(rcp, logrus.New(), catsrcLister)
+	ssp := make(StaticSourceProvider)
+	c := New(ssp)
 	c.ttl = 0 // instantly stale
 
-	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("csvname")), 1)
+	ssp[key] = &Snapshot{
+		Entries: []*Operator{
+			{Name: "v1"},
+		},
+	}
+	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("v1")), 1)
+
+	ssp[key] = &Snapshot{
+		Entries: []*Operator{
+			{Name: "v2"},
+		},
+	}
+	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("v1")), 0)
 }
 
 func TestOperatorCacheReuse(t *testing.T) {
-	rcp := RegistryClientProviderStub{}
-	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
 	key := SourceKey{Namespace: "dummynamespace", Name: "dummyname"}
-	rcp[key] = &RegistryClientStub{
-		BundleIterator: client.NewBundleIterator(&BundleStreamStub{
-			Bundles: []*api.Bundle{{
-				CsvName: "csvname",
-				ProvidedApis: []*api.GroupVersionKind{{
-					Group:   "g",
-					Version: "v1",
-					Kind:    "K",
-					Plural:  "ks",
-				}},
-			}},
-		}),
+	ssp := make(StaticSourceProvider)
+	c := New(ssp)
+
+	ssp[key] = &Snapshot{
+		Entries: []*Operator{
+			{Name: "v1"},
+		},
 	}
+	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("v1")), 1)
 
-	c := NewOperatorCache(rcp, logrus.New(), catsrcLister)
-
-	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("csvname")), 1)
+	ssp[key] = &Snapshot{
+		Entries: []*Operator{
+			{Name: "v2"},
+		},
+	}
+	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("v1")), 1)
 }
 
-func TestCatalogSnapshotExpired(t *testing.T) {
+func TestCatalogSnapshotValid(t *testing.T) {
 	type tc struct {
 		Name     string
 		Expiry   time.Time
+		Snapshot *Snapshot
+		Error    error
 		At       time.Time
 		Expected bool
 	}
@@ -200,25 +121,51 @@ func TestCatalogSnapshotExpired(t *testing.T) {
 		{
 			Name:     "after expiry",
 			Expiry:   time.Unix(0, 1),
+			Snapshot: &Snapshot{},
+			Error:    nil,
 			At:       time.Unix(0, 2),
-			Expected: true,
+			Expected: false,
 		},
 		{
 			Name:     "before expiry",
 			Expiry:   time.Unix(0, 2),
+			Snapshot: &Snapshot{},
+			Error:    nil,
+			At:       time.Unix(0, 1),
+			Expected: true,
+		},
+		{
+			Name:     "nil snapshot",
+			Expiry:   time.Unix(0, 2),
+			Snapshot: nil,
+			Error:    errors.New(""),
+			At:       time.Unix(0, 1),
+			Expected: false,
+		},
+		{
+			Name:     "non-nil error",
+			Expiry:   time.Unix(0, 2),
+			Snapshot: &Snapshot{},
+			Error:    errors.New(""),
 			At:       time.Unix(0, 1),
 			Expected: false,
 		},
 		{
 			Name:     "at expiry",
 			Expiry:   time.Unix(0, 1),
+			Snapshot: &Snapshot{},
+			Error:    nil,
 			At:       time.Unix(0, 1),
-			Expected: true,
+			Expected: false,
 		},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
-			s := CatalogSnapshot{expiry: tt.Expiry}
-			assert.Equal(t, tt.Expected, s.Expired(tt.At))
+			s := snapshotHeader{
+				expiry:   tt.Expiry,
+				snapshot: tt.Snapshot,
+				err:      tt.Error,
+			}
+			assert.Equal(t, tt.Expected, s.Valid(tt.At))
 		})
 	}
 
@@ -286,7 +233,7 @@ func TestCatalogSnapshotFind(t *testing.T) {
 		},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
-			s := CatalogSnapshot{Operators: tt.Operators}
+			s := snapshotHeader{snapshot: &Snapshot{Entries: tt.Operators}}
 			assert.Equal(t, tt.Expected, s.Find(tt.Predicate))
 		})
 	}
@@ -294,69 +241,41 @@ func TestCatalogSnapshotFind(t *testing.T) {
 }
 
 func TestStripPluralRequiredAndProvidedAPIKeys(t *testing.T) {
-	rcp := RegistryClientProviderStub{}
-	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
 	key := SourceKey{Namespace: "testnamespace", Name: "testname"}
-	rcp[key] = &RegistryClientStub{
-		BundleIterator: client.NewBundleIterator(&BundleStreamStub{
-			Bundles: []*api.Bundle{{
-				CsvName: fmt.Sprintf("%s/%s", key.Namespace, key.Name),
-				ProvidedApis: []*api.GroupVersionKind{{
-					Group:   "g",
-					Version: "v1",
-					Kind:    "K",
-					Plural:  "ks",
-				}},
-				RequiredApis: []*api.GroupVersionKind{{
-					Group:   "g2",
-					Version: "v2",
-					Kind:    "K2",
-					Plural:  "ks2",
-				}},
-				Properties: APISetToProperties(map[opregistry.APIKey]struct{}{
-					{
-						Group:   "g",
-						Version: "v1",
-						Kind:    "K",
-						Plural:  "ks",
-					}: {},
-				}, nil, false),
-				Dependencies: APISetToDependencies(map[opregistry.APIKey]struct{}{
-					{
-						Group:   "g2",
-						Version: "v2",
-						Kind:    "K2",
-						Plural:  "ks2",
-					}: {},
-				}, nil),
-			}},
-		}),
-	}
+	o, err := NewOperatorFromBundle(&api.Bundle{
+		CsvName: fmt.Sprintf("%s/%s", key.Namespace, key.Name),
+		ProvidedApis: []*api.GroupVersionKind{{
+			Group:   "g",
+			Version: "v1",
+			Kind:    "K",
+			Plural:  "ks",
+		}},
+		RequiredApis: []*api.GroupVersionKind{{
+			Group:   "g2",
+			Version: "v2",
+			Kind:    "K2",
+			Plural:  "ks2",
+		}},
+	}, "", key, "")
 
-	c := NewOperatorCache(rcp, logrus.New(), catsrcLister)
-
-	nc := c.Namespaced("testnamespace")
-	result, err := AtLeast(1, nc.Find(ProvidingAPIPredicate(opregistry.APIKey{Group: "g", Version: "v1", Kind: "K"})))
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, "K.v1.g", result[0].ProvidedAPIs.String())
-	assert.Equal(t, "K2.v2.g2", result[0].RequiredAPIs.String())
+	assert.Equal(t, "K.v1.g", o.ProvidedAPIs.String())
+	assert.Equal(t, "K2.v2.g2", o.RequiredAPIs.String())
+}
+
+type ErrorSource struct {
+	Error error
+}
+
+func (s ErrorSource) Snapshot(context.Context) (*Snapshot, error) {
+	return nil, s.Error
 }
 
 func TestNamespaceOperatorCacheError(t *testing.T) {
-	rcp := RegistryClientProviderStub{}
-	catsrcLister := operatorlister.NewLister().OperatorsV1alpha1().CatalogSourceLister()
 	key := SourceKey{Namespace: "dummynamespace", Name: "dummyname"}
-	rcp[key] = &RegistryClientStub{
-		ListBundlesError: errors.New("testing"),
-	}
+	c := New(StaticSourceProvider{
+		key: ErrorSource{Error: errors.New("testing")},
+	})
 
-	logger, _ := test.NewNullLogger()
-	c := NewOperatorCache(rcp, logger, catsrcLister)
 	require.EqualError(t, c.Namespaced("dummynamespace").Error(), "error using catalog dummyname (in namespace dummynamespace): testing")
-	if snapshot, ok := c.snapshots[key]; !ok {
-		t.Fatalf("cache snapshot not found")
-	} else {
-		require.Zero(t, snapshot.expiry)
-	}
 }

--- a/pkg/controller/registry/resolver/cache/operators.go
+++ b/pkg/controller/registry/resolver/cache/operators.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
@@ -194,7 +193,7 @@ type OperatorSourceInfo struct {
 	Package        string
 	Channel        string
 	StartingCSV    string
-	Catalog        registry.CatalogKey
+	Catalog        SourceKey
 	DefaultChannel bool
 	Subscription   *v1alpha1.Subscription
 }
@@ -203,7 +202,7 @@ func (i *OperatorSourceInfo) String() string {
 	return fmt.Sprintf("%s/%s in %s/%s", i.Package, i.Channel, i.Catalog.Name, i.Catalog.Namespace)
 }
 
-var NoCatalog = registry.CatalogKey{Name: "", Namespace: ""}
+var NoCatalog = SourceKey{Name: "", Namespace: ""}
 var ExistingOperator = OperatorSourceInfo{Package: "", Channel: "", StartingCSV: "", Catalog: NoCatalog, DefaultChannel: false}
 
 type Operator struct {
@@ -219,7 +218,7 @@ type Operator struct {
 	Properties   []*api.Property
 }
 
-func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey registry.CatalogKey, defaultChannel string) (*Operator, error) {
+func NewOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey SourceKey, defaultChannel string) (*Operator, error) {
 	parsedVersion, err := semver.ParseTolerant(bundle.Version)
 	version := &parsedVersion
 	if err != nil {

--- a/pkg/controller/registry/resolver/cache/operators_test.go
+++ b/pkg/controller/registry/resolver/cache/operators_test.go
@@ -11,7 +11,6 @@ import (
 
 	opver "github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
@@ -713,7 +712,7 @@ func TestCatalogKey_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			k := &registry.CatalogKey{
+			k := &SourceKey{
 				Name:      tt.fields.Name,
 				Namespace: tt.fields.Namespace,
 			}
@@ -878,7 +877,7 @@ func TestOperatorSourceInfo_String(t *testing.T) {
 			i := &OperatorSourceInfo{
 				Package: tt.fields.Package,
 				Channel: tt.fields.Channel,
-				Catalog: registry.CatalogKey{Name: tt.fields.CatalogSource, Namespace: tt.fields.CatalogSourceNamespace},
+				Catalog: SourceKey{Name: tt.fields.CatalogSource, Namespace: tt.fields.CatalogSourceNamespace},
 			}
 			if got := i.String(); got != tt.want {
 				t.Errorf("OperatorSourceInfo.String() = %v, want %v", got, tt.want)
@@ -1060,7 +1059,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 
 	type args struct {
 		bundle         *api.Bundle
-		sourceKey      registry.CatalogKey
+		sourceKey      SourceKey
 		replaces       string
 		defaultChannel string
 	}
@@ -1074,7 +1073,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 			name: "BundleNoAPIs",
 			args: args{
 				bundle:    bundleNoAPIs,
-				sourceKey: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+				sourceKey: SourceKey{Name: "source", Namespace: "testNamespace"},
 			},
 			want: &Operator{
 				Name:         "testBundle",
@@ -1085,7 +1084,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				SourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",
-					Catalog: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+					Catalog: SourceKey{Name: "source", Namespace: "testNamespace"},
 				},
 			},
 		},
@@ -1093,7 +1092,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 			name: "BundleWithAPIs",
 			args: args{
 				bundle:    bundleWithAPIs,
-				sourceKey: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+				sourceKey: SourceKey{Name: "source", Namespace: "testNamespace"},
 			},
 			want: &Operator{
 				Name:    "testBundle",
@@ -1148,7 +1147,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				SourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",
-					Catalog: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+					Catalog: SourceKey{Name: "source", Namespace: "testNamespace"},
 				},
 			},
 		},
@@ -1156,7 +1155,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 			name: "BundleIgnoreCSV",
 			args: args{
 				bundle:    bundleWithAPIsUnextracted,
-				sourceKey: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+				sourceKey: SourceKey{Name: "source", Namespace: "testNamespace"},
 			},
 			want: &Operator{
 				Name:         "testBundle",
@@ -1166,7 +1165,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				SourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",
-					Catalog: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+					Catalog: SourceKey{Name: "source", Namespace: "testNamespace"},
 				},
 			},
 		},
@@ -1174,7 +1173,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 			name: "BundleInDefaultChannel",
 			args: args{
 				bundle:         bundleNoAPIs,
-				sourceKey:      registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+				sourceKey:      SourceKey{Name: "source", Namespace: "testNamespace"},
 				defaultChannel: "testChannel",
 			},
 			want: &Operator{
@@ -1186,7 +1185,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				SourceInfo: &OperatorSourceInfo{
 					Package:        "testPackage",
 					Channel:        "testChannel",
-					Catalog:        registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+					Catalog:        SourceKey{Name: "source", Namespace: "testNamespace"},
 					DefaultChannel: true,
 				},
 			},
@@ -1195,7 +1194,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 			name: "BundleWithPropertiesAndDependencies",
 			args: args{
 				bundle:    bundleWithPropsAndDeps,
-				sourceKey: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+				sourceKey: SourceKey{Name: "source", Namespace: "testNamespace"},
 			},
 			want: &Operator{
 				Name:         "testBundle",
@@ -1224,7 +1223,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				SourceInfo: &OperatorSourceInfo{
 					Package: "testPackage",
 					Channel: "testChannel",
-					Catalog: registry.CatalogKey{Name: "source", Namespace: "testNamespace"},
+					Catalog: SourceKey{Name: "source", Namespace: "testNamespace"},
 				},
 			},
 		},

--- a/pkg/controller/registry/resolver/cache/predicates.go
+++ b/pkg/controller/registry/resolver/cache/predicates.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/blang/semver/v4"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 )
@@ -140,10 +139,10 @@ func (l labelPredicate) String() string {
 }
 
 type catalogPredicate struct {
-	key registry.CatalogKey
+	key SourceKey
 }
 
-func CatalogPredicate(key registry.CatalogKey) OperatorPredicate {
+func CatalogPredicate(key SourceKey) OperatorPredicate {
 	return catalogPredicate{key: key}
 }
 

--- a/pkg/controller/registry/resolver/installabletypes.go
+++ b/pkg/controller/registry/resolver/installabletypes.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
 	operatorregistry "github.com/operator-framework/operator-registry/pkg/registry"
@@ -37,13 +36,13 @@ func (i *BundleInstallable) AddConstraint(c solver.Constraint) {
 	i.constraints = append(i.constraints, c)
 }
 
-func (i *BundleInstallable) BundleSourceInfo() (string, string, registry.CatalogKey, error) {
+func (i *BundleInstallable) BundleSourceInfo() (string, string, cache.SourceKey, error) {
 	info := strings.Split(i.identifier.String(), "/")
 	// This should be enforced by Kube naming constraints
 	if len(info) != 4 {
-		return "", "", registry.CatalogKey{}, fmt.Errorf("Unable to parse identifier %s for source info", i.identifier)
+		return "", "", cache.SourceKey{}, fmt.Errorf("Unable to parse identifier %s for source info", i.identifier)
 	}
-	catalog := registry.CatalogKey{
+	catalog := cache.SourceKey{
 		Name:      info[0],
 		Namespace: info[1],
 	}
@@ -52,7 +51,7 @@ func (i *BundleInstallable) BundleSourceInfo() (string, string, registry.Catalog
 	return csvName, channel, catalog, nil
 }
 
-func bundleId(bundle, channel string, catalog registry.CatalogKey) solver.Identifier {
+func bundleId(bundle, channel string, catalog cache.SourceKey) solver.Identifier {
 	return solver.IdentifierFromString(fmt.Sprintf("%s/%s/%s", catalog.String(), channel, bundle))
 }
 

--- a/pkg/controller/registry/resolver/instrumented_resolver.go
+++ b/pkg/controller/registry/resolver/instrumented_resolver.go
@@ -4,8 +4,7 @@ import (
 	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
 type InstrumentedResolver struct {
@@ -35,6 +34,6 @@ func (ir *InstrumentedResolver) ResolveSteps(namespace string) ([]*v1alpha1.Step
 	return steps, lookups, subs, err
 }
 
-func (ir *InstrumentedResolver) Expire(key registry.CatalogKey) {
+func (ir *InstrumentedResolver) Expire(key cache.SourceKey) {
 	ir.resolver.Expire(key)
 }

--- a/pkg/controller/registry/resolver/instrumented_resolver_test.go
+++ b/pkg/controller/registry/resolver/instrumented_resolver_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
-
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,14 +23,14 @@ func (r *fakeResolverWithError) ResolveSteps(namespace string) ([]*v1alpha1.Step
 	return nil, nil, nil, errors.New("Fake error")
 }
 
-func (r *fakeResolverWithError) Expire(key registry.CatalogKey) {
+func (r *fakeResolverWithError) Expire(key cache.SourceKey) {
 }
 
 func (r *fakeResolverWithoutError) ResolveSteps(namespace string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {
 	return nil, nil, nil, nil
 }
 
-func (r *fakeResolverWithoutError) Expire(key registry.CatalogKey) {
+func (r *fakeResolverWithoutError) Expire(key cache.SourceKey) {
 }
 
 func newFakeResolverWithError() *fakeResolverWithError {

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1alpha1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
@@ -30,7 +29,7 @@ type SatResolver struct {
 	log   logrus.FieldLogger
 }
 
-func NewDefaultSatResolver(rcp cache.RegistryClientProvider, catsrcLister v1alpha1listers.CatalogSourceLister, log logrus.FieldLogger) *SatResolver {
+func NewDefaultSatResolver(rcp cache.SourceProvider, catsrcLister v1alpha1listers.CatalogSourceLister, log logrus.FieldLogger) *SatResolver {
 	return &SatResolver{
 		cache: cache.NewOperatorCache(rcp, log, catsrcLister),
 		log:   log,
@@ -63,7 +62,7 @@ func (r *SatResolver) SolveOperators(namespaces []string, csvs []*v1alpha1.Clust
 	}
 	namespacedCache := r.cache.Namespaced(namespaces...).WithExistingOperators(existingSnapshot)
 
-	_, existingInstallables, err := r.getBundleInstallables(registry.NewVirtualCatalogKey(namespaces[0]), existingSnapshot.Find(), namespacedCache, visited)
+	_, existingInstallables, err := r.getBundleInstallables(cache.NewVirtualSourceKey(namespaces[0]), existingSnapshot.Find(), namespacedCache, visited)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +176,7 @@ func (r *SatResolver) getSubscriptionInstallables(sub *v1alpha1.Subscription, cu
 	var cachePredicates, channelPredicates []cache.OperatorPredicate
 	installables := make(map[solver.Identifier]solver.Installable, 0)
 
-	catalog := registry.CatalogKey{
+	catalog := cache.SourceKey{
 		Name:      sub.Spec.CatalogSource,
 		Namespace: sub.Spec.CatalogSourceNamespace,
 	}
@@ -288,12 +287,12 @@ func (r *SatResolver) getSubscriptionInstallables(sub *v1alpha1.Subscription, cu
 			// safe to remove this conflict if properties
 			// annotations are made mandatory for
 			// resolution.
-			c.AddConflict(bundleId(current.Name, current.Channel(), registry.NewVirtualCatalogKey(sub.GetNamespace())))
+			c.AddConflict(bundleId(current.Name, current.Channel(), cache.NewVirtualSourceKey(sub.GetNamespace())))
 		}
 		depIds = append(depIds, c.Identifier())
 	}
 	if current != nil {
-		depIds = append(depIds, bundleId(current.Name, current.Channel(), registry.NewVirtualCatalogKey(sub.GetNamespace())))
+		depIds = append(depIds, bundleId(current.Name, current.Channel(), cache.NewVirtualSourceKey(sub.GetNamespace())))
 	}
 
 	// all candidates added as options for this constraint
@@ -303,7 +302,7 @@ func (r *SatResolver) getSubscriptionInstallables(sub *v1alpha1.Subscription, cu
 	return installables, nil
 }
 
-func (r *SatResolver) getBundleInstallables(catalog registry.CatalogKey, bundleStack []*cache.Operator, namespacedCache cache.MultiCatalogOperatorFinder, visited map[*cache.Operator]*BundleInstallable) (map[solver.Identifier]struct{}, map[solver.Identifier]*BundleInstallable, error) {
+func (r *SatResolver) getBundleInstallables(catalog cache.SourceKey, bundleStack []*cache.Operator, namespacedCache cache.MultiCatalogOperatorFinder, visited map[*cache.Operator]*BundleInstallable) (map[solver.Identifier]struct{}, map[solver.Identifier]*BundleInstallable, error) {
 	errs := make([]error, 0)
 	installables := make(map[solver.Identifier]*BundleInstallable, 0) // all installables, including dependencies
 
@@ -422,7 +421,7 @@ func (r *SatResolver) inferProperties(csv *v1alpha1.ClusterServiceVersion, subs 
 		// package against catalog contents, updates to the
 		// Subscription spec could result in a bad package
 		// inference.
-		for _, entry := range r.cache.Namespaced(sub.Namespace).Catalog(registry.CatalogKey{Namespace: sub.Spec.CatalogSourceNamespace, Name: sub.Spec.CatalogSource}).Find(cache.And(cache.CSVNamePredicate(csv.Name), cache.PkgPredicate(sub.Spec.Package))) {
+		for _, entry := range r.cache.Namespaced(sub.Namespace).Catalog(cache.SourceKey{Namespace: sub.Spec.CatalogSourceNamespace, Name: sub.Spec.CatalogSource}).Find(cache.And(cache.CSVNamePredicate(csv.Name), cache.PkgPredicate(sub.Spec.Package))) {
 			if pkg := entry.Package(); pkg != "" {
 				packages[pkg] = struct{}{}
 			}
@@ -456,7 +455,7 @@ func (r *SatResolver) inferProperties(csv *v1alpha1.ClusterServiceVersion, subs 
 }
 
 func (r *SatResolver) newSnapshotForNamespace(namespace string, subs []*v1alpha1.Subscription, csvs []*v1alpha1.ClusterServiceVersion) (*cache.CatalogSnapshot, error) {
-	existingOperatorCatalog := registry.NewVirtualCatalogKey(namespace)
+	existingOperatorCatalog := cache.NewVirtualSourceKey(namespace)
 	// build a catalog snapshot of CSVs without subscriptions
 	csvSubscriptions := make(map[*v1alpha1.ClusterServiceVersion]*v1alpha1.Subscription)
 	for _, sub := range subs {
@@ -579,17 +578,17 @@ func (r *SatResolver) addInvariants(namespacedCache cache.MultiCatalogOperatorFi
 
 func (r *SatResolver) sortBundles(bundles []*cache.Operator) ([]*cache.Operator, error) {
 	// assume bundles have been passed in sorted by catalog already
-	catalogOrder := make([]registry.CatalogKey, 0)
+	catalogOrder := make([]cache.SourceKey, 0)
 
 	type PackageChannel struct {
 		Package, Channel string
 		DefaultChannel   bool
 	}
 	// TODO: for now channels will be sorted lexicographically
-	channelOrder := make(map[registry.CatalogKey][]PackageChannel)
+	channelOrder := make(map[cache.SourceKey][]PackageChannel)
 
 	// partition by catalog -> channel -> bundle
-	partitionedBundles := map[registry.CatalogKey]map[PackageChannel][]*cache.Operator{}
+	partitionedBundles := map[cache.SourceKey]map[PackageChannel][]*cache.Operator{}
 	for _, b := range bundles {
 		pc := PackageChannel{
 			Package:        b.Package(),

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	listersv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
 	"github.com/operator-framework/operator-registry/pkg/api"
@@ -34,20 +36,16 @@ func TestSolveOperators(t *testing.T) {
 	newSub := newSub(namespace, "packageB", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Key: catalog,
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.1", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{namespace}, csvs, subs)
@@ -66,22 +64,18 @@ func TestDisjointChannelGraph(t *testing.T) {
 	newSub := newSub(namespace, "packageA", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Key: catalog,
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.side1.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 					genOperator("packageA.side1.v2", "0.0.2", "packageA.side1.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 					genOperator("packageA.side2.v1", "1.0.0", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 					genOperator("packageA.side2.v2", "2.0.0", "packageA.side2.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	_, err := satResolver.SolveOperators([]string{namespace}, nil, subs)
@@ -103,17 +97,13 @@ func TestPropertiesAnnotationHonored(t *testing.T) {
 
 	b := genOperator("packageB.v1", "1.0.1", "", "packageB", "alpha", "community", "olm", nil, nil, []*api.Dependency{{Type: "olm.package", Value: `{"packageName":"packageA","version":"1.0.0"}`}}, "", false)
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			community: {
-				Key:       community,
-				Operators: []*cache.Operator{b},
-			},
-		},
-	}
 	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		cache: cache.New(cache.StaticSourceProvider{
+			community: &cache.Snapshot{
+				Entries: []*cache.Operator{b},
+			},
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -138,21 +128,17 @@ func TestSolveOperators_MultipleChannels(t *testing.T) {
 	newSub := newSub(namespace, "packageB", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Key: catalog,
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "beta", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -179,28 +165,21 @@ func TestSolveOperators_FindLatestVersion(t *testing.T) {
 	newSub := newSub(namespace, "packageB", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
 			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+			}: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -244,17 +223,10 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 		},
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -266,11 +238,8 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 					genOperator("packageD.v1.0.2", "1.0.2", "packageD.v1.0.1", "packageD", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -319,17 +288,10 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 		},
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -341,11 +303,8 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 					genOperator("packageE.v1.0.0", "1.0.0", "", "packageE", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -365,6 +324,40 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 	}
 }
 
+type stubCatalogSourceLister struct {
+	catsrcs   []*v1alpha1.CatalogSource
+	namespace string
+}
+
+func (l *stubCatalogSourceLister) List(labels.Selector) ([]*v1alpha1.CatalogSource, error) {
+	if l.namespace == "" {
+		return l.catsrcs, nil
+	}
+	var result []*v1alpha1.CatalogSource
+	for _, cs := range l.catsrcs {
+		if cs.Namespace == l.namespace {
+			result = append(result, cs)
+		}
+	}
+	return result, nil
+}
+
+func (l *stubCatalogSourceLister) Get(name string) (*v1alpha1.CatalogSource, error) {
+	for _, cs := range l.catsrcs {
+		if cs.Name == name {
+			return cs, nil
+		}
+	}
+	return nil, errors.New("stub not found")
+}
+
+func (l *stubCatalogSourceLister) CatalogSources(namespace string) listersv1alpha1.CatalogSourceNamespaceLister {
+	return &stubCatalogSourceLister{
+		catsrcs:   l.catsrcs,
+		namespace: namespace,
+	}
+}
+
 func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	opToAddVersionDeps := []*api.Dependency{
 		{
@@ -378,54 +371,41 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	newSub := newSub(namespace, "packageA", "alpha", customCatalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
-					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", namespace, nil,
-						nil, opToAddVersionDeps, "", false),
-				},
+	ssp := cache.StaticSourceProvider{
+		cache.SourceKey{Namespace: "olm", Name: "community"}: &cache.Snapshot{
+			Entries: []*cache.Operator{
+				genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", namespace, nil,
+					nil, opToAddVersionDeps, "", false),
 			},
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community-operator",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community-operator",
-				},
-				Operators: []*cache.Operator{
-					genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
-						namespace, nil, nil, nil, "", false),
-				},
+		},
+		cache.SourceKey{Namespace: "olm", Name: "community-operator"}: &cache.Snapshot{
+			Entries: []*cache.Operator{
+				genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
+					namespace, nil, nil, nil, "", false),
 			},
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "high-priority-operator",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "high-priority-operator",
-				},
-				Priority: 100,
-				Operators: []*cache.Operator{
-					genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "high-priority-operator",
-						namespace, nil, nil, nil, "", false),
-				},
+		},
+		cache.SourceKey{Namespace: "olm", Name: "high-priority-operator"}: &cache.Snapshot{
+			Entries: []*cache.Operator{
+				genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "high-priority-operator",
+					namespace, nil, nil, nil, "", false),
 			},
 		},
 	}
 
-	// operators sorted by priority.
 	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
+		cache: cache.New(ssp, cache.WithCatalogSourceLister(&stubCatalogSourceLister{
+			catsrcs: []*v1alpha1.CatalogSource{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "olm",
+						Name:      "high-priority-operator",
+					},
+					Spec: v1alpha1.CatalogSourceSpec{
+						Priority: 100,
+					},
+				},
+			},
+		})),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, []*v1alpha1.ClusterServiceVersion{}, subs)
@@ -442,23 +422,39 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	}
 
 	// Catsrc with the same priority, ns, different name
-	fakeNamespacedOperatorCache.Snapshots[cache.SourceKey{
+	ssp[cache.SourceKey{
 		Namespace: "olm",
 		Name:      "community-operator",
-	}] = &cache.CatalogSnapshot{
-		Key: cache.SourceKey{
-			Namespace: "olm",
-			Name:      "community-operator",
-		},
-		Priority: 100,
-		Operators: []*cache.Operator{
+	}] = &cache.Snapshot{
+		Entries: []*cache.Operator{
 			genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
 				namespace, nil, nil, nil, "", false),
 		},
 	}
 
 	satResolver = SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
+		cache: cache.New(ssp, cache.WithCatalogSourceLister(&stubCatalogSourceLister{
+			catsrcs: []*v1alpha1.CatalogSource{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "olm",
+						Name:      "high-priority-operator",
+					},
+					Spec: v1alpha1.CatalogSourceSpec{
+						Priority: 100,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "olm",
+						Name:      "community-operator",
+					},
+					Spec: v1alpha1.CatalogSourceSpec{
+						Priority: 100,
+					},
+				},
+			},
+		})),
 	}
 
 	operators, err = satResolver.SolveOperators([]string{"olm"}, []*v1alpha1.ClusterServiceVersion{}, subs)
@@ -475,15 +471,11 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	}
 
 	// operators from the same catalogs source should be prioritized.
-	fakeNamespacedOperatorCache.Snapshots[cache.SourceKey{
+	ssp[cache.SourceKey{
 		Namespace: "olm",
 		Name:      "community",
-	}] = &cache.CatalogSnapshot{
-		Key: cache.SourceKey{
-			Namespace: "olm",
-			Name:      "community",
-		},
-		Operators: []*cache.Operator{
+	}] = &cache.Snapshot{
+		Entries: []*cache.Operator{
 			genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", namespace, nil,
 				nil, opToAddVersionDeps, "", false),
 			genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community",
@@ -492,7 +484,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	}
 
 	satResolver = SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
+		cache: cache.New(ssp),
 	}
 
 	operators, err = satResolver.SolveOperators([]string{"olm"}, []*v1alpha1.ClusterServiceVersion{}, subs)
@@ -530,27 +522,17 @@ func TestSolveOperators_WithDependencies(t *testing.T) {
 		},
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -590,21 +572,17 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 		},
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			community: {
-				Key: community,
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			community: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, Provides, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -647,25 +625,15 @@ func TestSolveOperators_WithLabelDependencies(t *testing.T) {
 		operatorBv1.Properties = append(operatorBv1.Properties, p)
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, deps, "", false),
 					operatorBv1,
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
+		}),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, nil, subs)
@@ -696,25 +664,15 @@ func TestSolveOperators_WithUnsatisfiableLabelDependencies(t *testing.T) {
 		},
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, deps, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
+		}),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, nil, subs)
@@ -749,17 +707,13 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 		},
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
 			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+			}: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 					genOperator("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
@@ -771,22 +725,15 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "certified",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "certified",
-				},
-				Operators: []*cache.Operator{
+			}: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageC.v1.0.0", "1.0.0", "", "packageC", "alpha", "certified", "olm", Provides2, Provides, deps2, "", false),
 					genOperator("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "certified", "olm", Provides2, Provides, deps2, "", false),
 					genOperator("packageD.v1.0.1", "1.0.1", "", "packageD", "alpha", "certified", "olm", nil, Provides2, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -836,35 +783,24 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 		},
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			community: {
-				Key: community,
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			community: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, unsatisfiableVersionDeps, "", false),
 				},
 			},
-			{
-				Namespace: "olm",
-				Name:      "certified",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "certified",
-				},
-				Operators: []*cache.Operator{
+			{Namespace: "olm", Name: "certified"}: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "certified", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "certified", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "certified", "olm", nil, nil, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -896,24 +832,20 @@ func TestSolveOperators_PreferCatalogInSameNamespace(t *testing.T) {
 	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
-			altnsCatalog: {
-				Operators: []*cache.Operator{
+			altnsCatalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", altnsCatalog.Name, altnsCatalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
-		},
-		Namespaces: []string{namespace, altNamespace},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{namespace}, csvs, subs)
@@ -940,19 +872,15 @@ func TestSolveOperators_ResolveOnlyInCachedNamespaces(t *testing.T) {
 	newSub := newSub(namespace, "packageA", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", otherCatalog.Name, otherCatalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
-		},
-		Namespaces: []string{otherCatalog.Namespace},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{namespace}, csvs, subs)
@@ -976,21 +904,17 @@ func TestSolveOperators_PreferDefaultChannelInResolution(t *testing.T) {
 	newSub := newSub(namespace, "packageA", "", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					// Default channel is stable in this case
 					genOperator("packageA.v0.0.2", "0.0.2", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 				},
 			},
-		},
-	}
-
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{namespace}, csvs, subs)
@@ -1017,21 +941,18 @@ func TestSolveOperators_PreferDefaultChannelInResolutionForTransitiveDependencie
 	subs := []*v1alpha1.Subscription{newSub}
 
 	const defaultChannel = "stable"
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Operators: []*cache.Operator{
+
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, Provides, nil, cache.APISetToDependencies(nil, Provides), defaultChannel, false),
 					genOperator("packageB.v0.0.1", "0.0.1", "packageB.v1", "packageB", defaultChannel, catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 					genOperator("packageB.v0.0.2", "0.0.2", "packageB.v0.0.1", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 				},
 			},
-		},
-	}
-
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{namespace}, csvs, subs)
@@ -1064,26 +985,16 @@ func TestSolveOperators_SubscriptionlessOperatorsSatisfyDependencies(t *testing.
 		},
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 					genOperator("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -1110,26 +1021,16 @@ func TestSolveOperators_SubscriptionlessOperatorsCanConflict(t *testing.T) {
 	newSub := newSub(namespace, "packageB", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, Provides, nil, "", false),
 					genOperator("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, Provides, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	_, err := satResolver.SolveOperators([]string{"olm"}, csvs, subs)
@@ -1151,11 +1052,10 @@ func TestSolveOperators_PackageCannotSelfSatisfy(t *testing.T) {
 	newSub := newSub(namespace, "packageA", "stable", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Key: catalog,
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, RequiresBoth, nil, nil, "", false),
 					// Despite satisfying dependencies of opA, this is not chosen because it is in the same package
 					genOperator("opABC.v1.0.0", "1.0.0", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "", false),
@@ -1164,19 +1064,15 @@ func TestSolveOperators_PackageCannotSelfSatisfy(t *testing.T) {
 					genOperator("opD.v1.0.0", "1.0.0", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
 				},
 			},
-			secondaryCatalog: {
-				Key: secondaryCatalog,
-				Operators: []*cache.Operator{
+			secondaryCatalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("opC.v1.0.0", "1.0.0", "", "packageB", "stable", secondaryCatalog.Name, secondaryCatalog.Namespace, nil, Provides2, nil, "stable", false),
 
 					genOperator("opE.v1.0.0", "1.0.0", "", "packageC", "stable", secondaryCatalog.Name, secondaryCatalog.Namespace, nil, Provides2, nil, "", false),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, nil, subs)
@@ -1204,14 +1100,13 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 
 	phases := []struct {
 		subs     []*v1alpha1.Subscription
-		catalog  *cache.CatalogSnapshot
+		catalog  cache.Source
 		expected cache.OperatorSet
 	}{
 		{
 			subs: []*v1alpha1.Subscription{newSub(namespace, "packageB", "stable", catalog)},
-			catalog: &cache.CatalogSnapshot{
-				Key: catalog,
-				Operators: []*cache.Operator{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
 					genOperator("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
 				},
@@ -1227,9 +1122,8 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 				existingSub(namespace, "opA.v1.0.0", "packageA", "stable", catalog),
 				existingSub(namespace, "opB.v1.0.0", "packageB", "stable", catalog),
 			},
-			catalog: &cache.CatalogSnapshot{
-				Key: catalog,
-				Operators: []*cache.Operator{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
 					genOperator("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
 					genOperator("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
@@ -1244,9 +1138,8 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 				existingSub(namespace, "opA.v1.0.0", "packageA", "stable", catalog),
 				existingSub(namespace, "opB.v1.0.0", "packageB", "stable", catalog),
 			},
-			catalog: &cache.CatalogSnapshot{
-				Key: catalog,
-				Operators: []*cache.Operator{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
 					genOperator("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
 					genOperator("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
@@ -1263,14 +1156,11 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 	var operators cache.OperatorSet
 	for i, p := range phases {
 		t.Run(fmt.Sprintf("phase %d", i+1), func(t *testing.T) {
-			fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-				Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-					catalog: p.catalog,
-				},
-			}
 			satResolver := SatResolver{
-				cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-				log:   logrus.New(),
+				cache: cache.New(cache.StaticSourceProvider{
+					catalog: p.catalog,
+				}),
+				log: logrus.New(),
 			}
 			csvs := make([]*v1alpha1.ClusterServiceVersion, 0)
 			for _, o := range operators {
@@ -1291,24 +1181,6 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 			}
 			assert.Equal(t, len(p.expected), len(operators))
 		})
-	}
-}
-
-type FakeOperatorCache struct {
-	fakedNamespacedOperatorCache cache.NamespacedOperatorCache
-}
-
-func (f *FakeOperatorCache) Namespaced(namespaces ...string) cache.MultiCatalogOperatorFinder {
-	return &f.fakedNamespacedOperatorCache
-}
-
-func (f *FakeOperatorCache) Expire(key cache.SourceKey) {
-	return
-}
-
-func getFakeOperatorCache(fakedNamespacedOperatorCache cache.NamespacedOperatorCache) cache.OperatorCacheProvider {
-	return &FakeOperatorCache{
-		fakedNamespacedOperatorCache: fakedNamespacedOperatorCache,
 	}
 }
 
@@ -1351,7 +1223,7 @@ func genOperator(name, version, replaces, pkg, channel, catalogName, catalogName
 		ProvidedAPIs: providedAPIs,
 		RequiredAPIs: requiredAPIs,
 	}
-	cache.EnsurePackageProperty(o, pkg, version)
+	EnsurePackageProperty(o, pkg, version)
 	return o
 }
 
@@ -1367,19 +1239,15 @@ func TestSolveOperators_WithoutDeprecated(t *testing.T) {
 		newSub(catalog.Namespace, "packageA", "alpha", catalog),
 	}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Key: catalog,
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", true),
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{catalog.Namespace}, nil, subs)
@@ -1395,15 +1263,12 @@ func TestSolveOperatorsWithDeprecatedInnerChannelEntry(t *testing.T) {
 	}
 	logger, _ := test.NewNullLogger()
 	resolver := SatResolver{
-		cache: getFakeOperatorCache(cache.NamespacedOperatorCache{
-			Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-				catalog: {
-					Key: catalog,
-					Operators: []*cache.Operator{
-						genOperator("a-1", "1.0.0", "", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
-						genOperator("a-2", "2.0.0", "a-1", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", true),
-						genOperator("a-3", "3.0.0", "a-2", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
-					},
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
+					genOperator("a-1", "1.0.0", "", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+					genOperator("a-2", "2.0.0", "a-1", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", true),
+					genOperator("a-3", "3.0.0", "a-2", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 				},
 			},
 		}),
@@ -1445,25 +1310,15 @@ func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 	op5.Skips = []string{"packageA.v2", "packageA.v3", "packageA.v4"}
 	op6 := genOperator("packageA.v6", "6.0.0", "packageA.v5", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			cache.SourceKey{
-				Namespace: "olm",
-				Name:      "community",
-			}: {
-				Key: cache.SourceKey{
-					Namespace: "olm",
-					Name:      "community",
-				},
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					opB, opB2, op1, op2, op3, op4, op5, op6,
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, nil, subs)
@@ -1487,19 +1342,15 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 	opB2 := genOperator("packageB.v2", "2.0.0", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false)
 	opB2.Skips = []string{"packageB.v1"}
 
-	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-			catalog: {
-				Key: catalog,
-				Operators: []*cache.Operator{
+	satResolver := SatResolver{
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
 					opB, opB2,
 				},
 			},
-		},
-	}
-	satResolver := SatResolver{
-		cache: getFakeOperatorCache(fakeNamespacedOperatorCache),
-		log:   logrus.New(),
+		}),
+		log: logrus.New(),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{namespace}, nil, subs)
@@ -1527,12 +1378,9 @@ func TestSolveOperatorsWithSkipsPreventingSelection(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	satResolver := SatResolver{
-		cache: getFakeOperatorCache(cache.NamespacedOperatorCache{
-			Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-				catalog: {
-					Key:       catalog,
-					Operators: []*cache.Operator{a1, b3, b2, b1},
-				},
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{a1, b3, b2, b1},
 			},
 		}),
 		log: logger,
@@ -1563,13 +1411,10 @@ func TestSolveOperatorsWithClusterServiceVersionHavingDependency(t *testing.T) {
 
 	log, _ := test.NewNullLogger()
 	r := SatResolver{
-		cache: getFakeOperatorCache(cache.NamespacedOperatorCache{
-			Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-				catalog: {
-					Key: catalog,
-					Operators: []*cache.Operator{
-						genOperator("b-2", "2.0.0", "b-1", "b", "default", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
-					},
+		cache: cache.New(cache.StaticSourceProvider{
+			catalog: &cache.Snapshot{
+				Entries: []*cache.Operator{
+					genOperator("b-2", "2.0.0", "b-1", "b", "default", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 				},
 			},
 		}),
@@ -1586,7 +1431,7 @@ func TestInferProperties(t *testing.T) {
 
 	for _, tc := range []struct {
 		Name          string
-		Cache         cache.NamespacedOperatorCache
+		Cache         cache.StaticSourceProvider
 		CSV           *v1alpha1.ClusterServiceVersion
 		Subscriptions []*v1alpha1.Subscription
 		Expected      []*api.Property
@@ -1663,16 +1508,13 @@ func TestInferProperties(t *testing.T) {
 		},
 		{
 			Name: "one matching subscription infers package property",
-			Cache: cache.NamespacedOperatorCache{
-				Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-					catalog: {
-						Key: catalog,
-						Operators: []*cache.Operator{
-							{
-								Name: "a",
-								Bundle: &api.Bundle{
-									PackageName: "x",
-								},
+			Cache: cache.StaticSourceProvider{
+				catalog: &cache.Snapshot{
+					Entries: []*cache.Operator{
+						{
+							Name: "a",
+							Bundle: &api.Bundle{
+								PackageName: "x",
 							},
 						},
 					},
@@ -1692,6 +1534,47 @@ func TestInferProperties(t *testing.T) {
 						Package:                "x",
 						CatalogSource:          catalog.Name,
 						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":"1.2.3"}`,
+				},
+			},
+		},
+		{
+			Name: "one matching subscription to other-namespace catalogsource infers package property",
+			Cache: cache.StaticSourceProvider{
+				{Namespace: "other-namespace", Name: "other-name"}: &cache.Snapshot{
+					Entries: []*cache.Operator{
+						{
+							Name: "a",
+							Bundle: &api.Bundle{
+								PackageName: "x",
+							},
+						},
+					},
+				},
+			},
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          "other-name",
+						CatalogSourceNamespace: "other-namespace",
 					},
 					Status: v1alpha1.SubscriptionStatus{
 						InstalledCSV: "a",
@@ -1728,16 +1611,13 @@ func TestInferProperties(t *testing.T) {
 		},
 		{
 			Name: "one matching subscription infers package property without csv version",
-			Cache: cache.NamespacedOperatorCache{
-				Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
-					catalog: {
-						Key: catalog,
-						Operators: []*cache.Operator{
-							{
-								Name: "a",
-								Bundle: &api.Bundle{
-									PackageName: "x",
-								},
+			Cache: cache.StaticSourceProvider{
+				catalog: &cache.Snapshot{
+					Entries: []*cache.Operator{
+						{
+							Name: "a",
+							Bundle: &api.Bundle{
+								PackageName: "x",
 							},
 						},
 					},
@@ -1772,10 +1652,8 @@ func TestInferProperties(t *testing.T) {
 			require := require.New(t)
 			logger, _ := test.NewNullLogger()
 			r := SatResolver{
-				log: logger,
-				cache: &FakeOperatorCache{
-					fakedNamespacedOperatorCache: tc.Cache,
-				},
+				log:   logger,
+				cache: cache.New(tc.Cache),
 			}
 			actual, err := r.inferProperties(tc.CSV, tc.Subscriptions)
 			require.NoError(err)

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
 	"github.com/operator-framework/operator-registry/pkg/api"
@@ -27,7 +26,7 @@ func TestSolveOperators(t *testing.T) {
 	Provides := APISet
 
 	const namespace = "test-namespace"
-	catalog := registry.CatalogKey{Name: "test-catalog", Namespace: namespace}
+	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -36,7 +35,7 @@ func TestSolveOperators(t *testing.T) {
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Key: catalog,
 				Operators: []*cache.Operator{
@@ -62,13 +61,13 @@ func TestSolveOperators(t *testing.T) {
 
 func TestDisjointChannelGraph(t *testing.T) {
 	const namespace = "test-namespace"
-	catalog := registry.CatalogKey{Name: "test-catalog", Namespace: namespace}
+	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 
 	newSub := newSub(namespace, "packageA", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Key: catalog,
 				Operators: []*cache.Operator{
@@ -93,7 +92,7 @@ func TestPropertiesAnnotationHonored(t *testing.T) {
 	const (
 		namespace = "olm"
 	)
-	community := registry.CatalogKey{"community", namespace}
+	community := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", nil, nil, nil, nil)
 	csv.Annotations = map[string]string{"operatorframework.io/properties": `{"properties":[{"type":"olm.package","value":{"packageName":"packageA","version":"1.0.0"}}]}`}
@@ -105,7 +104,7 @@ func TestPropertiesAnnotationHonored(t *testing.T) {
 	b := genOperator("packageB.v1", "1.0.1", "", "packageB", "alpha", "community", "olm", nil, nil, []*api.Dependency{{Type: "olm.package", Value: `{"packageName":"packageA","version":"1.0.0"}`}}, "", false)
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			community: {
 				Key:       community,
 				Operators: []*cache.Operator{b},
@@ -131,7 +130,7 @@ func TestSolveOperators_MultipleChannels(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -140,7 +139,7 @@ func TestSolveOperators_MultipleChannels(t *testing.T) {
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Key: catalog,
 				Operators: []*cache.Operator{
@@ -172,7 +171,7 @@ func TestSolveOperators_FindLatestVersion(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -181,12 +180,12 @@ func TestSolveOperators_FindLatestVersion(t *testing.T) {
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -226,7 +225,7 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -246,12 +245,12 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -295,7 +294,7 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -321,12 +320,12 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -375,17 +374,17 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	}
 
 	namespace := "olm"
-	customCatalog := registry.CatalogKey{"community", namespace}
+	customCatalog := cache.SourceKey{"community", namespace}
 	newSub := newSub(namespace, "packageA", "alpha", customCatalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -394,11 +393,11 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 						nil, opToAddVersionDeps, "", false),
 				},
 			},
-			registry.CatalogKey{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community-operator",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community-operator",
 				},
@@ -407,11 +406,11 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 						namespace, nil, nil, nil, "", false),
 				},
 			},
-			registry.CatalogKey{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "high-priority-operator",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "high-priority-operator",
 				},
@@ -443,11 +442,11 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	}
 
 	// Catsrc with the same priority, ns, different name
-	fakeNamespacedOperatorCache.Snapshots[registry.CatalogKey{
+	fakeNamespacedOperatorCache.Snapshots[cache.SourceKey{
 		Namespace: "olm",
 		Name:      "community-operator",
 	}] = &cache.CatalogSnapshot{
-		Key: registry.CatalogKey{
+		Key: cache.SourceKey{
 			Namespace: "olm",
 			Name:      "community-operator",
 		},
@@ -476,11 +475,11 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	}
 
 	// operators from the same catalogs source should be prioritized.
-	fakeNamespacedOperatorCache.Snapshots[registry.CatalogKey{
+	fakeNamespacedOperatorCache.Snapshots[cache.SourceKey{
 		Namespace: "olm",
 		Name:      "community",
 	}] = &cache.CatalogSnapshot{
-		Key: registry.CatalogKey{
+		Key: cache.SourceKey{
 			Namespace: "olm",
 			Name:      "community",
 		},
@@ -516,7 +515,7 @@ func TestSolveOperators_WithDependencies(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -532,12 +531,12 @@ func TestSolveOperators_WithDependencies(t *testing.T) {
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -574,7 +573,7 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	community := registry.CatalogKey{"community", namespace}
+	community := cache.SourceKey{"community", namespace}
 
 	csvs := []*v1alpha1.ClusterServiceVersion{
 		existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", nil, nil, nil, nil),
@@ -592,7 +591,7 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			community: {
 				Key: community,
 				Operators: []*cache.Operator{
@@ -624,7 +623,7 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 
 func TestSolveOperators_WithLabelDependencies(t *testing.T) {
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	newSub := newSub(namespace, "packageA", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
@@ -649,12 +648,12 @@ func TestSolveOperators_WithLabelDependencies(t *testing.T) {
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -685,7 +684,7 @@ func TestSolveOperators_WithLabelDependencies(t *testing.T) {
 
 func TestSolveOperators_WithUnsatisfiableLabelDependencies(t *testing.T) {
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	newSub := newSub(namespace, "packageA", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
@@ -698,12 +697,12 @@ func TestSolveOperators_WithUnsatisfiableLabelDependencies(t *testing.T) {
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -728,7 +727,7 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -751,12 +750,12 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -769,11 +768,11 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 					genOperator("packageD.v1.0.1", "1.0.1", "", "packageD", "alpha", "community", "olm", nil, Provides2, deps2, "", false),
 				},
 			},
-			registry.CatalogKey{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "certified",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "certified",
 				},
@@ -815,7 +814,7 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 	const namespace = "olm"
 
 	Provides := cache.APISet{opregistry.APIKey{Group: "g", Version: "v", Kind: "k", Plural: "ks"}: struct{}{}}
-	community := registry.CatalogKey{Name: "community", Namespace: namespace}
+	community := cache.SourceKey{Name: "community", Namespace: namespace}
 	csvs := []*v1alpha1.ClusterServiceVersion{
 		existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil),
 	}
@@ -838,7 +837,7 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			community: {
 				Key: community,
 				Operators: []*cache.Operator{
@@ -851,7 +850,7 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 				Namespace: "olm",
 				Name:      "certified",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "certified",
 				},
@@ -889,8 +888,8 @@ func TestSolveOperators_PreferCatalogInSameNamespace(t *testing.T) {
 
 	namespace := "olm"
 	altNamespace := "alt-olm"
-	catalog := registry.CatalogKey{"community", namespace}
-	altnsCatalog := registry.CatalogKey{"alt-community", altNamespace}
+	catalog := cache.SourceKey{"community", namespace}
+	altnsCatalog := cache.SourceKey{"alt-community", altNamespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -898,7 +897,7 @@ func TestSolveOperators_PreferCatalogInSameNamespace(t *testing.T) {
 	subs := []*v1alpha1.Subscription{sub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Operators: []*cache.Operator{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, "", false),
@@ -933,8 +932,8 @@ func TestSolveOperators_ResolveOnlyInCachedNamespaces(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
-	otherCatalog := registry.CatalogKey{Name: "secret", Namespace: "secret"}
+	catalog := cache.SourceKey{"community", namespace}
+	otherCatalog := cache.SourceKey{Name: "secret", Namespace: "secret"}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -942,7 +941,7 @@ func TestSolveOperators_ResolveOnlyInCachedNamespaces(t *testing.T) {
 	subs := []*v1alpha1.Subscription{newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Operators: []*cache.Operator{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", otherCatalog.Name, otherCatalog.Namespace, nil, Provides, nil, "", false),
@@ -968,7 +967,7 @@ func TestSolveOperators_PreferDefaultChannelInResolution(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{Name: "community", Namespace: namespace}
+	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
 	csvs := []*v1alpha1.ClusterServiceVersion{}
 
@@ -978,7 +977,7 @@ func TestSolveOperators_PreferDefaultChannelInResolution(t *testing.T) {
 	subs := []*v1alpha1.Subscription{newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Operators: []*cache.Operator{
 					// Default channel is stable in this case
@@ -1010,7 +1009,7 @@ func TestSolveOperators_PreferDefaultChannelInResolutionForTransitiveDependencie
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{Name: "community", Namespace: namespace}
+	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
 	csvs := []*v1alpha1.ClusterServiceVersion{}
 
@@ -1019,7 +1018,7 @@ func TestSolveOperators_PreferDefaultChannelInResolutionForTransitiveDependencie
 
 	const defaultChannel = "stable"
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Operators: []*cache.Operator{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, Provides, nil, cache.APISetToDependencies(nil, Provides), defaultChannel, false),
@@ -1051,7 +1050,7 @@ func TestSolveOperators_SubscriptionlessOperatorsSatisfyDependencies(t *testing.
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -1066,12 +1065,12 @@ func TestSolveOperators_SubscriptionlessOperatorsSatisfyDependencies(t *testing.
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -1104,7 +1103,7 @@ func TestSolveOperators_SubscriptionlessOperatorsCanConflict(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
 	csvs := []*v1alpha1.ClusterServiceVersion{csv}
@@ -1112,12 +1111,12 @@ func TestSolveOperators_SubscriptionlessOperatorsCanConflict(t *testing.T) {
 	subs := []*v1alpha1.Subscription{newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -1146,14 +1145,14 @@ func TestSolveOperators_PackageCannotSelfSatisfy(t *testing.T) {
 	RequiresBoth := Requires1.Union(Requires2)
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{Name: "community", Namespace: namespace}
-	secondaryCatalog := registry.CatalogKey{Namespace: "olm", Name: "secondary"}
+	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
+	secondaryCatalog := cache.SourceKey{Namespace: "olm", Name: "secondary"}
 
 	newSub := newSub(namespace, "packageA", "stable", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Key: catalog,
 				Operators: []*cache.Operator{
@@ -1201,7 +1200,7 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 	ProvidesBoth := Provides1.Union(Provides2)
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{Name: "community", Namespace: namespace}
+	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
 	phases := []struct {
 		subs     []*v1alpha1.Subscription
@@ -1265,7 +1264,7 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 	for i, p := range phases {
 		t.Run(fmt.Sprintf("phase %d", i+1), func(t *testing.T) {
 			fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-				Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+				Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 					catalog: p.catalog,
 				},
 			}
@@ -1303,7 +1302,7 @@ func (f *FakeOperatorCache) Namespaced(namespaces ...string) cache.MultiCatalogO
 	return &f.fakedNamespacedOperatorCache
 }
 
-func (f *FakeOperatorCache) Expire(key registry.CatalogKey) {
+func (f *FakeOperatorCache) Expire(key cache.SourceKey) {
 	return
 }
 
@@ -1341,7 +1340,7 @@ func genOperator(name, version, replaces, pkg, channel, catalogName, catalogName
 		},
 		Properties: properties,
 		SourceInfo: &cache.OperatorSourceInfo{
-			Catalog: registry.CatalogKey{
+			Catalog: cache.SourceKey{
 				Name:      catalogName,
 				Namespace: catalogNamespace,
 			},
@@ -1362,14 +1361,14 @@ func stripBundle(o *cache.Operator) *cache.Operator {
 }
 
 func TestSolveOperators_WithoutDeprecated(t *testing.T) {
-	catalog := registry.CatalogKey{Name: "catalog", Namespace: "namespace"}
+	catalog := cache.SourceKey{Name: "catalog", Namespace: "namespace"}
 
 	subs := []*v1alpha1.Subscription{
 		newSub(catalog.Namespace, "packageA", "alpha", catalog),
 	}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Key: catalog,
 				Operators: []*cache.Operator{
@@ -1389,7 +1388,7 @@ func TestSolveOperators_WithoutDeprecated(t *testing.T) {
 }
 
 func TestSolveOperatorsWithDeprecatedInnerChannelEntry(t *testing.T) {
-	catalog := registry.CatalogKey{Name: "catalog", Namespace: "namespace"}
+	catalog := cache.SourceKey{Name: "catalog", Namespace: "namespace"}
 
 	subs := []*v1alpha1.Subscription{
 		newSub(catalog.Namespace, "a", "c", catalog),
@@ -1397,7 +1396,7 @@ func TestSolveOperatorsWithDeprecatedInnerChannelEntry(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	resolver := SatResolver{
 		cache: getFakeOperatorCache(cache.NamespacedOperatorCache{
-			Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+			Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 				catalog: {
 					Key: catalog,
 					Operators: []*cache.Operator{
@@ -1422,7 +1421,7 @@ func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 	Provides := APISet
 
 	namespace := "olm"
-	catalog := registry.CatalogKey{"community", namespace}
+	catalog := cache.SourceKey{"community", namespace}
 
 	newSub := newSub(namespace, "packageB", "alpha", catalog, withStartingCSV("packageB.v1"))
 	subs := []*v1alpha1.Subscription{newSub}
@@ -1447,12 +1446,12 @@ func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 	op6 := genOperator("packageA.v6", "6.0.0", "packageA.v5", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
-			registry.CatalogKey{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
+			cache.SourceKey{
 				Namespace: "olm",
 				Name:      "community",
 			}: {
-				Key: registry.CatalogKey{
+				Key: cache.SourceKey{
 					Namespace: "olm",
 					Name:      "community",
 				},
@@ -1479,7 +1478,7 @@ func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 
 func TestSolveOperators_WithSkips(t *testing.T) {
 	const namespace = "test-namespace"
-	catalog := registry.CatalogKey{Name: "test-catalog", Namespace: namespace}
+	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 
 	newSub := newSub(namespace, "packageB", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
@@ -1489,7 +1488,7 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 	opB2.Skips = []string{"packageB.v1"}
 
 	fakeNamespacedOperatorCache := cache.NamespacedOperatorCache{
-		Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+		Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 			catalog: {
 				Key: catalog,
 				Operators: []*cache.Operator{
@@ -1513,7 +1512,7 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 
 func TestSolveOperatorsWithSkipsPreventingSelection(t *testing.T) {
 	const namespace = "test-namespace"
-	catalog := registry.CatalogKey{Name: "test-catalog", Namespace: namespace}
+	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 	gvks := cache.APISet{opregistry.APIKey{Group: "g", Version: "v", Kind: "k", Plural: "ks"}: struct{}{}}
 
 	// Subscription candidate a-1 requires a GVK provided
@@ -1529,7 +1528,7 @@ func TestSolveOperatorsWithSkipsPreventingSelection(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	satResolver := SatResolver{
 		cache: getFakeOperatorCache(cache.NamespacedOperatorCache{
-			Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+			Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 				catalog: {
 					Key:       catalog,
 					Operators: []*cache.Operator{a1, b3, b2, b1},
@@ -1545,7 +1544,7 @@ func TestSolveOperatorsWithSkipsPreventingSelection(t *testing.T) {
 
 func TestSolveOperatorsWithClusterServiceVersionHavingDependency(t *testing.T) {
 	const namespace = "test-namespace"
-	catalog := registry.CatalogKey{Name: "test-catalog", Namespace: namespace}
+	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 
 	a1 := existingOperator(namespace, "a-1", "a", "default", "", nil, nil, nil, nil)
 	a1.Annotations = map[string]string{
@@ -1565,7 +1564,7 @@ func TestSolveOperatorsWithClusterServiceVersionHavingDependency(t *testing.T) {
 	log, _ := test.NewNullLogger()
 	r := SatResolver{
 		cache: getFakeOperatorCache(cache.NamespacedOperatorCache{
-			Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+			Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 				catalog: {
 					Key: catalog,
 					Operators: []*cache.Operator{
@@ -1583,7 +1582,7 @@ func TestSolveOperatorsWithClusterServiceVersionHavingDependency(t *testing.T) {
 }
 
 func TestInferProperties(t *testing.T) {
-	catalog := registry.CatalogKey{Namespace: "namespace", Name: "name"}
+	catalog := cache.SourceKey{Namespace: "namespace", Name: "name"}
 
 	for _, tc := range []struct {
 		Name          string
@@ -1665,7 +1664,7 @@ func TestInferProperties(t *testing.T) {
 		{
 			Name: "one matching subscription infers package property",
 			Cache: cache.NamespacedOperatorCache{
-				Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+				Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 					catalog: {
 						Key: catalog,
 						Operators: []*cache.Operator{
@@ -1730,7 +1729,7 @@ func TestInferProperties(t *testing.T) {
 		{
 			Name: "one matching subscription infers package property without csv version",
 			Cache: cache.NamespacedOperatorCache{
-				Snapshots: map[registry.CatalogKey]*cache.CatalogSnapshot{
+				Snapshots: map[cache.SourceKey]*cache.CatalogSnapshot{
 					catalog: {
 						Key: catalog,
 						Operators: []*cache.Operator{

--- a/pkg/controller/registry/resolver/source_registry.go
+++ b/pkg/controller/registry/resolver/source_registry.go
@@ -1,0 +1,109 @@
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
+	"github.com/operator-framework/operator-registry/pkg/api"
+	"github.com/operator-framework/operator-registry/pkg/client"
+	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/sirupsen/logrus"
+)
+
+type RegistryClientProvider interface {
+	ClientsForNamespaces(namespaces ...string) map[registry.CatalogKey]client.Interface
+}
+
+type registryClientAdapter struct {
+	rcp    RegistryClientProvider
+	logger logrus.StdLogger
+}
+
+func SourceProviderFromRegistryClientProvider(rcp RegistryClientProvider, logger logrus.StdLogger) cache.SourceProvider {
+	return &registryClientAdapter{
+		rcp:    rcp,
+		logger: logger,
+	}
+}
+
+type registrySource struct {
+	key    cache.SourceKey
+	client client.Interface
+	logger logrus.StdLogger
+}
+
+func (s *registrySource) Snapshot(ctx context.Context) (*cache.Snapshot, error) {
+	// Fetching default channels this way makes many round trips
+	// -- may need to either add a new API to fetch all at once,
+	// or embed the information into Bundle.
+	defaultChannels := make(map[string]string)
+
+	it, err := s.client.ListBundles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list bundles: %w", err)
+	}
+
+	var operators []*cache.Operator
+	for b := it.Next(); b != nil; b = it.Next() {
+		defaultChannel, ok := defaultChannels[b.PackageName]
+		if !ok {
+			if p, err := s.client.GetPackage(ctx, b.PackageName); err != nil {
+				s.logger.Printf("failed to retrieve default channel for bundle, continuing: %v", err)
+				continue
+			} else {
+				defaultChannels[b.PackageName] = p.DefaultChannelName
+				defaultChannel = p.DefaultChannelName
+			}
+		}
+		o, err := cache.NewOperatorFromBundle(b, "", s.key, defaultChannel)
+		if err != nil {
+			s.logger.Printf("failed to construct operator from bundle, continuing: %v", err)
+			continue
+		}
+		o.ProvidedAPIs = o.ProvidedAPIs.StripPlural()
+		o.RequiredAPIs = o.RequiredAPIs.StripPlural()
+		o.Replaces = b.Replaces
+		EnsurePackageProperty(o, b.PackageName, b.Version)
+		operators = append(operators, o)
+	}
+	if err := it.Error(); err != nil {
+		return nil, fmt.Errorf("error encountered while listing bundles: %w", err)
+	}
+
+	return &cache.Snapshot{Entries: operators}, nil
+}
+
+func (a *registryClientAdapter) Sources(namespaces ...string) map[cache.SourceKey]cache.Source {
+	result := make(map[cache.SourceKey]cache.Source)
+	for key, client := range a.rcp.ClientsForNamespaces(namespaces...) {
+		result[cache.SourceKey(key)] = &registrySource{
+			key:    cache.SourceKey(key),
+			client: client,
+			logger: a.logger,
+		}
+	}
+	return result
+}
+
+func EnsurePackageProperty(o *cache.Operator, name, version string) {
+	for _, p := range o.Properties {
+		if p.Type == opregistry.PackageType {
+			return
+		}
+	}
+	prop := opregistry.PackageProperty{
+		PackageName: name,
+		Version:     version,
+	}
+	bytes, err := json.Marshal(prop)
+	if err != nil {
+		return
+	}
+	o.Properties = append(o.Properties, &api.Property{
+		Type:  opregistry.PackageType,
+		Value: string(bytes),
+	})
+}

--- a/pkg/controller/registry/resolver/step_resolver.go
+++ b/pkg/controller/registry/resolver/step_resolver.go
@@ -47,7 +47,7 @@ type OperatorStepResolver struct {
 var _ StepResolver = &OperatorStepResolver{}
 
 func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versioned.Interface, kubeclient kubernetes.Interface,
-	globalCatalogNamespace string, provider cache.RegistryClientProvider, log logrus.FieldLogger) *OperatorStepResolver {
+	globalCatalogNamespace string, provider RegistryClientProvider, log logrus.FieldLogger) *OperatorStepResolver {
 	return &OperatorStepResolver{
 		subLister:              lister.OperatorsV1alpha1().SubscriptionLister(),
 		csvLister:              lister.OperatorsV1alpha1().ClusterServiceVersionLister(),
@@ -55,7 +55,7 @@ func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versio
 		client:                 client,
 		kubeclient:             kubeclient,
 		globalCatalogNamespace: globalCatalogNamespace,
-		satResolver:            NewDefaultSatResolver(cache.SourceProviderFromRegistryClientProvider(provider), lister.OperatorsV1alpha1().CatalogSourceLister(), log),
+		satResolver:            NewDefaultSatResolver(SourceProviderFromRegistryClientProvider(provider, log), lister.OperatorsV1alpha1().CatalogSourceLister(), log),
 		log:                    log,
 	}
 }

--- a/pkg/fakes/fake_resolver.go
+++ b/pkg/fakes/fake_resolver.go
@@ -5,15 +5,15 @@ import (
 	"sync"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
 type FakeStepResolver struct {
-	ExpireStub        func(registry.CatalogKey)
+	ExpireStub        func(cache.SourceKey)
 	expireMutex       sync.RWMutex
 	expireArgsForCall []struct {
-		arg1 registry.CatalogKey
+		arg1 cache.SourceKey
 	}
 	ResolveStepsStub        func(string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error)
 	resolveStepsMutex       sync.RWMutex
@@ -36,10 +36,10 @@ type FakeStepResolver struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeStepResolver) Expire(arg1 registry.CatalogKey) {
+func (fake *FakeStepResolver) Expire(arg1 cache.SourceKey) {
 	fake.expireMutex.Lock()
 	fake.expireArgsForCall = append(fake.expireArgsForCall, struct {
-		arg1 registry.CatalogKey
+		arg1 cache.SourceKey
 	}{arg1})
 	fake.recordInvocation("Expire", []interface{}{arg1})
 	fake.expireMutex.Unlock()
@@ -54,13 +54,13 @@ func (fake *FakeStepResolver) ExpireCallCount() int {
 	return len(fake.expireArgsForCall)
 }
 
-func (fake *FakeStepResolver) ExpireCalls(stub func(registry.CatalogKey)) {
+func (fake *FakeStepResolver) ExpireCalls(stub func(cache.SourceKey)) {
 	fake.expireMutex.Lock()
 	defer fake.expireMutex.Unlock()
 	fake.ExpireStub = stub
 }
 
-func (fake *FakeStepResolver) ExpireArgsForCall(i int) registry.CatalogKey {
+func (fake *FakeStepResolver) ExpireArgsForCall(i int) cache.SourceKey {
 	fake.expireMutex.RLock()
 	defer fake.expireMutex.RUnlock()
 	argsForCall := fake.expireArgsForCall[i]


### PR DESCRIPTION
This is a continuation of the ongoing work to allow the runtime dependency resolution features of catalog-operator to be reusable outside of OLM.
