### PR TITLE
Remove unneeded replace pin for sigs.k8s.io/structured-merge-diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,4 @@ replace (
 	// Patch for a race condition involving metadata-only
 	// informers until it can be resolved upstream:
 	sigs.k8s.io/controller-runtime v0.9.2 => github.com/benluddy/controller-runtime v0.9.3-0.20210720171926-9bcb99bd9bd3
-
-	// pinned because no tag supports 1.18 yet
-	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1861,4 +1861,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-# sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06


### PR DESCRIPTION
Update the root go.mod and remove the replace pin for
sigs.k8s.io/structured-merge-diff.

It looks like the "// pinned because no tag supports 1.18 yet" message
may have also been an artifact of removing the helm replace pin that was
previously in place.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
