### PR TITLE
test: skip image polling test if running in a kind cluster

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -55,3 +55,13 @@ make file and use `-dryRun` with `-focus` and see if the regex would trigger you
 ## Build infrastructure
 
 Note that the make file target `e2e-local` is executed by the github workflow `.github/workflows/e2e-tests.yml` and uses two parallel `go test` processes.
+
+## Running on minikube
+
+The e2e suite is also runnable on a minikube cluster. First spin up the minikube cluster manually with the desired provisioner, 
+then run `make run-local` to deploy OLM onto the cluster. Tests can be run by invoking ginkgo and passing the required command line
+arguments to the test suite. For example to run a specific test:
+
+```bash
+GO111MODULE=on GOFLAGS="-mod=vendor" go run github.com/onsi/ginkgo/ginkgo -focus "static provider" -v --progress ./test/e2e -- -namespace=operators -olmNamespace=olm -dummyImage=bitnami/nginx:latest
+```

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -641,8 +640,10 @@ var _ = Describe("Catalog represents a store of bundles which OLM can use to ins
 	})
 
 	It("image update", func() {
-		if os.Getenv("GITHUB_ACTIONS") == "true" {
-			Skip("This spec fails when run using KIND cluster. See https://github.com/operator-framework/operator-lifecycle-manager/issues/1380 for more details")
+		if ok, err := inKind(c); ok && err == nil {
+			Skip("This spec fails when run using KIND cluster. See https://github.com/operator-framework/operator-lifecycle-manager/issues/2420 for more details")
+		} else if err != nil {
+			Skip("Could not determine whether running in a kind cluster. Skipping.")
 		}
 		// Create an image based catalog source from public Quay image
 		// Use a unique tag as identifier

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -918,3 +918,21 @@ func HaveMessage(goal string) gtypes.GomegaMatcher {
 		return plan.Status.Message
 	}, ContainSubstring(goal))
 }
+
+func inKind(client operatorclient.ClientInterface) (bool, error) {
+	nodes, err := client.KubernetesInterface().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		// error finding nodes
+		return false, err
+	}
+	for _, node := range nodes.Items {
+		if !strings.HasPrefix(node.GetName(), "kind-") {
+			continue
+		}
+		if !strings.HasSuffix(node.GetName(), "-control-plane") {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
Signed-off-by: Daniel Sover <dsover@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change skips the image polling test when running with a kind cluster. Previously this test was skipped on upstream CI only (which is also kind), but not locally, which caused the test to fail when running locally on a kind cluster. 

The reason for the failure seems to be the context for the `kubectl port-forward` command to work is not properly configured in the test. It's worth exploring potentially trying to getting the right context at test execution time and seeing if the test works correctly, as it does on minikube and openshift. 

**Motivation for the change:**
Closes #2420 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
