### PR TITLE
.github/workflows: Don't run the sanity jobs for markdown-only updates

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -5,9 +5,8 @@ on:
     branches:
       - '**'
   pull_request:
-    paths:
-      - '**'
-      - '!doc/**'
+    paths-ignore:
+    - '**/*.md'
 
 jobs:
   sanity:


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the sanity workflow and avoid running the defined jobs when only
markdown changes are present in the PR. This is a follow-up to #2347
which enabled this behavior with the other actions, and this sanity
action was introduced after that PR had already merged.

**Motivation for the change:**
No need to run CI checks on markdown-only changes.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
