### PR TITLE
Update goreleaser go version to 1.17

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: '~1.17'
 
       - name: Get the image tag
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
This commit updates the go version in the
goreleaser github action which was missed
in ab8bb974ab31bebe66bb62ad8735d31036534633.