### PR TITLE
Rename resolver/cache.Operator to Entry.

### DIFF
--- a/pkg/controller/registry/resolver/cache/cache.go
+++ b/pkg/controller/registry/resolver/cache/cache.go
@@ -261,8 +261,8 @@ func (c *NamespacedOperatorCache) Catalog(k SourceKey) OperatorFinder {
 	return EmptyOperatorFinder{}
 }
 
-func (c *NamespacedOperatorCache) FindPreferred(preferred *SourceKey, preferredNamespace string, p ...OperatorPredicate) []*Operator {
-	var result []*Operator
+func (c *NamespacedOperatorCache) FindPreferred(preferred *SourceKey, preferredNamespace string, p ...Predicate) []*Entry {
+	var result []*Entry
 	if preferred != nil && preferred.Empty() {
 		preferred = nil
 	}
@@ -291,12 +291,12 @@ func (c *NamespacedOperatorCache) WithExistingOperators(snapshot *Snapshot, name
 	return o
 }
 
-func (c *NamespacedOperatorCache) Find(p ...OperatorPredicate) []*Operator {
+func (c *NamespacedOperatorCache) Find(p ...Predicate) []*Entry {
 	return c.FindPreferred(nil, "", p...)
 }
 
 type Snapshot struct {
-	Entries []*Operator
+	Entries []*Entry
 }
 
 var _ Source = &Snapshot{}
@@ -402,7 +402,7 @@ func (s sortableSnapshots) Swap(i, j int) {
 	s.snapshots[i], s.snapshots[j] = s.snapshots[j], s.snapshots[i]
 }
 
-func (s *snapshotHeader) Find(p ...OperatorPredicate) []*Operator {
+func (s *snapshotHeader) Find(p ...Predicate) []*Entry {
 	s.m.RLock()
 	defer s.m.RUnlock()
 	if s.snapshot == nil {
@@ -412,12 +412,12 @@ func (s *snapshotHeader) Find(p ...OperatorPredicate) []*Operator {
 }
 
 type OperatorFinder interface {
-	Find(...OperatorPredicate) []*Operator
+	Find(...Predicate) []*Entry
 }
 
 type MultiCatalogOperatorFinder interface {
 	Catalog(SourceKey) OperatorFinder
-	FindPreferred(preferred *SourceKey, preferredNamespace string, predicates ...OperatorPredicate) []*Operator
+	FindPreferred(preferred *SourceKey, preferredNamespace string, predicates ...Predicate) []*Entry
 	WithExistingOperators(snapshot *Snapshot, namespace string) MultiCatalogOperatorFinder
 	Error() error
 	OperatorFinder
@@ -425,26 +425,26 @@ type MultiCatalogOperatorFinder interface {
 
 type EmptyOperatorFinder struct{}
 
-func (f EmptyOperatorFinder) Find(...OperatorPredicate) []*Operator {
+func (f EmptyOperatorFinder) Find(...Predicate) []*Entry {
 	return nil
 }
 
-func AtLeast(n int, operators []*Operator) ([]*Operator, error) {
+func AtLeast(n int, operators []*Entry) ([]*Entry, error) {
 	if len(operators) < n {
 		return nil, fmt.Errorf("expected at least %d operator(s), got %d", n, len(operators))
 	}
 	return operators, nil
 }
 
-func ExactlyOne(operators []*Operator) (*Operator, error) {
+func ExactlyOne(operators []*Entry) (*Entry, error) {
 	if len(operators) != 1 {
 		return nil, fmt.Errorf("expected exactly one operator, got %d", len(operators))
 	}
 	return operators[0], nil
 }
 
-func Filter(operators []*Operator, p ...OperatorPredicate) []*Operator {
-	var result []*Operator
+func Filter(operators []*Entry, p ...Predicate) []*Entry {
+	var result []*Entry
 	for _, o := range operators {
 		if Matches(o, p...) {
 			result = append(result, o)
@@ -453,6 +453,6 @@ func Filter(operators []*Operator, p ...OperatorPredicate) []*Operator {
 	return result
 }
 
-func Matches(o *Operator, p ...OperatorPredicate) bool {
+func Matches(o *Entry, p ...Predicate) bool {
 	return And(p...).Test(o)
 }

--- a/pkg/controller/registry/resolver/cache/cache_test.go
+++ b/pkg/controller/registry/resolver/cache/cache_test.go
@@ -25,7 +25,7 @@ func TestOperatorCacheConcurrency(t *testing.T) {
 			key := SourceKey{Namespace: strconv.Itoa(i), Name: strconv.Itoa(j)}
 			keys = append(keys, key)
 			sp[key] = &Snapshot{
-				Entries: []*Operator{
+				Entries: []*Entry{
 					{Name: fmt.Sprintf("%s/%s", key.Namespace, key.Name)},
 				},
 			}
@@ -71,14 +71,14 @@ func TestOperatorCacheExpiration(t *testing.T) {
 	c.ttl = 0 // instantly stale
 
 	ssp[key] = &Snapshot{
-		Entries: []*Operator{
+		Entries: []*Entry{
 			{Name: "v1"},
 		},
 	}
 	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("v1")), 1)
 
 	ssp[key] = &Snapshot{
-		Entries: []*Operator{
+		Entries: []*Entry{
 			{Name: "v2"},
 		},
 	}
@@ -91,14 +91,14 @@ func TestOperatorCacheReuse(t *testing.T) {
 	c := New(ssp)
 
 	ssp[key] = &Snapshot{
-		Entries: []*Operator{
+		Entries: []*Entry{
 			{Name: "v1"},
 		},
 	}
 	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("v1")), 1)
 
 	ssp[key] = &Snapshot{
-		Entries: []*Operator{
+		Entries: []*Entry{
 			{Name: "v2"},
 		},
 	}
@@ -172,18 +172,18 @@ func TestCatalogSnapshotValid(t *testing.T) {
 func TestCatalogSnapshotFind(t *testing.T) {
 	type tc struct {
 		Name      string
-		Predicate OperatorPredicate
-		Operators []*Operator
-		Expected  []*Operator
+		Predicate Predicate
+		Operators []*Entry
+		Expected  []*Entry
 	}
 
 	for _, tt := range []tc{
 		{
 			Name: "nothing satisfies predicate",
-			Predicate: OperatorPredicateTestFunc(func(*Operator) bool {
+			Predicate: OperatorPredicateTestFunc(func(*Entry) bool {
 				return false
 			}),
-			Operators: []*Operator{
+			Operators: []*Entry{
 				{Name: "a"},
 				{Name: "b"},
 				{Name: "c"},
@@ -192,7 +192,7 @@ func TestCatalogSnapshotFind(t *testing.T) {
 		},
 		{
 			Name: "no operators in snapshot",
-			Predicate: OperatorPredicateTestFunc(func(*Operator) bool {
+			Predicate: OperatorPredicateTestFunc(func(*Entry) bool {
 				return true
 			}),
 			Operators: nil,
@@ -200,15 +200,15 @@ func TestCatalogSnapshotFind(t *testing.T) {
 		},
 		{
 			Name: "everything satisfies predicate",
-			Predicate: OperatorPredicateTestFunc(func(*Operator) bool {
+			Predicate: OperatorPredicateTestFunc(func(*Entry) bool {
 				return true
 			}),
-			Operators: []*Operator{
+			Operators: []*Entry{
 				{Name: "a"},
 				{Name: "b"},
 				{Name: "c"},
 			},
-			Expected: []*Operator{
+			Expected: []*Entry{
 				{Name: "a"},
 				{Name: "b"},
 				{Name: "c"},
@@ -216,15 +216,15 @@ func TestCatalogSnapshotFind(t *testing.T) {
 		},
 		{
 			Name: "some satisfy predicate",
-			Predicate: OperatorPredicateTestFunc(func(o *Operator) bool {
+			Predicate: OperatorPredicateTestFunc(func(o *Entry) bool {
 				return o.Name != "a"
 			}),
-			Operators: []*Operator{
+			Operators: []*Entry{
 				{Name: "a"},
 				{Name: "b"},
 				{Name: "c"},
 			},
-			Expected: []*Operator{
+			Expected: []*Entry{
 				{Name: "b"},
 				{Name: "c"},
 			},

--- a/pkg/controller/registry/resolver/cache/operators.go
+++ b/pkg/controller/registry/resolver/cache/operators.go
@@ -135,21 +135,21 @@ func (s APISet) StripPlural() APISet {
 	return set
 }
 
-type APIOwnerSet map[opregistry.APIKey]*Operator
+type APIOwnerSet map[opregistry.APIKey]*Entry
 
 func EmptyAPIOwnerSet() APIOwnerSet {
-	return map[opregistry.APIKey]*Operator{}
+	return map[opregistry.APIKey]*Entry{}
 }
 
-type OperatorSet map[string]*Operator
+type OperatorSet map[string]*Entry
 
 func EmptyOperatorSet() OperatorSet {
-	return map[string]*Operator{}
+	return map[string]*Entry{}
 }
 
 // Snapshot returns a new set, pointing to the same values
 func (o OperatorSet) Snapshot() OperatorSet {
-	out := make(map[string]*Operator)
+	out := make(map[string]*Entry)
 	for key, val := range o {
 		out[key] = val
 	}
@@ -204,7 +204,7 @@ func (i *OperatorSourceInfo) String() string {
 var NoCatalog = SourceKey{Name: "", Namespace: ""}
 var ExistingOperator = OperatorSourceInfo{Package: "", Channel: "", StartingCSV: "", Catalog: NoCatalog, DefaultChannel: false}
 
-type Operator struct {
+type Entry struct {
 	Name         string
 	Replaces     string
 	Skips        []string
@@ -223,14 +223,14 @@ type Operator struct {
 	Bundle *api.Bundle
 }
 
-func (o *Operator) Package() string {
+func (o *Entry) Package() string {
 	if si := o.SourceInfo; si != nil {
 		return si.Package
 	}
 	return ""
 }
 
-func (o *Operator) Channel() string {
+func (o *Entry) Channel() string {
 	if si := o.SourceInfo; si != nil {
 		return si.Channel
 	}

--- a/pkg/controller/registry/resolver/cache/operators_test.go
+++ b/pkg/controller/registry/resolver/cache/operators_test.go
@@ -728,7 +728,7 @@ func TestAPIMultiOwnerSet_PopAPIKey(t *testing.T) {
 		{
 			name: "OneApi/OneOwner",
 			s: map[opregistry.APIKey]OperatorSet{
-				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Operator{
+				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Entry{
 					"owner1": {Name: "op1"},
 				},
 			},
@@ -736,7 +736,7 @@ func TestAPIMultiOwnerSet_PopAPIKey(t *testing.T) {
 		{
 			name: "OneApi/MultiOwner",
 			s: map[opregistry.APIKey]OperatorSet{
-				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Operator{
+				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Entry{
 					"owner1": {Name: "op1"},
 					"owner2": {Name: "op2"},
 				},
@@ -745,11 +745,11 @@ func TestAPIMultiOwnerSet_PopAPIKey(t *testing.T) {
 		{
 			name: "MultipleApi/MultiOwner",
 			s: map[opregistry.APIKey]OperatorSet{
-				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Operator{
+				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Entry{
 					"owner1": {Name: "op1"},
 					"owner2": {Name: "op2"},
 				},
-				{Group: "g2", Version: "v2", Kind: "k2", Plural: "p2"}: map[string]*Operator{
+				{Group: "g2", Version: "v2", Kind: "k2", Plural: "p2"}: map[string]*Entry{
 					"owner1": {Name: "op1"},
 					"owner2": {Name: "op2"},
 				},
@@ -788,23 +788,23 @@ func TestAPIMultiOwnerSet_PopAPIRequirers(t *testing.T) {
 		{
 			name: "OneApi/OneOwner",
 			s: map[opregistry.APIKey]OperatorSet{
-				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Operator{
+				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Entry{
 					"owner1": {Name: "op1"},
 				},
 			},
-			want: map[string]*Operator{
+			want: map[string]*Entry{
 				"owner1": {Name: "op1"},
 			},
 		},
 		{
 			name: "OneApi/MultiOwner",
 			s: map[opregistry.APIKey]OperatorSet{
-				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Operator{
+				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Entry{
 					"owner1": {Name: "op1"},
 					"owner2": {Name: "op2"},
 				},
 			},
-			want: map[string]*Operator{
+			want: map[string]*Entry{
 				"owner1": {Name: "op1"},
 				"owner2": {Name: "op2"},
 			},
@@ -812,16 +812,16 @@ func TestAPIMultiOwnerSet_PopAPIRequirers(t *testing.T) {
 		{
 			name: "MultipleApi/MultiOwner",
 			s: map[opregistry.APIKey]OperatorSet{
-				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Operator{
+				{Group: "g", Version: "v", Kind: "k", Plural: "p"}: map[string]*Entry{
 					"owner1": {Name: "op1"},
 					"owner2": {Name: "op2"},
 				},
-				{Group: "g2", Version: "v2", Kind: "k2", Plural: "p2"}: map[string]*Operator{
+				{Group: "g2", Version: "v2", Kind: "k2", Plural: "p2"}: map[string]*Entry{
 					"owner1": {Name: "op1"},
 					"owner2": {Name: "op2"},
 				},
 			},
-			want: map[string]*Operator{
+			want: map[string]*Entry{
 				"owner1": {Name: "op1"},
 				"owner2": {Name: "op2"},
 			},

--- a/pkg/controller/registry/resolver/cache/predicates_test.go
+++ b/pkg/controller/registry/resolver/cache/predicates_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type OperatorPredicateTestFunc func(*Operator) bool
+type OperatorPredicateTestFunc func(*Entry) bool
 
-func (opf OperatorPredicateTestFunc) Test(o *Operator) bool {
+func (opf OperatorPredicateTestFunc) Test(o *Entry) bool {
 	return opf(o)
 }
 
@@ -49,7 +49,7 @@ func TestCountingPredicate(t *testing.T) {
 				result bool
 			)
 
-			p := CountingPredicate(OperatorPredicateTestFunc(func(*Operator) bool {
+			p := CountingPredicate(OperatorPredicateTestFunc(func(*Entry) bool {
 				return result
 			}), &n)
 

--- a/pkg/controller/registry/resolver/installabletypes.go
+++ b/pkg/controller/registry/resolver/installabletypes.go
@@ -55,7 +55,7 @@ func bundleId(bundle, channel string, catalog cache.SourceKey) solver.Identifier
 	return solver.IdentifierFromString(fmt.Sprintf("%s/%s/%s", catalog.String(), channel, bundle))
 }
 
-func NewBundleInstallableFromOperator(o *cache.Operator) (BundleInstallable, error) {
+func NewBundleInstallableFromOperator(o *cache.Entry) (BundleInstallable, error) {
 	if o.SourceInfo == nil {
 		return BundleInstallable{}, fmt.Errorf("unable to resolve the source of bundle %s", o.Name)
 	}

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -40,7 +40,7 @@ func TestSolveOperators(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.1", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 				},
@@ -68,7 +68,7 @@ func TestDisjointChannelGraph(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.side1.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 					genOperator("packageA.side1.v2", "0.0.2", "packageA.side1.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 					genOperator("packageA.side2.v1", "1.0.0", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
@@ -101,7 +101,7 @@ func TestPropertiesAnnotationHonored(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			community: &cache.Snapshot{
-				Entries: []*cache.Operator{b},
+				Entries: []*cache.Entry{b},
 			},
 		}),
 		log: logrus.New(),
@@ -132,7 +132,7 @@ func TestSolveOperators_MultipleChannels(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "beta", "community", "olm", nil, nil, nil, "", false),
@@ -172,7 +172,7 @@ func TestSolveOperators_FindLatestVersion(t *testing.T) {
 				Namespace: "olm",
 				Name:      "community",
 			}: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -227,7 +227,7 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -292,7 +292,7 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -374,19 +374,19 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 
 	ssp := cache.StaticSourceProvider{
 		cache.SourceKey{Namespace: "olm", Name: "community"}: &cache.Snapshot{
-			Entries: []*cache.Operator{
+			Entries: []*cache.Entry{
 				genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", namespace, nil,
 					nil, opToAddVersionDeps, "", false),
 			},
 		},
 		cache.SourceKey{Namespace: "olm", Name: "community-operator"}: &cache.Snapshot{
-			Entries: []*cache.Operator{
+			Entries: []*cache.Entry{
 				genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
 					namespace, nil, nil, nil, "", false),
 			},
 		},
 		cache.SourceKey{Namespace: "olm", Name: "high-priority-operator"}: &cache.Snapshot{
-			Entries: []*cache.Operator{
+			Entries: []*cache.Entry{
 				genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "high-priority-operator",
 					namespace, nil, nil, nil, "", false),
 			},
@@ -427,7 +427,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 		Namespace: "olm",
 		Name:      "community-operator",
 	}] = &cache.Snapshot{
-		Entries: []*cache.Operator{
+		Entries: []*cache.Entry{
 			genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
 				namespace, nil, nil, nil, "", false),
 		},
@@ -476,7 +476,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 		Namespace: "olm",
 		Name:      "community",
 	}] = &cache.Snapshot{
-		Entries: []*cache.Operator{
+		Entries: []*cache.Entry{
 			genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", namespace, nil,
 				nil, opToAddVersionDeps, "", false),
 			genOperator("packageB.v1", "0.0.1", "", "packageB", "alpha", "community",
@@ -526,7 +526,7 @@ func TestSolveOperators_WithDependencies(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -576,7 +576,7 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			community: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, Provides, nil, "", false),
@@ -629,7 +629,7 @@ func TestSolveOperators_WithLabelDependencies(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, deps, "", false),
 					operatorBv1,
 				},
@@ -668,7 +668,7 @@ func TestSolveOperators_WithUnsatisfiableLabelDependencies(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, deps, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
@@ -714,7 +714,7 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 				Namespace: "olm",
 				Name:      "community",
 			}: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 					genOperator("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
@@ -727,7 +727,7 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 				Namespace: "olm",
 				Name:      "certified",
 			}: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageC.v1.0.0", "1.0.0", "", "packageC", "alpha", "certified", "olm", Provides2, Provides, deps2, "", false),
 					genOperator("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "certified", "olm", Provides2, Provides, deps2, "", false),
 					genOperator("packageD.v1.0.1", "1.0.1", "", "packageD", "alpha", "certified", "olm", nil, Provides2, nil, "", false),
@@ -787,14 +787,14 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			community: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, unsatisfiableVersionDeps, "", false),
 				},
 			},
 			{Namespace: "olm", Name: "certified"}: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", "certified", "olm", nil, nil, nil, "", false),
 					genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", "certified", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genOperator("packageC.v1", "0.1.0", "", "packageC", "alpha", "certified", "olm", nil, nil, nil, "", false),
@@ -836,12 +836,12 @@ func TestSolveOperators_PreferCatalogInSameNamespace(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
 			altnsCatalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", altnsCatalog.Name, altnsCatalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
@@ -876,7 +876,7 @@ func TestSolveOperators_ResolveOnlyInCachedNamespaces(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", otherCatalog.Name, otherCatalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
@@ -908,7 +908,7 @@ func TestSolveOperators_PreferDefaultChannelInResolution(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					// Default channel is stable in this case
 					genOperator("packageA.v0.0.2", "0.0.2", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
@@ -946,7 +946,7 @@ func TestSolveOperators_PreferDefaultChannelInResolutionForTransitiveDependencie
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, Provides, nil, apiSetToDependencies(nil, Provides), defaultChannel, false),
 					genOperator("packageB.v0.0.1", "0.0.1", "packageB.v1", "packageB", defaultChannel, catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 					genOperator("packageB.v0.0.2", "0.0.2", "packageB.v0.0.1", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
@@ -989,7 +989,7 @@ func TestSolveOperators_SubscriptionlessOperatorsSatisfyDependencies(t *testing.
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 					genOperator("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
 				},
@@ -1025,7 +1025,7 @@ func TestSolveOperators_SubscriptionlessOperatorsCanConflict(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, Provides, nil, "", false),
 					genOperator("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, Provides, nil, "", false),
 				},
@@ -1056,7 +1056,7 @@ func TestSolveOperators_PackageCannotSelfSatisfy(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, RequiresBoth, nil, nil, "", false),
 					// Despite satisfying dependencies of opA, this is not chosen because it is in the same package
 					genOperator("opABC.v1.0.0", "1.0.0", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "", false),
@@ -1066,7 +1066,7 @@ func TestSolveOperators_PackageCannotSelfSatisfy(t *testing.T) {
 				},
 			},
 			secondaryCatalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("opC.v1.0.0", "1.0.0", "", "packageB", "stable", secondaryCatalog.Name, secondaryCatalog.Namespace, nil, Provides2, nil, "stable", false),
 
 					genOperator("opE.v1.0.0", "1.0.0", "", "packageC", "stable", secondaryCatalog.Name, secondaryCatalog.Namespace, nil, Provides2, nil, "", false),
@@ -1107,7 +1107,7 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 		{
 			subs: []*v1alpha1.Subscription{newSub(namespace, "packageB", "stable", catalog)},
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
 					genOperator("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
 				},
@@ -1124,7 +1124,7 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 				existingSub(namespace, "opB.v1.0.0", "packageB", "stable", catalog),
 			},
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
 					genOperator("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
 					genOperator("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
@@ -1140,7 +1140,7 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 				existingSub(namespace, "opB.v1.0.0", "packageB", "stable", catalog),
 			},
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
 					genOperator("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
 					genOperator("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
@@ -1185,7 +1185,7 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 	}
 }
 
-func genOperator(name, version, replaces, pkg, channel, catalogName, catalogNamespace string, requiredAPIs, providedAPIs cache.APISet, dependencies []*api.Dependency, defaultChannel string, deprecated bool) *cache.Operator {
+func genOperator(name, version, replaces, pkg, channel, catalogName, catalogNamespace string, requiredAPIs, providedAPIs cache.APISet, dependencies []*api.Dependency, defaultChannel string, deprecated bool) *cache.Entry {
 	semversion, _ := semver.Make(version)
 	properties := apiSetToProperties(providedAPIs, nil, deprecated)
 	if len(dependencies) == 0 {
@@ -1201,7 +1201,7 @@ func genOperator(name, version, replaces, pkg, channel, catalogName, catalogName
 		}
 		properties = append(properties, ps...)
 	}
-	o := &cache.Operator{
+	o := &cache.Entry{
 		Name:       name,
 		Version:    &semversion,
 		Replaces:   replaces,
@@ -1232,7 +1232,7 @@ func TestSolveOperators_WithoutDeprecated(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", true),
 				},
 			},
@@ -1255,7 +1255,7 @@ func TestSolveOperatorsWithDeprecatedInnerChannelEntry(t *testing.T) {
 	resolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("a-1", "1.0.0", "", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 					genOperator("a-2", "2.0.0", "a-1", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", true),
 					genOperator("a-3", "3.0.0", "a-2", "a", "c", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
@@ -1303,7 +1303,7 @@ func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					opB, opB2, op1, op2, op3, op4, op5, op6,
 				},
 			},
@@ -1335,7 +1335,7 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					opB, opB2,
 				},
 			},
@@ -1370,7 +1370,7 @@ func TestSolveOperatorsWithSkipsPreventingSelection(t *testing.T) {
 	satResolver := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{a1, b3, b2, b1},
+				Entries: []*cache.Entry{a1, b3, b2, b1},
 			},
 		}),
 		log: logger,
@@ -1403,7 +1403,7 @@ func TestSolveOperatorsWithClusterServiceVersionHavingDependency(t *testing.T) {
 	r := SatResolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
-				Entries: []*cache.Operator{
+				Entries: []*cache.Entry{
 					genOperator("b-2", "2.0.0", "b-1", "b", "default", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 				},
 			},
@@ -1500,7 +1500,7 @@ func TestInferProperties(t *testing.T) {
 			Name: "one matching subscription infers package property",
 			Cache: cache.StaticSourceProvider{
 				catalog: &cache.Snapshot{
-					Entries: []*cache.Operator{
+					Entries: []*cache.Entry{
 						{
 							Name: "a",
 							SourceInfo: &cache.OperatorSourceInfo{
@@ -1541,7 +1541,7 @@ func TestInferProperties(t *testing.T) {
 			Name: "one matching subscription to other-namespace catalogsource infers package property",
 			Cache: cache.StaticSourceProvider{
 				{Namespace: "other-namespace", Name: "other-name"}: &cache.Snapshot{
-					Entries: []*cache.Operator{
+					Entries: []*cache.Entry{
 						{
 							Name: "a",
 							SourceInfo: &cache.OperatorSourceInfo{
@@ -1603,7 +1603,7 @@ func TestInferProperties(t *testing.T) {
 			Name: "one matching subscription infers package property without csv version",
 			Cache: cache.StaticSourceProvider{
 				catalog: &cache.Snapshot{
-					Entries: []*cache.Operator{
+					Entries: []*cache.Entry{
 						{
 							Name: "a",
 							SourceInfo: &cache.OperatorSourceInfo{
@@ -1655,13 +1655,13 @@ func TestInferProperties(t *testing.T) {
 func TestSortChannel(t *testing.T) {
 	for _, tc := range []struct {
 		Name string
-		In   []*cache.Operator
-		Out  []*cache.Operator
+		In   []*cache.Entry
+		Out  []*cache.Entry
 		Err  error
 	}{
 		{
 			Name: "wrinkle-free",
-			In: []*cache.Operator{
+			In: []*cache.Entry{
 				{
 					Name: "b",
 					SourceInfo: &cache.OperatorSourceInfo{
@@ -1678,7 +1678,7 @@ func TestSortChannel(t *testing.T) {
 					},
 				},
 			},
-			Out: []*cache.Operator{
+			Out: []*cache.Entry{
 				{
 					Name:     "a",
 					Replaces: "b",
@@ -1703,7 +1703,7 @@ func TestSortChannel(t *testing.T) {
 		},
 		{
 			Name: "replacement cycle",
-			In: []*cache.Operator{
+			In: []*cache.Entry{
 				{
 					Name:     "a",
 					Replaces: "b",
@@ -1725,7 +1725,7 @@ func TestSortChannel(t *testing.T) {
 		},
 		{
 			Name: "replacement cycle",
-			In: []*cache.Operator{
+			In: []*cache.Entry{
 				{
 					Name:     "a",
 					Replaces: "b",
@@ -1755,7 +1755,7 @@ func TestSortChannel(t *testing.T) {
 		},
 		{
 			Name: "skipped and replaced entry omitted",
-			In: []*cache.Operator{
+			In: []*cache.Entry{
 				{
 					Name:     "a",
 					Replaces: "b",
@@ -1765,7 +1765,7 @@ func TestSortChannel(t *testing.T) {
 					Name: "b",
 				},
 			},
-			Out: []*cache.Operator{
+			Out: []*cache.Entry{
 				{
 					Name:     "a",
 					Replaces: "b",
@@ -1775,7 +1775,7 @@ func TestSortChannel(t *testing.T) {
 		},
 		{
 			Name: "skipped entry omitted",
-			In: []*cache.Operator{
+			In: []*cache.Entry{
 				{
 					Name:     "a",
 					Replaces: "b",
@@ -1789,7 +1789,7 @@ func TestSortChannel(t *testing.T) {
 					Name: "c",
 				},
 			},
-			Out: []*cache.Operator{
+			Out: []*cache.Entry{
 				{
 					Name:     "a",
 					Replaces: "b",
@@ -1803,7 +1803,7 @@ func TestSortChannel(t *testing.T) {
 		},
 		{
 			Name: "two replaces chains",
-			In: []*cache.Operator{
+			In: []*cache.Entry{
 				{
 					Name: "a",
 					SourceInfo: &cache.OperatorSourceInfo{
@@ -1851,7 +1851,7 @@ func TestNewOperatorFromCSV(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *cache.Operator
+		want    *cache.Entry
 		wantErr error
 	}{
 		{
@@ -1866,7 +1866,7 @@ func TestNewOperatorFromCSV(t *testing.T) {
 					},
 				},
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name:         "operator.v1",
 				ProvidedAPIs: cache.EmptyAPISet(),
 				RequiredAPIs: cache.EmptyAPISet(),
@@ -1905,7 +1905,7 @@ func TestNewOperatorFromCSV(t *testing.T) {
 					},
 				},
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name: "operator.v1",
 				ProvidedAPIs: map[opregistry.APIKey]struct{}{
 					{Group: "g", Version: "v1", Kind: "APIKind", Plural: "apikinds"}: {},
@@ -1957,7 +1957,7 @@ func TestNewOperatorFromCSV(t *testing.T) {
 					},
 				},
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name:         "operator.v1",
 				ProvidedAPIs: cache.EmptyAPISet(),
 				RequiredAPIs: map[opregistry.APIKey]struct{}{
@@ -2024,7 +2024,7 @@ func TestNewOperatorFromCSV(t *testing.T) {
 					},
 				},
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name: "operator.v1",
 				ProvidedAPIs: map[opregistry.APIKey]struct{}{
 					{Group: "g", Version: "v1", Kind: "APIOwnedKind", Plural: "apiownedkinds"}: {},

--- a/pkg/controller/registry/resolver/source_registry.go
+++ b/pkg/controller/registry/resolver/source_registry.go
@@ -47,7 +47,7 @@ func (s *registrySource) Snapshot(ctx context.Context) (*cache.Snapshot, error) 
 		return nil, fmt.Errorf("failed to list bundles: %w", err)
 	}
 
-	var operators []*cache.Operator
+	var operators []*cache.Entry
 	for b := it.Next(); b != nil; b = it.Next() {
 		defaultChannel, ok := defaultChannels[b.PackageName]
 		if !ok {
@@ -89,7 +89,7 @@ func (a *registryClientAdapter) Sources(namespaces ...string) map[cache.SourceKe
 	return result
 }
 
-func EnsurePackageProperty(o *cache.Operator, name, version string) {
+func EnsurePackageProperty(o *cache.Entry, name, version string) {
 	for _, p := range o.Properties {
 		if p.Type == opregistry.PackageType {
 			return
@@ -109,7 +109,7 @@ func EnsurePackageProperty(o *cache.Operator, name, version string) {
 	})
 }
 
-func newOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey cache.SourceKey, defaultChannel string) (*cache.Operator, error) {
+func newOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey cache.SourceKey, defaultChannel string) (*cache.Entry, error) {
 	parsedVersion, err := semver.ParseTolerant(bundle.Version)
 	version := &parsedVersion
 	if err != nil {
@@ -153,7 +153,7 @@ func newOperatorFromBundle(bundle *api.Bundle, startingCSV string, sourceKey cac
 		properties = append(properties, ps...)
 	}
 
-	o := &cache.Operator{
+	o := &cache.Entry{
 		Name:         bundle.CsvName,
 		Replaces:     bundle.Replaces,
 		Version:      version,

--- a/pkg/controller/registry/resolver/source_registry_test.go
+++ b/pkg/controller/registry/resolver/source_registry_test.go
@@ -197,7 +197,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *cache.Operator
+		want    *cache.Entry
 		wantErr error
 	}{
 		{
@@ -206,7 +206,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				bundle:    bundleNoAPIs,
 				sourceKey: cache.SourceKey{Name: "source", Namespace: "testNamespace"},
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name:         "testBundle",
 				Version:      &version.Version,
 				ProvidedAPIs: cache.EmptyAPISet(),
@@ -225,7 +225,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				bundle:    bundleWithAPIs,
 				sourceKey: cache.SourceKey{Name: "source", Namespace: "testNamespace"},
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name:    "testBundle",
 				Version: &version.Version,
 				ProvidedAPIs: cache.APISet{
@@ -288,7 +288,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				bundle:    bundleWithAPIsUnextracted,
 				sourceKey: cache.SourceKey{Name: "source", Namespace: "testNamespace"},
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name:         "testBundle",
 				ProvidedAPIs: cache.EmptyAPISet(),
 				RequiredAPIs: cache.EmptyAPISet(),
@@ -307,7 +307,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				sourceKey:      cache.SourceKey{Name: "source", Namespace: "testNamespace"},
 				defaultChannel: "testChannel",
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name:         "testBundle",
 				Version:      &version.Version,
 				ProvidedAPIs: cache.EmptyAPISet(),
@@ -327,7 +327,7 @@ func TestNewOperatorFromBundle(t *testing.T) {
 				bundle:    bundleWithPropsAndDeps,
 				sourceKey: cache.SourceKey{Name: "source", Namespace: "testNamespace"},
 			},
-			want: &cache.Operator{
+			want: &cache.Entry{
 				Name:         "testBundle",
 				Version:      &version.Version,
 				ProvidedAPIs: cache.EmptyAPISet(),

--- a/pkg/controller/registry/resolver/util_test.go
+++ b/pkg/controller/registry/resolver/util_test.go
@@ -296,7 +296,7 @@ func bundleWithPermissions(name, pkg, channel, replaces string, providedCRDs, re
 	}
 }
 
-func withReplaces(operator *cache.Operator, replaces string) *cache.Operator {
+func withReplaces(operator *cache.Entry, replaces string) *cache.Entry {
 	operator.Replaces = replaces
 	return operator
 }


### PR DESCRIPTION
This type is a data object representing a resolver cache entry. It
doesn't have a particular connection to operators other than residing
where it resides. This name change should clarify what, exactly, the
type represents.
