### PR TITLE
[release-4.7] Fix kubebuilder installation in the build root Dockerfile

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -2,11 +2,12 @@
 
 FROM openshift/origin-release:golang-1.13
 
-# Install test dependencies
+ARG KUBEBUILDER_RELEASE=2.3.1
 RUN yum install -y skopeo && \
     export OS=$(go env GOOS) && \
     export ARCH=$(go env GOARCH) && \
-    curl -L "https://go.kubebuilder.io/dl/2.3.1/${OS}/${ARCH}" | tar -xz -C /tmp/ && \
-    mv /tmp/kubebuilder_2.3.1_${OS}_${ARCH}/ /usr/local/kubebuilder && \
+    curl -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_RELEASE}/kubebuilder_${KUBEBUILDER_RELEASE}_${OS}_${ARCH}.tar.gz" | tar -xz -C /tmp/ && \
+    mv /tmp/kubebuilder_${KUBEBUILDER_RELEASE}_${OS}_${ARCH}/ /usr/local/kubebuilder && \
     export PATH=$PATH:/usr/local/kubebuilder/bin && \
+    kubebuilder version && \
     echo "Kubebuilder installation complete!"


### PR DESCRIPTION
Update the base.Dockerfile and fix the kubebuilder installation. That
vanity URL is no longer correctly serving the v2.3.1 release tar.gz
file. Update to instead curl directly from the github releases URL.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
