### PR TITLE
Refactor catsrc e2e

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"net"
 	"strconv"
 	"strings"


### PR DESCRIPTION
**Description of the change:**
This PR refactors the catalog source e2e tests to use unique namespaces in an effort to cut down on flaky tests

**Motivation for the change:**
Cutting down flaky tests

Closes: #2642

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky