### PR TITLE
Stop processing non-index catalogsource in operator template controller

### DIFF
--- a/pkg/controller/operators/catalogtemplate/operator.go
+++ b/pkg/controller/operators/catalogtemplate/operator.go
@@ -130,6 +130,13 @@ func (o *Operator) syncCatalogSources(obj interface{}) error {
 		return nil
 	}
 
+	// This catalog template feature is not usable in configmap/internal catalogsource
+	// TODO: Filter the cache on catalogsource type (perhaps via labels)
+	if inputCatalogSource.Spec.SourceType == v1alpha1.SourceTypeInternal || inputCatalogSource.Spec.SourceType == v1alpha1.SourceTypeConfigmap {
+		o.logger.Debugf("skipping unsupported catalogsource type (%s): %s", inputCatalogSource.Spec.SourceType, inputCatalogSource.GetName())
+		return nil
+	}
+
 	outputCatalogSource := inputCatalogSource.DeepCopy()
 
 	logger := o.logger.WithFields(logrus.Fields{


### PR DESCRIPTION
The operator controller feature is not usable for internal/configmap-based
catalogsources. The controller should stop reconciling for those types.

Fix a bug in catalogsource library on status update.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
