### PR TITLE
fix: remove hardcoded minikube version from build_local.sh 

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -8,7 +8,7 @@ set -e
 [ -x "$(command -v kind)" ] && [[ "$(kubectl config current-context)" =~ ^kind-? ]] && KIND=1 NO_MINIKUBE=1
 
 if [ -z "$NO_MINIKUBE" ]; then
-  pgrep -f "[m]inikube" >/dev/null || minikube start --kubernetes-version="v1.16.4" --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
+  pgrep -f "[m]inikube" >/dev/null || minikube start --extra-config=apiserver.v=4 || { echo 'Cannot start minikube.'; exit 1; }
   eval "$(minikube docker-env)" || { echo 'Cannot switch to minikube docker'; exit 1; }
   kubectl config use-context minikube
 fi


### PR DESCRIPTION
This change supports OLM minikube users locally since the currently hardcoded kubernetes version v1.16.4 is severely outdated and doesn't work on recent versions of minikube. The script will instead use the version of kubernetes associated with the existing version of minikube. 

OLM has largely moved to kind for CI and local testing, but users running minikube locally should also be able to run OLM. 

Signed-off-by: Daniel Sover <dsover@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
