### PR TITLE
.github: Avoid disabling the go mod pkg cache for the golangci-lint action

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -20,4 +20,3 @@ jobs:
         with:
           version: "v1.43"
           skip-go-installation: true
-          skip-pkg-cache: true

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -6,17 +6,20 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  sanity:
+  vendor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '~1.17'
-      - name: Run sanity checks
-        run: make vendor && make diff
-      - name: Run linting checks
-        uses: "golangci/golangci-lint-action@v2"
-        with:
-          version: "v1.43"
-          skip-go-installation: true
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '~1.17'
+    - name: Run sanity checks
+      run: make vendor && make diff
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run linting checks
+      uses: "golangci/golangci-lint-action@v2"
+      with:
+        version: "v1.43"


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the sanity workflow and avoid setting the 'skip-pkg-cache' option
to true so the golangci-lint action can start caching and restoring the
~/go/pkg directory during CI runs.

Signed-off-by: timflannagan <timflannagan@gmail.com>

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
