### PR TITLE
pkg/controller: Remove the github.com/coreos/go-semver dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bshuster-repo/logrus-logstash-hook v1.0.0 // indirect
-	github.com/coreos/go-semver v0.3.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/distribution/distribution v2.7.1+incompatible
 	github.com/fsnotify/fsnotify v1.4.9

--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-semver/semver"
+	semver "github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +39,7 @@ func (a *Operator) minKubeVersionStatus(name string, minKubeVersion string) (met
 		return
 	}
 
-	serverVersion, err := semver.NewVersion(strings.Split(strings.TrimPrefix(serverVersionInfo.String(), "v"), "-")[0])
+	serverVersion, err := semver.Parse(strings.Split(strings.TrimPrefix(serverVersionInfo.String(), "v"), "-")[0])
 	if err != nil {
 		status.Status = v1alpha1.RequirementStatusReasonPresentNotSatisfied
 		status.Message = "Server version parsing error"
@@ -48,7 +48,7 @@ func (a *Operator) minKubeVersionStatus(name string, minKubeVersion string) (met
 		return
 	}
 
-	csvVersionInfo, err := semver.NewVersion(strings.TrimPrefix(minKubeVersion, "v"))
+	csvVersionInfo, err := semver.Parse(strings.TrimPrefix(minKubeVersion, "v"))
 	if err != nil {
 		status.Status = v1alpha1.RequirementStatusReasonPresentNotSatisfied
 		status.Message = "CSV version parsing error"
@@ -57,7 +57,7 @@ func (a *Operator) minKubeVersionStatus(name string, minKubeVersion string) (met
 		return
 	}
 
-	if csvVersionInfo.Compare(*serverVersion) > 0 {
+	if csvVersionInfo.Compare(serverVersion) > 0 {
 		status.Status = v1alpha1.RequirementStatusReasonPresentNotSatisfied
 		status.Message = fmt.Sprintf("CSV version requirement not met: minKubeVersion (%s) > server version (%s)", minKubeVersion, serverVersion.String())
 		met = false

--- a/pkg/controller/operators/olm/requirements_test.go
+++ b/pkg/controller/operators/olm/requirements_test.go
@@ -974,7 +974,7 @@ func TestMinKubeVersionStatus(t *testing.T) {
 			minKubeVersion: "0.0.0",
 			expectedMet:    true,
 			expectedRequirementStatuses: []v1alpha1.RequirementStatus{
-				v1alpha1.RequirementStatus{
+				{
 					Status:  v1alpha1.RequirementStatusReasonPresent,
 					Message: fmt.Sprintf("CSV minKubeVersion (%s) less than server version", "0.0.0"),
 					Group:   "operators.coreos.com",
@@ -990,7 +990,7 @@ func TestMinKubeVersionStatus(t *testing.T) {
 			minKubeVersion: "999.999.999",
 			expectedMet:    false,
 			expectedRequirementStatuses: []v1alpha1.RequirementStatus{
-				v1alpha1.RequirementStatus{
+				{
 					Status:  v1alpha1.RequirementStatusReasonPresentNotSatisfied,
 					Message: fmt.Sprintf("CSV version requirement not met: minKubeVersion (%s)", "999.999.999"),
 					Group:   "operators.coreos.com",
@@ -1006,7 +1006,7 @@ func TestMinKubeVersionStatus(t *testing.T) {
 			minKubeVersion: "a.b.c",
 			expectedMet:    false,
 			expectedRequirementStatuses: []v1alpha1.RequirementStatus{
-				v1alpha1.RequirementStatus{
+				{
 					Status:  v1alpha1.RequirementStatusReasonPresentNotSatisfied,
 					Message: "CSV version parsing error",
 					Group:   "operators.coreos.com",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -112,7 +112,6 @@ github.com/containerd/continuity/sysx
 # github.com/containerd/ttrpc v1.0.1
 github.com/containerd/ttrpc
 # github.com/coreos/go-semver v0.3.0
-## explicit
 github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd/v22 v22.3.2
 github.com/coreos/go-systemd/v22/daemon


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the semver library being used to compare the k8s server version with the minKubeVersion specified in an individual CSV resource.

**Motivation for the change:**
Cleanup number of direct dependencies for OLM

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
