### PR TITLE
Give Sources control of invalidation for Snapshots they produce.

### DIFF
--- a/pkg/controller/registry/resolver/cache/cache_test.go
+++ b/pkg/controller/registry/resolver/cache/cache_test.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,12 +67,12 @@ func TestOperatorCacheExpiration(t *testing.T) {
 	key := SourceKey{Namespace: "dummynamespace", Name: "dummyname"}
 	ssp := make(StaticSourceProvider)
 	c := New(ssp)
-	c.ttl = 0 // instantly stale
 
 	ssp[key] = &Snapshot{
 		Entries: []*Entry{
 			{Name: "v1"},
 		},
+		Valid: ValidOnce(),
 	}
 	require.Len(t, c.Namespaced("dummynamespace").Catalog(key).Find(CSVNamePredicate("v1")), 1)
 
@@ -108,62 +107,51 @@ func TestOperatorCacheReuse(t *testing.T) {
 func TestCatalogSnapshotValid(t *testing.T) {
 	type tc struct {
 		Name     string
-		Expiry   time.Time
 		Snapshot *Snapshot
 		Error    error
-		At       time.Time
 		Expected bool
 	}
 
 	for _, tt := range []tc{
 		{
-			Name:     "after expiry",
-			Expiry:   time.Unix(0, 1),
-			Snapshot: &Snapshot{},
+			Name: "invalidated",
+			Snapshot: &Snapshot{
+				Valid: ValidOnce(),
+			},
 			Error:    nil,
-			At:       time.Unix(0, 2),
 			Expected: false,
 		},
 		{
-			Name:     "before expiry",
-			Expiry:   time.Unix(0, 2),
-			Snapshot: &Snapshot{},
+			Name:     "valid",
+			Snapshot: &Snapshot{}, // valid forever
 			Error:    nil,
-			At:       time.Unix(0, 1),
 			Expected: true,
 		},
 		{
-			Name:     "nil snapshot",
-			Expiry:   time.Unix(0, 2),
+			Name:     "nil snapshot and non-nil error",
 			Snapshot: nil,
 			Error:    errors.New(""),
-			At:       time.Unix(0, 1),
 			Expected: false,
 		},
 		{
-			Name:     "non-nil error",
-			Expiry:   time.Unix(0, 2),
+			Name:     "non-nil snapshot and non-nil error",
 			Snapshot: &Snapshot{},
 			Error:    errors.New(""),
-			At:       time.Unix(0, 1),
 			Expected: false,
 		},
 		{
-			Name:     "at expiry",
-			Expiry:   time.Unix(0, 1),
-			Snapshot: &Snapshot{},
+			Name:     "nil snapshot and nil error",
+			Snapshot: nil,
 			Error:    nil,
-			At:       time.Unix(0, 1),
 			Expected: false,
 		},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
 			s := snapshotHeader{
-				expiry:   tt.Expiry,
 				snapshot: tt.Snapshot,
 				err:      tt.Error,
 			}
-			assert.Equal(t, tt.Expected, s.Valid(tt.At))
+			assert.Equal(t, tt.Expected, s.Valid())
 		})
 	}
 }

--- a/pkg/controller/registry/resolver/instrumented_resolver.go
+++ b/pkg/controller/registry/resolver/instrumented_resolver.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
 type InstrumentedResolver struct {
@@ -32,8 +31,4 @@ func (ir *InstrumentedResolver) ResolveSteps(namespace string) ([]*v1alpha1.Step
 		ir.successMetricsEmitter(time.Since(start))
 	}
 	return steps, lookups, subs, err
-}
-
-func (ir *InstrumentedResolver) Expire(key cache.SourceKey) {
-	ir.resolver.Expire(key)
 }

--- a/pkg/controller/registry/resolver/instrumented_resolver_test.go
+++ b/pkg/controller/registry/resolver/instrumented_resolver_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,14 +21,8 @@ func (r *fakeResolverWithError) ResolveSteps(namespace string) ([]*v1alpha1.Step
 	return nil, nil, nil, errors.New("Fake error")
 }
 
-func (r *fakeResolverWithError) Expire(key cache.SourceKey) {
-}
-
 func (r *fakeResolverWithoutError) ResolveSteps(namespace string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {
 	return nil, nil, nil, nil
-}
-
-func (r *fakeResolverWithoutError) Expire(key cache.SourceKey) {
 }
 
 func newFakeResolverWithError() *fakeResolverWithError {

--- a/pkg/controller/registry/resolver/source_csvs.go
+++ b/pkg/controller/registry/resolver/source_csvs.go
@@ -122,7 +122,10 @@ func (s *csvSource) Snapshot(ctx context.Context) (*cache.Snapshot, error) {
 		s.logger.Printf("considered csvs without properties annotation during resolution: %v", names)
 	}
 
-	return &cache.Snapshot{Entries: entries}, nil
+	return &cache.Snapshot{
+		Entries: entries,
+		Valid:   cache.ValidOnce(),
+	}, nil
 }
 
 func (s *csvSource) inferProperties(csv *v1alpha1.ClusterServiceVersion, subs []*v1alpha1.Subscription) ([]*api.Property, error) {

--- a/pkg/fakes/fake_resolver.go
+++ b/pkg/fakes/fake_resolver.go
@@ -6,15 +6,9 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
 type FakeStepResolver struct {
-	ExpireStub        func(cache.SourceKey)
-	expireMutex       sync.RWMutex
-	expireArgsForCall []struct {
-		arg1 cache.SourceKey
-	}
 	ResolveStepsStub        func(string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error)
 	resolveStepsMutex       sync.RWMutex
 	resolveStepsArgsForCall []struct {
@@ -34,37 +28,6 @@ type FakeStepResolver struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeStepResolver) Expire(arg1 cache.SourceKey) {
-	fake.expireMutex.Lock()
-	fake.expireArgsForCall = append(fake.expireArgsForCall, struct {
-		arg1 cache.SourceKey
-	}{arg1})
-	fake.recordInvocation("Expire", []interface{}{arg1})
-	fake.expireMutex.Unlock()
-	if fake.ExpireStub != nil {
-		fake.ExpireStub(arg1)
-	}
-}
-
-func (fake *FakeStepResolver) ExpireCallCount() int {
-	fake.expireMutex.RLock()
-	defer fake.expireMutex.RUnlock()
-	return len(fake.expireArgsForCall)
-}
-
-func (fake *FakeStepResolver) ExpireCalls(stub func(cache.SourceKey)) {
-	fake.expireMutex.Lock()
-	defer fake.expireMutex.Unlock()
-	fake.ExpireStub = stub
-}
-
-func (fake *FakeStepResolver) ExpireArgsForCall(i int) cache.SourceKey {
-	fake.expireMutex.RLock()
-	defer fake.expireMutex.RUnlock()
-	argsForCall := fake.expireArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *FakeStepResolver) ResolveSteps(arg1 string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {
@@ -139,8 +102,6 @@ func (fake *FakeStepResolver) ResolveStepsReturnsOnCall(i int, result1 []*v1alph
 func (fake *FakeStepResolver) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.expireMutex.RLock()
-	defer fake.expireMutex.RUnlock()
 	fake.resolveStepsMutex.RLock()
 	defer fake.resolveStepsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
This moves the hard-coded 5-minute TTL out of the cache and into the
registry-based implementation of cache.Source. The hack that makes
snapshots produced by "virtual" sources is no longer necessary.

/hold

Depends on #2632 now, but could be rebased onto master without much trouble if the other PR gets stuck.