### PR TITLE
CSV e2e - wait for 2 pods ready before delete one pod

### DIFF
--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -502,6 +502,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 		})
 
 		It("remains in phase Succeeded when only one pod is available", func() {
+			Eventually(func() int32 {
+				dep, err := c.GetDeployment(testNamespace, "deployment")
+				if err != nil || dep == nil {
+					return 0
+				}
+				return dep.Status.ReadyReplicas
+			}).Should(Equal(int32(2)))
+
 			var ps corev1.PodList
 			Expect(ctx.Ctx().Client().List(context.Background(), &ps, client.MatchingLabels{"app": "foobar"})).To(Succeed())
 			Expect(ps.Items).To(Not(BeEmpty()))


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Make sure 2 pods are ready for the deployment before the test deletes one of them for testing.

**Motivation for the change:**
Closes #2553

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
