### PR TITLE
Add linux node selector to bundleUnpacker job

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -211,6 +211,9 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 							},
 						},
 					},
+					NodeSelector: map[string]string{
+						"kubernetes.io/os": "linux",
+					},
 				},
 			},
 		},

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -329,6 +329,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 									},
+									NodeSelector: map[string]string{
+										"kubernetes.io/os": "linux",
+									},
 								},
 							},
 						},
@@ -530,6 +533,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 												EmptyDir: &corev1.EmptyDirVolumeSource{},
 											},
 										},
+									},
+									NodeSelector: map[string]string{
+										"kubernetes.io/os": "linux",
 									},
 								},
 							},
@@ -774,6 +780,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 									},
+									NodeSelector: map[string]string{
+										"kubernetes.io/os": "linux",
+									},
 								},
 							},
 						},
@@ -1011,6 +1020,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 										},
 									},
+									NodeSelector: map[string]string{
+										"kubernetes.io/os": "linux",
+									},
 								},
 							},
 						},
@@ -1217,6 +1229,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 												EmptyDir: &corev1.EmptyDirVolumeSource{},
 											},
 										},
+									},
+									NodeSelector: map[string]string{
+										"kubernetes.io/os": "linux",
 									},
 								},
 							},
@@ -1435,6 +1450,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 												EmptyDir: &corev1.EmptyDirVolumeSource{},
 											},
 										},
+									},
+									NodeSelector: map[string]string{
+										"kubernetes.io/os": "linux",
 									},
 								},
 							},


### PR DESCRIPTION
Signed-off-by: Michelle Nguyen <michellenguyen@pixielabs.ai>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:** Added default nodeSelector `"kubernetes.io/os": "linux"` to the bundle unpacker job's pod template.


**Motivation for the change:** For the most part, we've noticed that OLM does a good job of adding the `"kubernetes.io/os": "linux"` node selector by default to most of the K8s resources it deploys. However, we've noticed the bundle unpacker job does not have any nodeSelector applied to it. In multi-OS environments, this can be a problem if this job starts up on a non-linux nodes.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
