### PR TITLE
Do not modify object from the lister cache 

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -646,6 +646,7 @@ func (c *ConfigMapUnpacker) ensureRole(cmRef *corev1.ObjectReference) (role *rba
 			return
 		}
 	}
+	role = role.DeepCopy()
 	role.Rules = append(role.Rules, rule)
 
 	role, err = c.client.RbacV1().Roles(role.GetNamespace()).Update(context.TODO(), role, metav1.UpdateOptions{})

--- a/pkg/controller/install/apiservice.go
+++ b/pkg/controller/install/apiservice.go
@@ -41,6 +41,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateAPIService(caPEM []byte, des
 		}
 		apiService.SetName(apiServiceName)
 	} else {
+		apiService = apiService.DeepCopy()
 		csv, ok := i.owner.(*v1alpha1.ClusterServiceVersion)
 		if !ok {
 			return fmt.Errorf("failed to typecast the APIService owner: APIServices require a CSV owner")

--- a/pkg/controller/install/webhook.go
+++ b/pkg/controller/install/webhook.go
@@ -106,6 +106,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateMutatingWebhook(ogNamespacel
 		}
 	}
 	for _, webhook := range existingWebhooks.Items {
+		webhook = *webhook.DeepCopy()
 		// Update the list of webhooks
 		webhook.Webhooks = []admissionregistrationv1.MutatingWebhook{
 			desc.GetMutatingWebhook(i.owner.GetNamespace(), ogNamespacelabelSelector, caPEM),
@@ -154,6 +155,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateValidatingWebhook(ogNamespac
 		return nil
 	}
 	for _, webhook := range existingWebhooks.Items {
+		webhook = *webhook.DeepCopy()
 		// Update the list of webhooks
 		webhook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 			desc.GetValidatingWebhook(i.owner.GetNamespace(), ogNamespacelabelSelector, caPEM),

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -842,6 +842,7 @@ func (a *Operator) syncObject(obj interface{}) (syncError error) {
 	if related {
 		csvList := a.csvSet(metaObj.GetNamespace(), v1alpha1.CSVPhaseFailed)
 		for _, csv := range csvList {
+			csv = csv.DeepCopy()
 			if csv.Status.Reason != v1alpha1.CSVReasonComponentFailedNoRetry {
 				continue
 			}
@@ -1238,7 +1239,7 @@ func (a *Operator) allNamespaceOperatorGroups() ([]*v1.OperatorGroup, error) {
 	result := []*v1.OperatorGroup{}
 	for _, operatorGroup := range operatorGroups {
 		if NewNamespaceSet(operatorGroup.Status.Namespaces).IsAllNamespaces() {
-			result = append(result, operatorGroup)
+			result = append(result, operatorGroup.DeepCopy())
 		}
 	}
 	return result, nil
@@ -1477,7 +1478,7 @@ func (a *Operator) getCopiedCSVDisabledEventsForCSV(csv *v1alpha1.ClusterService
 			event.InvolvedObject.Name == csv.GetName() &&
 			event.InvolvedObject.UID == csv.GetUID() &&
 			event.Reason == v1.DisabledCopiedCSVsConditionType {
-			result = append(result, event)
+			result = append(result, *event.DeepCopy())
 		}
 	}
 
@@ -1586,7 +1587,7 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 		return nil
 	}
 
-	return operatorGroup
+	return operatorGroup.DeepCopy()
 }
 
 func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logger *logrus.Entry) (*v1.OperatorGroup, error) {
@@ -1627,7 +1628,7 @@ func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logg
 			return nil, nil
 		}
 		logger.Debug("csv in operatorgroup")
-		return operatorGroup, nil
+		return operatorGroup.DeepCopy(), nil
 	default:
 		err = fmt.Errorf("csv created in namespace with multiple operatorgroups, can't pick one automatically")
 		logger.WithError(err).Warn("csv failed to become an operatorgroup member")


### PR DESCRIPTION
Problem: Objects retrieved from the lister should
not be modified.

Solution: Return a DeepCopy of the object retrieved
from the lister which can then be manipulated as
needed.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>
