### PR TITLE
.github,test: Upload container logs during e2e runs as artifacts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.16'
-      - run: make e2e-local E2E_NODES=2 JUNIT_DIRECTORY=./artifacts/
+      - run: make e2e-local E2E_NODES=2 ARTIFACTS_DIR=./artifacts/
       - name: Archive Test Artifacts # test results, failed or not, are always uploaded.
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/test/e2e/ctx/provisioner_kind.go
+++ b/test/e2e/ctx/provisioner_kind.go
@@ -22,6 +22,7 @@ import (
 
 var (
 	images = flag.String("kind.images", "", "comma-separated list of image archives to load on cluster nodes, relative to the test binary or test package path")
+	logDir = "logs"
 
 	verbosity int
 )
@@ -139,6 +140,12 @@ func Provision(ctx *TestContext) (func(), error) {
 	var once sync.Once
 	deprovision := func() {
 		once.Do(func() {
+			if artifactsDir := os.Getenv("ARTIFACTS_DIR"); artifactsDir != "" {
+				ctx.Logf("collecting container logs for the %s cluster", name)
+				if err := provider.CollectLogs(name, filepath.Join(artifactsDir, logDir)); err != nil {
+					ctx.Logf("failed to collect logs: %v", err)
+				}
+			}
 			provider.Delete(name, kubeconfigPath)
 		})
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -43,6 +43,7 @@ var (
 	testNamespace           = ""
 	operatorNamespace       = ""
 	communityOperatorsImage = ""
+	junitDir                = "junit"
 )
 
 func TestEndToEnd(t *testing.T) {
@@ -52,8 +53,9 @@ func TestEndToEnd(t *testing.T) {
 	SetDefaultConsistentlyDuration(30 * time.Second)
 	SetDefaultConsistentlyPollingInterval(1 * time.Second)
 
-	if junitDir := os.Getenv("JUNIT_DIRECTORY"); junitDir != "" {
-		junitReporter := reporters.NewJUnitReporter(path.Join(junitDir, fmt.Sprintf("junit_e2e_%02d.xml", config.GinkgoConfig.ParallelNode)))
+	// always configure a junit report when ARTIFACTS_DIR has been set
+	if artifactsDir := os.Getenv("ARTIFACTS_DIR"); artifactsDir != "" {
+		junitReporter := reporters.NewJUnitReporter(path.Join(artifactsDir, junitDir, fmt.Sprintf("junit_e2e_%02d.xml", config.GinkgoConfig.ParallelNode)))
 		RunSpecsWithDefaultAndCustomReporters(t, "End-to-end", []Reporter{junitReporter})
 	} else {
 		RunSpecs(t, "End-to-end")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
@@ -75,10 +75,10 @@ var _ = BeforeSuite(func() {
 	deprovision = ctx.MustProvision(ctx.Ctx())
 	ctx.MustInstall(ctx.Ctx())
 
-	var groups v1.OperatorGroupList
+	var groups operatorsv1.OperatorGroupList
 	Expect(ctx.Ctx().Client().List(context.Background(), &groups, client.InNamespace(testNamespace))).To(Succeed())
 	if len(groups.Items) == 0 {
-		og := v1.OperatorGroup{
+		og := operatorsv1.OperatorGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "opgroup",
 				Namespace: testNamespace,
@@ -88,12 +88,12 @@ var _ = BeforeSuite(func() {
 	}
 
 	// Tests can assume the group in the test namespace has been reconciled at least once.
-	Eventually(func() ([]v1.OperatorGroupStatus, error) {
-		var groups v1.OperatorGroupList
+	Eventually(func() ([]operatorsv1.OperatorGroupStatus, error) {
+		var groups operatorsv1.OperatorGroupList
 		if err := ctx.Ctx().Client().List(context.Background(), &groups, client.InNamespace(testNamespace)); err != nil {
 			return nil, err
 		}
-		var statuses []v1.OperatorGroupStatus
+		var statuses []operatorsv1.OperatorGroupStatus
 		for _, group := range groups.Items {
 			statuses = append(statuses, group.Status)
 		}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Upload the container logs from the various kind clusters that were provisioned during individual e2e runs as artifacts using the upload-artifact action.

**Motivation for the change:**
Currently, there's little visibility into why individual e2e runs failed. A quick, short-term win is to collect the individual container logs that were running on the provisioned kind cluster to the configured artifacts directory for GHA.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
