### PR TITLE
.github/workflows: Avoid running CI on markdown-only pull requests 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,24 @@
 name: build
 on:
+  push:
   pull_request:
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          paths_ignore: '["**/*.md"]'
+          cancel_others: 'true'
+          concurrent_skipping: 'outdated_runs'
+          skip_after_successful_duplicate: 'true'
   image:
     runs-on: ubuntu-latest
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
     - name: Check out the repo
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: build
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   image:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,8 +5,22 @@ on:
       - master
   pull_request:
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          paths_ignore: '["**/*.md"]'
+          cancel_others: 'true'
+          concurrent_skipping: 'outdated_runs'
+          skip_after_successful_duplicate: 'true'
   e2e-tests:
     runs-on: ubuntu-latest
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-kind-local.yml
+++ b/.github/workflows/run-kind-local.yml
@@ -4,8 +4,22 @@ on:
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          paths_ignore: '["**/*.md"]'
+          cancel_others: 'true'
+          concurrent_skipping: 'outdated_runs'
+          skip_after_successful_duplicate: 'true'
   e2e-kind:
     runs-on: ubuntu-latest
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2

--- a/.github/workflows/run-kind-local.yml
+++ b/.github/workflows/run-kind-local.yml
@@ -1,8 +1,6 @@
 name: run-olm-kind
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/run-minikube-local.yml
+++ b/.github/workflows/run-minikube-local.yml
@@ -1,8 +1,6 @@
 name: run-olm-minikube
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/run-minikube-local.yml
+++ b/.github/workflows/run-minikube-local.yml
@@ -4,8 +4,22 @@ on:
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          paths_ignore: '["**/*.md"]'
+          cancel_others: 'true'
+          concurrent_skipping: 'outdated_runs'
+          skip_after_successful_duplicate: 'true'
   e2e-minikube:
     runs-on: ubuntu-latest
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - '**'
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   sanity:
     runs-on: ubuntu-latest

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -5,8 +5,22 @@ on:
       - '**'
   pull_request:
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          paths_ignore: '["**/*.md"]'
+          cancel_others: 'true'
+          concurrent_skipping: 'outdated_runs'
+          skip_after_successful_duplicate: 'true'
   sanity:
     runs-on: ubuntu-latest
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,8 +5,22 @@ on:
       - master
   pull_request:
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          paths_ignore: '["**/*.md"]'
+          cancel_others: 'true'
+          concurrent_skipping: 'outdated_runs'
+          skip_after_successful_duplicate: 'true'
   unit:
     runs-on: ubuntu-latest
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,8 +5,22 @@ on:
       - master
   pull_request:
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          paths_ignore: '["**/*.md"]'
+          cancel_others: 'true'
+          concurrent_skipping: 'outdated_runs'
+          skip_after_successful_duplicate: 'true'
   verify:
     runs-on: ubuntu-latest
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the relevant set of workflows defined in the .github/workflows
directory and avoid running the CI-related jobs when PRs only contain
markdown-only changes.

Previously, this functionality was achieved through the paths_ignore
workflow syntax, but that keyword doesn't play well with repositories
that have setup explicit required action context's through branch
protection. This results in documentation-only PRs with the requisite
labels present being gated as those skipped jobs are reported as unknown
checks and automatic merging tooling cannot perform the merge.

See [1] for more information on this behavior.

[1] https://github.community/t/path-filtering-on-required-pull-request-checks/18402/3

**Motivation for the change:**
Markdown-only PRs labeled with lgtm/approved cannot be successfully merged by tide due to the combination of how the paths-ignore keyword interacts with branch protection rules.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
