### PR TITLE
Add bugzilla metadata to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -25,3 +25,5 @@ reviewers:
   - timflannagan
   - perdasilva
   - akihikokuroda
+# Bugzilla metadata
+component: "OLM"


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

**Description of the change:**
Adds bugzilla metadata to owners file

**Motivation for the change:**
Internal requirement

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky
