### PR TITLE
Fix github alias links in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,8 +5,8 @@ for general contribution guidelines.
 
 ## Maintainers (in alphabetical order)
 
-- [Alexander Greene](github.com/awgreene), Red Hat
-- [Evan Cordell](github.com/ecordell), Authzed
-- [Kevin Rizza](github.com/kevinrizza), Red Hat
-- [Nick Hale](github.com/njhale), Red Hat
-- [Vu Dinh](github.com/dinhxuanvu), Red Hat
+- [Alexander Greene](https://github.com/awgreene), Red Hat
+- [Evan Cordell](https://github.com/ecordell), Authzed
+- [Kevin Rizza](https://github.com/kevinrizza), Red Hat
+- [Nick Hale](https://github.com/njhale), Red Hat
+- [Vu Dinh](https://github.com/dinhxuanvu), Red Hat


### PR DESCRIPTION
Prepend the https://github.com to ensure that markdown rendered links
are not resolved as local links.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
