### PR TITLE
recover nil GRPCConnectionState by update failure

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -793,8 +793,13 @@ func (o *Operator) syncConnection(logger *logrus.Entry, in *v1alpha1.CatalogSour
 		updateConnectionStateFunc(out, source)
 	}
 
+	// GRPCConnectionState update must fail before
+	if out.Status.GRPCConnectionState == nil {
+		updateConnectionStateFunc(out, source)
+	}
+
 	// connection is already good, but we need to update the sync time
-	if out.Status.GRPCConnectionState != nil && o.sourcesLastUpdate.After(out.Status.GRPCConnectionState.LastConnectTime.Time) {
+	if o.sourcesLastUpdate.After(out.Status.GRPCConnectionState.LastConnectTime.Time) {
 		// Set connection status and return.
 		out.Status.GRPCConnectionState.LastConnectTime = now
 		out.Status.GRPCConnectionState.LastObservedState = source.ConnectionState.String()


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR fixes the e2e test failures with the time out of the following message
```
waiting for catalog pod mock-ocs-main-j48j7 to be available (for sync) - NO_CONNECTION
``` 

When the grpc state change is processed first time, the `Status.GRPCConnectionState` of the CatalogSource instance is initialized in the `syncConnection` called by `syncCatalogSources`.  When the CalalogSource instance update at the end of the `syncCatalogSources` is failed (because it has been modified), the `Status.GRPCConnectionState` is never initialized again.  This change initializes the `Status.GRPCConnectionState` with the current values when is not initialized.

```
### CatalogSource sync entry
2022-01-05T19:11:07.689125083Z stderr F time="2022-01-05T19:11:07Z" level=debug msg="syncing catsrc" id=aOM/E source=catalog-r84z2
2022-01-05T19:11:07.689219283Z stderr F time="2022-01-05T19:11:07Z" level=debug msg="checking catsrc configmap state" id=aOM/E source=catalog-r84z2
2022-01-05T19:11:07.689755987Z stderr F time="2022-01-05T19:11:07Z" level=debug msg="check registry server healthy: true" id=aOM/E source=catalog-r84z2
2022-01-05T19:11:07.689930688Z stderr F time="2022-01-05T19:11:07Z" level=debug msg="registry state good" id=aOM/E source=catalog-r84z2
### first time grpc state change reported
2022-01-05T19:11:07.722578295Z stderr F time="2022-01-05T19:11:07Z" level=debug msg="Got source event: grpc.SourceState{Key:registry.CatalogKey{Name:\"catalog-r84z2\", Namespace:\"a-5kxzr\"}, State:1}"
2022-01-05T19:11:07.722608396Z stderr F time="2022-01-05T19:11:07Z" level=info msg="state.Key.Namespace=a-5kxzr state.Key.Name=catalog-r84z2 state.State=CONNECTING"
2022-01-05T19:11:07.724631709Z stderr F time="2022-01-05T19:11:07Z" level=info msg="syncing catalog source for annotation templates" catSrcName=catalog-r84z2 catSrcNamespace=a-5kxzr id=xAxXL
2022-01-05T19:11:07.724645509Z stderr F time="2022-01-05T19:11:07Z" level=debug msg="this catalog source is not participating in template replacement" catSrcName=catalog-r84z2 catSrcNamespace=a-5kxzr id=xAxXL
2022-01-05T19:11:07.724649709Z stderr F time="2022-01-05T19:11:07Z" level=debug msg="RemoveStatusConditions - request to remove status conditions did not result in any changes, so updates were not made" catSrcName=catalog-r84z2 catSrcNamespace=a-5kxzr id=xAxXL
### CatalogSource update failure
2022-01-05T19:11:07.724653909Z stderr F time="2022-01-05T19:11:07Z" level=error msg="UpdateStatus - error while setting CatalogSource status" error="Operation cannot be fulfilled on catalogsources.operators.coreos.com \"catalog-r84z2\": the object has been modified; please apply your changes to the latest version and try again" id=aOM/E source=catalog-r84z2
2022-01-05T19:11:07.724676309Z stderr F E0105 19:11:07.724190       1 queueinformer_operator.go:290] sync {"update" "a-5kxzr/catalog-r84z2"} failed: Operation cannot be fulfilled on catalogsources.operators.coreos.com "catalog-r84z2": the object has been modified; please apply your changes to the latest version and try again

```

**Motivation for the change:**

Closes #2560 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
