### PR TITLE
Remove unused ttl field from cache.Cache.

### DIFF
--- a/pkg/controller/registry/resolver/cache/cache.go
+++ b/pkg/controller/registry/resolver/cache/cache.go
@@ -86,7 +86,6 @@ type Cache struct {
 	sp                     SourceProvider
 	sourcePriorityProvider SourcePriorityProvider
 	snapshots              map[SourceKey]*snapshotHeader
-	ttl                    time.Duration
 	sem                    chan struct{}
 	m                      sync.RWMutex
 }
@@ -121,7 +120,6 @@ func New(sp SourceProvider, options ...Option) *Cache {
 		sp:                     sp,
 		sourcePriorityProvider: constantSourcePriorityProvider(0),
 		snapshots:              make(map[SourceKey]*snapshotHeader),
-		ttl:                    5 * time.Minute,
 		sem:                    make(chan struct{}, MaxConcurrentSnapshotUpdates),
 	}
 


### PR DESCRIPTION
The cache itself isn't responsible for snapshot invalidation anymore,
but this field has been left behind.
