### PR TITLE
feat: catalog source pod scheduling config overrides

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -169,6 +169,32 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 		},
 	}
 
+	// Override scheduling options if specified
+	if source.Spec.GrpcPodConfig != nil {
+		grpcPodConfig := source.Spec.GrpcPodConfig
+
+		// Override node selector
+		if grpcPodConfig.NodeSelector != nil {
+			pod.Spec.NodeSelector = make(map[string]string, len(grpcPodConfig.NodeSelector))
+			for key, value := range grpcPodConfig.NodeSelector {
+				pod.Spec.NodeSelector[key] = value
+			}
+		}
+
+		// Override priority class name
+		if grpcPodConfig.PriorityClassName != nil {
+			pod.Spec.PriorityClassName = *grpcPodConfig.PriorityClassName
+		}
+
+		// Override tolerations
+		if grpcPodConfig.Tolerations != nil {
+			pod.Spec.Tolerations = make([]v1.Toleration, len(grpcPodConfig.Tolerations))
+			for index, toleration := range grpcPodConfig.Tolerations {
+				pod.Spec.Tolerations[index] = *toleration.DeepCopy()
+			}
+		}
+	}
+
 	// Set priorityclass if its annotation exists
 	if prio, ok := annotations[CatalogPriorityClassKey]; ok && prio != "" {
 		pod.Spec.PriorityClassName = prio

--- a/test/e2e/catsrc_pod_config_e2e_test.go
+++ b/test/e2e/catsrc_pod_config_e2e_test.go
@@ -1,0 +1,198 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scontrollerclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const catalogSourceLabel = "olm.catalogSource"
+
+var _ = By
+
+var _ = Describe("CatalogSource Grpc Pod Config", func() {
+	var (
+		generatedNamespace corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		generatedNamespace = SetupGeneratedTestNamespace(genName("catsrc-grpc-pod-config-e2e-"))
+	})
+
+	AfterEach(func() {
+		TeardownNamespace(generatedNamespace.GetName())
+	})
+
+	When("the user wants more control over where the grpc catalog source pod gets scheduled", func() {
+		var (
+			client              k8scontrollerclient.Client
+			catalogSource       *v1alpha1.CatalogSource
+			defaultNodeSelector = map[string]string{
+				"kubernetes.io/os": "linux",
+			}
+			defaultTolerations       []corev1.Toleration = nil
+			catalogSourceName                            = "test-catsrc"
+			defaultPriorityClassName                     = ""
+		)
+
+		BeforeEach(func() {
+			client = ctx.Ctx().Client()
+
+			// must be a grpc source type with spec.image defined
+			catalogSource = &v1alpha1.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      catalogSourceName,
+					Namespace: generatedNamespace.GetName(),
+				},
+				Spec: v1alpha1.CatalogSourceSpec{
+					SourceType: v1alpha1.SourceTypeGrpc,
+					Image:      "repo/image:tag",
+				},
+			}
+		})
+
+		AfterEach(func() {
+			// assume the catalog source was created and just delete it
+			_ = client.Delete(context.TODO(), catalogSource)
+
+			// wait for it to go away
+			Expect(waitForDelete(func() error {
+				return client.Get(context.TODO(), k8scontrollerclient.ObjectKey{
+					Name:      catalogSource.GetName(),
+					Namespace: catalogSource.GetNamespace(),
+				}, &v1alpha1.CatalogSource{})
+			})).To(BeNil())
+		})
+
+		It("should override the pod's spec.priorityClassName", func() {
+			var overridenPriorityClassName = "system-node-critical"
+
+			// create catalog source
+			catalogSource.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
+				PriorityClassName: &overridenPriorityClassName,
+			}
+			mustCreateCatalogSource(client, catalogSource)
+
+			// Check overrides are present in the spec
+			catalogSourcePod := mustGetCatalogSourcePod(client, catalogSource)
+			Expect(catalogSourcePod).ToNot(BeNil())
+			Expect(catalogSourcePod.Spec.NodeSelector).To(BeEquivalentTo(defaultNodeSelector))
+			Expect(catalogSourcePod.Spec.Tolerations).To(ContainElements(defaultTolerations))
+			Expect(catalogSourcePod.Spec.PriorityClassName).To(Equal(overridenPriorityClassName))
+		})
+
+		It("should override the pod's spec.priorityClassName when it is empty", func() {
+			var overridenPriorityClassName = ""
+
+			// create catalog source
+			catalogSource.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
+				PriorityClassName: &overridenPriorityClassName,
+			}
+			mustCreateCatalogSource(client, catalogSource)
+
+			// Check overrides are present in the spec
+			catalogSourcePod := mustGetCatalogSourcePod(client, catalogSource)
+			Expect(catalogSourcePod).ToNot(BeNil())
+			Expect(catalogSourcePod.Spec.NodeSelector).To(BeEquivalentTo(defaultNodeSelector))
+			Expect(catalogSourcePod.Spec.Tolerations).To(ContainElements(defaultTolerations))
+			Expect(catalogSourcePod.Spec.PriorityClassName).To(Equal(overridenPriorityClassName))
+		})
+
+		It("should override the pod's spec.nodeSelector", func() {
+			var overridenNodeSelector = map[string]string{
+				"kubernetes.io/os": "linux",
+				"some":             "tag",
+			}
+
+			// create catalog source
+			catalogSource.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
+				NodeSelector: overridenNodeSelector,
+			}
+			mustCreateCatalogSource(client, catalogSource)
+
+			// Check overrides are present in the spec
+			catalogSourcePod := mustGetCatalogSourcePod(client, catalogSource)
+			Expect(catalogSourcePod).ToNot(BeNil())
+			Expect(catalogSourcePod.Spec.NodeSelector).To(BeEquivalentTo(overridenNodeSelector))
+			Expect(catalogSourcePod.Spec.Tolerations).To(ContainElements(defaultTolerations))
+			Expect(catalogSourcePod.Spec.PriorityClassName).To(Equal(defaultPriorityClassName))
+		})
+
+		It("should override the pod's spec.tolerations", func() {
+			var tolerationSeconds int64 = 120
+			var overriddenTolerations = []corev1.Toleration{
+				{
+					Key:               "some/key",
+					Operator:          corev1.TolerationOpExists,
+					Effect:            corev1.TaintEffectNoExecute,
+					TolerationSeconds: &tolerationSeconds,
+				},
+				{
+					Key:      "someother/key",
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			}
+
+			// create catalog source
+			catalogSource.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
+				Tolerations: overriddenTolerations,
+			}
+			mustCreateCatalogSource(client, catalogSource)
+
+			// Check overrides are present in the spec
+			catalogSourcePod := mustGetCatalogSourcePod(client, catalogSource)
+			Expect(catalogSourcePod).ToNot(BeNil())
+			Expect(catalogSourcePod.Spec.NodeSelector).To(BeEquivalentTo(defaultNodeSelector))
+			Expect(catalogSourcePod.Spec.Tolerations).To(ContainElements(overriddenTolerations))
+			Expect(catalogSourcePod.Spec.PriorityClassName).To(Equal(defaultPriorityClassName))
+		})
+	})
+})
+
+func mustGetCatalogSourcePod(client k8scontrollerclient.Client, catalogSource *v1alpha1.CatalogSource) *corev1.Pod {
+	var podList = corev1.PodList{}
+
+	var opts = []k8scontrollerclient.ListOption{
+		k8scontrollerclient.InNamespace(catalogSource.GetNamespace()),
+		// NOTE: this will fail if we stop setting the label on the catalog source pod
+		k8scontrollerclient.MatchingLabels{
+			catalogSourceLabel: catalogSource.GetName(),
+		},
+	}
+
+	// Try to get a pod until its found and there's only one of them
+	Eventually(func() error {
+		if err := client.List(context.TODO(), &podList, opts...); err != nil {
+			return err
+		}
+		if len(podList.Items) != 1 {
+			return errors.New(fmt.Sprintf("expecting one catalog source pod but found %d", len(podList.Items)))
+		}
+		return nil
+	}).Should(BeNil())
+
+	return &podList.Items[0]
+}
+
+func mustCreateCatalogSource(client k8scontrollerclient.Client, catalogSource *v1alpha1.CatalogSource) {
+	// create the object
+	Expect(client.Create(context.TODO(), catalogSource)).To(BeNil())
+
+	// wait for object to be appear
+	Eventually(func() error {
+		return client.Get(context.TODO(), k8scontrollerclient.ObjectKey{
+			Name:      catalogSource.Name,
+			Namespace: catalogSource.GetNamespace(),
+		}, &v1alpha1.CatalogSource{})
+	}).Should(BeNil())
+}

--- a/test/e2e/ctx/provisioner_kind.go
+++ b/test/e2e/ctx/provisioner_kind.go
@@ -83,6 +83,7 @@ func Provision(ctx *TestContext) (func(), error) {
 	}
 	kubeconfigPath := filepath.Join(dir, "kubeconfig")
 
+	ctx.Logf("e2e cluster kubeconfig: %s\n", kubeconfigPath)
 	provider := cluster.NewProvider(
 		cluster.ProviderWithLogger(kindLogAdapter{ctx}),
 	)


### PR DESCRIPTION
**Description of the change:**
The CatalogSource CRD was recently [updated](https://github.com/operator-framework/api/pull/173) to carry an additional and optional attribute `grpcPodConfig` as an envelope for pod spec overrides that we may want to give to the users, starting with: `tolerations`, `nodeSelector`, and `priorityClassName`. For instance:

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
...
# optional
grpcPodConfig:
  # optional
  priorityClassName: https://github.com/operator-framework/api/pull/173
  #optional
  tolerations:
    - key: some
      operator: Equal
      value: value
      effect: NoSchedule
  # optional
  nodeSelector: 
     kubernetes.io/os: linux
     some: tag
```

**Motivation for the change:**
We want to give cluster admins a way to force catalog source pods to be scheduled on specific infrastructure (i.e. nodes)

**Questions**

**Does it make sense to expose `priorityClassName` and not `priority`?**

`priorityClassName` seems to be used with special (custom) priority classes and `system-node-critical` and `system-cluster-critical` (which I think are reserved and very high priority). I think it should be fine to **not** expose the `priority` knob as well. I think `priorityClassName` covers most cases where an admin would want to affect priority. But, I'd be keen to have this assumption checked =)

**Should we update the api and use `*string` for `PriorityClassName`**

Since we want to override settings, it could make sense to differentiate between not set and empty. A priorityClassName of `""` says to use the default priority. We don't set our own priorityClassName in our catalog source pod definition. So, the only issue here is that in case we decide to do that (which I don't think is likely), the user will not be able to unset it, i.e. override it to be `""`. But, even though unlikely, if we have the chance and it is quick, why not "do it right"? (if you guys also agree that seems the most correctest)

**NOTE:** This PR will eventually also introduce `vendor` changes. For reviewer sanity, I'll try to keep those off the PR for as long as possible

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive