### PR TITLE
cmd: Silence warning about logrus.Fatal usage when directive has been supplied

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -92,8 +92,6 @@ func main() {
 	// Check if version flag was set
 	if *version {
 		fmt.Print(olmversion.String())
-
-		// Exit early
 		os.Exit(0)
 	}
 
@@ -111,7 +109,7 @@ func main() {
 
 	listenAndServe, err := server.GetListenAndServeFunc(server.WithLogger(logger), server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath), server.WithDebug(*debug))
 	if err != nil {
-		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
+		logger.Fatalf("Error setting up health/metric/pprof service: %v", err)
 	}
 
 	go func() {
@@ -138,12 +136,12 @@ func main() {
 	// Create a new instance of the operator.
 	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *opmImage, *utilImage, *catalogNamespace, k8sscheme.Scheme, *installPlanTimeout, *bundleUnpackTimeout)
 	if err != nil {
-		log.Panicf("error configuring catalog operator: %s", err.Error())
+		log.Fatalf("error configuring catalog operator: %s", err.Error())
 	}
 
 	opCatalogTemplate, err := catalogtemplate.NewOperator(ctx, *kubeConfigPath, logger, *wakeupInterval, *catalogNamespace)
 	if err != nil {
-		log.Panicf("error configuring catalog template operator: %s", err.Error())
+		log.Fatalf("error configuring catalog template operator: %s", err.Error())
 	}
 
 	op.Run(ctx)

--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -120,7 +120,7 @@ func main() {
 
 	listenAndServe, err := server.GetListenAndServeFunc(server.WithLogger(logger), server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath), server.WithDebug(*debug))
 	if err != nil {
-		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
+		logger.Fatalf("Error setting up health/metric/pprof service: %v", err)
 	}
 
 	go func() {
@@ -131,7 +131,7 @@ func main() {
 
 	mgr, err := Manager(ctx, *debug)
 	if err != nil {
-		logger.WithError(err).Fatalf("error configuring controller manager")
+		logger.WithError(err).Fatal("error configuring controller manager")
 	}
 	config := mgr.GetConfig()
 
@@ -164,7 +164,7 @@ func main() {
 		olm.WithConfigClient(versionedConfigClient),
 	)
 	if err != nil {
-		logger.WithError(err).Fatalf("error configuring operator")
+		logger.WithError(err).Fatal("error configuring operator")
 		return
 	}
 
@@ -173,7 +173,7 @@ func main() {
 
 	// Emit CSV metric
 	if err = op.EnsureCSVMetric(); err != nil {
-		logger.WithError(err).Fatalf("error emitting metrics for existing CSV")
+		logger.WithError(err).Fatal("error emitting metrics for existing CSV")
 	}
 
 	if *writeStatusName != "" {
@@ -187,12 +187,12 @@ func main() {
 			openshift.WithOLMOperator(),
 		)
 		if err != nil {
-			logger.WithError(err).Fatalf("error configuring openshift integration")
+			logger.WithError(err).Fatal("error configuring openshift integration")
 			return
 		}
 
 		if err := reconciler.SetupWithManager(mgr); err != nil {
-			logger.WithError(err).Fatalf("error configuring openshift integration")
+			logger.WithError(err).Fatal("error configuring openshift integration")
 			return
 		}
 	}


### PR DESCRIPTION
Update the cmd/[catalog,olm] main packages and silence any vet warnings
about logrus.Fatal usage that supply formatting directives:

```bash
$ go vet ./cmd/...
cmd/catalog/main.go:114:3: Fatal call has possible formatting directive %v
cmd/olm/main.go:123:3: Fatal call has possible formatting directive %v
```

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
