### PR TITLE
Introduce Maintainers File

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+This page lists all active maintainers of this repository.
+
+See [CONTRIBUTING.md](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md)
+for general contribution guidelines.
+
+## Maintainers (in alphabetical order)
+
+- [Alexander Greene](github.com/awgreene), Red Hat
+- [Evan Cordell](github.com/ecordell), Authzed
+- [Kevin Rizza](github.com/kevinrizza), Red Hat
+- [Nick Hale](github.com/njhale), Red Hat
+- [Vu Dinh](github.com/dinhxuanvu), Red Hat


### PR DESCRIPTION
This commit introduces the MAINTAINERS.md file in an effort
to decouple project maintainer status from approval and lgtm
permissions relied on by the project automated continuous
integration tooling.
