### PR TITLE
pkg/controllers: Avoid logging transient errors to reduce log spam

### DIFF
--- a/pkg/controller/operators/operatorcondition_controller.go
+++ b/pkg/controller/operators/operatorcondition_controller.go
@@ -100,8 +100,7 @@ func (r *OperatorConditionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	operatorCondition := &operatorsv2.OperatorCondition{}
 	err := r.Client.Get(context.TODO(), req.NamespacedName, operatorCondition)
 	if err != nil {
-		log.V(1).Error(err, "Unable to find operatorcondition")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	err = r.ensureOperatorConditionRole(operatorCondition)

--- a/pkg/controller/operators/operatorconditiongenerator_controller.go
+++ b/pkg/controller/operators/operatorconditiongenerator_controller.go
@@ -96,8 +96,7 @@ func (r *OperatorConditionGeneratorReconciler) Reconcile(ctx context.Context, re
 	in := &operatorsv1alpha1.ClusterServiceVersion{}
 	err := r.Client.Get(context.TODO(), req.NamespacedName, in)
 	if err != nil {
-		log.V(1).Error(err, "Unable to find ClusterServiceVersion")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	operatorCondition := &operatorsv2.OperatorCondition{


### PR DESCRIPTION
Update the operatorcondition and operatorconditiongenerator controllers
and avoid logging any apierrors.IsNotFound(err) to reduce the log spam.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
