### PR TITLE
test/e2e: Collect CatalogSource testing artifacts

### DIFF
--- a/test/e2e/collect-ci-artifacts.sh
+++ b/test/e2e/collect-ci-artifacts.sh
@@ -11,6 +11,7 @@ set -o errexit
 mkdir -p "${TEST_ARTIFACTS_DIR}"
 
 commands=()
+commands+=("get catalogsources -o yaml")
 commands+=("get subscriptions -o yaml")
 commands+=("get operatorgroups -o yaml")
 commands+=("get clusterserviceversions -o yaml")


### PR DESCRIPTION
Update the test/e2e/collect-ci-artifacts.sh bash script and extend the
list of resources gathered to also create a snapshot of CatalogSource
resources in the test namespace.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
