### PR TITLE
Integrate goreleaser to produce draft releases when new tags are pushed

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         if: startsWith(github.ref, 'refs/tags')
         with:
-          version: latest
+          version: 0.177.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,73 @@
+name: release
+on:
+  pull_request:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Get the image tag
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          # Source: https://github.community/t/how-to-get-just-the-tag-name/16241/32
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            echo IMAGE_TAG="${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          fi
+
+      - name: Create a draft release
+        uses: actions/create-release@v1
+        id: release
+        if: startsWith(github.ref, 'refs/tags')
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          draft: true
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+
+      - name: Docker Login
+        uses: docker/login-action@v1
+        if: startsWith(github.ref, 'refs/tags')
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        if: startsWith(github.ref, 'refs/tags')
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          IMAGE_REPO: ${{ secrets.QUAY_USERNAME }}/olm
+          PKG: github.com/operator-framework/operator-lifecycle-manager
+
+      - name: Generate quickstart release manifests
+        if: startsWith(github.ref, 'refs/tags')
+        run: make release ver=${{ env.IMAGE_TAG }} IMAGE_REPO=quay.io/${{ secrets.QUAY_USERNAME }}/olm
+
+      - name: Update release artifacts with rendered Kubernetes manifests
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags')
+        with:
+          name: ${{ env.IMAGE_TAG }}
+          files: |
+            deploy/upstream/quickstart/crds.yaml
+            deploy/upstream/quickstart/olm.yaml
+            deploy/upstream/quickstart/install.sh
+          draft: true
+          token: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -455,3 +455,5 @@ apiserver.key
 
 !vendor/**
 test/e2e-local.image.tar
+
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,106 @@
+env:
+- GO111MODULE=on
+- CGO_ENABLED=0
+before:
+  hooks:
+    - go mod tidy
+    - go mod vendor
+builds:
+  - id: olm
+    main: ./cmd/olm
+    binary: olm
+    goos:
+    - linux
+    goarch:
+    - amd64
+    - arm64
+    tags:
+    - json1
+    flags:
+    - -mod=vendor
+    ldflags:
+    - -X {{ .Env.PKG }}/pkg/version.GitCommit={{ .FullCommit }}
+    - -X {{ .Env.PKG }}/pkg/version.OLMVersion={{ .Tag }}
+  - id: catalog
+    main: ./cmd/catalog
+    binary: catalog
+    goos:
+    - linux
+    goarch:
+    - amd64
+    - arm64
+    tags:
+    - json1
+    flags:
+    - -mod=vendor
+    ldflags:
+    - -X {{ .Env.PKG }}/pkg/version.GitCommit={{ .FullCommit }}
+    - -X {{ .Env.PKG }}/pkg/version.OLMVersion={{ .Tag }}
+  - id: cpb
+    main: ./util/cpb
+    binary: cpb
+    goos:
+    - linux
+    goarch:
+    - amd64
+    - arm64
+    tags:
+    - json1
+    flags:
+    - -mod=vendor
+    ldflags:
+    - -X {{ .Env.PKG }}/pkg/version.GitCommit={{ .FullCommit }}
+    - -X {{ .Env.PKG }}/pkg/version.OLMVersion={{ .Tag }}
+  - id: package-server
+    main: ./cmd/package-server
+    binary: package-server
+    goos:
+    - linux
+    goarch:
+    - amd64
+    - arm64
+    tags:
+    - json1
+    flags:
+    - -mod=vendor
+    ldflags:
+    - -X {{ .Env.PKG }}/pkg/version.GitCommit={{ .FullCommit }}
+    - -X {{ .Env.PKG }}/pkg/version.OLMVersion={{ .Tag }}
+dockers:
+- image_templates:
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64
+  dockerfile: Dockerfile.goreleaser
+  use: buildx
+  goos: linux
+  goarch: amd64
+  build_flag_templates:
+  - --platform=linux/amd64
+- image_templates:
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64
+  dockerfile: Dockerfile.goreleaser
+  use: buildx
+  goos: linux
+  goarch: arm64
+  build_flag_templates:
+  - --platform=linux/arm64
+docker_manifests:
+- name_template: quay.io/{{ .Env.IMAGE_REPO }}:v{{ .Major }}.{{ .Minor }}
+  image_templates:
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64
+- name_template: quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}
+  image_templates:
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^doc:'
+      - '^test:'
+release:
+  draft: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ builds:
     goarch:
     - amd64
     - arm64
+    - ppc64le
+    - s390x
     tags:
     - json1
     flags:
@@ -29,6 +31,8 @@ builds:
     goarch:
     - amd64
     - arm64
+    - ppc64le
+    - s390x
     tags:
     - json1
     flags:
@@ -44,6 +48,8 @@ builds:
     goarch:
     - amd64
     - arm64
+    - ppc64le
+    - s390x
     tags:
     - json1
     flags:
@@ -59,6 +65,8 @@ builds:
     goarch:
     - amd64
     - arm64
+    - ppc64le
+    - s390x
     tags:
     - json1
     flags:
@@ -83,15 +91,35 @@ dockers:
   goarch: arm64
   build_flag_templates:
   - --platform=linux/arm64
+- image_templates:
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le
+  dockerfile: Dockerfile.goreleaser
+  use: buildx
+  goos: linux
+  goarch: ppc64le
+  build_flag_templates:
+  - --platform=linux/ppc64le
+- image_templates:
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x
+  dockerfile: Dockerfile.goreleaser
+  use: buildx
+  goos: linux
+  goarch: s390x
+  build_flag_templates:
+  - --platform=linux/s390x
 docker_manifests:
 - name_template: quay.io/{{ .Env.IMAGE_REPO }}:v{{ .Major }}.{{ .Minor }}
   image_templates:
   - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64
   - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x
 - name_template: quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}
   image_templates:
   - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64
   - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le
+  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,13 @@
+FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:debug
+LABEL stage=olm
+WORKDIR /
+# bundle unpack Jobs require cp at /bin/cp
+RUN ["/busybox/ln", "-s", "/busybox/cp", "/bin/cp"]
+# copy goreleaser built binaries
+COPY olm /bin/olm
+COPY catalog /bin/catalog
+COPY package-server /bin/package-server
+COPY cpb /bin/cpb
+EXPOSE 8080
+EXPOSE 5443
+ENTRYPOINT ["/bin/olm"]

--- a/Makefile
+++ b/Makefile
@@ -217,15 +217,16 @@ verify: verify-codegen verify-mockgen verify-manifests
 
 # before running release, bump the version in OLM_VERSION and push to master,
 # then tag those builds in quay with the version in OLM_VERSION
-release: ver=$(shell cat OLM_VERSION)
+release: ver=v$(shell cat OLM_VERSION)
 release: manifests
-	docker pull quay.io/operator-framework/olm:v$(ver)
+	@echo "Generating the $(ver) release"
+	docker pull $(IMAGE_REPO):$(ver)
 	$(MAKE) target=upstream ver=$(ver) quickstart=true package
 
 verify-release: release
 	$(MAKE) diff
 
-package: olmref=$(shell docker inspect --format='{{index .RepoDigests 0}}' quay.io/operator-framework/olm:v$(ver))
+package: olmref=$(shell docker inspect --format='{{index .RepoDigests 0}}' $(IMAGE_REPO):$(ver))
 package:
 ifndef target
 	$(error target is undefined)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Integrate goreleaser to the OLM repository for building multi-arch
binaries and manifestlist container images, and help automate the
release process for OLM.

Add a GHA release workflow that's triggered on tags that's responsible
for building and pushing multi-arch (i.e. manifestlist) OLM container
images using goreleaser.

Goreleaser will also create a draft release, and generate a changelog
since the previous tag.

Rendering the release quickstart manifests is done after goreleaser has
created this draft release as there's no easy way to hook this
functionality into goreleaser after the docker images/manifestlists have
been pushed but before release artifacts are generated.

Use the 'softprops/action-gh-release' to update the newly created draft
release with these quickstart manifests as assets.

Update the release target and avoid hardcoding the
quay.io/operator-framework/olm quay repository and instead use the
existing IMAGE_REPO variable defined further up in the Makefile.

Update how the $(ver) variable is handled and avoid hardcoding the 'v'
prefix when overriding that 'ver' variable in the environment.

**Motivation for the change:**
Alleviate the need for a multi-stage release process.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

Partially fixed #2118 

-->
