### PR TITLE
Makefile: Update the e2e target to use ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,18 @@ setup-bare: clean e2e.namespace
 	. ./scripts/package_release.sh 1.0.0 test/e2e/resources test/e2e/e2e-bare-values.yaml
 	. ./scripts/install_bare.sh $(shell cat ./e2e.namespace) test/e2e/resources
 
-# e2e test exculding the rh-operators directory which tests rh-operators and their metric cardinality.
+GINKGO_OPTS := -flakeAttempts 3 -randomizeAllSpecs -v --timeout 120m
+
+# TODO(tflannag): Remove this target entirely and move downstream
 e2e:
-	go test -v $(MOD_FLAGS)  -failfast -timeout 150m ./test/e2e/... -namespace=openshift-operators -kubeconfig=${KUBECONFIG} -olmNamespace=openshift-operator-lifecycle-manager -dummyImage=bitnami/nginx:latest -ginkgo.flakeAttempts=3
+	$(GINKGO) \
+        ./test/e2e \
+        $(GINKGO_OPTS) \
+        $< -- \
+        -namespace=openshift-operators \
+        -kubeconfig=${KUBECONFIG} \
+        -olmNamespace=openshift-operator-lifecycle-manager \
+        -dummyImage=bitnami/nginx:latest
 
 ### Start: End To End Tests ###
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the root Makefile and update the `e2e` target to use the ginkgo
executable instead of `go test ...` as logs produce when running the e2e
suite aren't captured until after the process has completed. This leads
to situations where failing tests aren't immediately communicated back
and loss of logs entirely in the case where the process was manually
teminated.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
