### PR TITLE
test/e2e: Fix unset $KUBECONFIG when gathering CI testing artifacts

### DIFF
--- a/test/e2e/ctx/ctx.go
+++ b/test/e2e/ctx/ctx.go
@@ -35,6 +35,8 @@ type TestContext struct {
 	dynamicClient  dynamic.Interface
 	packageClient  pversioned.Interface
 	ssaClient      *controllerclient.ServerSideApplier
+
+	kubeconfigPath string
 	artifactsDir   string
 
 	scheme *runtime.Scheme
@@ -101,10 +103,16 @@ func (ctx TestContext) DumpNamespaceArtifacts(namespace string) error {
 	if err := os.MkdirAll(logDir, os.ModePerm); err != nil {
 		return err
 	}
+	kubeconfigPath := ctx.kubeconfigPath
+	if kubeconfigPath == "" {
+		ctx.Logf("unable to determine kubeconfig path so defaulting to the $KUBECONFIG value")
+		kubeconfigPath = os.Getenv("KUBECONFIG")
+	}
+
 	envvars := []string{
 		"TEST_NAMESPACE=" + namespace,
 		"TEST_ARTIFACTS_DIR=" + logDir,
-		"KUBECONFIG=" + os.Getenv("KUBECONFIG"),
+		"KUBECONFIG=" + kubeconfigPath,
 	}
 
 	// compiled test binary running e2e tests is run from the root ./bin directory


### PR DESCRIPTION
**Description of the change:**
Update the testing e2e packages and ensure that the $KUBECONFIG
environment variable is correctly set before running the bash script
responsible for collecting CI artifacts.

This should fix the following error message that was popping up in
individual CI runs:

```
collecting logs in the ./artifacts/ artifacts directory
../test/e2e/collect-ci-artifacts.sh: line 7: KUBECONFIG: parameter null or not set
failed to collect namespace artifacts: exit status 1
```

Update the kind provisioner to avoid prematurely removing the temporary
directory that contains the constructed (and ephemeral) kubeconfig file
and track that metadata in the TestContext structure. In the case that
field is unset for that object, fall back to the os.Getenv("KUBECONFIG")
value.

Signed-off-by: timflannagan <timflannagan@gmail.com>


**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
