### PR TITLE
Fix a bug in deletion of webhook service for replacement

### DIFF
--- a/pkg/controller/install/certresources.go
+++ b/pkg/controller/install/certresources.go
@@ -246,7 +246,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Delete the Service to replace
 		deleteErr := i.strategyClient.GetOpClient().DeleteService(service.GetNamespace(), service.GetName(), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(deleteErr) {
+		if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
 			return nil, nil, fmt.Errorf("could not delete existing service %s", service.GetName())
 		}
 	}


### PR DESCRIPTION
The condition that checks for an error with the webhook service deletion is based on the wrong variable, and the return statement is never reached, which leads to a continuous error when OLM tries to replace the webhook service on certain conditions

Signed-off-by: orenc1 <ocohen@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

https://bugzilla.redhat.com/show_bug.cgi?id=2048441

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
