### PR TITLE
Remove CatalogSourceLister usage from resolver/cache.

### DIFF
--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/operator-framework/api/pkg/constraints"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	v1alpha1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
@@ -32,9 +31,9 @@ type SatResolver struct {
 	systemConstraintsProvider solver.ConstraintProvider
 }
 
-func NewDefaultSatResolver(rcp cache.SourceProvider, catsrcLister v1alpha1listers.CatalogSourceLister, logger logrus.FieldLogger) *SatResolver {
+func NewDefaultSatResolver(rcp cache.SourceProvider, sourcePriorityProvider cache.SourcePriorityProvider, logger logrus.FieldLogger) *SatResolver {
 	return &SatResolver{
-		cache: cache.New(rcp, cache.WithLogger(logger), cache.WithCatalogSourceLister(catsrcLister)),
+		cache: cache.New(rcp, cache.WithLogger(logger), cache.WithSourcePriorityProvider(sourcePriorityProvider)),
 		log:   logger,
 		pc: &predicateConverter{
 			celEnv: constraints.NewCelEnvironment(),

--- a/pkg/controller/registry/resolver/resolver_test.go
+++ b/pkg/controller/registry/resolver/resolver_test.go
@@ -505,7 +505,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	}
 
 	satResolver := SatResolver{
-		cache: cache.New(ssp, cache.WithCatalogSourceLister(&stubCatalogSourceLister{
+		cache: cache.New(ssp, cache.WithSourcePriorityProvider(catsrcPriorityProvider{lister: &stubCatalogSourceLister{
 			catsrcs: []*v1alpha1.CatalogSource{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -517,7 +517,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 					},
 				},
 			},
-		})),
+		}})),
 	}
 
 	operators, err := satResolver.SolveOperators([]string{"olm"}, []*v1alpha1.ClusterServiceVersion{}, subs)
@@ -545,7 +545,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	}
 
 	satResolver = SatResolver{
-		cache: cache.New(ssp, cache.WithCatalogSourceLister(&stubCatalogSourceLister{
+		cache: cache.New(ssp, cache.WithSourcePriorityProvider(catsrcPriorityProvider{lister: &stubCatalogSourceLister{
 			catsrcs: []*v1alpha1.CatalogSource{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -566,7 +566,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 					},
 				},
 			},
-		})),
+		}})),
 	}
 
 	operators, err = satResolver.SolveOperators([]string{"olm"}, []*v1alpha1.ClusterServiceVersion{}, subs)


### PR DESCRIPTION
The cache hardcodes the use of a CatalogSourceLister (imported from a
non-resolver package in the OLM module) in order to assign source
priorities based on the spec.priority field of CatalogSource. Not all
cache sources map to a CatalogSource, so this can instead accept a
priority provider interface and the resolver -> non-resolver imports
can be removed.
