### PR TITLE
Operator API controller: Remove broken thread-safety

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Operator API", func() {
 	// 15. Delete o
 	// 16. Ensure o is not re-created
 	// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2628
-	It("[FLAKE] should surface components in its status", func() {
+	It("should surface components in its status", func() {
 		o := &operatorsv1.Operator{}
 		o.SetName(genName("o-"))
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Remove broken thread-safety from the Operator API controller.

**Motivation for the change:**

The underlying queue will ensure a reconciler never races itself when processing a given resource event.

The thread-safety logic is flawed and can prevent Operator resources from being reconciled when component resources are updated.  It also ensures idempotence when enqueuing a resource for reconciliation; In other words, enqueuing no-ops if the given resource is already in the queue.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky

Closes #2581