### PR TITLE
remove panic

### DIFF
--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -16,10 +16,12 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -1551,7 +1553,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
-		compareResources(GinkgoT(), fetchedCSV, sameCSV)
+		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 	})
 	It("create with owned API service", func() {
 
@@ -2547,7 +2549,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
-		compareResources(GinkgoT(), fetchedCSV, sameCSV)
+		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 	})
 	It("update different deployment name", func() {
 
@@ -2725,7 +2727,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
-		compareResources(GinkgoT(), fetchedCSV, sameCSV)
+		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 		// Should have created new deployment and deleted old
 		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
@@ -2915,7 +2917,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
-		compareResources(GinkgoT(), fetchedCSV, sameCSV)
+		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 		// Should have created new deployment and deleted old
 		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
@@ -3285,7 +3287,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
-		compareResources(GinkgoT(), fetchedCSV, sameCSV)
+		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 		// Should have created new deployment and deleted old one
 		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
@@ -3364,7 +3366,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Fetch cluster service version again to check for unnecessary control loops
 		sameCSV, err = fetchCSV(crc, csvNew2.Name, testNamespace, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
-		compareResources(GinkgoT(), fetchedCSV, sameCSV)
+		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 		// Should have created new deployment and deleted old one
 		depNew, err = c.GetDeployment(testNamespace, strategyNew2.DeploymentSpecs[0].Name)

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -25,11 +25,13 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -712,8 +714,8 @@ var _ = Describe("Install Plan", func() {
 		// Fetch installplan again to check for unnecessary control loops
 		fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 			// Don't compare object meta as labels can be applied by the operator controller.
-			compareResources(GinkgoT(), fetchedInstallPlan.Spec, fip.Spec)
-			compareResources(GinkgoT(), fetchedInstallPlan.Status, fip.Status)
+			Expect(equality.Semantic.DeepEqual(fetchedInstallPlan.Spec, fip.Spec)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
+			Expect(equality.Semantic.DeepEqual(fetchedInstallPlan.Status, fip.Status)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 			return true
 		})
 		require.NoError(GinkgoT(), err)
@@ -875,7 +877,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Fetch installplan again to check for unnecessary control loops
 			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
-				compareResources(GinkgoT(), fetchedInstallPlan, fip)
+				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
 			require.NoError(GinkgoT(), err)
@@ -2343,7 +2345,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Fetch installplan again to check for unnecessary control loops
 			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
-				compareResources(GinkgoT(), fetchedInstallPlan, fip)
+				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
 			require.NoError(GinkgoT(), err)
@@ -2544,7 +2546,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Fetch installplan again to check for unnecessary control loops
 			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
-				compareResources(GinkgoT(), fetchedInstallPlan, fip)
+				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
 			require.NoError(GinkgoT(), err)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extScheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
-	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -224,14 +222,6 @@ func awaitAnnotations(t GinkgoTInterface, query func() (metav1.ObjectMeta, error
 	})
 
 	return err
-}
-
-// compareResources compares resource equality then prints a diff for easier debugging
-func compareResources(t GinkgoTInterface, expected, actual interface{}) {
-	if eq := equality.Semantic.DeepEqual(expected, actual); !eq {
-		t.Fatalf("Resource does not match expected value: %s",
-			diff.ObjectDiff(expected, actual))
-	}
 }
 
 type checkResourceFunc func() error


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
There are places that cause 'panic' when the test fails.  This PR changes to report the test failure instead of panic when the test fails.

**Motivation for the change:**
This fixes the panic of https://github.com/operator-framework/operator-lifecycle-manager/issues/2439.  It doesn't fix the test failure.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
