### PR TITLE
Expose pprof endpoint if tls is not configured

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -109,7 +109,7 @@ func main() {
 		*catalogNamespace = catalogNamespaceEnvVarValue
 	}
 
-	listenAndServe, err := server.GetListenAndServeFunc(logger, tlsCertPath, tlsKeyPath, clientCAPath, *debug)
+	listenAndServe, err := server.GetListenAndServeFunc(server.WithLogger(logger), server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath), server.WithDebug(*debug))
 	if err != nil {
 		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
 	}

--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -118,7 +118,7 @@ func main() {
 	}
 	logger.Infof("log level %s", logger.Level)
 
-	listenAndServe, err := server.GetListenAndServeFunc(logger, tlsCertPath, tlsKeyPath, clientCAPath, *debug)
+	listenAndServe, err := server.GetListenAndServeFunc(server.WithLogger(logger), server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath), server.WithDebug(*debug))
 	if err != nil {
 		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
 	}

--- a/pkg/lib/profile/profile.go
+++ b/pkg/lib/profile/profile.go
@@ -23,8 +23,10 @@ func (p *profileConfig) apply(options []Option) {
 	}
 }
 
-func DisableTLS(p *profileConfig) {
-	p.enableTLS = false
+func WithTLS(enabled bool) Option {
+	return func(p *profileConfig) {
+		p.enableTLS = enabled
+	}
 }
 
 func defaultProfileConfig() *profileConfig {

--- a/pkg/lib/server/server.go
+++ b/pkg/lib/server/server.go
@@ -13,80 +13,136 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func GetListenAndServeFunc(logger *logrus.Logger, tlsCertPath, tlsKeyPath, clientCAPath *string, debug bool) (func() error, error) {
+// Option applies a configuration option to the given config.
+type Option func(s *serverConfig)
+
+func GetListenAndServeFunc(options ...Option) (func() error, error) {
+	sc := defaultServerConfig()
+	sc.apply(options)
+
+	return sc.getListenAndServeFunc()
+}
+
+func WithTLS(tlsCertPath, tlsKeyPath, clientCAPath *string) Option {
+	return func(sc *serverConfig) {
+		sc.tlsCertPath = tlsCertPath
+		sc.tlsKeyPath = tlsKeyPath
+		sc.clientCAPath = clientCAPath
+	}
+}
+
+func WithLogger(logger *logrus.Logger) Option {
+	return func(sc *serverConfig) {
+		sc.logger = logger
+	}
+}
+
+func WithDebug(debug bool) Option {
+	return func(sc *serverConfig) {
+		sc.debug = debug
+	}
+}
+
+type serverConfig struct {
+	logger       *logrus.Logger
+	tlsCertPath  *string
+	tlsKeyPath   *string
+	clientCAPath *string
+	debug        bool
+}
+
+func (sc *serverConfig) apply(options []Option) {
+	for _, o := range options {
+		o(sc)
+	}
+}
+
+func defaultServerConfig() serverConfig {
+	return serverConfig{
+		tlsCertPath:  nil,
+		tlsKeyPath:   nil,
+		clientCAPath: nil,
+		logger:       nil,
+		debug:        false,
+	}
+}
+func (sc *serverConfig) tlsEnabled() (bool, error) {
+	if *sc.tlsCertPath != "" && *sc.tlsKeyPath != "" {
+		return true, nil
+	}
+	if *sc.tlsCertPath != "" || *sc.tlsKeyPath != "" {
+		return false, fmt.Errorf("both --tls-key and --tls-crt must be provided for TLS to be enabled")
+	}
+	return false, nil
+}
+
+func (sc *serverConfig) getAddress(tlsEnabled bool) string {
+	if tlsEnabled {
+		return ":8443"
+	}
+	return ":8080"
+}
+
+func (sc serverConfig) getListenAndServeFunc() (func() error, error) {
+	tlsEnabled, err := sc.tlsEnabled()
+	if err != nil {
+		return nil, fmt.Errorf("both --tls-key and --tls-crt must be provided for TLS to be enabled")
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	profile.RegisterHandlers(mux, profile.WithTLS(tlsEnabled || !sc.debug))
 
 	s := http.Server{
 		Handler: mux,
-		Addr:    ":8080",
-	}
-	var listenAndServe func() error
-
-	if !debug && *tlsCertPath != "" && *tlsKeyPath != "" {
-		logger.Info("TLS keys set, using https for metrics")
-		profile.RegisterHandlers(mux)
-
-		certStore, err := filemonitor.NewCertStore(*tlsCertPath, *tlsKeyPath)
-		if err != nil {
-			return nil, fmt.Errorf("certificate monitoring for metrics (https) failed: %v", err)
-		}
-
-		csw, err := filemonitor.NewWatch(logger, []string{filepath.Dir(*tlsCertPath), filepath.Dir(*tlsKeyPath)}, certStore.HandleFilesystemUpdate)
-		if err != nil {
-			return nil, fmt.Errorf("error creating cert file watcher: %v", err)
-		}
-		csw.Run(context.Background())
-		certPoolStore, err := filemonitor.NewCertPoolStore(*clientCAPath)
-		if err != nil {
-			return nil, fmt.Errorf("certificate monitoring for client-ca failed: %v", err)
-		}
-		cpsw, err := filemonitor.NewWatch(logger, []string{filepath.Dir(*clientCAPath)}, certPoolStore.HandleCABundleUpdate)
-		if err != nil {
-			return nil, fmt.Errorf("error creating cert file watcher: %v", err)
-		}
-		cpsw.Run(context.Background())
-
-		s.Addr = ":8443"
-		s.TLSConfig = &tls.Config{
-			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-				return certStore.GetCertificate(), nil
-			},
-			GetConfigForClient: func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
-				var certs []tls.Certificate
-				if cert := certStore.GetCertificate(); cert != nil {
-					certs = append(certs, *cert)
-				}
-				return &tls.Config{
-					Certificates: certs,
-					ClientCAs:    certPoolStore.GetCertPool(),
-					ClientAuth:   tls.VerifyClientCertIfGiven,
-				}, nil
-			},
-		}
-
-		listenAndServe = func() error {
-			return s.ListenAndServeTLS("", "")
-		}
-	} else if *tlsCertPath != "" || *tlsKeyPath != "" {
-		return nil, fmt.Errorf("both --tls-key and --tls-crt must be provided for TLS to be enabled")
-	} else {
-		options := []profile.Option{}
-		if debug {
-			logger.Info("TLS keys not set and debug mode enabled, requests to pprof endpoint no longer require certificates")
-			options = append(options, profile.DisableTLS)
-		}
-
-		profile.RegisterHandlers(mux, options...)
-		logger.Info("TLS keys not set, using non-https for metrics and healthz endpoints")
-		listenAndServe = s.ListenAndServe
+		Addr:    sc.getAddress(tlsEnabled),
 	}
 
-	if listenAndServe == nil {
-		return nil, fmt.Errorf("unable to configure healthz/metrics/pprof server")
+	if !tlsEnabled {
+		return s.ListenAndServe, nil
 	}
-	return listenAndServe, nil
+
+	sc.logger.Info("TLS keys set, using https for metrics")
+	certStore, err := filemonitor.NewCertStore(*sc.tlsCertPath, *sc.tlsKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("certificate monitoring for metrics (https) failed: %v", err)
+	}
+
+	csw, err := filemonitor.NewWatch(sc.logger, []string{filepath.Dir(*sc.tlsCertPath), filepath.Dir(*sc.tlsKeyPath)}, certStore.HandleFilesystemUpdate)
+	if err != nil {
+		return nil, fmt.Errorf("error creating cert file watcher: %v", err)
+	}
+	csw.Run(context.Background())
+	certPoolStore, err := filemonitor.NewCertPoolStore(*sc.clientCAPath)
+	if err != nil {
+		return nil, fmt.Errorf("certificate monitoring for client-ca failed: %v", err)
+	}
+	cpsw, err := filemonitor.NewWatch(sc.logger, []string{filepath.Dir(*sc.clientCAPath)}, certPoolStore.HandleCABundleUpdate)
+	if err != nil {
+		return nil, fmt.Errorf("error creating cert file watcher: %v", err)
+	}
+	cpsw.Run(context.Background())
+
+	s.TLSConfig = &tls.Config{
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return certStore.GetCertificate(), nil
+		},
+		GetConfigForClient: func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+			var certs []tls.Certificate
+			if cert := certStore.GetCertificate(); cert != nil {
+				certs = append(certs, *cert)
+			}
+			return &tls.Config{
+				Certificates: certs,
+				ClientCAs:    certPoolStore.GetCertPool(),
+				ClientAuth:   tls.VerifyClientCertIfGiven,
+			}, nil
+		},
+	}
+	return func() error {
+		return s.ListenAndServeTLS("", "")
+	}, nil
 }


### PR DESCRIPTION
Problem: Currently, if OLM is not configured to use TLS it is not
possible to reach the pprof endpoint. This limitation makes it
difficult to debug complex performance problems on clusters where
OLM is not configured to use tls.

Solution: If OLM is not configured to use tls, do not require a
tls certificate to access the pprof endpoint.