### PR TITLE
chore(constraint): Correct message to failureMessage in olm.constraint schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/onsi/gomega v1.15.0
 	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/operator-framework/api v0.11.0
+	github.com/operator-framework/api v0.11.1
 	github.com/operator-framework/operator-registry v1.17.5
 	github.com/otiai10/copy v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
-github.com/operator-framework/api v0.11.0 h1:W9V1NNwl3LWPQL9S1pDaFONCarJLl8Xu6gdF9w54hTE=
-github.com/operator-framework/api v0.11.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/api v0.11.1 h1:5eNUMplyL/GZrnBgG4SS2csO3+Fl4F79OqXN6POHQyA=
+github.com/operator-framework/api v0.11.1/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
 github.com/operator-framework/operator-registry v1.17.5 h1:LR8m1rFz5Gcyje8WK6iYt+gIhtzqo52zMRALdmTYHT0=
 github.com/operator-framework/operator-registry v1.17.5/go.mod h1:sRQIgDMZZdUcmHltzyCnM6RUoDF+WS8Arj1BQIARDS8=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/pkg/controller/registry/resolver/cache/predicates.go
+++ b/pkg/controller/registry/resolver/cache/predicates.go
@@ -358,9 +358,9 @@ func CountingPredicate(p Predicate, n *int) Predicate {
 }
 
 type celPredicate struct {
-	program constraints.CelProgram
-	rule    string
-	message string
+	program        constraints.CelProgram
+	rule           string
+	failureMessage string
 }
 
 func (cp *celPredicate) Test(entry *Entry) bool {
@@ -383,14 +383,14 @@ func (cp *celPredicate) Test(entry *Entry) bool {
 	return ok
 }
 
-func CreateCelPredicate(env *constraints.CelEnvironment, rule string, message string) (Predicate, error) {
+func CreateCelPredicate(env *constraints.CelEnvironment, rule string, failureMessage string) (Predicate, error) {
 	prog, err := env.Validate(rule)
 	if err != nil {
 		return nil, err
 	}
-	return &celPredicate{program: prog, rule: rule, message: message}, nil
+	return &celPredicate{program: prog, rule: rule, failureMessage: failureMessage}, nil
 }
 
 func (cp *celPredicate) String() string {
-	return fmt.Sprintf("with constraint: %q and message: %q", cp.rule, cp.message)
+	return fmt.Sprintf("with constraint: %q and message: %q", cp.rule, cp.failureMessage)
 }

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -837,7 +837,7 @@ func (pc *predicateConverter) convertConstraints(constraints ...constraints.Cons
 			subs, perr := pc.convertConstraints(constraint.None.Constraints...)
 			preds[i], err = cache.Not(subs...), perr
 		case constraint.Cel != nil:
-			preds[i], err = cache.CreateCelPredicate(pc.celEnv, constraint.Cel.Rule, constraint.Message)
+			preds[i], err = cache.CreateCelPredicate(pc.celEnv, constraint.Cel.Rule, constraint.FailureMessage)
 		default:
 			// Unknown constraint types are handled by constraints.Parse(),
 			// but parsed constraints may be empty.

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -903,7 +903,7 @@ func TestSolveOperators_OLMConstraint_CompoundAll(t *testing.T) {
 		catName: csName, catNamespace: namespace,
 		properties: []*api.Property{{
 			Type: constraints.OLMConstraintType,
-			Value: `{"message": "all constraint",
+			Value: `{"failureMessage": "all constraint",
 				"all": {"constraints": [
 					{"package": {"packageName": "foo", "versionRange": ">=1.0.0"}},
 					{"gvk": {"group": "g1", "version": "v1", "kind": "k1"}},
@@ -985,7 +985,7 @@ func TestSolveOperators_OLMConstraint_CompoundAny(t *testing.T) {
 		catName: csName, catNamespace: namespace,
 		properties: []*api.Property{{
 			Type: constraints.OLMConstraintType,
-			Value: `{"message": "any constraint",
+			Value: `{"failureMessage": "any constraint",
 				"any": {"constraints": [
 					{"gvk": {"group": "g1", "version": "v1", "kind": "k1"}},
 					{"gvk": {"group": "g2", "version": "v2", "kind": "k2"}}
@@ -1065,7 +1065,7 @@ func TestSolveOperators_OLMConstraint_CompoundNone(t *testing.T) {
 		properties: []*api.Property{
 			{
 				Type: constraints.OLMConstraintType,
-				Value: `{"message": "compound none constraint",
+				Value: `{"failureMessage": "compound none constraint",
 					"all": {"constraints": [
 						{"gvk": {"group": "g0", "version": "v0", "kind": "k0"}},
 						{"none": {"constraints": [
@@ -1150,7 +1150,7 @@ func TestSolveOperators_OLMConstraint_Unknown(t *testing.T) {
 		catName: csName, catNamespace: namespace,
 		properties: []*api.Property{{
 			Type:  constraints.OLMConstraintType,
-			Value: `{"message": "unknown constraint", "unknown": {"foo": "bar"}}`,
+			Value: `{"failureMessage": "unknown constraint", "unknown": {"foo": "bar"}}`,
 		}},
 	}}
 
@@ -2489,21 +2489,21 @@ func TestSolveOperators_GenericConstraint(t *testing.T) {
 	deps1 := []*api.Dependency{
 		{
 			Type: "olm.constraint",
-			Value: `{"message":"gvk-constraint",
+			Value: `{"failureMessage":"gvk-constraint",
 				"cel":{"rule":"properties.exists(p, p.type == 'olm.gvk' && p.value == {'group': 'g', 'version': 'v', 'kind': 'k'})"}}`,
 		},
 	}
 	deps2 := []*api.Dependency{
 		{
 			Type: "olm.constraint",
-			Value: `{"message":"gvk2-constraint",
+			Value: `{"failureMessage":"gvk2-constraint",
 				"cel":{"rule":"properties.exists(p, p.type == 'olm.gvk' && p.value == {'group': 'g2', 'version': 'v', 'kind': 'k'})"}}`,
 		},
 	}
 	deps3 := []*api.Dependency{
 		{
 			Type: "olm.constraint",
-			Value: `{"message":"package-constraint",
+			Value: `{"failureMessage":"package-constraint",
 				"cel":{"rule":"properties.exists(p, p.type == 'olm.package' && p.value.packageName == 'packageB' && (semver_compare(p.value.version, '1.0.1') == 0))"}}`,
 		},
 	}

--- a/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
+++ b/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
@@ -12,9 +12,9 @@ const OLMConstraintType = "olm.constraint"
 
 // Constraint holds parsed, potentially nested dependency constraints.
 type Constraint struct {
-	// Constraint message that surfaces in resolution
+	// Constraint failure message that surfaces in resolution
 	// This field is optional
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	FailureMessage string `json:"failureMessage,omitempty" yaml:"failureMessage,omitempty"`
 
 	// The cel struct that contraints CEL expression
 	Cel *Cel `json:"cel,omitempty" yaml:"cel,omitempty"`

--- a/vendor/github.com/operator-framework/api/pkg/validation/internal/good_practices.go
+++ b/vendor/github.com/operator-framework/api/pkg/validation/internal/good_practices.go
@@ -65,10 +65,10 @@ func validateResourceRequests(csv *operatorsv1alpha1.ClusterServiceVersion) (err
 	for _, dSpec := range deploymentSpec {
 		for _, c := range dSpec.Spec.Template.Spec.Containers {
 			if c.Resources.Requests == nil || !(len(c.Resources.Requests.Cpu().String()) != 0 && len(c.Resources.Requests.Memory().String()) != 0) {
-				msg := fmt.Errorf("unable to find the resource requests for the container %s. It is recommended "+
+				msg := fmt.Errorf("unable to find the resource requests for the container: (%s). It is recommended "+
 					"to ensure the resource request for CPU and Memory. Be aware that for some clusters configurations "+
 					"it is required to specify requests or limits for those values. Otherwise, the system or quota may "+
-					"reject Pod creation. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/", c.Name)
+					"reject Pod creation. More info: https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/", c.Name)
 				warns = append(warns, msg)
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -624,7 +624,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/operator-framework/api v0.11.0
+# github.com/operator-framework/api v0.11.1
 ## explicit; go 1.16
 github.com/operator-framework/api/crds
 github.com/operator-framework/api/pkg/constraints


### PR DESCRIPTION
The correct field for olm.constraint is `failureMessage` instead of `message`
as it is currently in the code. This change is to honor the field name that
is specified in the original enhancement.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
