### PR TITLE
.github/workflows: Avoid specifying the paths-ignore keyword

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: build
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   image:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-kind-local.yml
+++ b/.github/workflows/run-kind-local.yml
@@ -1,8 +1,6 @@
 name: run-olm-kind
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/run-minikube-local.yml
+++ b/.github/workflows/run-minikube-local.yml
@@ -1,8 +1,6 @@
 name: run-olm-minikube
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - '**'
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   sanity:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the CI-related workflows and avoid specifying the paths-ignore
keyword. Because we have configure required status contexts through
branch protection rules, any workflow that is skipped due to path
filtering results in an unknown status, which results in tide stalling
any merge despite a PR matching the merge criteria (e.g. lgtm/approval
label present).

This is a short term fix to the solution: the long term
solution is dynamically filtering out certain file paths as a
pre-requisite job vs. statically filtering using the paths-ignore
filter, while we wait for GitHub to add this as first-class functionality.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
