### PR TITLE
Introduce a sanity workflow for checking static linting violations in CI

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,0 +1,23 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    paths:
+      - '**'
+      - '!doc/**'
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Run sanity checks
+        run: make vendor && make lint && make diff

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,9 @@ clean:
 	@rm -rf test/e2e/log
 	@rm -rf e2e.namespace
 
+lint:
+	find . -name '*.go' -not -path "./vendor/*" -not -path "./pkg/lib/operatorclient/operatorclientmocks/*" | xargs gofmt -w
+	find . -name '*.go' -not -path "./vendor/*" -not -path "./pkg/lib/operatorclient/operatorclientmocks/*" | xargs goimports -w
 
 # Copy CRD manifests
 manifests: vendor

--- a/pkg/controller/certs/certs.go
+++ b/pkg/controller/certs/certs.go
@@ -16,12 +16,12 @@ import (
 )
 
 type CertGenerator interface {
-  Generate(notAfter time.Time, organization string, ca *KeyPair, hosts []string) (*KeyPair, error)
+	Generate(notAfter time.Time, organization string, ca *KeyPair, hosts []string) (*KeyPair, error)
 }
 
 type CertGeneratorFunc func(notAfter time.Time, organization string, ca *KeyPair, hosts []string) (*KeyPair, error)
 
-func (f CertGeneratorFunc) Generate(notAfter time.Time, organization string, ca *KeyPair, hosts []string) (*KeyPair, error)  {
+func (f CertGeneratorFunc) Generate(notAfter time.Time, organization string, ca *KeyPair, hosts []string) (*KeyPair, error) {
 	return f(notAfter, organization, ca, hosts)
 }
 

--- a/pkg/controller/operators/catalog/installplan_sync.go
+++ b/pkg/controller/operators/catalog/installplan_sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/controller/operators/openshift/clusteroperator_controller_test.go
+++ b/pkg/controller/operators/openshift/clusteroperator_controller_test.go
@@ -2,6 +2,7 @@ package openshift
 
 import (
 	"fmt"
+
 	semver "github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/controller/operators/operatorcondition_controller_test.go
+++ b/pkg/controller/operators/operatorcondition_controller_test.go
@@ -6,8 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	operatorsv2 "github.com/operator-framework/api/pkg/operators/v2"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv2 "github.com/operator-framework/api/pkg/operators/v2"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/controller/operators/operatorconditiongenerator_controller_test.go
+++ b/pkg/controller/operators/operatorconditiongenerator_controller_test.go
@@ -14,8 +14,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	operatorsv2 "github.com/operator-framework/api/pkg/operators/v2"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv2 "github.com/operator-framework/api/pkg/operators/v2"
 )
 
 var _ = Describe("The OperatorConditionsGenerator Controller", func() {

--- a/pkg/controller/registry/grpc/source.go
+++ b/pkg/controller/registry/grpc/source.go
@@ -2,9 +2,10 @@ package grpc
 
 import (
 	"context"
-	"github.com/operator-framework/operator-registry/pkg/client"
 	"sync"
 	"time"
+
+	"github.com/operator-framework/operator-registry/pkg/client"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"

--- a/pkg/controller/registry/resolver/rbac.go
+++ b/pkg/controller/registry/resolver/rbac.go
@@ -22,7 +22,7 @@ func generateName(base string, o interface{}) string {
 	hashutil.DeepHashObject(hasher, o)
 	hash := utilrand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
 	if len(base)+len(hash) > maxNameLength {
-		base = base[:maxNameLength - len(hash) - 1]
+		base = base[:maxNameLength-len(hash)-1]
 	}
 
 	return fmt.Sprintf("%s-%s", base, hash)

--- a/pkg/controller/registry/resolver/rbac_test.go
+++ b/pkg/controller/registry/resolver/rbac_test.go
@@ -29,7 +29,7 @@ func TestGenerateName(t *testing.T) {
 			name: "generate",
 			args: args{
 				base: "myname",
-				o: []string{"something"},
+				o:    []string{"something"},
 			},
 			want: "myname-9c895f74f",
 		},
@@ -37,7 +37,7 @@ func TestGenerateName(t *testing.T) {
 			name: "truncated",
 			args: args{
 				base: strings.Repeat("name", 100),
-				o: []string{"something", "else"},
+				o:    []string{"something", "else"},
 			},
 			want: "namenamenamenamenamenamenamenamenamenamenamenamename-78fd8b4d6b",
 		},

--- a/pkg/lib/controller-runtime/client/ssa_test.go
+++ b/pkg/lib/controller-runtime/client/ssa_test.go
@@ -2,8 +2,9 @@ package client
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/testobj"
 	"github.com/stretchr/testify/require"

--- a/pkg/lib/crd/storage.go
+++ b/pkg/lib/crd/storage.go
@@ -2,6 +2,7 @@ package crd
 
 import (
 	"fmt"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/lib/crd/storage_test.go
+++ b/pkg/lib/crd/storage_test.go
@@ -1,10 +1,11 @@
 package crd
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 const crdName = "test"

--- a/pkg/lib/crd/version.go
+++ b/pkg/lib/crd/version.go
@@ -38,4 +38,3 @@ func Version(manifest *string) (string, error) {
 
 	return v, nil
 }
-

--- a/pkg/lib/operatorlister/configmap.go
+++ b/pkg/lib/operatorlister/configmap.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/lib/operatorlister/operatorgroup.go
+++ b/pkg/lib/operatorlister/operatorgroup.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/operator-framework/api/pkg/operators/v1"
+	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1"
 )
 

--- a/pkg/lib/operatorlister/pod.go
+++ b/pkg/lib/operatorlister/pod.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/package-server/provider/registry.go
+++ b/pkg/package-server/provider/registry.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"io"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"

--- a/test/e2e/registry.go
+++ b/test/e2e/registry.go
@@ -3,10 +3,11 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os/exec"
+
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os/exec"
 )
 
 // This module contains helper functions for copying images and creating image registries


### PR DESCRIPTION
Update the Makefile and introduce a `lint` target. This target is responsible for running both `gofmt` and `goimports` against non-vendor packages in the codebase.

Introduce the ci/sanity GH workflow:
- Runs `make vendor`
- Runs `make lint`
- Ensures that both of those targets don't produce a diff when running
  `make diff`

Fix any linting gofmt/goimports linting violations that came up when running the `make lint` target locally.