### PR TITLE
Fix catalog source e2e test

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -739,7 +739,9 @@ var _ = Describe("Catalog represents a store of bundles which OLM can use to ins
 				Image:      image,
 				UpdateStrategy: &v1alpha1.UpdateStrategy{
 					RegistryPoll: &v1alpha1.RegistryPoll{
-						Interval: &metav1.Duration{Duration: 1 * time.Minute},
+						// Using RawInterval rather than Interval due to this issue:
+						// https://github.com/operator-framework/operator-lifecycle-manager/issues/2621
+						RawInterval: "1m0s",
 					},
 				},
 			},


### PR DESCRIPTION
**Description of the change:**
This PR updates the Catalog Source in the `image update` `CatalogSource` e2e test to use `rawInterval` to define the polling interval.

**Motivation for the change:**
Perhaps due to #2621, the polling period does not seem to be applied properly leading to test failures


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
