### PR TITLE
Bump olmConfig controller logging message to debug

### DIFF
--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -1245,7 +1245,7 @@ func (a *Operator) allNamespaceOperatorGroups() ([]*v1.OperatorGroup, error) {
 }
 
 func (a *Operator) syncOLMConfig(obj interface{}) (syncError error) {
-	a.logger.Info("Processing olmConfig")
+	a.logger.Debug("Processing olmConfig")
 	olmConfig, ok := obj.(*v1.OLMConfig)
 	if !ok {
 		return fmt.Errorf("casting OLMConfig failed")


### PR DESCRIPTION
Problem: Minimal value is gained from logging olmConfig
reconcile message.

Solution: Bump message from info level to debug level.