### PR TITLE
Remove extra registry pod when it is created

### DIFF
--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -234,6 +234,11 @@ func (c *ConfigMapRegistryReconciler) currentPodsWithCorrectResourceVersion(sour
 	}
 	if len(pods) > 1 {
 		logrus.WithField("selector", source.Labels()).Debug("multiple pods found for selector")
+		for i := 1; i < len(pods); i++ {
+			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(source.GetNamespace()).Delete(context.TODO(), pods[i].GetName(), *metav1.NewDeleteOptions(0)); err != nil && !k8serrors.IsNotFound(err) {
+				logrus.Debugf("error deleting extra pod: %s", pods[i].GetName())
+			}
+		}
 	}
 	return pods
 }


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This PR adds a mutex block around the creation of the configmap retistry pod.  I reproduced this error locally a couple of times.  I saw 2 registry pods created with the same **configMapResourceVersion**.  The 2 queue process workers created the pod at the same time.  This mutex block prevent 2 workers checking and creating the registry pod at the same time. 

**Motivation for the change:**
Closes #2613 
**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
