### PR TITLE
e2e: Fix authentication issue when connecting to the OCP image registry

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -35,6 +35,11 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
+const (
+	openshiftregistryFQDN = "image-registry.openshift-image-registry.svc:5000"
+	catsrcImage           = "docker://quay.io/olmtest/catsrc-update-test:"
+)
+
 var _ = Describe("Catalog represents a store of bundles which OLM can use to install Operators", func() {
 	var (
 		c   operatorclient.ClientInterface
@@ -694,7 +699,7 @@ var _ = Describe("Catalog represents a store of bundles which OLM can use to ins
 			err = registryPortForward(ns.GetName())
 			Expect(err).NotTo(HaveOccurred(), "port-forwarding local registry: %s", err)
 		} else {
-			registryURL = openshiftregistryFQDN
+			registryURL = fmt.Sprintf("%s/%s", openshiftregistryFQDN, ns.GetName())
 			registryAuth, err = openshiftRegistryAuth(c, ns.GetName())
 			Expect(err).NotTo(HaveOccurred(), "error getting openshift registry authentication: %s", err)
 		}
@@ -1154,11 +1159,6 @@ var _ = Describe("Catalog represents a store of bundles which OLM can use to ins
 		}
 	})
 })
-
-const (
-	openshiftregistryFQDN = "image-registry.openshift-image-registry.svc:5000/openshift-operators"
-	catsrcImage           = "docker://quay.io/olmtest/catsrc-update-test:"
-)
 
 func getOperatorDeployment(c operatorclient.ClientInterface, namespace string, operatorLabels labels.Set) (*appsv1.Deployment, error) {
 	deployments, err := c.ListDeploymentsWithLabels(namespace, operatorLabels)


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
#2690 updated this test case to avoid creating the requisite testing resources in the same global `operators` namespace as the rest of the CatalogSource e2e tests, but we neglected to update how we generate the auth bearer token that's used in the skopeo Pod to authenticate to the internal OCP image registry.

**Motivation for the change:**
Fix failing/flaky e2e tests.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
