### PR TITLE
Bump controller-runtime to v0.11.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	k8s.io/kube-aggregator v0.22.0
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
-	sigs.k8s.io/controller-runtime v0.11.0
+	sigs.k8s.io/controller-runtime v0.11.1
 	sigs.k8s.io/controller-tools v0.8.0
 	sigs.k8s.io/kind v0.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1916,8 +1916,9 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.25 h1:DEQ12ZRxJjsglk5JIi5bLgpKaHihGervKmg5uryaEHw=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.25/go.mod h1:Mlj9PNLmG9bZ6BHFwFKDo5afkpWyUISkb9Me0GnK66I=
 sigs.k8s.io/controller-runtime v0.8.0/go.mod h1:v9Lbj5oX443uR7GXYY46E0EE2o7k2YxQ58GxVNeXSW4=
-sigs.k8s.io/controller-runtime v0.11.0 h1:DqO+c8mywcZLFJWILq4iktoECTyn30Bkj0CwgqMpZWQ=
 sigs.k8s.io/controller-runtime v0.11.0/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=
+sigs.k8s.io/controller-runtime v0.11.1 h1:7YIHT2QnHJArj/dk9aUkYhfqfK5cIxPOX5gPECfdZLU=
+sigs.k8s.io/controller-runtime v0.11.1/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/controller-tools v0.8.0 h1:uUkfTGEwrguqYYfcI2RRGUnC8mYdCFDqfwPKUcNJh1o=
 sigs.k8s.io/controller-tools v0.8.0/go.mod h1:qE2DXhVOiEq5ijmINcFbqi9GZrrUjzB1TuJU0xa6eoY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1896,7 +1896,7 @@ k8s.io/utils/trace
 ## explicit; go 1.17
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/controller-runtime v0.11.0
+# sigs.k8s.io/controller-runtime v0.11.1
 ## explicit; go 1.17
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go
@@ -409,41 +409,31 @@ func createMetadataListWatch(gvk schema.GroupVersionKind, ip *specificInformersM
 	}, nil
 }
 
-type gvkFixupWatcher struct {
-	watcher watch.Interface
-	ch      chan watch.Event
-	gvk     schema.GroupVersionKind
-	wg      sync.WaitGroup
-}
-
+// newGVKFixupWatcher adds a wrapper that preserves the GVK information when
+// events come in.
+//
+// This works around a bug where GVK information is not passed into mapping
+// functions when using the OnlyMetadata option in the builder.
+// This issue is most likely caused by kubernetes/kubernetes#80609.
+// See kubernetes-sigs/controller-runtime#1484.
+//
+// This was originally implemented as a cache.ResourceEventHandler wrapper but
+// that contained a data race which was resolved by setting the GVK in a watch
+// wrapper, before the objects are written to the cache.
+// See kubernetes-sigs/controller-runtime#1650.
+//
+// The original watch wrapper was found to be incompatible with
+// k8s.io/client-go/tools/cache.Reflector so it has been re-implemented as a
+// watch.Filter which is compatible.
+// See kubernetes-sigs/controller-runtime#1789.
 func newGVKFixupWatcher(gvk schema.GroupVersionKind, watcher watch.Interface) watch.Interface {
-	ch := make(chan watch.Event)
-	w := &gvkFixupWatcher{
-		gvk:     gvk,
-		watcher: watcher,
-		ch:      ch,
-	}
-	w.wg.Add(1)
-	go w.run()
-	return w
-}
-
-func (w *gvkFixupWatcher) run() {
-	for e := range w.watcher.ResultChan() {
-		e.Object.GetObjectKind().SetGroupVersionKind(w.gvk)
-		w.ch <- e
-	}
-	w.wg.Done()
-}
-
-func (w *gvkFixupWatcher) Stop() {
-	w.watcher.Stop()
-	w.wg.Wait()
-	close(w.ch)
-}
-
-func (w *gvkFixupWatcher) ResultChan() <-chan watch.Event {
-	return w.ch
+	return watch.Filter(
+		watcher,
+		func(in watch.Event) (watch.Event, bool) {
+			in.Object.GetObjectKind().SetGroupVersionKind(gvk)
+			return in, true
+		},
+	)
 }
 
 // resyncPeriod returns a function which generates a duration each time it is


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Bump the controller-runtime dependency to v0.11.1 to pick up the partial metadata informer fixes. We previously had to hack around this issue using custom c-r replace pins throughout OLM as we had seen #2628 and the [`It("should automatically adopt components")`](https://github.com/operator-framework/operator-lifecycle-manager/blob/87bd5a7b90dd37c8610b6e69a79f77824e86ba8c/test/e2e/operator_test.go#L336) test case(s) regress over time.

Previous to these changes, and when testing in downstream CI environments, those test cases I outlined consistently failed as the adoption controller wasn't able to pick up the kiali-operator ServiceAccount resource (as we place a metadata-only watcher on that resource), which resulted in the kiali-operator Operator resource missing that underlying resource in it's list of component references propagated to the status. After incorporating these changes, this test case is no longer failing.

**Motivation for the change:**
Burn down testing flakes/failures.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
