### PR TITLE
Fixes difficult to understand error message when CSV is missing APIVersion

### DIFF
--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -47,6 +47,21 @@ func IsMultipleExistingCRDOwnersError(err error) bool {
 	return false
 }
 
+type FatalError struct {
+	error
+}
+
+func NewFatalError(err error) FatalError {
+	return FatalError{err}
+}
+func IsFatal(err error) bool {
+	switch err.(type) {
+	case FatalError:
+		return true
+	}
+	return false
+}
+
 // GroupVersionKindNotFoundError occurs when we can't find an API via discovery
 type GroupVersionKindNotFoundError struct {
 	Group   string

--- a/pkg/controller/registry/resolver/steps.go
+++ b/pkg/controller/registry/resolver/steps.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	olmerrors "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	extScheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,6 +117,15 @@ func NewStepResourceFromBundle(bundle *api.Bundle, namespace, replaces, catalogS
 	csv, err := V1alpha1CSVFromBundle(bundle)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check unpacked bundled for for missing APIVersion or Kind
+	if csv.APIVersion == "" {
+		return nil, olmerrors.NewFatalError(fmt.Errorf("bundle CSV %s missing APIVersion", csv.Name))
+	}
+
+	if csv.Kind == "" {
+		return nil, olmerrors.NewFatalError(fmt.Errorf("bundle CSV %s missing Kind", csv.Name))
 	}
 
 	csv.SetNamespace(namespace)

--- a/test/e2e/testdata/bad-csv/bad-csv.yaml
+++ b/test/e2e/testdata/bad-csv/bad-csv.yaml
@@ -1,0 +1,25 @@
+---
+schema: olm.package
+name: packageA
+defaultChannel: stable
+---
+schema: olm.channel
+package: packageA
+name: stable
+entries:
+  - name: bad-csv
+---
+schema: olm.bundle
+name: bad-csv
+package: packageA
+image: quay.io/olmtest/missing_api_version:latest
+properties:
+  - type: olm.gvk
+    value:
+      group: example.com
+      kind: TestA
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: packageA
+      version: 1.0.0


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Modifies CSV unbundle process so that after unbundling APIVersion or Kind are missing the installPlan is failed and the user receives a helpful and descriptive failure message letting them know that data was missing.

**Motivation for the change:**

Per BZ#1982737[](https://bugzilla.redhat.com/show_bug.cgi?id=1982737) currently when a CSV is missing APIVersion the associated installPlan fails with a cryptic message involving failure to create a service account. I initially tried to solve this by inferring the APIVersion if left blank per PR#2609[](https://github.com/operator-framework/operator-lifecycle-manager/pull/2609#issue-1122164908) however the conversation following the PR made it clear that approach was not an acceptable fix. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
