### PR TITLE
Add workflow for automatically rebasing open PRs

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -1,0 +1,20 @@
+name: rebase pull request
+on:
+  push:
+    branches:
+    - master
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/rebase@v1
+        with:
+          base: master
+      - name: Send failure message
+        uses: peter-evans/create-or-update-comment@v1
+        if: ${{ failure() }}
+        with:
+          issue-number: ${{ github.event.issue.number || github.event.number }}
+          body: |
+            Automatic rebasing for this PR has failed. You'll need to manually
+            rebase against the default branch.


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Introduce a workflow that's reponsible for automatically rebasing open
PRs when a commit has landed in the default (e.g. master) branch. Ensure
a comment is posted on that PR when the rebasing action job has failed.

**Motivation for the change:**
This repository currently specifies the "require branches to be up-to-date before merging" branch protection rule for the master branch to avoid merging PRs that break or regress master builds.


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
