### PR TITLE
make wait longer than installplan timeout

### DIFF
--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -19,6 +19,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// InstallPlan timeout is 60 seconds. This timeout is longer than that to get the "InstallPlanPhaseFailed" status
+	installPlanTestTimeout = time.Second * 75
+)
+
 var _ = Describe("CRD Versions", func() {
 
 	var (
@@ -274,7 +279,7 @@ var _ = Describe("CRD Versions", func() {
 		// Check the error on the installplan - should be related to data loss and the CRD upgrade missing a stored version
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Get(context.TODO(), s.Status.InstallPlanRef.Name, metav1.GetOptions{})
-		}).Should(And(
+		}, installPlanTestTimeout).Should(And(   // InstallPlan timeout is 60 seconds.  This must be longer than that to get the "InstallPlanPhaseFailed" status
 			WithTransform(
 				func(v *operatorsv1alpha1.InstallPlan) operatorsv1alpha1.InstallPlanPhase {
 					return v.Status.Phase


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Increased the wait timeout for the installplan state change.  The installplan timeout is 60 seconds by default.  The test must wait longer than that.  The default **Eventually** timeout is also 60 seconds.  This PR change the wait time for the specific wait to 90 seconds.

**Motivation for the change:**
Closes #2638
**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
