### PR TITLE
test/e2e: Avoid cleaning up kubeconfig tempdir until deprovision

### DIFF
--- a/test/e2e/ctx/provisioner_kind.go
+++ b/test/e2e/ctx/provisioner_kind.go
@@ -80,7 +80,6 @@ func Provision(ctx *TestContext) (func(), error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %s", err.Error())
 	}
-	defer os.RemoveAll(dir)
 	kubeconfigPath := filepath.Join(dir, "kubeconfig")
 
 	provider := cluster.NewProvider(
@@ -140,6 +139,7 @@ func Provision(ctx *TestContext) (func(), error) {
 	deprovision := func() {
 		once.Do(func() {
 			provider.Delete(name, kubeconfigPath)
+			os.RemoveAll(dir)
 		})
 	}
 


### PR DESCRIPTION
Update the kind provisioner and avoid cleaning up the tempdir containing
the generated kubeconfig until the process of deprovisioning the cluster
is encountered. This is largely to help increase the quality of life
trying to debug local installations while e2e is still running. Before,
the kubeconfig would be deleted before e2e tests were running.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
