### PR TITLE
Fix the subscription annotation

### DIFF
--- a/pkg/controller/operators/decorators/operator.go
+++ b/pkg/controller/operators/decorators/operator.go
@@ -128,14 +128,25 @@ func (o *Operator) ComponentLabelKey() (string, error) {
 		return o.componentLabelKey, nil
 	}
 
-	if o.GetName() == "" {
+	name := o.GetName()
+	if name == "" {
 		return "", fmt.Errorf(componentLabelKeyError, "empty name field")
 	}
 
-	name := o.GetName()
 	if len(name) > 63 {
 		// Truncate
 		name = name[0:63]
+		for true {
+			lastChar := name[len(name)-1:]
+			if lastChar != "." && lastChar != "_" && lastChar != "-" {
+				break
+			}
+			if len(name)-1 == 0 {
+				return "", fmt.Errorf(componentLabelKeyError, "unsupported name field")
+			}
+
+			name = name[0 : len(name)-1]
+		}
 	}
 	o.componentLabelKey = ComponentLabelKeyPrefix + name
 


### PR DESCRIPTION
generating invalid metadata.Labels for an already adopted Subscription resource

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
