### PR TITLE
Remove cache.OperatorCacheProvider interface.

### DIFF
--- a/pkg/controller/registry/resolver/cache/cache.go
+++ b/pkg/controller/registry/resolver/cache/cache.go
@@ -90,8 +90,6 @@ type Cache struct {
 	m                      sync.RWMutex
 }
 
-var _ OperatorCacheProvider = &Cache{}
-
 type Option func(*Cache)
 
 func WithLogger(logger logrus.StdLogger) Option {

--- a/pkg/controller/registry/resolver/resolver.go
+++ b/pkg/controller/registry/resolver/resolver.go
@@ -29,7 +29,7 @@ type constraintProvider interface {
 }
 
 type Resolver struct {
-	cache                     cache.OperatorCacheProvider
+	cache                     *cache.Cache
 	log                       logrus.FieldLogger
 	pc                        *predicateConverter
 	systemConstraintsProvider constraintProvider


### PR DESCRIPTION
This interface is unused, so it can be removed as a step toward a
stable and supported cache package API.
