### PR TITLE
.github/workflows: Update the checkouts action to use the v1 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v1
     - name: Build the container image
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.16'

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
         with:
           fetch-depth: 0
       - name: Set up Go

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -7,7 +7,7 @@ jobs:
   install-quickstart:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - run: |
         curl -sLo kind "$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '[.assets[] | select(.name == "kind-linux-amd64")] | first | .browser_download_url')"
         chmod +x kind

--- a/.github/workflows/run-kind-local.yml
+++ b/.github/workflows/run-kind-local.yml
@@ -9,7 +9,7 @@ jobs:
   e2e-kind:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - uses: actions/setup-go@v2
       with:
         go-version: '~1.16'

--- a/.github/workflows/run-minikube-local.yml
+++ b/.github/workflows/run-minikube-local.yml
@@ -9,7 +9,7 @@ jobs:
   e2e-minikube:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - uses: actions/setup-go@v2
       with:
         go-version: '~1.16'

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -10,7 +10,7 @@ jobs:
   sanity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.16'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,7 +10,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.16'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.16'


### PR DESCRIPTION
Update any relevant workflows and downgrade the checkouts action from
the v2 to v1 version. This change is predicated on the problematic
checkouts@v2 behavior that can lead to an increased change of regressing
when landing changes to the default branch (e.g. master/main). This is
because there's an existing bug in the v2 world where PRs can checkout
the wrong HEAD commit, leading to scenarios where you're testing against
an out-of-date commit compared to what's in the master branch.

A concrete use case is when a PR is opened, and that PR checks out the
current HEAD commit from master, and then a change lands in the master
branch, and any subsequent workflow retries for that PR will result in
that previous HEAD commit being checked out. There are workarounds that
exist, like rebasing the existing PR, or like explicitly pointing the
ref to the default branch, but this interaction isn't ideal with workflows
are triggered on pushes to branches on top of reacting to pull request
triggers. The simplest solution is to revert back to the v1 version and
find a better longer term solution.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
