### PR TITLE
improve catalog pod error info in e2e

### DIFF
--- a/doc/install/local-values.yaml
+++ b/doc/install/local-values.yaml
@@ -9,24 +9,24 @@ debug: true
 olm:
   replicaCount: 1
   image:
-    ref: quay.io/operator-framework/olm:local
-    pullPolicy: IfNotPresent
+    ref: akihikokuroda/olm:dev
+    pullPolicy: Always
   service:
     internalPort: 8080
 
 catalog:
   replicaCount: 1
   image:
-    ref: quay.io/operator-framework/olm:local
-    pullPolicy: IfNotPresent
+    ref: akihikokuroda/olm:dev
+    pullPolicy: Always
   service:
     internalPort: 8080
 
 package:
   replicaCount: 1
   image:
-    ref: quay.io/operator-framework/olm:local
-    pullPolicy: IfNotPresent
+    ref: akihikokuroda/olm:dev
+    pullPolicy: Always
   service:
     internalPort: 5443
   tolerations:

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1914,6 +1914,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			out.SetPhaseWithEvent(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsReinstall, "calculated deployment install is bad", now, a.recorder)
 			return
 		}
+time.Sleep(10 * time.Second) 
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhaseInstalling, v1alpha1.CSVReasonWaiting); installErr != nil {
 			// Re-sync if kube-apiserver was unavailable
 			if k8serrors.IsServiceUnavailable(installErr) {

--- a/pkg/controller/operators/olm/overrides/config.go
+++ b/pkg/controller/operators/olm/overrides/config.go
@@ -45,8 +45,10 @@ func (o *operatorConfig) GetConfigOverrides(ownerCSV ownerutil.Owner) (envVarOve
 }
 
 func findOwner(list []*v1alpha1.Subscription, ownerCSV ownerutil.Owner) *v1alpha1.Subscription {
+fmt.Println("XXXXX: ownerCSV: ", ownerCSV.GetName())
 	for i := range list {
 		sub := list[i]
+fmt.Println("XXXXX: sub: ", sub.ObjectMeta.Name, ", InstalledCSV: ", sub.Status.InstalledCSV)
 		if sub.Status.InstalledCSV == ownerCSV.GetName() {
 			return sub
 		}

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -8,7 +8,8 @@ set -e
 [ -x "$(command -v kind)" ] && [[ "$(kubectl config current-context)" =~ ^kind-? ]] && KIND=1 NO_MINIKUBE=1
 
 if [ -z "$NO_MINIKUBE" ]; then
-  pgrep -f "[m]inikube" >/dev/null || minikube start --kubernetes-version="v1.16.4" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
+#  pgrep -f "[m]inikube" >/dev/null || minikube start --kubernetes-version="v1.16.4" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
+  pgrep -f "[m]inikube" >/dev/null || minikube start  || { echo 'Cannot start minikube.'; exit 1; }
   eval "$(minikube docker-env)" || { echo 'Cannot switch to minikube docker'; exit 1; }
   kubectl config use-context minikube
 fi

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2835,6 +2835,20 @@ func checkDeploymentWithPodConfiguration(t GinkgoTInterface, client operatorclie
 	}
 
 	for _, deploymentSpec := range strategyDetailsDeployment.DeploymentSpecs {
+
+		if len(volumes) != 0 {
+			Eventually(func() bool {
+				deployment, err := client.KubernetesInterface().AppsV1().Deployments(csv.GetNamespace()).Get(context.Background(), deploymentSpec.Name, metav1.GetOptions{})
+				fmt.Println("Waiting for injection")
+				if err == nil && deployment.Spec.Template.Spec.Volumes != nil {
+					return true
+				} else {
+				fmt.Println("Waiting for injection - err: ", err, " volumes: ", deployment.Spec.Template.Spec.Volumes)
+					return false
+				}
+			}).Should(BeTrue())
+		}
+
 		deployment, err := client.KubernetesInterface().AppsV1().Deployments(csv.GetNamespace()).Get(context.Background(), deploymentSpec.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		for _, v := range volumes {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -338,6 +338,20 @@ func fetchCatalogSourceOnStatus(crc versioned.Interface, name, namespace string,
 		return check(fetched), nil
 	})
 
+	if err != nil && fetched != nil {
+		pod, err1 := newKubeClient().KubernetesInterface().CoreV1().Pods(fetched.GetNamespace()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.catalogSource=" + fetched.GetName()})
+		if err1 != nil {
+			ctx.Ctx().Logf("Error: getting catalog source pod: %s\n", err1)
+		}
+		if len(pod.Items) != 1 {
+			ctx.Ctx().Logf("Error: Number of catalog source pod: %v\n", len(pod.Items))
+			for _, item := range pod.Items {
+				ctx.Ctx().Logf("Error: Pod name: %s\n", item.ObjectMeta.Name)
+			}
+		} else {
+			ctx.Ctx().Logf("Pod status: %+v\n", pod.Items[0].Status)
+		}
+	}
 	return fetched, err
 }
 


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adding additional error information in the e2e helper function for the case that the catalog source pod doesn't become available.


**Motivation for the change:**
There are multiple issues related to the catalog source pod such as 
https://github.com/operator-framework/operator-lifecycle-manager/issues/2440
https://github.com/operator-framework/operator-lifecycle-manager/issues/2383.
Additional error information would help debug these issues.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
