### PR TITLE
Remove the unused 'lint' Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,10 +186,6 @@ clean:
 	@rm -rf test/e2e/log
 	@rm -rf e2e.namespace
 
-lint:
-	find . -name '*.go' -not -path "./vendor/*" -not -path "./pkg/lib/operatorclient/operatorclientmocks/*" | xargs gofmt -w
-	find . -name '*.go' -not -path "./vendor/*" -not -path "./pkg/lib/operatorclient/operatorclientmocks/*" | xargs goimports -w
-
 # Copy CRD manifests
 manifests: vendor
 	./scripts/copy_crds.sh


### PR DESCRIPTION
The 'lint' target is no longer used throughout CI since the integration
with golangci-lint, which runs both the goimports and gofmt tooling
under-the-hood.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
