### PR TITLE
.github/workflows: Don't run CI checks for markdown-only updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: ci
 on:
   pull_request:
     paths-ignore:
-    - 'doc/**/*.md'
     - '**/*.md'
 jobs:
   image:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: ci
 on:
   pull_request:
-    paths:
-    - '**'
-    - '!doc/contributors/**'
-    - '!doc/design/**'
+    paths-ignore:
+    - 'doc/**/*.md'
     - '**/*.md'
 jobs:
   image:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     - '**'
     - '!doc/contributors/**'
     - '!doc/design/**'
+    - '**/*.md'
 jobs:
   image:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-kind.yml
+++ b/.github/workflows/e2e-kind.yml
@@ -5,6 +5,7 @@ on:
     - '**'
     - '!doc/contributors/**'
     - '!doc/design/**'
+    - '!**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/e2e-kind.yml
+++ b/.github/workflows/e2e-kind.yml
@@ -1,11 +1,9 @@
 name: ci
 on:
   pull_request:
-    paths:
-    - '**'
-    - '!doc/contributors/**'
-    - '!doc/design/**'
-    - '!**/*.md'
+    paths-ignore:
+    - 'doc/**/*.md'
+    - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/e2e-kind.yml
+++ b/.github/workflows/e2e-kind.yml
@@ -2,7 +2,6 @@ name: ci
 on:
   pull_request:
     paths-ignore:
-    - 'doc/**/*.md'
     - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases

--- a/.github/workflows/e2e-minikube.yml
+++ b/.github/workflows/e2e-minikube.yml
@@ -5,6 +5,7 @@ on:
     - '**'
     - '!doc/contributors/**'
     - '!doc/design/**'
+    - '!**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/e2e-minikube.yml
+++ b/.github/workflows/e2e-minikube.yml
@@ -1,11 +1,9 @@
 name: ci
 on:
   pull_request:
-    paths:
-    - '**'
-    - '!doc/contributors/**'
-    - '!doc/design/**'
-    - '!**/*.md'
+    paths-ignore:
+    - 'doc/**/*.md'
+    - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/e2e-minikube.yml
+++ b/.github/workflows/e2e-minikube.yml
@@ -2,7 +2,6 @@ name: ci
 on:
   pull_request:
     paths-ignore:
-    - 'doc/**/*.md'
     - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '**'
       - '!doc/**'
+      - '!**/*.md'
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,7 +5,6 @@ on:
       - master
   pull_request:
     paths-ignore:
-    - 'doc/**/*.md'
     - '**/*.md'
 jobs:
   e2e-tests:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,10 +4,9 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - '**'
-      - '!doc/**'
-      - '!**/*.md'
+    paths-ignore:
+    - 'doc/**/*.md'
+    - '**/*.md'
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,10 +4,9 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - '**'
-      - '!doc/**'
-      - '!**/*.md'
+    paths-ignore:
+    - 'doc/**/*.md'
+    - '**/*.md'
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,7 +5,6 @@ on:
       - master
   pull_request:
     paths-ignore:
-    - 'doc/**/*.md'
     - '**/*.md'
 jobs:
   unit:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '**'
       - '!doc/**'
+      - '!**/*.md'
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,7 +5,6 @@ on:
       - master
   pull_request:
     paths-ignore:
-    - 'doc/**/*.md'
     - '**/*.md'
 jobs:
   verify:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,10 +4,9 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - '**'
-      - '!doc/**'
-      - '!**/*.md'
+    paths-ignore:
+    - 'doc/**/*.md'
+    - '**/*.md'
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '**'
       - '!doc/**'
+      - '!**/*.md'
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the ci-prefixed workflows and ensure that CI isn't running when
only markdown files are updated.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
