### PR TITLE
Makefile,test: Support configuring the e2e testdata directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ e2e:
 # See workflows/e2e-tests.yml See test/e2e/README.md for details.
 .PHONY: e2e-local
 e2e-local: BUILD_TAGS="json1 experimental_metrics"
-e2e-local: extra_args=-kind.images=../test/e2e-local.image.tar
+e2e-local: extra_args=-kind.images=../test/e2e-local.image.tar -test-data-dir=../test/e2e/testdata
 e2e-local: run=bin/e2e-local.test
 e2e-local: bin/e2e-local.test test/e2e-local.image.tar
 e2e-local: e2e

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -33,13 +33,22 @@ var (
 	communityOperators = flag.String(
 		"communityOperators",
 		"quay.io/operator-framework/upstream-community-operators@sha256:098457dc5e0b6ca9599bd0e7a67809f8eca397907ca4d93597380511db478fec",
-		"reference to upstream-community-operators image")
+		"reference to upstream-community-operators image",
+	)
 
 	dummyImage = flag.String(
 		"dummyImage",
 		"bitnami/nginx:latest",
-		"dummy image to treat as an operator in tests")
+		"dummy image to treat as an operator in tests",
+	)
 
+	testdataPath = flag.String(
+		"test-data-dir",
+		"./testdata",
+		"configures where to find the testdata directory",
+	)
+
+	testdataDir             = ""
 	testNamespace           = ""
 	operatorNamespace       = ""
 	communityOperatorsImage = ""
@@ -74,6 +83,7 @@ var _ = BeforeSuite(func() {
 	testNamespace = *namespace
 	operatorNamespace = *olmNamespace
 	communityOperatorsImage = *communityOperators
+	testdataDir = *testdataPath
 	deprovision = ctx.MustProvision(ctx.Ctx())
 	ctx.MustInstall(ctx.Ctx())
 

--- a/test/e2e/fbc_provider.go
+++ b/test/e2e/fbc_provider.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"errors"
+	"fmt"
+	"os"
 )
 
 type FileBasedCatalogProvider interface {
@@ -13,7 +15,10 @@ type fileBasedFileBasedCatalogProvider struct {
 }
 
 func NewFileBasedFiledBasedCatalogProvider(path string) (FileBasedCatalogProvider, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("path %s does not exist: %w", path, err)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/magic_catalog_test.go
+++ b/test/e2e/magic_catalog_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,7 +28,7 @@ var _ = Describe("MagicCatalog", func() {
 		const catalogName = "test"
 		namespace := generatedNamespace.GetName()
 		kubeClient := ctx.Ctx().Client()
-		provider, err := NewFileBasedFiledBasedCatalogProvider("../test/e2e/testdata/fbc_catalog.json")
+		provider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(testdataDir, "fbc_catalog.json"))
 		Expect(err).To(BeNil())
 
 		// create and deploy and undeploy the magic catalog


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Avoid hardcoding the testdata directory that's used to configure a MagicCatalog provider. 

Right now, there's two e2e-related targets: `make e2e`, and `make e2e-local` where the latter calls the former under-the-hood and specifies additional configuration options that the kind provisioner needs to create and manage hermetically sealed clusters. The problem is that the e2e target has a different working directory compared to the e2e-local target, which means that running `make e2e TEST="MagicCatalog"` locally will result in a failed test case as it cannot find the fbc_catalog.json configuration file from that hardcoded testdata directory. 

These changes introduce an e2e suite flag that defaults to the ./testdata directory, which enables `make e2e` to work by itself, and the e2e-local target overrides this flag value to ../test/e2e/testdata so the CI pipeline can properly source this filepath as well.

**Motivation for the change:**
Closes #2687 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
