### PR TITLE
Add instructions for setting up envtest

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,6 +27,8 @@
 
 This project uses the built-in testing support for golang.
 
+Envtest is also used and needs to be set up. Follow [controller-runtime instructions] and set `KUBEBUILDER_ASSETS` environment variable to point to the installation directory, for instance: `/usr/local/kubebuilder/bin`.
+
 To run the tests for all go packages outside of the vendor directory, run:
 ```sh
 $ make test
@@ -46,11 +48,14 @@ To run a specific e2e test locally:
 $ make e2e-local TEST=TestCreateInstallPlanManualApproval
 ```
 
+[controller-runtime instructions]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest#section-readme
+
 #### Building
 
-Ensure your version of go is up to date; check that you're running v1.9 with the
-command:
+Ensure your version of go is up to date; check that you're running the same version as in go.mod with the
+commands:
 ```sh
+$ head go.mod
 $ go version
 ```
 


### PR DESCRIPTION
Signed-off-by: Frederic Giloux <fgiloux@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Added instructions for installing envtest, mainly a link to controller-runtime documentation.

**Motivation for the change:**

The first instruction `$ make test` fails when envtest is not available. 

**Reviewer Checklist**
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
