### PR TITLE
test/e2e: Reduce subscription e2e test pollution

### DIFF
--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Subscription", func() {
 		It("should create a Subscription for the latest entry providing the required GVK", func() {
 			Eventually(func() ([]operatorsv1alpha1.Subscription, error) {
 				var list operatorsv1alpha1.SubscriptionList
-				if err := ctx.Ctx().Client().List(context.TODO(), &list); err != nil {
+				if err := ctx.Ctx().Client().List(context.Background(), &list); err != nil {
 					return nil, err
 				}
 				return list.Items, nil
@@ -149,7 +149,7 @@ var _ = Describe("Subscription", func() {
 
 		var currentCSV string
 		Eventually(func() bool {
-			fetched, err := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.TODO(), testSubscriptionName, metav1.GetOptions{})
+			fetched, err := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), testSubscriptionName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -323,7 +323,7 @@ var _ = Describe("Subscription", func() {
 
 		var ipName string
 		Eventually(func() bool {
-			fetched, err := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.TODO(), "manual-subscription", metav1.GetOptions{})
+			fetched, err := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), "manual-subscription", metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -1556,7 +1556,7 @@ var _ = Describe("Subscription", func() {
 		// ensure correct CSVs were picked
 		var got []string
 		Eventually(func() []string {
-			ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
+			ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.Background(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
 			if err != nil {
 				return nil
 			}
@@ -1677,7 +1677,7 @@ var _ = Describe("Subscription", func() {
 				It("choose the dependency from the right CatalogSource based on lexicographical name ordering of catalogs", func() {
 					// ensure correct CSVs were picked
 					Eventually(func() ([]string, error) {
-						ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
+						ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.Background(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
 						if err != nil {
 							return nil, err
 						}
@@ -1761,7 +1761,7 @@ var _ = Describe("Subscription", func() {
 				It("choose the dependent package from the same catsrc as the installing operator", func() {
 					// ensure correct CSVs were picked
 					Eventually(func() ([]string, error) {
-						ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
+						ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.Background(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
 						if err != nil {
 							return nil, err
 						}
@@ -1855,7 +1855,7 @@ var _ = Describe("Subscription", func() {
 				It("choose the dependent package from the catsrc with higher priority", func() {
 					// ensure correct CSVs were picked
 					Eventually(func() ([]string, error) {
-						ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
+						ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.Background(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
 						if err != nil {
 							return nil, err
 						}
@@ -1948,7 +1948,7 @@ var _ = Describe("Subscription", func() {
 				It("choose the dependent package from the catsrc in the same namespace as the installing operator", func() {
 					// ensure correct CSVs were picked
 					Eventually(func() ([]string, error) {
-						ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
+						ip, err := crClient.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.Background(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
 						if err != nil {
 							return nil, err
 						}
@@ -2288,7 +2288,7 @@ var _ = Describe("Subscription", func() {
 		It("should create a Subscription using the candidate's default channel", func() {
 			Eventually(func() ([]operatorsv1alpha1.Subscription, error) {
 				var list operatorsv1alpha1.SubscriptionList
-				if err := ctx.Ctx().Client().List(context.TODO(), &list); err != nil {
+				if err := ctx.Ctx().Client().List(context.Background(), &list); err != nil {
 					return nil, err
 				}
 				return list.Items, nil
@@ -2919,6 +2919,6 @@ func updateInternalCatalog(t GinkgoTInterface, c operatorclient.ClientInterface,
 
 func updateCatSrcPriority(crClient versioned.Interface, namespace string, catsrc *operatorsv1alpha1.CatalogSource, priority int) {
 	catsrc.Spec.Priority = priority
-	_, err := crClient.OperatorsV1alpha1().CatalogSources(namespace).Update(context.TODO(), catsrc, metav1.UpdateOptions{})
+	_, err := crClient.OperatorsV1alpha1().CatalogSources(namespace).Update(context.Background(), catsrc, metav1.UpdateOptions{})
 	Expect(err).Should(BeNil())
 }

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -1002,27 +1002,26 @@ var _ = Describe("Subscription", func() {
 	// InstallPlan states.
 	//
 	// Steps:
-	// 1. Create namespace, ns
-	// 2. Create CatalogSource, cs, in ns
-	// 3. Create OperatorGroup, og, in ns selecting its own namespace
-	// 4. Create Subscription to a package of cs in ns, sub
-	// 5. Wait for the package from sub to install successfully with no remaining InstallPlan status conditions
-	// 6. Store conditions for later comparision
-	// 7. Get the InstallPlan
-	// 8. Set the InstallPlan's approval mode to Manual
-	// 9. Set the InstallPlan's phase to None
-	// 10. Wait for sub to have status condition SubscriptionInstallPlanPending true and reason InstallPlanNotYetReconciled
-	// 11. Get the latest IntallPlan and set the phase to InstallPlanPhaseRequiresApproval
-	// 12. Wait for sub to have status condition SubscriptionInstallPlanPending true and reason RequiresApproval
-	// 13. Get the latest InstallPlan and set the phase to InstallPlanPhaseInstalling
-	// 14. Wait for sub to have status condition SubscriptionInstallPlanPending true and reason Installing
-	// 15. Get the latest InstallPlan and set the phase to InstallPlanPhaseFailed and remove all status conditions
-	// 16. Wait for sub to have status condition SubscriptionInstallPlanFailed true and reason InstallPlanFailed
-	// 17. Get the latest InstallPlan and set status condition of type Installed to false with reason InstallComponentFailed
-	// 18. Wait for sub to have status condition SubscriptionInstallPlanFailed true and reason InstallComponentFailed
-	// 19. Delete the referenced InstallPlan
-	// 20. Wait for sub to have status condition SubscriptionInstallPlanMissing true
-	// 21. Ensure original non-InstallPlan status conditions remain after InstallPlan transitions
+	// - Utilize the namespace and OG targeting that namespace created in the BeforeEach clause
+	// - Create CatalogSource, cs, in ns
+	// - Create Subscription to a package of cs in ns, sub
+	// - Wait for the package from sub to install successfully with no remaining InstallPlan status conditions
+	// - Store conditions for later comparision
+	// - Get the InstallPlan
+	// - Set the InstallPlan's approval mode to Manual
+	// - Set the InstallPlan's phase to None
+	// - Wait for sub to have status condition SubscriptionInstallPlanPending true and reason InstallPlanNotYetReconciled
+	// - Get the latest IntallPlan and set the phase to InstallPlanPhaseRequiresApproval
+	// - Wait for sub to have status condition SubscriptionInstallPlanPending true and reason RequiresApproval
+	// - Get the latest InstallPlan and set the phase to InstallPlanPhaseInstalling
+	// - Wait for sub to have status condition SubscriptionInstallPlanPending true and reason Installing
+	// - Get the latest InstallPlan and set the phase to InstallPlanPhaseFailed and remove all status conditions
+	// - Wait for sub to have status condition SubscriptionInstallPlanFailed true and reason InstallPlanFailed
+	// - Get the latest InstallPlan and set status condition of type Installed to false with reason InstallComponentFailed
+	// - Wait for sub to have status condition SubscriptionInstallPlanFailed true and reason InstallComponentFailed
+	// - Delete the referenced InstallPlan
+	// - Wait for sub to have status condition SubscriptionInstallPlanMissing true
+	// - Ensure original non-InstallPlan status conditions remain after InstallPlan transitions
 	It("can reconcile InstallPlan status", func() {
 		c := newKubeClient()
 		crc := newCRClient()
@@ -1046,13 +1045,6 @@ var _ = Describe("Subscription", func() {
 		defer cleanupCatalogSource()
 		_, err := fetchCatalogSourceOnStatus(crc, catalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		Expect(err).ToNot(HaveOccurred())
-
-		// Create OperatorGroup, og, in ns selecting its own namespace
-		og := newOperatorGroup(generatedNamespace.GetName(), genName("og-"), nil, nil, []string{generatedNamespace.GetName()}, false)
-		Eventually(func() error {
-			_, err = crc.OperatorsV1().OperatorGroups(og.GetNamespace()).Create(context.Background(), og, metav1.CreateOptions{})
-			return err
-		}).Should(Succeed())
 
 		// Create Subscription to a package of cs in ns, sub
 		subName := genName("sub-")

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -36,7 +36,6 @@ import (
 	k8scontrollerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	gtypes "github.com/onsi/gomega/types"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
@@ -282,7 +281,7 @@ func waitForGVR(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource
 	})
 }
 
-type catalogSourceCheckFunc func(*v1alpha1.CatalogSource) bool
+type catalogSourceCheckFunc func(*operatorsv1alpha1.CatalogSource) bool
 
 // This check is disabled for most test runs, but can be enabled for verifying pod health if the e2e tests are running
 // in the same kubernetes cluster as the registry pods (currently this only happens with e2e-local-docker)
@@ -311,7 +310,7 @@ func registryPodHealthy(address string) bool {
 	return true
 }
 
-func catalogSourceRegistryPodSynced(catalog *v1alpha1.CatalogSource) bool {
+func catalogSourceRegistryPodSynced(catalog *operatorsv1alpha1.CatalogSource) bool {
 	registry := catalog.Status.RegistryServiceStatus
 	connState := catalog.Status.GRPCConnectionState
 	if registry != nil && connState != nil && !connState.LastConnectTime.IsZero() && connState.LastObservedState == "READY" {
@@ -326,12 +325,12 @@ func catalogSourceRegistryPodSynced(catalog *v1alpha1.CatalogSource) bool {
 	return false
 }
 
-func catalogSourceInvalidSpec(catalog *v1alpha1.CatalogSource) bool {
-	return catalog.Status.Reason == v1alpha1.CatalogSourceSpecInvalidError
+func catalogSourceInvalidSpec(catalog *operatorsv1alpha1.CatalogSource) bool {
+	return catalog.Status.Reason == operatorsv1alpha1.CatalogSourceSpecInvalidError
 }
 
-func fetchCatalogSourceOnStatus(crc versioned.Interface, name, namespace string, check catalogSourceCheckFunc) (*v1alpha1.CatalogSource, error) {
-	var fetched *v1alpha1.CatalogSource
+func fetchCatalogSourceOnStatus(crc versioned.Interface, name, namespace string, check catalogSourceCheckFunc) (*operatorsv1alpha1.CatalogSource, error) {
+	var fetched *operatorsv1alpha1.CatalogSource
 	var err error
 
 	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
@@ -405,11 +404,11 @@ func TearDown(namespace string) {
 
 	logf("deleting test subscriptions...")
 	Eventually(func() error {
-		return client.DeleteAllOf(clientCtx, &v1alpha1.Subscription{}, inNamespace)
+		return client.DeleteAllOf(clientCtx, &operatorsv1alpha1.Subscription{}, inNamespace)
 	}).Should(Succeed(), "failed to delete test subscriptions")
 
-	Eventually(func() (remaining []v1alpha1.Subscription, err error) {
-		list := &v1alpha1.SubscriptionList{}
+	Eventually(func() (remaining []operatorsv1alpha1.Subscription, err error) {
+		list := &operatorsv1alpha1.SubscriptionList{}
 		err = client.List(clientCtx, list, inNamespace)
 		if list != nil {
 			remaining = list.Items
@@ -420,11 +419,11 @@ func TearDown(namespace string) {
 
 	logf("deleting test installplans...")
 	Eventually(func() error {
-		return client.DeleteAllOf(clientCtx, &v1alpha1.InstallPlan{}, inNamespace)
+		return client.DeleteAllOf(clientCtx, &operatorsv1alpha1.InstallPlan{}, inNamespace)
 	}).Should(Succeed(), "failed to delete test installplans")
 
-	Eventually(func() (remaining []v1alpha1.InstallPlan, err error) {
-		list := &v1alpha1.InstallPlanList{}
+	Eventually(func() (remaining []operatorsv1alpha1.InstallPlan, err error) {
+		list := &operatorsv1alpha1.InstallPlanList{}
 		err = client.List(clientCtx, list, inNamespace)
 		if list != nil {
 			remaining = list.Items
@@ -435,11 +434,11 @@ func TearDown(namespace string) {
 
 	logf("deleting test catalogsources...")
 	Eventually(func() error {
-		return client.DeleteAllOf(clientCtx, &v1alpha1.CatalogSource{}, inNamespace, ephemeralCatalogFieldSelector)
+		return client.DeleteAllOf(clientCtx, &operatorsv1alpha1.CatalogSource{}, inNamespace, ephemeralCatalogFieldSelector)
 	}).Should(Succeed(), "failed to delete test catalogsources")
 
-	Eventually(func() (remaining []v1alpha1.CatalogSource, err error) {
-		list := &v1alpha1.CatalogSourceList{}
+	Eventually(func() (remaining []operatorsv1alpha1.CatalogSource, err error) {
+		list := &operatorsv1alpha1.CatalogSourceList{}
 		err = client.List(clientCtx, list, inNamespace, ephemeralCatalogFieldSelector)
 		if list != nil {
 			remaining = list.Items
@@ -449,8 +448,8 @@ func TearDown(namespace string) {
 	}).Should(BeEmpty(), "failed to await deletion of test catalogsources")
 
 	logf("deleting test crds...")
-	remainingCSVs := func() (csvs []v1alpha1.ClusterServiceVersion, err error) {
-		list := &v1alpha1.ClusterServiceVersionList{}
+	remainingCSVs := func() (csvs []operatorsv1alpha1.ClusterServiceVersion, err error) {
+		list := &operatorsv1alpha1.ClusterServiceVersionList{}
 		err = client.List(clientCtx, list, inNamespace, ephemeralCSVFieldSelector)
 		if list != nil {
 			csvs = list.Items
@@ -497,7 +496,7 @@ func TearDown(namespace string) {
 
 	logf("deleting test csvs...")
 	Eventually(func() error {
-		return client.DeleteAllOf(clientCtx, &v1alpha1.ClusterServiceVersion{}, inNamespace, ephemeralCSVFieldSelector)
+		return client.DeleteAllOf(clientCtx, &operatorsv1alpha1.ClusterServiceVersion{}, inNamespace, ephemeralCSVFieldSelector)
 	}).Should(Succeed(), "failed to delete test csvs")
 
 	Eventually(remainingCSVs).Should(BeEmpty(), "failed to await deletion of test csvs")
@@ -505,7 +504,7 @@ func TearDown(namespace string) {
 	logf("test resources deleted")
 }
 
-func buildCatalogSourceCleanupFunc(crc versioned.Interface, namespace string, catalogSource *v1alpha1.CatalogSource) cleanupFunc {
+func buildCatalogSourceCleanupFunc(crc versioned.Interface, namespace string, catalogSource *operatorsv1alpha1.CatalogSource) cleanupFunc {
 	return func() {
 		ctx.Ctx().Logf("Deleting catalog source %s...", catalogSource.GetName())
 		err := crc.OperatorsV1alpha1().CatalogSources(namespace).Delete(context.TODO(), catalogSource.GetName(), metav1.DeleteOptions{})
@@ -528,18 +527,18 @@ func buildServiceAccountCleanupFunc(t GinkgoTInterface, c operatorclient.ClientI
 	}
 }
 
-func createInvalidGRPCCatalogSource(crc versioned.Interface, name, namespace string) (*v1alpha1.CatalogSource, cleanupFunc) {
+func createInvalidGRPCCatalogSource(crc versioned.Interface, name, namespace string) (*operatorsv1alpha1.CatalogSource, cleanupFunc) {
 
-	catalogSource := &v1alpha1.CatalogSource{
+	catalogSource := &operatorsv1alpha1.CatalogSource{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.CatalogSourceKind,
-			APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+			Kind:       operatorsv1alpha1.CatalogSourceKind,
+			APIVersion: operatorsv1alpha1.CatalogSourceCRDAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.CatalogSourceSpec{
+		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: "grpc",
 			Image:      "localhost:0/not/exists:catsrc",
 		},
@@ -552,20 +551,20 @@ func createInvalidGRPCCatalogSource(crc versioned.Interface, name, namespace str
 	return catalogSource, buildCatalogSourceCleanupFunc(crc, namespace, catalogSource)
 }
 
-func createInternalCatalogSource(c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensions.CustomResourceDefinition, csvs []v1alpha1.ClusterServiceVersion) (*v1alpha1.CatalogSource, cleanupFunc) {
+func createInternalCatalogSource(c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensions.CustomResourceDefinition, csvs []operatorsv1alpha1.ClusterServiceVersion) (*operatorsv1alpha1.CatalogSource, cleanupFunc) {
 	configMap, configMapCleanup := createConfigMapForCatalogData(c, name, namespace, manifests, crds, csvs)
 
 	// Create an internal CatalogSource custom resource pointing to the ConfigMap
-	catalogSource := &v1alpha1.CatalogSource{
+	catalogSource := &operatorsv1alpha1.CatalogSource{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.CatalogSourceKind,
-			APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+			Kind:       operatorsv1alpha1.CatalogSourceKind,
+			APIVersion: operatorsv1alpha1.CatalogSourceCRDAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.CatalogSourceSpec{
+		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: "internal",
 			ConfigMap:  configMap.GetName(),
 		},
@@ -587,20 +586,20 @@ func createInternalCatalogSource(c operatorclient.ClientInterface, crc versioned
 
 func createInternalCatalogSourceWithPriority(c operatorclient.ClientInterface, crc versioned.Interface, name,
 	namespace string, manifests []registry.PackageManifest, crds []apiextensions.CustomResourceDefinition,
-	csvs []v1alpha1.ClusterServiceVersion, priority int) (*v1alpha1.CatalogSource, cleanupFunc) {
+	csvs []operatorsv1alpha1.ClusterServiceVersion, priority int) (*operatorsv1alpha1.CatalogSource, cleanupFunc) {
 
 	configMap, configMapCleanup := createConfigMapForCatalogData(c, name, namespace, manifests, crds, csvs)
 	// Create an internal CatalogSource custom resource pointing to the ConfigMap
-	catalogSource := &v1alpha1.CatalogSource{
+	catalogSource := &operatorsv1alpha1.CatalogSource{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.CatalogSourceKind,
-			APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+			Kind:       operatorsv1alpha1.CatalogSourceKind,
+			APIVersion: operatorsv1alpha1.CatalogSourceCRDAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.CatalogSourceSpec{
+		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: "internal",
 			ConfigMap:  configMap.GetName(),
 			Priority:   priority,
@@ -622,20 +621,20 @@ func createInternalCatalogSourceWithPriority(c operatorclient.ClientInterface, c
 	return catalogSource, cleanupInternalCatalogSource
 }
 
-func createV1CRDInternalCatalogSource(t GinkgoTInterface, c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensionsv1.CustomResourceDefinition, csvs []v1alpha1.ClusterServiceVersion) (*v1alpha1.CatalogSource, cleanupFunc) {
+func createV1CRDInternalCatalogSource(t GinkgoTInterface, c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensionsv1.CustomResourceDefinition, csvs []operatorsv1alpha1.ClusterServiceVersion) (*operatorsv1alpha1.CatalogSource, cleanupFunc) {
 	configMap, configMapCleanup := createV1CRDConfigMapForCatalogData(t, c, name, namespace, manifests, crds, csvs)
 
 	// Create an internal CatalogSource custom resource pointing to the ConfigMap
-	catalogSource := &v1alpha1.CatalogSource{
+	catalogSource := &operatorsv1alpha1.CatalogSource{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.CatalogSourceKind,
-			APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+			Kind:       operatorsv1alpha1.CatalogSourceKind,
+			APIVersion: operatorsv1alpha1.CatalogSourceCRDAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: v1alpha1.CatalogSourceSpec{
+		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: "internal",
 			ConfigMap:  configMap.GetName(),
 		},
@@ -656,7 +655,7 @@ func createV1CRDInternalCatalogSource(t GinkgoTInterface, c operatorclient.Clien
 	return catalogSource, cleanupInternalCatalogSource
 }
 
-func createConfigMapForCatalogData(c operatorclient.ClientInterface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensions.CustomResourceDefinition, csvs []v1alpha1.ClusterServiceVersion) (*corev1.ConfigMap, cleanupFunc) {
+func createConfigMapForCatalogData(c operatorclient.ClientInterface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensions.CustomResourceDefinition, csvs []operatorsv1alpha1.ClusterServiceVersion) (*corev1.ConfigMap, cleanupFunc) {
 	// Create a config map containing the PackageManifests and CSVs
 	configMapName := fmt.Sprintf("%s-configmap", name)
 	catalogConfigMap := &corev1.ConfigMap{
@@ -703,7 +702,7 @@ func createConfigMapForCatalogData(c operatorclient.ClientInterface, name, names
 	return createdConfigMap, buildConfigMapCleanupFunc(c, namespace, createdConfigMap)
 }
 
-func createV1CRDConfigMapForCatalogData(t GinkgoTInterface, c operatorclient.ClientInterface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensionsv1.CustomResourceDefinition, csvs []v1alpha1.ClusterServiceVersion) (*corev1.ConfigMap, cleanupFunc) {
+func createV1CRDConfigMapForCatalogData(t GinkgoTInterface, c operatorclient.ClientInterface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensionsv1.CustomResourceDefinition, csvs []operatorsv1alpha1.ClusterServiceVersion) (*corev1.ConfigMap, cleanupFunc) {
 	// Create a config map containing the PackageManifests and CSVs
 	configMapName := fmt.Sprintf("%s-configmap", name)
 	catalogConfigMap := &corev1.ConfigMap{

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -36,8 +36,8 @@ import (
 	k8scontrollerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	gtypes "github.com/onsi/gomega/types"
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
@@ -920,23 +920,22 @@ func HaveMessage(goal string) gtypes.GomegaMatcher {
 	}, ContainSubstring(goal))
 }
 
-func SetUpGeneratedTestNamespace(name string) (string, corev1.Namespace) {
-	generatedNamespace := genName(name)
+func SetupGeneratedTestNamespace(name string) corev1.Namespace {
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: generatedNamespace,
+			Name: name,
 		},
 	}
 	Eventually(func() error {
 		return ctx.Ctx().Client().Create(context.Background(), &ns)
 	}).Should(Succeed())
 
-	og := v1.OperatorGroup{
+	og := operatorsv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-operatorgroup", ns.GetName()),
 			Namespace: ns.GetName(),
 		},
-		Spec: v1.OperatorGroupSpec{
+		Spec: operatorsv1.OperatorGroupSpec{
 			TargetNamespaces: []string{ns.GetName()},
 		},
 	}
@@ -944,5 +943,7 @@ func SetUpGeneratedTestNamespace(name string) (string, corev1.Namespace) {
 		return ctx.Ctx().Client().Create(context.Background(), &og)
 	}).Should(Succeed())
 
-	return generatedNamespace, ns
+	ctx.Ctx().Logf("created the %s testing namespace", ns.GetName())
+
+	return ns
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Reduce the overall testing pollution in the subscription e2e suite by generating a testing namespace for individual tests.

**Motivation for the change:**
Various flakes within this e2e package are popping up more frequently. Recent changes made to reduce the flake tolerance budget from three attempts to a single attempt were hiding inadequate isolation and cleanup between individual tests. A simple example is a test that created test fixtures in a shared namespace but neglected to cleanup those resources. Another, unrelated test will build up it's own set of text fixtures, and fail that test's individual assertions as the previously created and improperly cleaned up resources have unattended consequences, ex: a subscription fails resolution as another test had created a subscription in the same namespace, waited for an installplan to be created and report a completed state, that installplan is removed after that test had finished but the subscription still exists and the new test fails assertions that expect the newer subscription to report a ready state.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x]  Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
