### PR TITLE
[WIP] Create catalog pods as pullIFNotPresent, use a pullalways probe pod to check for new SHAs

### DIFF
--- a/pkg/controller/registry/reconciler/configmap_test.go
+++ b/pkg/controller/registry/reconciler/configmap_test.go
@@ -198,7 +198,7 @@ func objectsForCatalogSource(catsrc *v1alpha1.CatalogSource) []runtime.Object {
 		if catsrc.Spec.Image != "" {
 			decorated := grpcCatalogSourceDecorator{catsrc}
 			objs = clientfake.AddSimpleGeneratedNames(
-				decorated.Pod(catsrc.GetName()),
+				decorated.Pod(catsrc.GetName(), ""),
 				decorated.Service(),
 				decorated.ServiceAccount(),
 			)

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -332,7 +332,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 
 			// Check for resource existence
 			decorated := grpcCatalogSourceDecorator{tt.in.catsrc}
-			pod := decorated.Pod(tt.in.catsrc.GetName())
+			pod := decorated.Pod(tt.in.catsrc.GetName(), "")
 			service := decorated.Service()
 			sa := decorated.ServiceAccount()
 			listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{CatalogSourceLabelKey: tt.in.catsrc.GetName()}).String()}
@@ -422,7 +422,7 @@ func TestRegistryPodPriorityClass(t *testing.T) {
 
 			// Check for resource existence
 			decorated := grpcCatalogSourceDecorator{tt.in.catsrc}
-			pod := decorated.Pod(tt.in.catsrc.GetName())
+			pod := decorated.Pod(tt.in.catsrc.GetName(), "")
 			listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{CatalogSourceLabelKey: tt.in.catsrc.GetName()}).String()}
 			outPods, podErr := client.KubernetesInterface().CoreV1().Pods(pod.GetNamespace()).List(context.TODO(), listOptions)
 			require.NoError(t, podErr)
@@ -637,6 +637,7 @@ func TestUpdatePodByDigest(t *testing.T) {
 	}
 
 	for i, tt := range table {
-		require.Equal(t, tt.result, imageChanged(tt.updatePod, tt.servingPods), table[i].description)
+		changed, _ := imageChanged(tt.updatePod, tt.servingPods)
+		require.Equal(t, tt.result, changed, table[i].description)
 	}
 }

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -112,6 +112,10 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 	}
 
 	readOnlyRootFilesystem := false
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["operatorframework.io/catalog-source-image"] = source.Spec.Image
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Instead of just creating catalog pods as pull always (becomes a problem in temporarily disconnected clusters), create themn as pull if not present.

when creating a new pod to check for updates, create it as pullalways, see if it gets a new SHA, if so, delete it and recreate it as a pullifnotpresent pod but using the new SHA.


**Motivation for the change:**
Clusters w/ only intermittent registry connection experience pod startup failures when
catalog pods are restarted while the registry is inaccessible.  This change
reduces the period of time during which registry access is required.

The downside is that when there is an update to the catalog image for a given catalogsource, we will do 2 pod creations/startups instead of just one. (And, if the 2 pods land on different nodes, we'll also have to pull the image twice).


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->