### PR TITLE
e2e: Filter out terminating namespaces when calculating AllNamespace copied CSVs

### DIFF
--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -4417,10 +4417,17 @@ var _ = Describe("Disabling copied CSVs", func() {
 					return err
 				}
 
-				if len(namespaces.Items)-1 != len(copiedCSVs.Items) {
-					return fmt.Errorf("%d copied CSVs found, expected %d", len(copiedCSVs.Items), len(namespaces.Items)-1)
+				targetNamespaces := len(namespaces.Items) - 1
+				for _, ns := range namespaces.Items {
+					// filter out any namespaces that are currently reporting a Terminating phase
+					// as the API server will reject any resource events in terminating namespaces.
+					if ns.Status.Phase == "Terminating" {
+						targetNamespaces--
+					}
 				}
-
+				if targetNamespaces != len(copiedCSVs.Items) {
+					return fmt.Errorf("%d copied CSVs found, expected %d", len(copiedCSVs.Items), targetNamespaces)
+				}
 				return nil
 			}).Should(Succeed())
 		})


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This test was consistently failing in both upstream and downstream CI environments, and reproducing this locally can be a challenging experience at times. This test case was consistently failing in downstream CI environments (e.g. openshift) and the root cause appeared to be namespaces that were stuck in terminating for longer than KinD clusters, and those terminating namespaces were stuck in that phase longer than the 60s eventually poll which skewed the comparison between copied CSVs in a cluster vs. the amount of namespaces in a cluster.

**Motivation for the change:**
Burn down failing/flaky e2e tests to help improve CI noise.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
