### PR TITLE
.github/workflows: Update the e2e-kind/e2e-minikube workflow(s)

### DIFF
--- a/.github/workflows/run-kind-local.yml
+++ b/.github/workflows/run-kind-local.yml
@@ -6,7 +6,7 @@ on:
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:
-  e2e-kind:
+  run-kind-local:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -22,5 +22,5 @@ jobs:
       run: |
         kind create cluster
         kind export kubeconfig
-    - name: Run e2e tests
+    - name: Ensure local OLM installation is successful
       run: make run-local

--- a/.github/workflows/run-minikube-local.yml
+++ b/.github/workflows/run-minikube-local.yml
@@ -6,7 +6,7 @@ on:
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:
-  e2e-minikube:
+  run-minikube-local:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -21,5 +21,5 @@ jobs:
         sudo mv minikube /bin/
     - name: Setup minikube
       run: minikube config set vm-driver docker
-    - name: Run e2e tests
+    - name: Ensure local OLM installation is successful
       run: make run-local


### PR DESCRIPTION
Rename the e2e-kind and e2e-minikube workflows to communicate that these
tests are used to ensure that OLM doesn't regress when running new OLM
local installations on these cluster types. These workflows were
accidentally renamed when the jobs in the e2e-tests workflow were split
out to their own workflows to allow individual retesting