### PR TITLE
OWNERS: Remove the bugzilla component

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -22,5 +22,3 @@ reviewers:
   - ankitathomas
   - joelanford
   - timflannagan
-# Bugzilla component
-component: "OLM"


### PR DESCRIPTION
Update the root OWNERS file and remove the BZ component as it's no
longer relevant since the upstream/downstream split.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
