### PR TITLE
fix(sub): Only update subscriptions that have changes in status

### DIFF
--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -155,14 +155,6 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
-						Conditions: []v1alpha1.SubscriptionCondition{
-							{
-								Type:    "ResolutionFailed",
-								Status:  corev1.ConditionFalse,
-								Reason:  "",
-								Message: "",
-							},
-						},
 					},
 				},
 			},
@@ -306,14 +298,6 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
-						Conditions: []v1alpha1.SubscriptionCondition{
-							{
-								Type:    "ResolutionFailed",
-								Status:  corev1.ConditionFalse,
-								Reason:  "",
-								Message: "",
-							},
-						},
 					},
 				},
 			},
@@ -462,14 +446,6 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						InstallPlanGeneration: 1,
 						LastUpdated:           now,
-						Conditions: []v1alpha1.SubscriptionCondition{
-							{
-								Type:    "ResolutionFailed",
-								Status:  corev1.ConditionFalse,
-								Reason:  "",
-								Message: "",
-							},
-						},
 					},
 				},
 			},
@@ -623,14 +599,6 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
-						Conditions: []v1alpha1.SubscriptionCondition{
-							{
-								Type:    "ResolutionFailed",
-								Status:  corev1.ConditionFalse,
-								Reason:  "",
-								Message: "",
-							},
-						},
 					},
 				},
 			},
@@ -807,14 +775,6 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
-						Conditions: []v1alpha1.SubscriptionCondition{
-							{
-								Type:    "ResolutionFailed",
-								Status:  corev1.ConditionFalse,
-								Reason:  "",
-								Message: "",
-							},
-						},
 					},
 				},
 			},
@@ -998,14 +958,6 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 2,
-						Conditions: []v1alpha1.SubscriptionCondition{
-							{
-								Type:    "ResolutionFailed",
-								Status:  corev1.ConditionFalse,
-								Reason:  "",
-								Message: "",
-							},
-						},
 					},
 				},
 			},

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2169,14 +2169,14 @@ var _ = Describe("Subscription", func() {
 
 				updateInternalCatalog(GinkgoT(), c, crc, catSrcName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB}, packages)
 			})
-			It("the ResolutionFailed condition previously set in it's status that indicated the resolution error is cleared off", func() {
+			It("the ResolutionFailed condition previously set in its status that indicated the resolution error is cleared off", func() {
 				Eventually(func() (corev1.ConditionStatus, error) {
 					sub, err := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
 					if err != nil {
-						return corev1.ConditionUnknown, err
+						return corev1.ConditionFalse, err
 					}
 					return sub.Status.GetCondition(operatorsv1alpha1.SubscriptionResolutionFailed).Status, nil
-				}).Should(Equal(corev1.ConditionFalse))
+				}).Should(Equal(corev1.ConditionUnknown))
 			})
 		})
 	})


### PR DESCRIPTION
Currently, when resolution happens, every subscription will get
updated regardless if there are any changes applied or not. This
resolves into unnecessary API update calls.

This commit will filter out subscriptions that don't get changed
and only changed ones get updated.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
