### PR TITLE
feat: update api version to be 0.12.0 in order to use new Not constraint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/onsi/gomega v1.15.0
 	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/operator-framework/api v0.11.1
+	github.com/operator-framework/api v0.12.0
 	github.com/operator-framework/operator-registry v1.17.5
 	github.com/otiai10/copy v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
-github.com/operator-framework/api v0.11.1 h1:5eNUMplyL/GZrnBgG4SS2csO3+Fl4F79OqXN6POHQyA=
-github.com/operator-framework/api v0.11.1/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/api v0.12.0 h1:aHxHk50/Y1J4Ogdk2J6tYofgX+GEqyBPCMyun+JFqV4=
+github.com/operator-framework/api v0.12.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
 github.com/operator-framework/operator-registry v1.17.5 h1:LR8m1rFz5Gcyje8WK6iYt+gIhtzqo52zMRALdmTYHT0=
 github.com/operator-framework/operator-registry v1.17.5/go.mod h1:sRQIgDMZZdUcmHltzyCnM6RUoDF+WS8Arj1BQIARDS8=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -833,8 +833,8 @@ func (pc *predicateConverter) convertConstraints(constraints ...constraints.Cons
 		case constraint.Any != nil:
 			subs, perr := pc.convertConstraints(constraint.Any.Constraints...)
 			preds[i], err = cache.Or(subs...), perr
-		case constraint.None != nil:
-			subs, perr := pc.convertConstraints(constraint.None.Constraints...)
+		case constraint.Not != nil:
+			subs, perr := pc.convertConstraints(constraint.Not.Constraints...)
 			preds[i], err = cache.Not(subs...), perr
 		case constraint.Cel != nil:
 			preds[i], err = cache.CreateCelPredicate(pc.celEnv, constraint.Cel.Rule, constraint.FailureMessage)

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -1053,7 +1053,7 @@ func TestSolveOperators_OLMConstraint_CompoundAny(t *testing.T) {
 	}
 }
 
-func TestSolveOperators_OLMConstraint_CompoundNone(t *testing.T) {
+func TestSolveOperators_OLMConstraint_CompoundNot(t *testing.T) {
 	namespace := "olm"
 	csName := "community"
 	catalog := cache.SourceKey{Name: csName, Namespace: namespace}
@@ -1065,10 +1065,10 @@ func TestSolveOperators_OLMConstraint_CompoundNone(t *testing.T) {
 		properties: []*api.Property{
 			{
 				Type: constraints.OLMConstraintType,
-				Value: `{"failureMessage": "compound none constraint",
+				Value: `{"failureMessage": "compound not constraint",
 					"all": {"constraints": [
 						{"gvk": {"group": "g0", "version": "v0", "kind": "k0"}},
-						{"none": {"constraints": [
+						{"not": {"constraints": [
 							{"gvk": {"group": "g1", "version": "v1", "kind": "k1"}},
 							{"gvk": {"group": "g2", "version": "v2", "kind": "k2"}}
 						]}}

--- a/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
+++ b/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
@@ -25,14 +25,15 @@ type Constraint struct {
 	// GVK defines a constraint for a GVK.
 	GVK *GVKConstraint `json:"gvk,omitempty" yaml:"gvk,omitempty"`
 
-	// All, Any, and None are compound constraints. See this enhancement for details:
+	// All, Any, and Not are compound constraints. See this enhancement for details:
 	// https://github.com/operator-framework/enhancements/blob/master/enhancements/compound-bundle-constraints.md
 	All *CompoundConstraint `json:"all,omitempty" yaml:"all,omitempty"`
 	Any *CompoundConstraint `json:"any,omitempty" yaml:"any,omitempty"`
-	// A note on None: this constraint is not particularly useful by itself.
+	// A note on Not: this constraint isn't particularly useful by itself.
 	// It should be used within an All constraint alongside some other constraint type
-	// since saying "none of these GVKs/packages/etc." without an alternative doesn't make sense.
-	None *CompoundConstraint `json:"none,omitempty" yaml:"none,omitempty"`
+	// since saying "do not use any of these GVKs/packages/etc." without an alternative
+	// doesn't make sense.
+	Not *CompoundConstraint `json:"not,omitempty" yaml:"not,omitempty"`
 }
 
 // CompoundConstraint holds a list of potentially nested constraints

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -624,7 +624,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/operator-framework/api v0.11.1
+# github.com/operator-framework/api v0.12.0
 ## explicit; go 1.16
 github.com/operator-framework/api/crds
 github.com/operator-framework/api/pkg/constraints


### PR DESCRIPTION
Signed-off-by: Tyler Slaton <tyslaton@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updating the o-f/api version to be [0.12.0](https://github.com/operator-framework/api/releases) in order to bring in the renaming compound constraint of "None" -> "Not". This also updates the code around that uses the compound constraint API to use Not instead of None.

**Motivation for the change:**
This is to make the interface for interacting with the negation compound constraint clearer. It also helps to avoid the confusion described in BZ 2034319.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
