### PR TITLE
Fix the image repository goreleaser configuration

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -53,14 +53,14 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          IMAGE_REPO: ${{ secrets.QUAY_USERNAME }}/olm
+          IMAGE_REPO: quay.io/operator-framework/olm
           PKG: github.com/operator-framework/operator-lifecycle-manager
 
       - name: Generate quickstart release manifests
         if: startsWith(github.ref, 'refs/tags')
-        run: make release ver=${{ env.IMAGE_TAG }} IMAGE_REPO=quay.io/${{ secrets.QUAY_USERNAME }}/olm
+        run: make release ver=${{ env.IMAGE_TAG }} IMAGE_REPO=quay.io/operator-framework/olm
 
-      - name: Update release artifacts with rendered Kubernetes manifests
+      - name: Update release artifacts with rendered Kubernetes release manifests
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags')
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,7 @@ builds:
     - -X {{ .Env.PKG }}/pkg/version.OLMVersion={{ .Tag }}
 dockers:
 - image_templates:
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64"
   dockerfile: Dockerfile.goreleaser
   use: buildx
   goos: linux
@@ -84,7 +84,7 @@ dockers:
   build_flag_templates:
   - --platform=linux/amd64
 - image_templates:
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64"
   dockerfile: Dockerfile.goreleaser
   use: buildx
   goos: linux
@@ -92,7 +92,7 @@ dockers:
   build_flag_templates:
   - --platform=linux/arm64
 - image_templates:
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le"
   dockerfile: Dockerfile.goreleaser
   use: buildx
   goos: linux
@@ -100,7 +100,7 @@ dockers:
   build_flag_templates:
   - --platform=linux/ppc64le
 - image_templates:
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x"
   dockerfile: Dockerfile.goreleaser
   use: buildx
   goos: linux
@@ -108,18 +108,18 @@ dockers:
   build_flag_templates:
   - --platform=linux/s390x
 docker_manifests:
-- name_template: quay.io/{{ .Env.IMAGE_REPO }}:v{{ .Major }}.{{ .Minor }}
+- name_template: "{{ .Env.IMAGE_REPO }}:v{{ .Major }}.{{ .Minor }}"
   image_templates:
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x
-- name_template: quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x"
+- name_template: "{{ .Env.IMAGE_REPO }}:{{ .Tag }}"
   image_templates:
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le
-  - quay.io/{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-arm64"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-ppc64le"
+  - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-s390x"
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Update the .goreleaser.yaml and CI action configurations and ensure the
correct container image registry repository is provided when automation
is triggered on the creation of a new git tag.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
