### PR TITLE
test/e2e: use v1 PDB in e2e bundle test

### DIFF
--- a/test/e2e/bundle_e2e_test.go
+++ b/test/e2e/bundle_e2e_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Installing bundles with new object types", func() {
 			By("first installing the VPA CRD on cluster")
 			const (
 				sourceName = "test-catalog"
-				imageName  = "quay.io/olmtest/single-bundle-index:pdb"
+				imageName  = "quay.io/olmtest/single-bundle-index:pdb-v1"
 			)
 
 			// create VPA CRD on cluster
@@ -140,11 +140,6 @@ var _ = Describe("Installing bundles with new object types", func() {
 
 			// confirm extra bundle objects are installed
 			Eventually(func() error {
-				_, err := kubeClient.KubernetesInterface().PolicyV1beta1().PodDisruptionBudgets(testNamespace).Get(context.TODO(), pdbName, metav1.GetOptions{})
-				return err
-			}).Should(Succeed(), "expected no error getting pdb object associated with CSV")
-
-			Eventually(func() error {
 				_, err := kubeClient.KubernetesInterface().SchedulingV1().PriorityClasses().Get(context.TODO(), priorityClassName, metav1.GetOptions{})
 				return err
 			}).Should(Succeed(), "expected no error getting priorityclass object associated with CSV")
@@ -153,6 +148,11 @@ var _ = Describe("Installing bundles with new object types", func() {
 				_, err := dynamicClient.Resource(resource).Namespace(testNamespace).Get(context.TODO(), vpaName, metav1.GetOptions{})
 				return err
 			}).Should(Succeed(), "expected no error finding vpa object associated with csv")
+
+			Eventually(func() error {
+				_, err := kubeClient.KubernetesInterface().PolicyV1().PodDisruptionBudgets(testNamespace).Get(context.TODO(), pdbName, metav1.GetOptions{})
+				return err
+			}).Should(Succeed(), "expected no error getting pdb object associated with CSV")
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
Signed-off-by: Daniel Sover <dsover@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Changes the version of the PDB object in the bundle to v1 since v1beta1 PDBs were deprecated in 1.21.

**Motivation for the change:**
Flaky test

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
