### PR TITLE
Add system constraint provider logic to resolver

### DIFF
--- a/pkg/controller/registry/resolver/hooks.go
+++ b/pkg/controller/registry/resolver/hooks.go
@@ -1,0 +1,9 @@
+package resolver
+
+// stepResolverInitHook provides a way for the downstream
+// to modify the step resolver at creation time.
+// This is a bit of a hack to enable system constraints downstream
+// without affecting the upstream. We may want to clean this up when
+// either we have a more pluggable architecture; or system constraints
+// come to the upstream
+type stepResolverInitHook func(*OperatorStepResolver) error

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -66,6 +66,109 @@ func TestSolveOperators(t *testing.T) {
 	require.EqualValues(t, expected, operators)
 }
 
+func TestSolveOperators_WithSystemConstraints(t *testing.T) {
+	const namespace = "test-namespace"
+	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
+
+	packageASub := newSub(namespace, "packageA", "alpha", catalog)
+	packageDSub := existingSub(namespace, "packageD.v1", "packageD", "alpha", catalog)
+
+	APISet := cache.APISet{opregistry.APIKey{Group: "g", Version: "v", Kind: "k", Plural: "ks"}: struct{}{}}
+
+	// packageA requires an API that can be provided by B or C
+	packageA := genOperator("packageA.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, APISet, nil, nil, "", false)
+	packageB := genOperator("packageB.v1", "1.0.0", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, APISet, nil, "", false)
+	packageC := genOperator("packageC.v1", "1.0.0", "", "packageC", "alpha", catalog.Name, catalog.Namespace, nil, APISet, nil, "", false)
+
+	// Existing operators
+	packageD := genOperator("packageD.v1", "1.0.0", "", "packageD", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false)
+	existingPackageD := existingOperator(namespace, "packageD.v1", "packageD", "alpha", "", nil, nil, nil, nil)
+	existingPackageD.Annotations = map[string]string{"operatorframework.io/properties": `{"properties":[{"type":"olm.package","value":{"packageName":"packageD","version":"1.0.0"}}]}`}
+
+	whiteListConstraintProvider := func(whiteList ...*cache.Entry) solver.ConstraintProviderFunc {
+		return func(entry *cache.Entry) ([]solver.Constraint, error) {
+			for _, whiteListedEntry := range whiteList {
+				if whiteListedEntry.Package() == entry.Package() &&
+					whiteListedEntry.Name == entry.Name &&
+					whiteListedEntry.Version == entry.Version {
+					return nil, nil
+				}
+			}
+			return []solver.Constraint{PrettyConstraint(
+				solver.Prohibited(),
+				fmt.Sprintf("package: %s is not white listed", entry.Package()),
+			)}, nil
+		}
+	}
+
+	testCases := []struct {
+		title                     string
+		systemConstraintsProvider solver.ConstraintProvider
+		expectedOperators         cache.OperatorSet
+		csvs                      []*v1alpha1.ClusterServiceVersion
+		subs                      []*v1alpha1.Subscription
+		snapshotEntries           []*cache.Entry
+		err                       string
+	}{
+		{
+			title:                     "No runtime constraints",
+			snapshotEntries:           []*cache.Entry{packageA, packageB, packageC, packageD},
+			systemConstraintsProvider: nil,
+			expectedOperators:         cache.OperatorSet{"packageA.v1": packageA, "packageB.v1": packageB},
+			csvs:                      nil,
+			subs:                      []*v1alpha1.Subscription{packageASub},
+			err:                       "",
+		},
+		{
+			title:                     "Runtime constraints only accept packages A and C",
+			snapshotEntries:           []*cache.Entry{packageA, packageB, packageC, packageD},
+			systemConstraintsProvider: whiteListConstraintProvider(packageA, packageC),
+			expectedOperators:         cache.OperatorSet{"packageA.v1": packageA, "packageC.v1": packageC},
+			csvs:                      nil,
+			subs:                      []*v1alpha1.Subscription{packageASub},
+			err:                       "",
+		},
+		{
+			title:                     "Existing packages are ignored",
+			snapshotEntries:           []*cache.Entry{packageA, packageB, packageC, packageD},
+			systemConstraintsProvider: whiteListConstraintProvider(packageA, packageC),
+			expectedOperators:         cache.OperatorSet{"packageA.v1": packageA, "packageC.v1": packageC},
+			csvs:                      []*v1alpha1.ClusterServiceVersion{existingPackageD},
+			subs:                      []*v1alpha1.Subscription{packageASub, packageDSub},
+			err:                       "",
+		},
+		{
+			title:                     "Runtime constraints don't allow A",
+			snapshotEntries:           []*cache.Entry{packageA, packageB, packageC, packageD},
+			systemConstraintsProvider: whiteListConstraintProvider(),
+			expectedOperators:         nil,
+			csvs:                      nil,
+			subs:                      []*v1alpha1.Subscription{packageASub},
+			err:                       "packageA is not white listed",
+		},
+	}
+
+	for _, testCase := range testCases {
+		satResolver := SatResolver{
+			cache: cache.New(cache.StaticSourceProvider{
+				catalog: &cache.Snapshot{
+					Entries: testCase.snapshotEntries,
+				},
+			}),
+			log:                       logrus.New(),
+			systemConstraintsProvider: testCase.systemConstraintsProvider,
+		}
+		operators, err := satResolver.SolveOperators([]string{namespace}, testCase.csvs, testCase.subs)
+
+		if testCase.err != "" {
+			require.Containsf(t, err.Error(), testCase.err, "Test %s failed", testCase.title)
+		} else {
+			require.NoErrorf(t, err, "Test %s failed", testCase.title)
+		}
+		require.EqualValuesf(t, testCase.expectedOperators, operators, "Test %s failed", testCase.title)
+	}
+}
+
 func TestDisjointChannelGraph(t *testing.T) {
 	const namespace = "test-namespace"
 	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}

--- a/pkg/controller/registry/resolver/solver/constraint_provider.go
+++ b/pkg/controller/registry/resolver/solver/constraint_provider.go
@@ -1,0 +1,19 @@
+package solver
+
+import "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
+
+// ConstraintProvider knows how to provide solver constraints for a given cache entry.
+// For instance, it could be used to surface additional constraints against an entry given some
+// properties it may expose. E.g. olm.maxOpenShiftVersion could be checked against the cluster version
+// and prohibit any entry that doesn't meet the requirement
+type ConstraintProvider interface {
+	// Constraints returns a set of solver constraints for a cache entry.
+	Constraints(e *cache.Entry) ([]Constraint, error)
+}
+
+// ConstraintProviderFunc is a simple implementation of ConstraintProvider
+type ConstraintProviderFunc func(e *cache.Entry) ([]Constraint, error)
+
+func (c ConstraintProviderFunc) Constraints(e *cache.Entry) ([]Constraint, error) {
+	return c(e)
+}

--- a/pkg/controller/registry/resolver/step_resolver.go
+++ b/pkg/controller/registry/resolver/step_resolver.go
@@ -26,6 +26,9 @@ const (
 	BundleLookupConditionPacked v1alpha1.BundleLookupConditionType = "BundleLookupNotPersisted"
 )
 
+// init hooks provides the downstream a way to modify the upstream behavior
+var initHooks []stepResolverInitHook
+
 var timeNow = func() metav1.Time { return metav1.NewTime(time.Now().UTC()) }
 
 type StepResolver interface {
@@ -48,7 +51,7 @@ var _ StepResolver = &OperatorStepResolver{}
 
 func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versioned.Interface, kubeclient kubernetes.Interface,
 	globalCatalogNamespace string, provider RegistryClientProvider, log logrus.FieldLogger) *OperatorStepResolver {
-	return &OperatorStepResolver{
+	stepResolver := &OperatorStepResolver{
 		subLister:              lister.OperatorsV1alpha1().SubscriptionLister(),
 		csvLister:              lister.OperatorsV1alpha1().ClusterServiceVersionLister(),
 		ipLister:               lister.OperatorsV1alpha1().InstallPlanLister(),
@@ -58,6 +61,15 @@ func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versio
 		satResolver:            NewDefaultSatResolver(SourceProviderFromRegistryClientProvider(provider, log), lister.OperatorsV1alpha1().CatalogSourceLister(), log),
 		log:                    log,
 	}
+
+	// init hooks can be added to the downstream to
+	// modify resolver behaviour
+	for _, initHook := range initHooks {
+		if err := initHook(stepResolver); err != nil {
+			panic(err)
+		}
+	}
+	return stepResolver
 }
 
 func (r *OperatorStepResolver) Expire(key cache.SourceKey) {


### PR DESCRIPTION
Signed-off-by: Per G. da Silva <perdasilva@redhat.com>

**Description of the change:**
This PR adds a `systemConstraintsProvider` to the `resolver`. It also modifies the resolver to apply any constraints comming from the `systemContraintsProvider`. Secondly, it add `initHooks` to the `OperatorStepResolver`. This allows the downstream to modify resolver behaviour.

**Motivation for the change:**
For 4.10 we'd like to have a way for the resolver to respect the `maxOpenShiftVersion` property that can be provided by bundles to ensure that operator supports the cluster onto which it is being installed. This is done by injecting an OpenShift `systemConstraintsProvider` into the `satResolver` using an `initHook` on the downstream.

The init hooks provide a lightweight way of doing this from downstream without affecting the upstream or providing (in the upstream) a way for users to reach the `systemConstraintsProvider`. At least until we want to open this more generally.

*Note:* This PR must be merged sync'ed with the downstream before the downstream PR can be cut


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
