### PR TITLE
E2E Kube client

### DIFF
--- a/test/e2e/resource_manager_test.go
+++ b/test/e2e/resource_manager_test.go
@@ -1,0 +1,78 @@
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/util"
+	corev1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
+)
+
+var _ = Describe("ResourceManager", func() {
+
+	var generatedNamespace corev1.Namespace
+
+	BeforeEach(func() {
+		ctx.Ctx().NewE2EClientSession()
+		generatedNamespace = SetupGeneratedTestNamespace(genName("resource-manager-e2e-"))
+	})
+
+	AfterEach(func() {
+		TeardownNamespace(generatedNamespace.GetName())
+		Expect(ctx.Ctx().E2EClient().Reset()).To(Succeed())
+	})
+
+	It("should tag resources created with it", func() {
+		// Create a namespace
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: genName("test-"),
+			},
+		}
+		Expect(ctx.Ctx().E2EClient().Create(context.TODO(), ns)).To(Succeed())
+
+		// Get namespace
+		Expect(ctx.Ctx().E2EClient().Get(context.TODO(), client.ObjectKeyFromObject(ns), ns)).To(Succeed())
+		Expect(ns.GetAnnotations()).NotTo(BeEmpty())
+		Expect(ns.GetAnnotations()[util.E2ETestNameTag]).To(Equal("ResourceManager should tag resources created with it"))
+	})
+
+	It("should delete resources on reset", func() {
+		// Create a namespace
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: genName("test-"),
+			},
+		}
+		Expect(ctx.Ctx().E2EClient().Create(context.TODO(), ns)).To(Succeed())
+
+		// Add a config map
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: genName("configmap-"),
+
+				// creating the configmap in the generated (spec) namespace
+				// so if the namespace (ns, above) gets deleted on reset it won't take the config map with it
+				Namespace: generatedNamespace.GetName(),
+			},
+		}
+		Expect(ctx.Ctx().E2EClient().Create(context.TODO(), configMap))
+
+		// Reset the client
+		Expect(ctx.Ctx().E2EClient().Reset()).To(Succeed())
+
+		// And just like that resources should be gone
+		Eventually(func() error {
+			return ctx.Ctx().E2EClient().Get(context.TODO(), client.ObjectKeyFromObject(configMap), configMap)
+		}).Should(WithTransform(k8serror.IsNotFound, BeTrue()))
+		Eventually(func() error {
+			return ctx.Ctx().E2EClient().Get(context.TODO(), client.ObjectKeyFromObject(ns), ns)
+		}).Should(WithTransform(k8serror.IsNotFound, BeTrue()))
+	})
+})

--- a/test/e2e/util/e2e_client.go
+++ b/test/e2e/util/e2e_client.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	k8scontrollerclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	E2ETestNameTag = "e2e.testName"
+)
+
+type E2EKubeClient struct {
+	k8scontrollerclient.Client
+	createdResources *ResourceQueue
+}
+
+func NewK8sResourceManager(client k8scontrollerclient.Client) *E2EKubeClient {
+	return &E2EKubeClient{
+		Client:           client,
+		createdResources: NewResourceQueue(),
+	}
+}
+
+func (m *E2EKubeClient) Create(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.CreateOption) error {
+	m.annotateTestResource(obj)
+	if err := m.Client.Create(context, obj, options...); err != nil {
+		return err
+	}
+	m.createdResources.EnqueueIgnoreExisting(obj)
+	return nil
+}
+
+func (m *E2EKubeClient) Update(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.UpdateOption) error {
+	m.annotateTestResource(obj)
+	if err := m.Client.Update(context, obj, options...); err != nil {
+		return err
+	}
+	m.createdResources.EnqueueIgnoreExisting(obj)
+	return nil
+}
+
+func (m *E2EKubeClient) Delete(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.DeleteOption) error {
+	if err := m.Client.Delete(context, obj, options...); err != nil {
+		return err
+	}
+	m.createdResources.RemoveIgnoreNotFound(obj)
+	return nil
+}
+
+func (m *E2EKubeClient) Reset() error {
+	for {
+		obj, ok := m.createdResources.DequeueTail()
+
+		if !ok {
+			break
+		}
+
+		if err := m.Delete(context.TODO(), obj); err != nil && !k8serror.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *E2EKubeClient) annotateTestResource(obj k8scontrollerclient.Object) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[E2ETestNameTag] = ginkgo.CurrentGinkgoTestDescription().FullTestText
+	obj.SetAnnotations(annotations)
+}

--- a/test/e2e/util/resource_queue.go
+++ b/test/e2e/util/resource_queue.go
@@ -1,0 +1,100 @@
+package util
+
+import (
+	"fmt"
+	k8scontrollerclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sync"
+)
+
+type ResourceQueue struct {
+	queue       []k8scontrollerclient.Object
+	lookupTable map[k8scontrollerclient.Object]bool
+	lock        *sync.Mutex
+}
+
+func NewResourceQueue() *ResourceQueue {
+	return &ResourceQueue{
+		queue:       []k8scontrollerclient.Object{},
+		lookupTable: map[k8scontrollerclient.Object]bool{},
+		lock:        &sync.Mutex{},
+	}
+}
+
+func (q *ResourceQueue) Enqueue(obj k8scontrollerclient.Object) error {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if _, ok := q.lookupTable[obj]; ok {
+		return fmt.Errorf("error inserting duplicate object: %s", obj)
+	}
+	q.queue = append(q.queue, obj)
+	q.lookupTable[obj] = true
+	return nil
+}
+
+func (q *ResourceQueue) EnqueueIgnoreExisting(obj k8scontrollerclient.Object) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if _, ok := q.lookupTable[obj]; ok {
+		return
+	}
+	q.queue = append(q.queue, obj)
+	q.lookupTable[obj] = true
+}
+
+func (q *ResourceQueue) Length() int {
+	return len(q.queue)
+}
+
+func (q *ResourceQueue) RemoveIgnoreNotFound(obj k8scontrollerclient.Object) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if _, ok := q.lookupTable[obj]; ok {
+		for index, existingObj := range q.queue {
+			if q.equals(existingObj, obj) {
+				_ = q.removeItem(index)
+				delete(q.lookupTable, obj)
+				return
+			}
+		}
+	}
+}
+
+func (q *ResourceQueue) equals(objOne k8scontrollerclient.Object, objTwo k8scontrollerclient.Object) bool {
+	return objOne.GetName() == objTwo.GetName() && objOne.GetNamespace() == objTwo.GetNamespace()
+}
+
+func (q *ResourceQueue) DequeueHead() (k8scontrollerclient.Object, bool) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if q.Length() == 0 {
+		return nil, false
+	}
+	return q.removeItem(0), true
+}
+
+func (q *ResourceQueue) DequeueTail() (k8scontrollerclient.Object, bool) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	
+	if len(q.queue) == 0 {
+		return nil, false
+	}
+	return q.removeItem(q.Length() - 1), true
+}
+
+func (q *ResourceQueue) removeItem(index int) k8scontrollerclient.Object {
+	if index < 0 || index >= q.Length() {
+		panic("index out of bounds")
+	}
+	item := q.queue[index]
+	copy(q.queue[index:], q.queue[index+1:])
+	q.queue[len(q.queue)-1] = nil
+	q.queue = q.queue[:len(q.queue)-1]
+	delete(q.lookupTable, item)
+
+	return item
+}


### PR DESCRIPTION
**Description of the change:**
This PR introduces the e2e kubernetes client. It tags and keeps track of resources created/updated with it and has a method to delete all resources.

**Motivation for the change:**
This client should eventually be used with the e2e tests to help with resource leaks

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
