### PR TITLE
Replace hardcoded resolver cache mutation with CSV cache.Source.

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -189,7 +189,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 	}
 	op.sources = grpc.NewSourceStore(logger, 10*time.Second, 10*time.Minute, op.syncSourceState)
 	op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, opClient, configmapRegistryImage, op.now, ssaClient)
-	res := resolver.NewOperatorStepResolver(lister, crClient, opClient.KubernetesInterface(), operatorNamespace, op.sources, logger)
+	res := resolver.NewOperatorStepResolver(lister, crClient, operatorNamespace, op.sources, logger)
 	op.resolver = resolver.NewInstrumentedResolver(res, metrics.RegisterDependencyResolutionSuccess, metrics.RegisterDependencyResolutionFailure)
 
 	// Wire OLM CR sharedIndexInformers

--- a/pkg/controller/registry/resolver/cache/operators.go
+++ b/pkg/controller/registry/resolver/cache/operators.go
@@ -199,9 +199,6 @@ func (i *OperatorSourceInfo) String() string {
 	return fmt.Sprintf("%s/%s in %s/%s", i.Package, i.Channel, i.Catalog.Name, i.Catalog.Namespace)
 }
 
-var NoCatalog = SourceKey{Name: "", Namespace: ""}
-var ExistingOperator = OperatorSourceInfo{Package: "", Channel: "", StartingCSV: "", Catalog: NoCatalog, DefaultChannel: false}
-
 type Entry struct {
 	Name         string
 	Replaces     string

--- a/pkg/controller/registry/resolver/source_csvs.go
+++ b/pkg/controller/registry/resolver/source_csvs.go
@@ -1,0 +1,214 @@
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1alpha1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
+	"github.com/operator-framework/operator-registry/pkg/api"
+	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type csvSourceProvider struct {
+	csvLister v1alpha1listers.ClusterServiceVersionLister
+	subLister v1alpha1listers.SubscriptionLister
+	logger    logrus.StdLogger
+}
+
+func (csp *csvSourceProvider) Sources(namespaces ...string) map[cache.SourceKey]cache.Source {
+	result := make(map[cache.SourceKey]cache.Source)
+	for _, namespace := range namespaces {
+		result[cache.NewVirtualSourceKey(namespace)] = &csvSource{
+			key:       cache.NewVirtualSourceKey(namespace),
+			csvLister: csp.csvLister.ClusterServiceVersions(namespace),
+			subLister: csp.subLister.Subscriptions(namespace),
+			logger:    csp.logger,
+		}
+		break // first ns is assumed to be the target ns, todo: make explicit
+	}
+	return result
+}
+
+type csvSource struct {
+	key       cache.SourceKey
+	csvLister v1alpha1listers.ClusterServiceVersionNamespaceLister
+	subLister v1alpha1listers.SubscriptionNamespaceLister
+	logger    logrus.StdLogger
+}
+
+func (s *csvSource) Snapshot(ctx context.Context) (*cache.Snapshot, error) {
+	csvs, err := s.csvLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	subs, err := s.subLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	// build a catalog snapshot of CSVs without subscriptions
+	csvSubscriptions := make(map[*v1alpha1.ClusterServiceVersion]*v1alpha1.Subscription)
+	for _, sub := range subs {
+		for _, csv := range csvs {
+			if csv.IsCopied() {
+				continue
+			}
+			if csv.Name == sub.Status.InstalledCSV {
+				csvSubscriptions[csv] = sub
+				break
+			}
+		}
+	}
+
+	var csvsMissingProperties []*v1alpha1.ClusterServiceVersion
+	var entries []*cache.Entry
+	for _, csv := range csvs {
+		if csv.IsCopied() {
+			continue
+		}
+		entry, err := newEntryFromV1Alpha1CSV(csv)
+		if err != nil {
+			return nil, err
+		}
+		entry.SourceInfo = &cache.OperatorSourceInfo{
+			Catalog:      s.key,
+			Subscription: csvSubscriptions[csv],
+		}
+
+		entries = append(entries, entry)
+
+		if anno, ok := csv.GetAnnotations()[projection.PropertiesAnnotationKey]; !ok {
+			csvsMissingProperties = append(csvsMissingProperties, csv)
+			if inferred, err := s.inferProperties(csv, subs); err != nil {
+				s.logger.Printf("unable to infer properties for csv %q: %w", csv.Name, err)
+			} else {
+				entry.Properties = append(entry.Properties, inferred...)
+			}
+		} else if props, err := projection.PropertyListFromPropertiesAnnotation(anno); err != nil {
+			return nil, fmt.Errorf("failed to retrieve properties of csv %q: %w", csv.GetName(), err)
+		} else {
+			entry.Properties = props
+		}
+
+		// Try to determine source package name from properties and add to SourceInfo.
+		for _, p := range entry.Properties {
+			if p.Type != opregistry.PackageType {
+				continue
+			}
+			var pp opregistry.PackageProperty
+			err := json.Unmarshal([]byte(p.Value), &pp)
+			if err != nil {
+				s.logger.Printf("failed to unmarshal package property of csv %q: %w", csv.Name, err)
+				continue
+			}
+			entry.SourceInfo.Package = pp.PackageName
+		}
+	}
+
+	if len(csvsMissingProperties) > 0 {
+		names := make([]string, len(csvsMissingProperties))
+		for i, csv := range csvsMissingProperties {
+			names[i] = csv.GetName()
+		}
+		s.logger.Printf("considered csvs without properties annotation during resolution: %v", names)
+	}
+
+	return &cache.Snapshot{Entries: entries}, nil
+}
+
+func (s *csvSource) inferProperties(csv *v1alpha1.ClusterServiceVersion, subs []*v1alpha1.Subscription) ([]*api.Property, error) {
+	var properties []*api.Property
+
+	packages := make(map[string]struct{})
+	for _, sub := range subs {
+		if sub.Status.InstalledCSV != csv.Name {
+			continue
+		}
+		if pkg := sub.Spec.Package; pkg != "" {
+			packages[pkg] = struct{}{}
+		}
+		// An erroneous package inference is possible if a user edits spec.package in a
+		// Subscription that already references a ClusterServiceVersion via
+		// status.installedCSV, but all recent versions of the catalog operator project
+		// properties onto all ClusterServiceVersions they create.
+	}
+	if l := len(packages); l != 1 {
+		s.logger.Printf("could not unambiguously infer package name for %q (found %d distinct package names)", csv.Name, l)
+		return properties, nil
+	}
+	var pkg string
+	for pkg = range packages {
+		// Assign the single key to pkg.
+	}
+	var version string // Emit empty string rather than "0.0.0" if .spec.version is zero-valued.
+	if !csv.Spec.Version.Version.Equals(semver.Version{}) {
+		version = csv.Spec.Version.String()
+	}
+	pp, err := json.Marshal(opregistry.PackageProperty{
+		PackageName: pkg,
+		Version:     version,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal inferred package property: %w", err)
+	}
+	properties = append(properties, &api.Property{
+		Type:  opregistry.PackageType,
+		Value: string(pp),
+	})
+
+	return properties, nil
+}
+
+func newEntryFromV1Alpha1CSV(csv *v1alpha1.ClusterServiceVersion) (*cache.Entry, error) {
+	providedAPIs := cache.EmptyAPISet()
+	for _, crdDef := range csv.Spec.CustomResourceDefinitions.Owned {
+		parts := strings.SplitN(crdDef.Name, ".", 2)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("error parsing crd name: %s", crdDef.Name)
+		}
+		providedAPIs[opregistry.APIKey{Plural: parts[0], Group: parts[1], Version: crdDef.Version, Kind: crdDef.Kind}] = struct{}{}
+	}
+	for _, api := range csv.Spec.APIServiceDefinitions.Owned {
+		providedAPIs[opregistry.APIKey{Group: api.Group, Version: api.Version, Kind: api.Kind, Plural: api.Name}] = struct{}{}
+	}
+
+	requiredAPIs := cache.EmptyAPISet()
+	for _, crdDef := range csv.Spec.CustomResourceDefinitions.Required {
+		parts := strings.SplitN(crdDef.Name, ".", 2)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("error parsing crd name: %s", crdDef.Name)
+		}
+		requiredAPIs[opregistry.APIKey{Plural: parts[0], Group: parts[1], Version: crdDef.Version, Kind: crdDef.Kind}] = struct{}{}
+	}
+	for _, api := range csv.Spec.APIServiceDefinitions.Required {
+		requiredAPIs[opregistry.APIKey{Group: api.Group, Version: api.Version, Kind: api.Kind, Plural: api.Name}] = struct{}{}
+	}
+
+	properties, err := providedAPIsToProperties(providedAPIs)
+	if err != nil {
+		return nil, err
+	}
+	dependencies, err := requiredAPIsToProperties(requiredAPIs)
+	if err != nil {
+		return nil, err
+	}
+	properties = append(properties, dependencies...)
+
+	return &cache.Entry{
+		Name:         csv.GetName(),
+		Version:      &csv.Spec.Version.Version,
+		ProvidedAPIs: providedAPIs,
+		RequiredAPIs: requiredAPIs,
+		SourceInfo:   &cache.OperatorSourceInfo{},
+		Properties:   properties,
+	}, nil
+}

--- a/pkg/controller/registry/resolver/source_csvs_test.go
+++ b/pkg/controller/registry/resolver/source_csvs_test.go
@@ -1,0 +1,469 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	opver "github.com/operator-framework/api/pkg/lib/version"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
+	"github.com/operator-framework/operator-registry/pkg/api"
+	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
+)
+
+func TestInferProperties(t *testing.T) {
+	catalog := cache.SourceKey{Namespace: "namespace", Name: "name"}
+
+	for _, tc := range []struct {
+		Name          string
+		CSV           *v1alpha1.ClusterServiceVersion
+		Subscriptions []*v1alpha1.Subscription
+		Expected      []*api.Property
+	}{
+		{
+			Name: "no subscriptions infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+		},
+		{
+			Name: "one unrelated subscription infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "b",
+					},
+				},
+			},
+		},
+		{
+			Name: "one subscription with empty package field infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "two related subscriptions infers no properties",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "x",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package: "y",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+		},
+		{
+			Name: "one matching subscription infers package property",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: opver.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          catalog.Name,
+						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":"1.2.3"}`,
+				},
+			},
+		},
+		{
+			Name: "one matching subscription to other-namespace catalogsource infers package property",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					Version: opver.OperatorVersion{Version: semver.MustParse("1.2.3")},
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          "other-name",
+						CatalogSourceNamespace: "other-namespace",
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":"1.2.3"}`,
+				},
+			},
+		},
+		{
+			Name: "one matching subscription infers package property without csv version",
+			CSV: &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			},
+			Subscriptions: []*v1alpha1.Subscription{
+				{
+					Spec: &v1alpha1.SubscriptionSpec{
+						Package:                "x",
+						CatalogSource:          catalog.Name,
+						CatalogSourceNamespace: catalog.Namespace,
+					},
+					Status: v1alpha1.SubscriptionStatus{
+						InstalledCSV: "a",
+					},
+				},
+			},
+			Expected: []*api.Property{
+				{
+					Type:  "olm.package",
+					Value: `{"packageName":"x","version":""}`,
+				},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			require := require.New(t)
+			logger, _ := test.NewNullLogger()
+			s := &csvSource{
+				logger: logger,
+			}
+			actual, err := s.inferProperties(tc.CSV, tc.Subscriptions)
+			require.NoError(err)
+			require.Equal(tc.Expected, actual)
+		})
+	}
+}
+
+func TestNewEntryFromCSV(t *testing.T) {
+	version := opver.OperatorVersion{Version: semver.MustParse("0.1.0-abc")}
+	type args struct {
+		csv *v1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *cache.Entry
+		wantErr error
+	}{
+		{
+			name: "NoProvided/NoRequired",
+			args: args{
+				csv: &v1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "operator.v1",
+					},
+					Spec: v1alpha1.ClusterServiceVersionSpec{
+						Version: version,
+					},
+				},
+			},
+			want: &cache.Entry{
+				Name:         "operator.v1",
+				ProvidedAPIs: cache.EmptyAPISet(),
+				RequiredAPIs: cache.EmptyAPISet(),
+				SourceInfo:   &cache.OperatorSourceInfo{},
+				Version:      &version.Version,
+			},
+		},
+		{
+			name: "Provided/NoRequired",
+			args: args{
+				csv: &v1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "operator.v1",
+					},
+					Spec: v1alpha1.ClusterServiceVersionSpec{
+						Version: version,
+						CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+							Owned: []v1alpha1.CRDDescription{
+								{
+									Name:    "crdkinds.g",
+									Version: "v1",
+									Kind:    "CRDKind",
+								},
+							},
+						},
+						APIServiceDefinitions: v1alpha1.APIServiceDefinitions{
+							Owned: []v1alpha1.APIServiceDescription{
+								{
+									Name:    "apikinds",
+									Group:   "g",
+									Version: "v1",
+									Kind:    "APIKind",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &cache.Entry{
+				Name: "operator.v1",
+				ProvidedAPIs: map[opregistry.APIKey]struct{}{
+					{Group: "g", Version: "v1", Kind: "APIKind", Plural: "apikinds"}: {},
+					{Group: "g", Version: "v1", Kind: "CRDKind", Plural: "crdkinds"}: {},
+				},
+				Properties: []*api.Property{
+					{
+						Type:  "olm.gvk",
+						Value: "{\"group\":\"g\",\"kind\":\"APIKind\",\"version\":\"v1\"}",
+					},
+					{
+						Type:  "olm.gvk",
+						Value: "{\"group\":\"g\",\"kind\":\"CRDKind\",\"version\":\"v1\"}",
+					},
+				},
+				RequiredAPIs: cache.EmptyAPISet(),
+				SourceInfo:   &cache.OperatorSourceInfo{},
+				Version:      &version.Version,
+			},
+		},
+		{
+			name: "NoProvided/Required",
+			args: args{
+				csv: &v1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "operator.v1",
+					},
+					Spec: v1alpha1.ClusterServiceVersionSpec{
+						Version: version,
+						CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+							Required: []v1alpha1.CRDDescription{
+								{
+									Name:    "crdkinds.g",
+									Version: "v1",
+									Kind:    "CRDKind",
+								},
+							},
+						},
+						APIServiceDefinitions: v1alpha1.APIServiceDefinitions{
+							Required: []v1alpha1.APIServiceDescription{
+								{
+									Name:    "apikinds",
+									Group:   "g",
+									Version: "v1",
+									Kind:    "APIKind",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &cache.Entry{
+				Name:         "operator.v1",
+				ProvidedAPIs: cache.EmptyAPISet(),
+				RequiredAPIs: map[opregistry.APIKey]struct{}{
+					{Group: "g", Version: "v1", Kind: "APIKind", Plural: "apikinds"}: {},
+					{Group: "g", Version: "v1", Kind: "CRDKind", Plural: "crdkinds"}: {},
+				},
+				Properties: []*api.Property{
+					{
+						Type:  "olm.gvk.required",
+						Value: "{\"group\":\"g\",\"kind\":\"APIKind\",\"version\":\"v1\"}",
+					},
+					{
+						Type:  "olm.gvk.required",
+						Value: "{\"group\":\"g\",\"kind\":\"CRDKind\",\"version\":\"v1\"}",
+					},
+				},
+				SourceInfo: &cache.OperatorSourceInfo{},
+				Version:    &version.Version,
+			},
+		},
+		{
+			name: "Provided/Required",
+			args: args{
+				csv: &v1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "operator.v1",
+					},
+					Spec: v1alpha1.ClusterServiceVersionSpec{
+						Version: version,
+						CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+							Owned: []v1alpha1.CRDDescription{
+								{
+									Name:    "crdownedkinds.g",
+									Version: "v1",
+									Kind:    "CRDOwnedKind",
+								},
+							},
+							Required: []v1alpha1.CRDDescription{
+								{
+									Name:    "crdreqkinds.g2",
+									Version: "v1",
+									Kind:    "CRDReqKind",
+								},
+							},
+						},
+						APIServiceDefinitions: v1alpha1.APIServiceDefinitions{
+							Owned: []v1alpha1.APIServiceDescription{
+								{
+									Name:    "apiownedkinds",
+									Group:   "g",
+									Version: "v1",
+									Kind:    "APIOwnedKind",
+								},
+							},
+							Required: []v1alpha1.APIServiceDescription{
+								{
+									Name:    "apireqkinds",
+									Group:   "g2",
+									Version: "v1",
+									Kind:    "APIReqKind",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &cache.Entry{
+				Name: "operator.v1",
+				ProvidedAPIs: map[opregistry.APIKey]struct{}{
+					{Group: "g", Version: "v1", Kind: "APIOwnedKind", Plural: "apiownedkinds"}: {},
+					{Group: "g", Version: "v1", Kind: "CRDOwnedKind", Plural: "crdownedkinds"}: {},
+				},
+				RequiredAPIs: map[opregistry.APIKey]struct{}{
+					{Group: "g2", Version: "v1", Kind: "APIReqKind", Plural: "apireqkinds"}: {},
+					{Group: "g2", Version: "v1", Kind: "CRDReqKind", Plural: "crdreqkinds"}: {},
+				},
+				Properties: []*api.Property{
+					{
+						Type:  "olm.gvk",
+						Value: "{\"group\":\"g\",\"kind\":\"APIOwnedKind\",\"version\":\"v1\"}",
+					},
+					{
+						Type:  "olm.gvk",
+						Value: "{\"group\":\"g\",\"kind\":\"CRDOwnedKind\",\"version\":\"v1\"}",
+					},
+					{
+						Type:  "olm.gvk.required",
+						Value: "{\"group\":\"g2\",\"kind\":\"APIReqKind\",\"version\":\"v1\"}",
+					},
+					{
+						Type:  "olm.gvk.required",
+						Value: "{\"group\":\"g2\",\"kind\":\"CRDReqKind\",\"version\":\"v1\"}",
+					},
+				},
+				SourceInfo: &cache.OperatorSourceInfo{},
+				Version:    &version.Version,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newEntryFromV1Alpha1CSV(tt.args.csv)
+			require.Equal(t, tt.wantErr, err)
+			requirePropertiesEqual(t, tt.want.Properties, got.Properties)
+			tt.want.Properties, got.Properties = nil, nil
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type fakeCSVLister []*v1alpha1.ClusterServiceVersion
+
+func (f fakeCSVLister) List(selector labels.Selector) ([]*v1alpha1.ClusterServiceVersion, error) {
+	return f, nil
+}
+
+func (f fakeCSVLister) Get(name string) (*v1alpha1.ClusterServiceVersion, error) {
+	for _, csv := range f {
+		if csv.Name == name {
+			return csv, nil
+		}
+	}
+	return nil, errors.NewNotFound(v1alpha1.SchemeGroupVersion.WithResource("clusterserviceversions").GroupResource(), name)
+}
+
+type fakeSubscriptionLister []*v1alpha1.Subscription
+
+func (f fakeSubscriptionLister) List(selector labels.Selector) ([]*v1alpha1.Subscription, error) {
+	return f, nil
+}
+
+func (f fakeSubscriptionLister) Get(name string) (*v1alpha1.Subscription, error) {
+	for _, sub := range f {
+		if sub.Name == name {
+			return sub, nil
+		}
+	}
+	return nil, errors.NewNotFound(v1alpha1.SchemeGroupVersion.WithResource("subscriptions").GroupResource(), name)
+}
+
+func TestPropertiesAnnotationHonored(t *testing.T) {
+	src := &csvSource{
+		csvLister: fakeCSVLister{
+			&v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"operatorframework.io/properties": `{"properties":[{"type":"test-type","value":{"test":"value"}}]}`,
+					},
+				},
+			},
+		},
+		subLister: fakeSubscriptionLister{},
+	}
+	ss, err := src.Snapshot(context.Background())
+	require.NoError(t, err)
+	requirePropertiesEqual(t, []*api.Property{{Type: "test-type", Value: `{"test":"value"}`}}, ss.Entries[0].Properties)
+}

--- a/pkg/controller/registry/resolver/step_resolver.go
+++ b/pkg/controller/registry/resolver/step_resolver.go
@@ -9,8 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
@@ -37,7 +35,6 @@ type OperatorStepResolver struct {
 	subLister              v1alpha1listers.SubscriptionLister
 	csvLister              v1alpha1listers.ClusterServiceVersionLister
 	client                 versioned.Interface
-	kubeclient             kubernetes.Interface
 	globalCatalogNamespace string
 	satResolver            *SatResolver
 	log                    logrus.FieldLogger
@@ -57,15 +54,23 @@ func (pp catsrcPriorityProvider) Priority(key cache.SourceKey) int {
 	return catsrc.Spec.Priority
 }
 
-func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versioned.Interface, kubeclient kubernetes.Interface,
-	globalCatalogNamespace string, provider RegistryClientProvider, log logrus.FieldLogger) *OperatorStepResolver {
+func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versioned.Interface, globalCatalogNamespace string, provider RegistryClientProvider, log logrus.FieldLogger) *OperatorStepResolver {
+	cacheSourceProvider := &mergedSourceProvider{
+		sps: []cache.SourceProvider{
+			SourceProviderFromRegistryClientProvider(provider, log),
+			&csvSourceProvider{
+				csvLister: lister.OperatorsV1alpha1().ClusterServiceVersionLister(),
+				subLister: lister.OperatorsV1alpha1().SubscriptionLister(),
+				logger:    log,
+			},
+		},
+	}
 	stepResolver := &OperatorStepResolver{
 		subLister:              lister.OperatorsV1alpha1().SubscriptionLister(),
 		csvLister:              lister.OperatorsV1alpha1().ClusterServiceVersionLister(),
 		client:                 client,
-		kubeclient:             kubeclient,
 		globalCatalogNamespace: globalCatalogNamespace,
-		satResolver:            NewDefaultSatResolver(SourceProviderFromRegistryClientProvider(provider, log), catsrcPriorityProvider{lister: lister.OperatorsV1alpha1().CatalogSourceLister()}, log),
+		satResolver:            NewDefaultSatResolver(cacheSourceProvider, catsrcPriorityProvider{lister: lister.OperatorsV1alpha1().CatalogSourceLister()}, log),
 		log:                    log,
 	}
 
@@ -84,21 +89,6 @@ func (r *OperatorStepResolver) Expire(key cache.SourceKey) {
 }
 
 func (r *OperatorStepResolver) ResolveSteps(namespace string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {
-	// create a generation - a representation of the current set of installed operators and their provided/required apis
-	allCSVs, err := r.csvLister.ClusterServiceVersions(namespace).List(labels.Everything())
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	// TODO: build this index ahead of time
-	// omit copied csvs from generation - they indicate that apis are provided to the namespace, not by the namespace
-	var csvs []*v1alpha1.ClusterServiceVersion
-	for i := range allCSVs {
-		if !allCSVs[i].IsCopied() {
-			csvs = append(csvs, allCSVs[i])
-		}
-	}
-
 	subs, err := r.listSubscriptions(namespace)
 	if err != nil {
 		return nil, nil, nil, err
@@ -106,7 +96,7 @@ func (r *OperatorStepResolver) ResolveSteps(namespace string) ([]*v1alpha1.Step,
 
 	var operators cache.OperatorSet
 	namespaces := []string{namespace, r.globalCatalogNamespace}
-	operators, err = r.satResolver.SolveOperators(namespaces, csvs, subs)
+	operators, err = r.satResolver.SolveOperators(namespaces, subs)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -249,4 +239,22 @@ func (r *OperatorStepResolver) listSubscriptions(namespace string) ([]*v1alpha1.
 	}
 
 	return subs, nil
+}
+
+type mergedSourceProvider struct {
+	sps    []cache.SourceProvider
+	logger logrus.StdLogger
+}
+
+func (msp *mergedSourceProvider) Sources(namespaces ...string) map[cache.SourceKey]cache.Source {
+	result := make(map[cache.SourceKey]cache.Source)
+	for _, sp := range msp.sps {
+		for key, source := range sp.Sources(namespaces...) {
+			if _, ok := result[key]; ok {
+				msp.logger.Printf("warning: duplicate sourcekey: %q\n", key)
+			}
+			result[key] = source
+		}
+	}
+	return result
 }

--- a/pkg/controller/registry/resolver/util_test.go
+++ b/pkg/controller/registry/resolver/util_test.go
@@ -18,16 +18,6 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
-// RequireStepsEqual is similar to require.ElementsMatch, but produces better error messages
-func RequireStepsEqual(t *testing.T, expectedSteps, steps []*v1alpha1.Step) {
-	for _, s := range expectedSteps {
-		require.Contains(t, steps, s, "step in expected not found in steps")
-	}
-	for _, s := range steps {
-		require.Contains(t, expectedSteps, s, "step in steps not found in expected")
-	}
-}
-
 func csv(name, replaces string, ownedCRDs, requiredCRDs, ownedAPIServices, requiredAPIServices cache.APISet, permissions, clusterPermissions []v1alpha1.StrategyDeploymentPermissions) *v1alpha1.ClusterServiceVersion {
 	var singleInstance = int32(1)
 	strategy := v1alpha1.StrategyDetailsDeployment{


### PR DESCRIPTION
The resolver depends on getting a cache of snapshots of all available catalogs, then synthesizing an extra snapshot containing the CSVs in the target namespace and inserting it into the cache. The `cache.Source` and `cache.SourceProvider` interfaces were introduced to support injecting cache entries from various non-registry sources. Implementing these interfaces reduces the coupling between the core resolution component and the CSV API, which should be a benefit if/when it comes time to support new on-cluster dependency resolution APIs. As an added benefit, the exported surface of the cache package shrinks.

