### PR TITLE
pkg,test: Remove duplicate package imports

### DIFF
--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apiserver/pkg/storage/names"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
@@ -1302,7 +1301,7 @@ func TestValidateExistingCRs(t *testing.T) {
 	unstructuredForFile := func(file string) *unstructured.Unstructured {
 		data, err := ioutil.ReadFile(file)
 		require.NoError(t, err)
-		dec := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
+		dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 		k8sFile := &unstructured.Unstructured{}
 		require.NoError(t, dec.Decode(k8sFile))
 		return k8sFile
@@ -1311,7 +1310,7 @@ func TestValidateExistingCRs(t *testing.T) {
 	unversionedCRDForV1beta1File := func(file string) *apiextensions.CustomResourceDefinition {
 		data, err := ioutil.ReadFile(file)
 		require.NoError(t, err)
-		dec := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
+		dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 		k8sFile := &apiextensionsv1beta1.CustomResourceDefinition{}
 		require.NoError(t, dec.Decode(k8sFile))
 		convertedCRD := &apiextensions.CustomResourceDefinition{}

--- a/pkg/controller/operators/olm/labeler.go
+++ b/pkg/controller/operators/olm/labeler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
-	"github.com/operator-framework/operator-registry/pkg/registry"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -98,7 +97,7 @@ func labelSetsForCRDv1beta1(crd *extv1beta1.CustomResourceDefinition) ([]labels.
 
 	// Add label sets for each version
 	for _, version := range crd.Spec.Versions {
-		hash, err := cache.APIKeyToGVKHash(registry.APIKey{
+		hash, err := cache.APIKeyToGVKHash(opregistry.APIKey{
 			Group:   crd.Spec.Group,
 			Version: version.Name,
 			Kind:    crd.Spec.Names.Kind,
@@ -129,7 +128,7 @@ func labelSetsForCRDv1(crd *extv1.CustomResourceDefinition) ([]labels.Set, error
 
 	// Add label sets for each version
 	for _, version := range crd.Spec.Versions {
-		hash, err := cache.APIKeyToGVKHash(registry.APIKey{
+		hash, err := cache.APIKeyToGVKHash(opregistry.APIKey{
 			Group:   crd.Spec.Group,
 			Version: version.Name,
 			Kind:    crd.Spec.Names.Kind,

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -2050,7 +2049,7 @@ func (a *Operator) apiServiceOwnerConflicts(csv *v1alpha1.ClusterServiceVersion)
 
 		adoptable, err := install.IsAPIServiceAdoptable(a.lister, csv, apiService)
 		if err != nil {
-			a.logger.WithFields(log.Fields{"obj": "apiService", "labels": apiService.GetLabels()}).Errorf("adoption check failed - %v", err)
+			a.logger.WithFields(logrus.Fields{"obj": "apiService", "labels": apiService.GetLabels()}).Errorf("adoption check failed - %v", err)
 		}
 
 		if !adoptable {

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -326,7 +325,7 @@ func (c *GrpcRegistryReconciler) ensureService(source grpcCatalogSourceDecorator
 	return err
 }
 
-func (c *GrpcRegistryReconciler) ensureSA(source grpcCatalogSourceDecorator) (*v1.ServiceAccount, error) {
+func (c *GrpcRegistryReconciler) ensureSA(source grpcCatalogSourceDecorator) (*corev1.ServiceAccount, error) {
 	sa := source.ServiceAccount()
 	if _, err := c.OpClient.CreateServiceAccount(sa); err != nil {
 		return sa, err

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/operator-framework/api/pkg/lib/version"
 	opver "github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	listersv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
@@ -1515,7 +1514,7 @@ func TestInferProperties(t *testing.T) {
 					Name: "a",
 				},
 				Spec: v1alpha1.ClusterServiceVersionSpec{
-					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+					Version: opver.OperatorVersion{Version: semver.MustParse("1.2.3")},
 				},
 			},
 			Subscriptions: []*v1alpha1.Subscription{
@@ -1556,7 +1555,7 @@ func TestInferProperties(t *testing.T) {
 					Name: "a",
 				},
 				Spec: v1alpha1.ClusterServiceVersionSpec{
-					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+					Version: opver.OperatorVersion{Version: semver.MustParse("1.2.3")},
 				},
 			},
 			Subscriptions: []*v1alpha1.Subscription{
@@ -1585,7 +1584,7 @@ func TestInferProperties(t *testing.T) {
 					Name: "a",
 				},
 				Spec: v1alpha1.ClusterServiceVersionSpec{
-					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+					Version: opver.OperatorVersion{Version: semver.MustParse("1.2.3")},
 				},
 			},
 			Subscriptions: []*v1alpha1.Subscription{

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -37,11 +37,9 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	opver "github.com/operator-framework/api/pkg/lib/version"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle"
@@ -614,7 +612,7 @@ var _ = Describe("Install Plan", func() {
 			Expect(ctx.Ctx().Client().Create(context.Background(), plan)).To(Succeed())
 			Expect(ctx.Ctx().Client().Status().Update(context.Background(), plan)).To(Succeed())
 
-			key := runtimeclient.ObjectKeyFromObject(plan)
+			key := client.ObjectKeyFromObject(plan)
 
 			Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 				return plan, ctx.Ctx().Client().Get(context.Background(), key, plan)
@@ -3198,9 +3196,9 @@ var _ = Describe("Install Plan", func() {
 			fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fetchedInstallPlan).NotTo(BeNil())
-			cond := v1alpha1.InstallPlanCondition{Type: v1alpha1.InstallPlanInstalled, Status: corev1.ConditionFalse, Reason: v1alpha1.InstallPlanReasonInstallCheckFailed,
+			cond := operatorsv1alpha1.InstallPlanCondition{Type: operatorsv1alpha1.InstallPlanInstalled, Status: corev1.ConditionFalse, Reason: operatorsv1alpha1.InstallPlanReasonInstallCheckFailed,
 				Message: "no operator group found that is managing this namespace"}
-			Expect(fetchedInstallPlan.Status.Phase).To(Equal(v1alpha1.InstallPlanPhaseInstalling))
+			Expect(fetchedInstallPlan.Status.Phase).To(Equal(operatorsv1alpha1.InstallPlanPhaseInstalling))
 			Expect(hasCondition(fetchedInstallPlan, cond)).To(BeTrue())
 
 			// Create an operatorgroup for the same namespace
@@ -3316,7 +3314,7 @@ var _ = Describe("Install Plan", func() {
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
 					ClusterServiceVersionNames: []string{"foobar"},
-					Approval:                   v1alpha1.ApprovalAutomatic,
+					Approval:                   operatorsv1alpha1.ApprovalAutomatic,
 					Approved:                   true,
 				},
 				Status: operatorsv1alpha1.InstallPlanStatus{
@@ -3676,7 +3674,7 @@ var _ = Describe("Install Plan", func() {
 		Expect(ctx.Ctx().Client().Create(context.Background(), plan)).To(Succeed())
 		Expect(ctx.Ctx().Client().Status().Update(context.Background(), plan)).To(Succeed())
 
-		key := runtimeclient.ObjectKeyFromObject(plan)
+		key := client.ObjectKeyFromObject(plan)
 
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return plan, ctx.Ctx().Client().Get(context.Background(), key, plan)
@@ -3747,7 +3745,7 @@ var _ = Describe("Install Plan", func() {
 		Expect(ctx.Ctx().Client().Create(context.Background(), newPlan)).To(Succeed())
 		Expect(ctx.Ctx().Client().Status().Update(context.Background(), newPlan)).To(Succeed())
 
-		newKey := runtimeclient.ObjectKeyFromObject(newPlan)
+		newKey := client.ObjectKeyFromObject(newPlan)
 
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return newPlan, ctx.Ctx().Client().Get(context.Background(), newKey, newPlan)
@@ -3946,7 +3944,7 @@ var _ = Describe("Install Plan", func() {
 		Expect(ctx.Ctx().Client().Create(context.Background(), plan)).To(Succeed())
 		Expect(ctx.Ctx().Client().Status().Update(context.Background(), plan)).To(Succeed())
 
-		key := runtimeclient.ObjectKeyFromObject(plan)
+		key := client.ObjectKeyFromObject(plan)
 
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return plan, ctx.Ctx().Client().Get(context.Background(), key, plan)
@@ -3992,7 +3990,7 @@ var _ = Describe("Install Plan", func() {
 		Expect(ctx.Ctx().Client().Create(context.Background(), newPlan)).To(Succeed())
 		Expect(ctx.Ctx().Client().Status().Update(context.Background(), newPlan)).To(Succeed())
 
-		newKey := runtimeclient.ObjectKeyFromObject(newPlan)
+		newKey := client.ObjectKeyFromObject(newPlan)
 
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return newPlan, ctx.Ctx().Client().Get(context.Background(), newKey, newPlan)
@@ -4286,7 +4284,7 @@ func newInstallPlanWithDummySteps(name, namespace string, phase operatorsv1alpha
 	}
 }
 
-func hasCondition(ip *v1alpha1.InstallPlan, expectedCondition v1alpha1.InstallPlanCondition) bool {
+func hasCondition(ip *operatorsv1alpha1.InstallPlan, expectedCondition operatorsv1alpha1.InstallPlanCondition) bool {
 	for _, cond := range ip.Status.Conditions {
 		if cond.Type == expectedCondition.Type && cond.Message == expectedCondition.Message && cond.Status == expectedCondition.Status {
 			return true


### PR DESCRIPTION
Update various pkg,test packages are removed any obvious duplicate
package imports that violate local static linters.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Remove any obvious duplicate package imports that are identified by local, static linters.

**Motivation for the change:**
Reduce duplicate package imports to help increase maintainability over time (and help alleviate a huge diff when migrating to enforcing this eventually in CI).

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
