### PR TITLE
fix disable copied csv e2e test failure

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -951,7 +951,7 @@ func HaveMessage(goal string) gtypes.GomegaMatcher {
 	}, ContainSubstring(goal))
 }
 
-func SetupGeneratedTestNamespace(name string) corev1.Namespace {
+func SetupGeneratedTestNamespaceWithOperatorGroup(name string, og operatorsv1.OperatorGroup) corev1.Namespace {
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -961,15 +961,6 @@ func SetupGeneratedTestNamespace(name string) corev1.Namespace {
 		return ctx.Ctx().Client().Create(context.Background(), &ns)
 	}).Should(Succeed())
 
-	og := operatorsv1.OperatorGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-operatorgroup", ns.GetName()),
-			Namespace: ns.GetName(),
-		},
-		Spec: operatorsv1.OperatorGroupSpec{
-			TargetNamespaces: []string{ns.GetName()},
-		},
-	}
 	Eventually(func() error {
 		return ctx.Ctx().Client().Create(context.Background(), &og)
 	}).Should(Succeed())
@@ -977,6 +968,20 @@ func SetupGeneratedTestNamespace(name string) corev1.Namespace {
 	ctx.Ctx().Logf("created the %s testing namespace", ns.GetName())
 
 	return ns
+}
+
+func SetupGeneratedTestNamespace(name string) corev1.Namespace {
+	og := operatorsv1.OperatorGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-operatorgroup", name),
+			Namespace: name,
+		},
+		Spec: operatorsv1.OperatorGroupSpec{
+			TargetNamespaces: []string{name},
+		},
+	}
+
+	return SetupGeneratedTestNamespaceWithOperatorGroup(name, og)
 }
 
 func TeardownNamespace(ns string) {


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
The all tests in ` Describe("Disabling copied CSVs"` need a namespace, operatorgroup and csv but they are setup only for the first test.  These are not cleaned up after the test so the following tests success when the tests are executed from top to bottom.  This PR adds the setup and clean up for all tests in "Disabling copied CSVs".

**Motivation for the change:**
Closes #2542 
**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
