### PR TITLE
Introduce GRPC Proxy unit tests

### DIFF
--- a/pkg/controller/registry/grpc/source_test.go
+++ b/pkg/controller/registry/grpc/source_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -142,6 +144,247 @@ func TestConnectionEvents(t *testing.T) {
 					connectivity.Ready,
 				},
 			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, test(tt))
+	}
+}
+
+func TestGetEnvAny(t *testing.T) {
+	type envVar struct {
+		key   string
+		value string
+	}
+
+	type testcase struct {
+		name          string
+		envVars       []envVar
+		expectedValue string
+	}
+
+	test := func(tt testcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, envVar := range tt.envVars {
+				os.Setenv(envVar.key, envVar.value)
+			}
+
+			defer func() {
+				for _, envVar := range tt.envVars {
+					os.Setenv(envVar.key, "")
+				}
+			}()
+
+			require.Equal(t, getEnvAny("NO_PROXY", "no_proxy"), tt.expectedValue)
+		}
+	}
+
+	cases := []testcase{
+		{
+			name:          "NotFound",
+			expectedValue: "",
+		},
+		{
+			name: "LowerCaseFound",
+			envVars: []envVar{
+				{
+					key:   "no_proxy",
+					value: "foo",
+				},
+			},
+			expectedValue: "foo",
+		},
+		{
+			name: "UpperCaseFound",
+			envVars: []envVar{
+				{
+					key:   "NO_PROXY",
+					value: "bar",
+				},
+			},
+			expectedValue: "bar",
+		},
+		{
+			name: "OrderPreference",
+			envVars: []envVar{
+				{
+					key:   "no_proxy",
+					value: "foo",
+				},
+				{
+					key:   "NO_PROXY",
+					value: "bar",
+				},
+			},
+			expectedValue: "bar",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, test(tt))
+	}
+}
+
+func TestGetGRPCProxyEnv(t *testing.T) {
+	type envVar struct {
+		key   string
+		value string
+	}
+
+	type testcase struct {
+		name          string
+		envVars       []envVar
+		expectedValue string
+	}
+
+	test := func(tt testcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, envVar := range tt.envVars {
+				os.Setenv(envVar.key, envVar.value)
+			}
+
+			defer func() {
+				for _, envVar := range tt.envVars {
+					os.Setenv(envVar.key, "")
+				}
+			}()
+
+			require.Equal(t, getGRPCProxyEnv(), tt.expectedValue)
+		}
+	}
+
+	cases := []testcase{
+		{
+			name:          "NotFound",
+			expectedValue: "",
+		},
+		{
+			name: "LowerCaseFound",
+			envVars: []envVar{
+				{
+					key:   "grpc_proxy",
+					value: "foo",
+				},
+			},
+			expectedValue: "foo",
+		},
+		{
+			name: "UpperCaseFound",
+			envVars: []envVar{
+				{
+					key:   "GRPC_PROXY",
+					value: "bar",
+				},
+			},
+			expectedValue: "bar",
+		},
+		{
+			name: "UpperCasePreference",
+			envVars: []envVar{
+				{
+					key:   "grpc_proxy",
+					value: "foo",
+				},
+				{
+					key:   "GRPC_PROXY",
+					value: "bar",
+				},
+			},
+			expectedValue: "bar",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, test(tt))
+	}
+}
+
+func TestGRPCProxyURL(t *testing.T) {
+	type envVar struct {
+		key   string
+		value string
+	}
+
+	type testcase struct {
+		name          string
+		address       string
+		envVars       []envVar
+		expectedProxy string
+		expectedError error
+	}
+
+	test := func(tt testcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, envVar := range tt.envVars {
+				os.Setenv(envVar.key, envVar.value)
+			}
+
+			defer func() {
+				for _, envVar := range tt.envVars {
+					os.Setenv(envVar.key, "")
+				}
+			}()
+
+			var expectedProxyURL *url.URL
+			var err error
+			if tt.expectedProxy != "" {
+				expectedProxyURL, err = url.Parse(tt.expectedProxy)
+				require.NoError(t, err)
+			}
+
+			proxyUrl, err := grpcProxyURL(tt.address)
+			require.Equal(t, expectedProxyURL, proxyUrl)
+			require.Equal(t, tt.expectedError, err)
+		}
+	}
+
+	cases := []testcase{
+		{
+			name:          "NoGRPCProxySet",
+			address:       "foo.com:8080",
+			expectedProxy: "",
+			expectedError: nil,
+		},
+		{
+			name:    "GRPCProxyFoundForAddress",
+			address: "foo.com:8080",
+			envVars: []envVar{
+				{
+					key:   "GRPC_PROXY",
+					value: "http://my-proxy:8080",
+				},
+			},
+			expectedProxy: "http://my-proxy:8080",
+			expectedError: nil,
+		},
+		{
+			name:    "GRPCNoProxyIncludesAddress",
+			address: "foo.com:8080",
+			envVars: []envVar{
+				{
+					key:   "GRPC_PROXY",
+					value: "http://my-proxy:8080",
+				},
+				{
+					key:   "NO_PROXY",
+					value: "foo.com:8080",
+				},
+			},
+			expectedProxy: "",
+			expectedError: nil,
+		},
+		{
+			name:          "MissingPort",
+			address:       "foo.com",
+			expectedProxy: "",
+			expectedError: error(&net.AddrError{Err: "missing port in address", Addr: "foo.com"}),
+		},
+		{
+			name:          "TooManyColons",
+			address:       "http://bar.com:8080",
+			expectedProxy: "",
+			expectedError: error(&net.AddrError{Err: "too many colons in address", Addr: "http://bar.com:8080"}),
 		},
 	}
 


### PR DESCRIPTION
This commit introduces a series of unit tests
that ensure that GRPC connections are configurable
through the use of the GRPC_PROXY environment
variable.
