### PR TITLE
pkg/controller: Fix panic when creating cluster-scoped RBAC in OG controller

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -532,11 +532,12 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			}
 			// TODO: this should do something smarter if the cluster role already exists
 			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
-				// if the CR already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && ownerutil.IsOwnedByLabel(cr, csv) {
-					continue
-				} else {
+				if !k8serrors.IsAlreadyExists(err) {
 					return err
+				}
+				// if the CR already exists, but the label is correct, the cache is just behind
+				if cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
+					continue
 				}
 			}
 			a.logger.Debug("created cluster role")
@@ -572,12 +573,14 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			}
 			// TODO: this should do something smarter if the cluster role binding already exists
 			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
-				// if the CR already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && ownerutil.IsOwnedByLabel(crb, csv) {
-					continue
-				} else {
+				if !k8serrors.IsAlreadyExists(err) {
 					return err
 				}
+				// if the CRB already exists, but the label is correct, the cache is just behind
+				if crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
+					continue
+				}
+				return err
 			}
 		}
 	}

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -532,13 +532,11 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			}
 			// TODO: this should do something smarter if the cluster role already exists
 			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
-				if !k8serrors.IsAlreadyExists(err) {
-					return err
-				}
-				// if the CR already exists, but the label is correct, the cache is just behind
-				if cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
+				// If the CR already exists, but the label is correct, the cache is just behind
+				if k8serrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
 					continue
 				}
+				return err
 			}
 			a.logger.Debug("created cluster role")
 		}
@@ -573,11 +571,8 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			}
 			// TODO: this should do something smarter if the cluster role binding already exists
 			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
-				if !k8serrors.IsAlreadyExists(err) {
-					return err
-				}
-				// if the CRB already exists, but the label is correct, the cache is just behind
-				if crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
+				// If the CRB already exists, but the label is correct, the cache is just behind
+				if k8serrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
 					continue
 				}
 				return err


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fixes [#2091](https://github.com/operator-framework/operator-lifecycle-manager/issues/2091).
    
This is a follow-up to [operator-framework#2309](operator-framework#2309) that attempted to fix the original issue. When checking whether the ClusterRole/ClusterRoleBinding resources already exist, we're also checking whether the existing labels are owned by the CSV we're currently handling. When accessing the "cr" or "crb" variables that the Create calls output, a panic is produced as we're attempting to access the meta.Labels key from those resources, except those resources themselves are nil. Update the check to verify that the cr/crb variables are not nil before attempting to access those object's labels. The testing fake client may need to be updated in the future to handle returning these resources properly.

I ran `go test ./pkg/controller/operators/olm/... -v -run ^TestSyncOperatorGroups$ -count 250` a couple of times and wasn't able to reproduce. I was able to consistently reproduce without these changes using a much smaller count sizing before.

**Motivation for the change:**
Reduce testing flakes.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
