### PR TITLE
fix: lower logging level to reduce noisiness 

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -121,7 +121,7 @@ func (o *options) run(ctx context.Context, logger *logrus.Logger) error {
 	<-opCatalogTemplate.Ready()
 
 	if o.writeStatusName != "" {
-		operatorstatus.MonitorClusterStatus(o.writeStatusName, op.AtLevel(), op.Done(), opClient, configClient, crClient)
+		operatorstatus.MonitorClusterStatus(o.writeStatusName, op.AtLevel(), op.Done(), opClient, configClient, crClient, logger)
 	}
 
 	<-op.Done()

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -462,7 +462,7 @@ func (o *Operator) now() metav1.Time {
 func (o *Operator) syncSourceState(state grpc.SourceState) {
 	o.sourcesLastUpdate.Set(o.now().Time)
 
-	o.logger.Infof("state.Key.Namespace=%s state.Key.Name=%s state.State=%s", state.Key.Namespace, state.Key.Name, state.State.String())
+	o.logger.Debugf("state.Key.Namespace=%s state.Key.Name=%s state.State=%s", state.Key.Namespace, state.Key.Name, state.State.String())
 	metrics.RegisterCatalogSourceState(state.Key.Name, state.Key.Namespace, state.State)
 
 	switch state.State {

--- a/pkg/controller/operators/catalogtemplate/operator.go
+++ b/pkg/controller/operators/catalogtemplate/operator.go
@@ -137,7 +137,7 @@ func (o *Operator) syncCatalogSources(obj interface{}) error {
 		"catSrcName":      outputCatalogSource.GetName(),
 		"id":              queueinformer.NewLoopID(),
 	})
-	logger.Info("syncing catalog source for annotation templates")
+	logger.Debug("syncing catalog source for annotation templates")
 
 	catalogImageTemplate := catalogsource.GetCatalogTemplateAnnotation(outputCatalogSource)
 	if catalogImageTemplate == "" {

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -140,7 +140,7 @@ func (c *GrpcRegistryReconciler) currentService(source grpcCatalogSourceDecorato
 	serviceName := source.Service().GetName()
 	service, err := c.Lister.CoreV1().ServiceLister().Services(source.GetNamespace()).Get(serviceName)
 	if err != nil {
-		logrus.WithField("service", serviceName).Warn("couldn't find service in cache")
+		logrus.WithField("service", serviceName).Debug("couldn't find service in cache")
 		return nil
 	}
 	return service
@@ -153,7 +153,7 @@ func (c *GrpcRegistryReconciler) currentPods(source grpcCatalogSourceDecorator) 
 		return nil
 	}
 	if len(pods) > 1 {
-		logrus.WithField("selector", source.Selector()).Warn("multiple pods found for selector")
+		logrus.WithField("selector", source.Selector()).Debug("multiple pods found for selector")
 	}
 	return pods
 }
@@ -165,7 +165,7 @@ func (c *GrpcRegistryReconciler) currentUpdatePods(source grpcCatalogSourceDecor
 		return nil
 	}
 	if len(pods) > 1 {
-		logrus.WithField("selector", source.Selector()).Warn("multiple pods found for selector")
+		logrus.WithField("selector", source.Selector()).Debug("multiple pods found for selector")
 	}
 	return pods
 }
@@ -274,7 +274,7 @@ func (c *GrpcRegistryReconciler) ensureUpdatePod(source grpcCatalogSourceDecorat
 	currentUpdatePods := c.currentUpdatePods(source)
 
 	if source.Update() && len(currentUpdatePods) == 0 {
-		logrus.WithField("CatalogSource", source.GetName()).Infof("catalog update required at %s", time.Now().String())
+		logrus.WithField("CatalogSource", source.GetName()).Debugf("catalog update required at %s", time.Now().String())
 		pod, err := c.createUpdatePod(source, saName)
 		if err != nil {
 			return errors.Wrapf(err, "creating update catalog source pod")
@@ -315,7 +315,7 @@ func (c *GrpcRegistryReconciler) ensureUpdatePod(source grpcCatalogSourceDecorat
 			return nil
 		}
 		// delete update pod right away, since the digest match, to prevent long-lived duplicate catalog pods
-		logrus.WithField("CatalogSource", source.GetName()).Info("catalog polling result: no update")
+		logrus.WithField("CatalogSource", source.GetName()).Debug("catalog polling result: no update")
 		err := c.removePods([]*corev1.Pod{updatePod}, source.GetNamespace())
 		if err != nil {
 			return errors.Wrapf(err, "error deleting duplicate catalog polling pod: %s", updatePod.GetName())

--- a/pkg/lib/csv/replace_finder.go
+++ b/pkg/lib/csv/replace_finder.go
@@ -41,7 +41,7 @@ func (r *replace) IsBeingReplaced(in *v1alpha1.ClusterServiceVersion, csvsInName
 			continue
 		}
 
-		r.logger.Infof("checking %s", csv.GetName())
+		r.logger.Debugf("checking %s", csv.GetName())
 
 		if csv.Spec.Replaces == in.GetName() {
 			r.logger.Infof("%s replaced by %s", in.GetName(), csv.GetName())

--- a/pkg/lib/operatorstatus/status.go
+++ b/pkg/lib/operatorstatus/status.go
@@ -10,7 +10,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +33,8 @@ const (
 	installPlanResource           = "installplans"
 )
 
-func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct{}, opClient operatorclient.ClientInterface, configClient configv1client.ConfigV1Interface, crClient versioned.Interface) {
+func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct{}, opClient operatorclient.ClientInterface,
+	configClient configv1client.ConfigV1Interface, crClient versioned.Interface, log *logrus.Logger) {
 	var (
 		syncs              int
 		successfulSyncs    int
@@ -123,7 +124,7 @@ func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct
 				log.Errorf("Failed to create cluster operator: %v\n", createErr)
 				return
 			}
-			created.Status.RelatedObjects, err = relatedObjects(name, opClient, crClient)
+			created.Status.RelatedObjects, err = relatedObjects(name, opClient, crClient, log)
 			if err != nil {
 				log.Errorf("Failed to get related objects: %v", err)
 			}
@@ -208,7 +209,7 @@ func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct
 		}
 
 		// always update the related objects in case changes have occurred
-		existing.Status.RelatedObjects, err = relatedObjects(name, opClient, crClient)
+		existing.Status.RelatedObjects, err = relatedObjects(name, opClient, crClient, log)
 		if err != nil {
 			log.Errorf("Failed to get related objects: %v", err)
 		}
@@ -265,9 +266,9 @@ func findOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCond
 
 // relatedObjects returns RelatedObjects in the ClusterOperator.Status.
 // RelatedObjects are consumed by https://github.com/openshift/must-gather
-func relatedObjects(name string, opClient operatorclient.ClientInterface, crClient versioned.Interface) ([]configv1.ObjectReference, error) {
+func relatedObjects(name string, opClient operatorclient.ClientInterface, crClient versioned.Interface, log *logrus.Logger) ([]configv1.ObjectReference, error) {
 	var objectReferences []configv1.ObjectReference
-	log.Infof("Adding related objects for %v", name)
+	log.Debugf("Adding related objects for %v", name)
 	namespace := openshiftNamespace // hard-coded to constant
 
 	switch name {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change moves following logs to the debug level, to lower the amount of logs generated by OLM by default:
```
* syncing catalog source for annotation templates
* catalog polling result: no update
* catalog update required
* state.Key.Namespace={NS} state.Key.Name={NAME} state.State={STATE}
* multiple pods found for selector
* checking {CSVNAME}
```

This PR does not address the logs generated by conflicts as those are emitted by the queue_informer and it is not readily apparent how to turn the logging level down for those particular events. 

**Motivation for the change:**
Large numbers of uneventful logs generated by OLM causes unnecessarily high memory usage by log aggregation tools that parse OLM logs. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
