### PR TITLE
Add summary and description for prometheus alerts

### DIFF
--- a/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
+++ b/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
@@ -18,6 +18,8 @@ spec:
           severity: warning
           namespace: "{{ "{{ $labels.namespace }}" }}"
         annotations:
+          summary: CSV failed for over 2 minutes
+          description: Occurs whenever a CSV has been failing for more than 2 minutes
           message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Reason-{{ printf "{{ $labels.reason }}" }}
       - alert: CsvAbnormalOver30Min
         expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)"}
@@ -26,6 +28,8 @@ spec:
           severity: warning
           namespace: "{{ "{{ $labels.namespace }}" }}"
         annotations:
+          summary: CSV abnormal for over 30 minutes
+          description: Occurs whenever a CSV is abnormal for more than 30 minutes
           message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Phase-{{ printf "{{ $labels.phase }}" }} Reason-{{ printf "{{ $labels.reason }}" }}
   - name: olm.installplan.rules
     rules:
@@ -34,5 +38,7 @@ spec:
       labels:
         severity: warning
       annotations:
+        summary: API returned a warning when modifying an operator
+        description: Occurs whenever the API server returns a warning when attempting to modify an operator.
         message: The API server returned a warning during installation or upgrade of an operator. An Event with reason "AppliedWithWarnings" has been created with complete details, including a reference to the InstallPlan step that generated the warning.
 {{ end }}

--- a/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
+++ b/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
@@ -19,7 +19,7 @@ spec:
           namespace: "{{ "{{ $labels.namespace }}" }}"
         annotations:
           summary: CSV failed for over 2 minutes
-          description: Fires whenever a CSV has been in a state other than succeeded for more than 2 minutes
+          description: Fires whenever a CSV has been in the failed phase for more than 2 minutes.
           message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Reason-{{ printf "{{ $labels.reason }}" }}
       - alert: CsvAbnormalOver30Min
         expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)"}
@@ -29,7 +29,7 @@ spec:
           namespace: "{{ "{{ $labels.namespace }}" }}"
         annotations:
           summary: CSV abnormal for over 30 minutes
-          description: Fires whenever a CSV is abnormal for more than 30 minutes
+          description: Fires whenever a CSV is in the Replacing, Pending, Deleting, or Unkown phase for more than 30 minutes.
           message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Phase-{{ printf "{{ $labels.phase }}" }} Reason-{{ printf "{{ $labels.reason }}" }}
   - name: olm.installplan.rules
     rules:

--- a/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
+++ b/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
@@ -19,7 +19,7 @@ spec:
           namespace: "{{ "{{ $labels.namespace }}" }}"
         annotations:
           summary: CSV failed for over 2 minutes
-          description: Occurs whenever a CSV has been failing for more than 2 minutes
+          description: Fires whenever a CSV has been in a state other than succeeded for more than 2 minutes
           message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Reason-{{ printf "{{ $labels.reason }}" }}
       - alert: CsvAbnormalOver30Min
         expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)"}
@@ -29,7 +29,7 @@ spec:
           namespace: "{{ "{{ $labels.namespace }}" }}"
         annotations:
           summary: CSV abnormal for over 30 minutes
-          description: Occurs whenever a CSV is abnormal for more than 30 minutes
+          description: Fires whenever a CSV is abnormal for more than 30 minutes
           message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Phase-{{ printf "{{ $labels.phase }}" }} Reason-{{ printf "{{ $labels.reason }}" }}
   - name: olm.installplan.rules
     rules:
@@ -39,6 +39,6 @@ spec:
         severity: warning
       annotations:
         summary: API returned a warning when modifying an operator
-        description: Occurs whenever the API server returns a warning when attempting to modify an operator.
+        description: Fires whenever the API server returns a warning when attempting to modify an operator.
         message: The API server returned a warning during installation or upgrade of an operator. An Event with reason "AppliedWithWarnings" has been created with complete details, including a reference to the InstallPlan step that generated the warning.
 {{ end }}

--- a/pkg/controller/operators/catalog/testdata/prometheusrule.cr.yaml
+++ b/pkg/controller/operators/catalog/testdata/prometheusrule.cr.yaml
@@ -12,7 +12,7 @@ spec:
         - alert: SeriousAlert 
           annotations:
             summary: Serious Alert!
-            description: This is a very serious alert!
+            description: This is a test alert, it is not real.
             message: A serious alert! 
           expr: alert_status{prioirity="Serious"}
           labels:

--- a/pkg/controller/operators/catalog/testdata/prometheusrule.cr.yaml
+++ b/pkg/controller/operators/catalog/testdata/prometheusrule.cr.yaml
@@ -11,6 +11,8 @@ spec:
       rules:
         - alert: SeriousAlert 
           annotations:
+            summary: Serious Alert!
+            description: This is a very serious alert!
             message: A serious alert! 
           expr: alert_status{prioirity="Serious"}
           labels:


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Adding a summary annotation and replace the message annotation with description for prometheus alerts.

**Motivation for the change:**
Fixing Bug 1992510 which references the [Open Shift alerting standards](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#documentation-required).

**Reviewer Checklist**
- [X] Implementation matches the proposed design, or proposal is updated to match implementation
- [X] Sufficient unit test coverage
- [X] Sufficient end-to-end test coverage
- [X] Docs updated or added to `/doc`
- [X] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
