### PR TITLE
pkg/controller: Migrate to using a read lock instead of a readwrite lock when checking for any namespace caching errors

### DIFF
--- a/pkg/controller/registry/resolver/cache/cache.go
+++ b/pkg/controller/registry/resolver/cache/cache.go
@@ -136,9 +136,9 @@ type NamespacedOperatorCache struct {
 func (c *NamespacedOperatorCache) Error() error {
 	var errs []error
 	for key, snapshot := range c.snapshots {
-		snapshot.m.Lock()
+		snapshot.m.RLock()
 		err := snapshot.err
-		snapshot.m.Unlock()
+		snapshot.m.RUnlock()
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error using catalog %s (in namespace %s): %w", key.Name, key.Namespace, err))
 		}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
