### PR TITLE
chore(github): run e2e workflow against master periodically

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,5 +1,7 @@
 name: e2e
 on:
+  schedule:
+    - cron: '30 5,17 * * *' # run this every day at 5:30 and 17:30 UTC (00:30 and 12:30 ET)
   push:
     branches:
       - master


### PR DESCRIPTION
**Description of the change:**

Run the e2e GitHub workflow against master periodically, twice per day, at 00:30 and 12:30 ET.

**Motivation for the change:**

In order to effectively judge if a failing test is due to changes introduced by a given PR, we need a baseline to compare against; i.e. was this test failing in master before this change? how often? is this actually a flake? By making the e2e tests periodic, we can start building a historical set of test artifacts to act as this baseline.
