### PR TITLE
Add importas linting configuration to enforce common package import naming

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,24 @@ linters:
   disable:
   - errcheck
 
+linters-settings:
+  importas:
+    alias:
+    - pkg: k8s.io/api/core/v1
+      alias: corev1
+    - pkg: k8s.io/api/apps/v1
+      alias: appsv1
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+    - pkg: k8s.io/apimachinery/pkg/api/errors
+      alias: apierrors
+    - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
+      alias: operatorsv1alpha1
+    - pkg: github.com/operator-framework/api/pkg/operators/v1
+      alias: operatorsv1
+    - pkg: github.com/operator-framework/api/pkg/operators/v2
+      alias: operatorsv2
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -13,7 +13,7 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -103,8 +103,8 @@ func main() {
 	// the empty string, the resulting array will be `[]string{""}`.
 	namespaces := strings.Split(*watchedNamespaces, ",")
 	for _, ns := range namespaces {
-		if ns == v1.NamespaceAll {
-			namespaces = []string{v1.NamespaceAll}
+		if ns == corev1.NamespaceAll {
+			namespaces = []string{corev1.NamespaceAll}
 			break
 		}
 	}

--- a/pkg/controller/install/apiservice.go
+++ b/pkg/controller/install/apiservice.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
@@ -26,7 +26,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateAPIService(caPEM []byte, des
 	exists := true
 	apiService, err := i.strategyClient.GetOpLister().APIRegistrationV1().APIServiceLister().Get(apiServiceName)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 
@@ -120,14 +120,14 @@ func IsAPIServiceAdoptable(opLister operatorlister.OperatorLister, target *v1alp
 
 	// Get the CSV that target replaces
 	replacing, replaceGetErr := opLister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(target.GetNamespace()).Get(target.Spec.Replaces)
-	if replaceGetErr != nil && !k8serrors.IsNotFound(replaceGetErr) && !k8serrors.IsGone(replaceGetErr) {
+	if replaceGetErr != nil && !apierrors.IsNotFound(replaceGetErr) && !apierrors.IsGone(replaceGetErr) {
 		err = replaceGetErr
 		return
 	}
 
 	// Get the current owner CSV of the APIService
 	currentOwnerCSV, ownerGetErr := opLister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ownerNamespace).Get(ownerName)
-	if ownerGetErr != nil && !k8serrors.IsNotFound(ownerGetErr) && !k8serrors.IsGone(ownerGetErr) {
+	if ownerGetErr != nil && !apierrors.IsNotFound(ownerGetErr) && !apierrors.IsGone(ownerGetErr) {
 		err = ownerGetErr
 		return
 	}
@@ -179,13 +179,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 		// Attempt to delete the legacy Service.
 		existingService, err := i.strategyClient.GetOpClient().GetService(namespace, legacyServiceName)
 		if err != nil {
-			if !k8serrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				return err
 			}
 		} else if ownerutil.AdoptableLabels(existingService.GetLabels(), true, i.owner) {
 			logger.Infof("Deleting Service with legacy APIService name %s", existingService.Name)
 			err = i.strategyClient.GetOpClient().DeleteService(namespace, legacyServiceName, &metav1.DeleteOptions{})
-			if err != nil && !k8serrors.IsNotFound(err) {
+			if err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
 		} else {
@@ -198,13 +198,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy Secret.
 	existingSecret, err := i.strategyClient.GetOpClient().GetSecret(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingSecret.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting Secret with legacy APIService name %s", existingSecret.Name)
 		err = i.strategyClient.GetOpClient().DeleteSecret(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -214,13 +214,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy Role.
 	existingRole, err := i.strategyClient.GetOpClient().GetRole(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRole.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting Role with legacy APIService name %s", existingRole.Name)
 		err = i.strategyClient.GetOpClient().DeleteRole(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -230,13 +230,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy secret RoleBinding.
 	existingRoleBinding, err := i.strategyClient.GetOpClient().GetRoleBinding(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting RoleBinding with legacy APIService name %s", existingRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteRoleBinding(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -246,13 +246,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy ClusterRoleBinding.
 	existingClusterRoleBinding, err := i.strategyClient.GetOpClient().GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingClusterRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting ClusterRoleBinding with legacy APIService name %s", existingClusterRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteClusterRoleBinding(apiServiceName+"-system:auth-delegator", &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -262,13 +262,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy AuthReadingRoleBinding.
 	existingRoleBinding, err = i.strategyClient.GetOpClient().GetRoleBinding(KubeSystem, apiServiceName+"-auth-reader")
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting RoleBinding with legacy APIService name %s", existingRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteRoleBinding(KubeSystem, apiServiceName+"-auth-reader", &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {

--- a/pkg/controller/install/certresources.go
+++ b/pkg/controller/install/certresources.go
@@ -9,7 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -246,7 +246,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Delete the Service to replace
 		deleteErr := i.strategyClient.GetOpClient().DeleteService(service.GetNamespace(), service.GetName(), &metav1.DeleteOptions{})
-		if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 			return nil, nil, fmt.Errorf("could not delete existing service %s", service.GetName())
 		}
 	}
@@ -315,11 +315,11 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret %s", secret.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the secret
 		ownerutil.AddNonBlockingOwner(secret, i.owner)
 		if _, err := i.strategyClient.GetOpClient().CreateSecret(secret); err != nil {
-			if !k8serrors.IsAlreadyExists(err) {
+			if !apierrors.IsAlreadyExists(err) {
 				log.Warnf("could not create secret %s: %v", secret.GetName(), err)
 				return nil, nil, err
 			}
@@ -360,7 +360,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret role %s", secretRole.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role
 		ownerutil.AddNonBlockingOwner(secretRole, i.owner)
 		_, err = i.strategyClient.GetOpClient().CreateRole(secretRole)
@@ -406,7 +406,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret rolebinding %s", secretRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role
 		ownerutil.AddNonBlockingOwner(secretRoleBinding, i.owner)
 		_, err = i.strategyClient.GetOpClient().CreateRoleBinding(secretRoleBinding)
@@ -451,7 +451,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update auth delegator clusterrolebinding %s", authDelegatorClusterRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role.
 		if err := ownerutil.AddOwnerLabels(authDelegatorClusterRoleBinding, i.owner); err != nil {
 			return nil, nil, err
@@ -498,7 +498,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update auth reader role binding %s", authReaderRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role.
 		if err := ownerutil.AddOwnerLabels(authReaderRoleBinding, i.owner); err != nil {
 			return nil, nil, err

--- a/pkg/controller/install/deployment.go
+++ b/pkg/controller/install/deployment.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
@@ -192,7 +192,7 @@ func (i *StrategyDeploymentInstaller) Install(s Strategy) error {
 	}
 
 	if err := i.installDeployments(updatedStrategy.DeploymentSpecs); err != nil {
-		if k8serrors.IsForbidden(err) {
+		if apierrors.IsForbidden(err) {
 			return StrategyError{Reason: StrategyErrInsufficientPermissions, Message: fmt.Sprintf("install strategy failed: %s", err)}
 		}
 		return err

--- a/pkg/controller/install/rule_checker_test.go
+++ b/pkg/controller/install/rule_checker_test.go
@@ -18,12 +18,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 
-	v1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 )
 
 func TestRuleSatisfied(t *testing.T) {
-	csv := &v1alpha1.ClusterServiceVersion{}
+	csv := &operatorsv1alpha1.ClusterServiceVersion{}
 	csv.SetName("barista-operator")
 	csv.SetUID(types.UID("barista-operator"))
 
@@ -572,7 +572,7 @@ func TestRuleSatisfied(t *testing.T) {
 	}
 }
 
-func NewFakeCSVRuleChecker(k8sObjs []runtime.Object, csv *v1alpha1.ClusterServiceVersion, namespace string, stopCh <-chan struct{}) (*CSVRuleChecker, error) {
+func NewFakeCSVRuleChecker(k8sObjs []runtime.Object, csv *operatorsv1alpha1.ClusterServiceVersion, namespace string, stopCh <-chan struct{}) (*CSVRuleChecker, error) {
 	// create client fakes
 	opClientFake := operatorclient.NewClient(k8sfake.NewSimpleClientset(k8sObjs...), apiextensionsfake.NewSimpleClientset(), apiregistrationfake.NewSimpleClientset())
 

--- a/pkg/controller/install/status_viewer_test.go
+++ b/pkg/controller/install/status_viewer_test.go
@@ -5,24 +5,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	apps "k8s.io/api/apps/v1"
-	core "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDeploymentStatusViewerStatus(t *testing.T) {
 	tests := []struct {
 		generation int64
-		status     apps.DeploymentStatus
+		status     appsv1.DeploymentStatus
 		err        error
 		msg        string
 		done       bool
 	}{
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentProgressing,
+						Type:   appsv1.DeploymentProgressing,
 						Reason: TimedOutReason,
 					},
 				},
@@ -31,15 +31,15 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentProgressing,
+						Type:   appsv1.DeploymentProgressing,
 						Reason: "NotTimedOut",
 					},
 					{
-						Type:   apps.DeploymentAvailable,
-						Status: core.ConditionTrue,
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
@@ -48,14 +48,14 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 		},
 		{
 			generation: 1,
-			status: apps.DeploymentStatus{
+			status: appsv1.DeploymentStatus{
 				ObservedGeneration: 0,
 			},
 			msg:  "waiting for spec update of deployment \"foo\" to be observed...",
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
+			status: appsv1.DeploymentStatus{
 				Replicas:        5,
 				UpdatedReplicas: 3,
 			},
@@ -63,16 +63,16 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{},
-			msg:    fmt.Sprintf("deployment \"foo\" not available: missing condition %q", apps.DeploymentAvailable),
+			status: appsv1.DeploymentStatus{},
+			msg:    fmt.Sprintf("deployment \"foo\" not available: missing condition %q", appsv1.DeploymentAvailable),
 			done:   false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:    apps.DeploymentAvailable,
-						Status:  core.ConditionFalse,
+						Type:    appsv1.DeploymentAvailable,
+						Status:  corev1.ConditionFalse,
 						Message: "test message",
 					},
 				},
@@ -81,11 +81,11 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:    apps.DeploymentAvailable,
-						Status:  core.ConditionUnknown,
+						Type:    appsv1.DeploymentAvailable,
+						Status:  corev1.ConditionUnknown,
 						Message: "test message",
 					},
 				},
@@ -94,11 +94,11 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentAvailable,
-						Status: core.ConditionTrue,
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
@@ -109,7 +109,7 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i+1), func(t *testing.T) {
-			d := &apps.Deployment{
+			d := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:  "bar",
 					Name:       "foo",

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -21,7 +21,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	extinf "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -629,7 +629,7 @@ func (o *Operator) syncConfigMap(logger *logrus.Entry, in *v1alpha1.CatalogSourc
 	// Get the catalog source's config map
 	configMap, err := o.lister.CoreV1().ConfigMapLister().ConfigMaps(in.GetNamespace()).Get(in.Spec.ConfigMap)
 	// Attempt to look up the CM via api call if there is a cache miss
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		configMap, err = o.opClient.KubernetesInterface().CoreV1().ConfigMaps(in.GetNamespace()).Get(context.TODO(), in.Spec.ConfigMap, metav1.GetOptions{})
 		// Found cm in the cluster, add managed label to configmap
 		if err == nil {
@@ -2322,7 +2322,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			}
 			return nil
 		}(i, step); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// Check for APIVersions present in the installplan steps that are not available on the server.
 				// The check is made via discovery per step in the plan. Transient communication failures to the api-server are handled by the plan retry logic.
 				notFoundErr := discoveryQuerier.WithStepResource(step.Resource).QueryForGVK()

--- a/pkg/controller/operators/catalog/step_ensurer.go
+++ b/pkg/controller/operators/catalog/step_ensurer.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -43,7 +43,7 @@ func (o *StepEnsurer) EnsureClusterServiceVersion(csv *v1alpha1.ClusterServiceVe
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating csv %s", csv.GetName())
 		return
 	}
@@ -60,7 +60,7 @@ func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (s
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating subscription %s", subscription.GetName())
 		return
 	}
@@ -74,7 +74,7 @@ func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (s
 func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string) (status v1alpha1.StepStatus, err error) {
 	secret, getError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(operatorNamespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if getError != nil {
-		if k8serrors.IsNotFound(getError) {
+		if apierrors.IsNotFound(getError) {
 			err = fmt.Errorf("secret %s does not exist - %v", name, getError)
 			return
 		}
@@ -97,7 +97,7 @@ func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string
 	}
 
 	if _, createError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(planNamespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); createError != nil {
-		if k8serrors.IsAlreadyExists(createError) {
+		if apierrors.IsAlreadyExists(createError) {
 			status = v1alpha1.StepStatusPresent
 			return
 		}
@@ -118,7 +118,7 @@ func (o *StepEnsurer) EnsureBundleSecret(namespace string, secret *corev1.Secret
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating secret: %s", secret.GetName())
 		return
 	}
@@ -142,7 +142,7 @@ func (o *StepEnsurer) EnsureServiceAccount(namespace string, sa *corev1.ServiceA
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating service account: %s", sa.GetName())
 		return
 	}
@@ -180,7 +180,7 @@ func (o *StepEnsurer) EnsureService(namespace string, service *corev1.Service) (
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating service: %s", service.GetName())
 		return
 	}
@@ -203,7 +203,7 @@ func (o *StepEnsurer) EnsureClusterRole(cr *rbacv1.ClusterRole, step *v1alpha1.S
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating clusterrole %s", cr.GetName())
 		return
 	}
@@ -230,7 +230,7 @@ func (o *StepEnsurer) EnsureClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, s
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating clusterrolebinding %s", crb.GetName())
 		return
 	}
@@ -257,7 +257,7 @@ func (o *StepEnsurer) EnsureRole(namespace string, role *rbacv1.Role) (status v1
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating role %s", role.GetName())
 		return
 	}
@@ -281,7 +281,7 @@ func (o *StepEnsurer) EnsureRoleBinding(namespace string, rb *rbacv1.RoleBinding
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating rolebinding %s", rb.GetName())
 		return
 	}
@@ -304,7 +304,7 @@ func (o *StepEnsurer) EnsureUnstructuredObject(client dynamic.ResourceInterface,
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating unstructured object %s", obj.GetName())
 		return
 	}
@@ -336,7 +336,7 @@ func (o *StepEnsurer) EnsureConfigMap(namespace string, configmap *corev1.Config
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating configmap: %s", configmap.GetName())
 		return
 	}

--- a/pkg/controller/operators/olm/apiservices.go
+++ b/pkg/controller/operators/olm/apiservices.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -148,7 +148,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 
 		// Ensure the existing Deployment has a matching CA hash annotation
 		deployment, err := a.lister.AppsV1().DeploymentLister().Deployments(csv.GetNamespace()).Get(desc.DeploymentName)
-		if k8serrors.IsNotFound(err) || err != nil {
+		if apierrors.IsNotFound(err) || err != nil {
 			logger.WithField("deployment", desc.DeploymentName).Warnf("expected Deployment could not be retrieved")
 			errs = append(errs, err)
 			continue
@@ -227,7 +227,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 func (a *Operator) areAPIServicesAvailable(csv *v1alpha1.ClusterServiceVersion) (bool, error) {
 	for _, desc := range csv.Spec.APIServiceDefinitions.Owned {
 		apiService, err := a.lister.APIRegistrationV1().APIServiceLister().Get(desc.GetName())
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 
@@ -410,7 +410,7 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 		}
 		if _, ok := csvWebhookGenerateNames[webhookGenerateNameLabel]; !ok {
 			err = a.opClient.KubernetesInterface().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -428,7 +428,7 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 		}
 		if _, ok := csvWebhookGenerateNames[webhookGenerateNameLabel]; !ok {
 			err = a.opClient.KubernetesInterface().AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/pkg/controller/operators/olm/groups.go
+++ b/pkg/controller/operators/olm/groups.go
@@ -3,7 +3,7 @@ package olm
 import (
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
@@ -106,14 +106,14 @@ type OperatorGroup struct {
 	providedAPIs cache.APISet
 }
 
-func NewOperatorGroup(group *v1.OperatorGroup) *OperatorGroup {
+func NewOperatorGroup(group *operatorsv1.OperatorGroup) *OperatorGroup {
 	// Add operatorgroup namespace if not NamespaceAll
 	namespaces := group.Status.Namespaces
 	if len(namespaces) >= 1 && namespaces[0] != "" {
 		namespaces = append(namespaces, group.GetNamespace())
 	}
 	// TODO: Sanitize OperatorGroup if len(namespaces) > 1 and contains ""
-	gvksStr := group.GetAnnotations()[v1.OperatorGroupProvidedAPIsAnnotationKey]
+	gvksStr := group.GetAnnotations()[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey]
 
 	return &OperatorGroup{
 		namespace:    group.GetNamespace(),
@@ -123,7 +123,7 @@ func NewOperatorGroup(group *v1.OperatorGroup) *OperatorGroup {
 	}
 }
 
-func NewOperatorGroupSurfaces(groups ...v1.OperatorGroup) []OperatorGroupSurface {
+func NewOperatorGroupSurfaces(groups ...operatorsv1.OperatorGroup) []OperatorGroupSurface {
 	operatorGroups := make([]OperatorGroupSurface, len(groups))
 	for i, group := range groups {
 		operatorGroups[i] = NewOperatorGroup(&group)

--- a/pkg/controller/operators/olm/groups_test.go
+++ b/pkg/controller/operators/olm/groups_test.go
@@ -4,24 +4,24 @@ import (
 	"strings"
 	"testing"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
-func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []string) *v1.OperatorGroup {
-	return &v1.OperatorGroup{
+func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []string) *operatorsv1.OperatorGroup {
+	return &operatorsv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 			Annotations: map[string]string{
-				v1.OperatorGroupProvidedAPIsAnnotationKey: strings.Join(gvks, ","),
+				operatorsv1.OperatorGroupProvidedAPIsAnnotationKey: strings.Join(gvks, ","),
 			},
 		},
-		Status: v1.OperatorGroupStatus{
+		Status: operatorsv1.OperatorGroupStatus{
 			Namespaces: targets,
 		},
 	}
@@ -29,7 +29,7 @@ func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []stri
 func TestNewOperatorGroup(t *testing.T) {
 	tests := []struct {
 		name string
-		in   *v1.OperatorGroup
+		in   *operatorsv1.OperatorGroup
 		want *OperatorGroup
 	}{
 		{

--- a/pkg/controller/operators/olm/operatorconditions.go
+++ b/pkg/controller/operators/olm/operatorconditions.go
@@ -3,7 +3,7 @@ package olm
 import (
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,7 +19,7 @@ func (a *Operator) isOperatorUpgradeable(csv *v1alpha1.ClusterServiceVersion) (b
 
 	cond, err := a.lister.OperatorsV2().OperatorConditionLister().OperatorConditions(csv.GetNamespace()).Get(csv.GetName())
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, err

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -7,17 +7,17 @@ import (
 	"reflect"
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	utillabels "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/labels"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/errors"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/decorators"
@@ -54,7 +54,7 @@ func aggregationLabelFromAPIKey(k opregistry.APIKey, suffix string) (string, err
 }
 
 func (a *Operator) syncOperatorGroups(obj interface{}) error {
-	op, ok := obj.(*v1.OperatorGroup)
+	op, ok := obj.(*operatorsv1.OperatorGroup)
 	if !ok {
 		a.logger.Debugf("wrong type: %#v\n", obj)
 		return fmt.Errorf("casting OperatorGroup failed")
@@ -74,10 +74,10 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 	// Check if there is a stale multiple OG condition and clear it if existed.
 	if len(groups) == 1 {
 		og := groups[0].DeepCopy()
-		if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
-			meta.RemoveStatusCondition(&og.Status.Conditions, v1.MutlipleOperatorGroupCondition)
+		if c := meta.FindStatusCondition(og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition); c != nil {
+			meta.RemoveStatusCondition(&og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition)
 			if og.GetName() == op.GetName() {
-				meta.RemoveStatusCondition(&op.Status.Conditions, v1.MutlipleOperatorGroupCondition)
+				meta.RemoveStatusCondition(&op.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition)
 			}
 			_, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), og, metav1.UpdateOptions{})
 			if err != nil {
@@ -88,14 +88,14 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		// Add to all OG's status conditions to indicate they're multiple OGs in the
 		// same namespace which is not allowed.
 		cond := metav1.Condition{
-			Type:    v1.MutlipleOperatorGroupCondition,
+			Type:    operatorsv1.MutlipleOperatorGroupCondition,
 			Status:  metav1.ConditionTrue,
-			Reason:  v1.MultipleOperatorGroupsReason,
+			Reason:  operatorsv1.MultipleOperatorGroupsReason,
 			Message: "Multiple OperatorGroup found in the same namespace",
 		}
 		for i := range groups {
 			og := groups[i].DeepCopy()
-			if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
+			if c := meta.FindStatusCondition(og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition); c != nil {
 				continue
 			}
 			meta.SetStatusCondition(&og.Status.Conditions, cond)
@@ -122,7 +122,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		}
 		for i := range csvList {
 			csv := csvList[i].DeepCopy()
-			if group, ok := csv.GetAnnotations()[v1.OperatorGroupAnnotationKey]; !ok || group != op.GetName() {
+			if group, ok := csv.GetAnnotations()[operatorsv1.OperatorGroupAnnotationKey]; !ok || group != op.GetName() {
 				continue
 			}
 			if csv.Status.Reason == v1alpha1.CSVReasonComponentFailedNoRetry {
@@ -152,13 +152,13 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 
 		// Update operatorgroup target namespace selection
 		logger.WithField("targets", targetNamespaces).Debug("namespace change detected")
-		op.Status = v1.OperatorGroupStatus{
+		op.Status = operatorsv1.OperatorGroupStatus{
 			Namespaces:  targetNamespaces,
 			LastUpdated: a.now(),
 			Conditions:  op.Status.Conditions,
 		}
 
-		if _, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), op, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if _, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), op, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.WithError(err).Warn("operatorgroup update failed")
 			return err
 		}
@@ -223,7 +223,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 }
 
 func (a *Operator) operatorGroupDeleted(obj interface{}) {
-	op, ok := obj.(*v1.OperatorGroup)
+	op, ok := obj.(*operatorsv1.OperatorGroup)
 	if !ok {
 		a.logger.Debugf("casting OperatorGroup failed, wrong type: %#v\n", obj)
 		return
@@ -254,7 +254,7 @@ func (a *Operator) operatorGroupDeleted(obj interface{}) {
 	}
 }
 
-func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []string, logger *logrus.Entry) error {
+func (a *Operator) annotateCSVs(group *operatorsv1.OperatorGroup, targetNamespaces []string, logger *logrus.Entry) error {
 	updateErrs := []error{}
 	targetNamespaceSet := NewNamespaceSet(targetNamespaces)
 
@@ -264,13 +264,13 @@ func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []stri
 		}
 		logger := logger.WithField("csv", csv.GetName())
 
-		originalNamespacesAnnotation := a.copyOperatorGroupAnnotations(&csv.ObjectMeta)[v1.OperatorGroupTargetsAnnotationKey]
+		originalNamespacesAnnotation := a.copyOperatorGroupAnnotations(&csv.ObjectMeta)[operatorsv1.OperatorGroupTargetsAnnotationKey]
 		originalNamespaceSet := NewNamespaceSetFromString(originalNamespacesAnnotation)
 
 		if a.operatorGroupAnnotationsDiffer(&csv.ObjectMeta, group) {
 			a.setOperatorGroupAnnotations(&csv.ObjectMeta, group, true)
 			// CRDs don't support strategic merge patching, but in the future if they do this should be updated to patch
-			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(context.TODO(), csv, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(context.TODO(), csv, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				logger.WithError(err).Warnf("error adding operatorgroup annotations")
 				updateErrs = append(updateErrs, err)
 				continue
@@ -298,7 +298,7 @@ func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []stri
 	return errors.NewAggregate(updateErrs)
 }
 
-func (a *Operator) providedAPIsFromCSVs(group *v1.OperatorGroup, logger *logrus.Entry) map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion {
+func (a *Operator) providedAPIsFromCSVs(group *operatorsv1.OperatorGroup, logger *logrus.Entry) map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion {
 	set := a.csvSet(group.Namespace, v1alpha1.CSVPhaseAny)
 	providedAPIsFromCSVs := make(map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion)
 	for _, csv := range set {
@@ -323,7 +323,7 @@ func (a *Operator) providedAPIsFromCSVs(group *v1.OperatorGroup, logger *logrus.
 	return providedAPIsFromCSVs
 }
 
-func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs cache.APISet, providedAPIsFromCSVs map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion, logger *logrus.Entry) {
+func (a *Operator) pruneProvidedAPIs(group *operatorsv1.OperatorGroup, groupProvidedAPIs cache.APISet, providedAPIsFromCSVs map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion, logger *logrus.Entry) {
 	// Don't prune providedAPIsFromCSVs if static
 	if group.Spec.StaticProvidedAPIs {
 		a.logger.Debug("group has static provided apis. skipping provided api pruning")
@@ -337,7 +337,7 @@ func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs 
 		} else {
 			csv := providedAPIsFromCSVs[api]
 			_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(csv.GetNamespace()).Get(csv.GetName())
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			if csv.DeletionTimestamp == nil && (csv.Status.Phase == v1alpha1.CSVPhaseNone || csv.Status.Phase == v1alpha1.CSVPhasePending) {
@@ -360,10 +360,10 @@ func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs 
 
 		// Don't need to check for nil annotations since we already know |annotations| > 0
 		annotations := group.GetAnnotations()
-		annotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = intersection.String()
+		annotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] = intersection.String()
 		group.SetAnnotations(annotations)
 		logger.Debug("removing provided apis from annotation to match cluster state")
-		if _, err := a.client.OperatorsV1().OperatorGroups(group.GetNamespace()).Update(context.TODO(), group, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if _, err := a.client.OperatorsV1().OperatorGroups(group.GetNamespace()).Update(context.TODO(), group, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.WithError(err).Warn("could not update provided api annotations")
 		}
 	}
@@ -390,15 +390,15 @@ func (a *Operator) ensureProvidedAPIClusterRole(namePrefix, suffix string, verbs
 	}
 
 	existingCR, err := a.lister.RbacV1().ClusterRoleLister().Get(clusterRole.Name)
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		existingCR, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err == nil {
 			return nil
 		}
-		if !k8serrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			a.logger.WithError(err).Errorf("Create cluster role failed: %v", clusterRole)
 			return err
 		}
@@ -456,7 +456,7 @@ func (a *Operator) ensureClusterRolesForCSV(csv *v1alpha1.ClusterServiceVersion)
 	return nil
 }
 
-func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersion, operatorGroup *v1.OperatorGroup) error {
+func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersion, operatorGroup *operatorsv1.OperatorGroup) error {
 	targetNamespaces := operatorGroup.Status.Namespaces
 	if targetNamespaces == nil {
 		return nil
@@ -535,7 +535,7 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			// TODO: this should do something smarter if the cluster role already exists
 			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
 				// If the CR already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
+				if apierrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
 					continue
 				}
 				return err
@@ -574,7 +574,7 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			// TODO: this should do something smarter if the cluster role binding already exists
 			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
 				// If the CRB already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
+				if apierrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
 					continue
 				}
 				return err
@@ -688,7 +688,7 @@ func (a *Operator) ensureTenantRBAC(operatorNamespace, targetNamespace string, c
 	return nil
 }
 
-func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, operatorGroup *v1.OperatorGroup, targets NamespaceSet) error {
+func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, operatorGroup *operatorsv1.OperatorGroup, targets NamespaceSet) error {
 	namespaces, err := a.lister.CoreV1().NamespaceLister().List(labels.Everything())
 	if err != nil {
 		return err
@@ -798,7 +798,7 @@ func (a *Operator) copyToNamespace(prototype *v1alpha1.ClusterServiceVersion, ns
 	prototype.UID = ""
 
 	existing, err := a.copiedCSVLister.ClusterServiceVersions(nsTo).Get(prototype.GetName())
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		created, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(nsTo).Create(context.TODO(), prototype, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
@@ -855,7 +855,7 @@ func (a *Operator) pruneFromNamespace(operatorGroupName, namespace string) error
 	}
 
 	for _, csv := range fetchedCSVs {
-		if csv.IsCopied() && csv.GetAnnotations()[v1.OperatorGroupAnnotationKey] == operatorGroupName {
+		if csv.IsCopied() && csv.GetAnnotations()[operatorsv1.OperatorGroupAnnotationKey] == operatorGroupName {
 			a.logger.Debugf("Found CSV '%v' in namespace %v to delete", csv.GetName(), namespace)
 			if err := a.copiedCSVGCQueueSet.Requeue(csv.GetNamespace(), csv.GetName()); err != nil {
 				return err
@@ -865,36 +865,36 @@ func (a *Operator) pruneFromNamespace(operatorGroupName, namespace string) error
 	return nil
 }
 
-func (a *Operator) setOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *v1.OperatorGroup, addTargets bool) {
-	metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
-	metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupAnnotationKey, op.GetName())
+func (a *Operator) setOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *operatorsv1.OperatorGroup, addTargets bool) {
+	metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
+	metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupAnnotationKey, op.GetName())
 
 	if addTargets && op.Status.Namespaces != nil {
-		metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupTargetsAnnotationKey, op.BuildTargetNamespaces())
+		metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupTargetsAnnotationKey, op.BuildTargetNamespaces())
 	}
 }
 
-func (a *Operator) operatorGroupAnnotationsDiffer(obj *metav1.ObjectMeta, op *v1.OperatorGroup) bool {
+func (a *Operator) operatorGroupAnnotationsDiffer(obj *metav1.ObjectMeta, op *operatorsv1.OperatorGroup) bool {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return true
 	}
-	if operatorGroupNamespace, ok := annotations[v1.OperatorGroupNamespaceAnnotationKey]; !ok || operatorGroupNamespace != op.GetNamespace() {
+	if operatorGroupNamespace, ok := annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey]; !ok || operatorGroupNamespace != op.GetNamespace() {
 		return true
 	}
-	if operatorGroup, ok := annotations[v1.OperatorGroupAnnotationKey]; !ok || operatorGroup != op.GetName() {
+	if operatorGroup, ok := annotations[operatorsv1.OperatorGroupAnnotationKey]; !ok || operatorGroup != op.GetName() {
 		return true
 	}
-	if targets, ok := annotations[v1.OperatorGroupTargetsAnnotationKey]; !ok || targets != op.BuildTargetNamespaces() {
+	if targets, ok := annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]; !ok || targets != op.BuildTargetNamespaces() {
 		a.logger.WithFields(logrus.Fields{
-			"annotationTargets": annotations[v1.OperatorGroupTargetsAnnotationKey],
+			"annotationTargets": annotations[operatorsv1.OperatorGroupTargetsAnnotationKey],
 			"opgroupTargets":    op.BuildTargetNamespaces(),
 		}).Debug("annotations different")
 		return true
 	}
 
 	a.logger.WithFields(logrus.Fields{
-		"annotationTargets": annotations[v1.OperatorGroupTargetsAnnotationKey],
+		"annotationTargets": annotations[operatorsv1.OperatorGroupTargetsAnnotationKey],
 		"opgroupTargets":    op.BuildTargetNamespaces(),
 	}).Debug("annotations correct")
 	return false
@@ -904,11 +904,11 @@ func (a *Operator) copyOperatorGroupAnnotations(obj *metav1.ObjectMeta) map[stri
 	copiedAnnotations := make(map[string]string)
 	for k, v := range obj.GetAnnotations() {
 		switch k {
-		case v1.OperatorGroupNamespaceAnnotationKey:
+		case operatorsv1.OperatorGroupNamespaceAnnotationKey:
 			fallthrough
-		case v1.OperatorGroupAnnotationKey:
+		case operatorsv1.OperatorGroupAnnotationKey:
 			fallthrough
-		case v1.OperatorGroupTargetsAnnotationKey:
+		case operatorsv1.OperatorGroupTargetsAnnotationKey:
 			copiedAnnotations[k] = v
 		}
 	}
@@ -932,7 +932,7 @@ func namespacesChanged(clusterNamespaces []string, statusNamespaces []string) bo
 	return false
 }
 
-func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]struct{}, error) {
+func (a *Operator) getOperatorGroupTargets(op *operatorsv1.OperatorGroup) (map[string]struct{}, error) {
 	selector, err := metav1.LabelSelectorAsSelector(op.Spec.Selector)
 
 	if err != nil {
@@ -964,7 +964,7 @@ func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]str
 	return namespaceSet, nil
 }
 
-func (a *Operator) updateNamespaceList(op *v1.OperatorGroup) ([]string, error) {
+func (a *Operator) updateNamespaceList(op *operatorsv1.OperatorGroup) ([]string, error) {
 	namespaceSet, err := a.getOperatorGroupTargets(op)
 	if err != nil {
 		return nil, err
@@ -977,7 +977,7 @@ func (a *Operator) updateNamespaceList(op *v1.OperatorGroup) ([]string, error) {
 	return namespaceList, nil
 }
 
-func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string, apis cache.APISet) error {
+func (a *Operator) ensureOpGroupClusterRole(op *operatorsv1.OperatorGroup, suffix string, apis cache.APISet) error {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: strings.Join([]string{op.GetName(), suffix}, "-"),
@@ -1006,15 +1006,15 @@ func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string,
 	}
 
 	existingRole, err := a.lister.RbacV1().ClusterRoleLister().Get(clusterRole.Name)
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		existingRole, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err == nil {
 			return nil
 		}
-		if !k8serrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			a.logger.WithError(err).Errorf("Create cluster role failed: %v", clusterRole)
 			return err
 		}
@@ -1031,7 +1031,7 @@ func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string,
 	return nil
 }
 
-func (a *Operator) ensureOpGroupClusterRoles(op *v1.OperatorGroup, apis cache.APISet) error {
+func (a *Operator) ensureOpGroupClusterRoles(op *operatorsv1.OperatorGroup, apis cache.APISet) error {
 	for _, suffix := range Suffices {
 		if err := a.ensureOpGroupClusterRole(op, suffix, apis); err != nil {
 			return err
@@ -1107,7 +1107,7 @@ func csvCopyPrototype(src, dst *v1alpha1.ClusterServiceVersion) {
 		Status: src.Status,
 	}
 	for k, v := range src.Annotations {
-		if k == v1.OperatorGroupTargetsAnnotationKey {
+		if k == operatorsv1.OperatorGroupTargetsAnnotationKey {
 			continue
 		}
 		if k == "kubectl.kubernetes.io/last-applied-configuration" {

--- a/pkg/controller/operators/operatorcondition_controller.go
+++ b/pkg/controller/operators/operatorcondition_controller.go
@@ -8,7 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -147,7 +147,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRole(operatorCondit
 	existingRole := &rbacv1.Role{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: role.GetName(), Namespace: role.GetNamespace()}, existingRole)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), role)
@@ -193,7 +193,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRoleBinding(operato
 	existingRoleBinding := &rbacv1.RoleBinding{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: roleBinding.GetName(), Namespace: roleBinding.GetNamespace()}, existingRoleBinding)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), roleBinding)

--- a/pkg/controller/operators/operatorconditiongenerator_controller.go
+++ b/pkg/controller/operators/operatorconditiongenerator_controller.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -156,7 +156,7 @@ func (r *OperatorConditionGeneratorReconciler) ensureOperatorCondition(operatorC
 	existingOperatorCondition := &operatorsv2.OperatorCondition{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: operatorCondition.GetName(), Namespace: operatorCondition.GetNamespace()}, existingOperatorCondition)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), &operatorCondition)

--- a/pkg/controller/operators/operatorconditiongenerator_controller_test.go
+++ b/pkg/controller/operators/operatorconditiongenerator_controller_test.go
@@ -8,7 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -147,7 +147,7 @@ var _ = Describe("The OperatorConditionsGenerator Controller", func() {
 		time.Sleep(time.Second * 10)
 		err := k8sClient.Get(ctx, namespacedName, operatorCondition)
 		Expect(err).ToNot(BeNil())
-		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	It("creates an OperatorCondition for a CSV with multiple ServiceAccounts and Deployments", func() {

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -360,7 +360,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 				require.NoError(t, podErr)
 				require.Len(t, outPods.Items, 0)
 				require.NoError(t, err)
-				require.True(t, k8serrors.IsNotFound(serviceErr))
+				require.True(t, apierrors.IsNotFound(serviceErr))
 			}
 		})
 	}

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -6,12 +6,12 @@ import (
 	"hash/fnv"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
@@ -32,13 +32,13 @@ const (
 // RegistryEnsurer describes methods for ensuring a registry exists.
 type RegistryEnsurer interface {
 	// EnsureRegistryServer ensures a registry server exists for the given CatalogSource.
-	EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error
+	EnsureRegistryServer(catalogSource *operatorsv1alpha1.CatalogSource) error
 }
 
 // RegistryChecker describes methods for checking a registry.
 type RegistryChecker interface {
 	// CheckRegistryServer returns true if the given CatalogSource is considered healthy; false otherwise.
-	CheckRegistryServer(catalogSource *v1alpha1.CatalogSource) (healthy bool, err error)
+	CheckRegistryServer(catalogSource *operatorsv1alpha1.CatalogSource) (healthy bool, err error)
 }
 
 // RegistryReconciler knows how to reconcile a registry.
@@ -49,7 +49,7 @@ type RegistryReconciler interface {
 
 // RegistryReconcilerFactory describes factory methods for RegistryReconcilers.
 type RegistryReconcilerFactory interface {
-	ReconcilerForSource(source *v1alpha1.CatalogSource) RegistryReconciler
+	ReconcilerForSource(source *operatorsv1alpha1.CatalogSource) RegistryReconciler
 }
 
 // RegistryReconcilerFactory is a factory for RegistryReconcilers.
@@ -62,17 +62,17 @@ type registryReconcilerFactory struct {
 }
 
 // ReconcilerForSource returns a RegistryReconciler based on the configuration of the given CatalogSource.
-func (r *registryReconcilerFactory) ReconcilerForSource(source *v1alpha1.CatalogSource) RegistryReconciler {
+func (r *registryReconcilerFactory) ReconcilerForSource(source *operatorsv1alpha1.CatalogSource) RegistryReconciler {
 	// TODO: add memoization by source type
 	switch source.Spec.SourceType {
-	case v1alpha1.SourceTypeInternal, v1alpha1.SourceTypeConfigmap:
+	case operatorsv1alpha1.SourceTypeInternal, operatorsv1alpha1.SourceTypeConfigmap:
 		return &ConfigMapRegistryReconciler{
 			now:      r.now,
 			Lister:   r.Lister,
 			OpClient: r.OpClient,
 			Image:    r.ConfigMapServerImage,
 		}
-	case v1alpha1.SourceTypeGrpc:
+	case operatorsv1alpha1.SourceTypeGrpc:
 		if source.Spec.Image != "" {
 			return &GrpcRegistryReconciler{
 				now:       r.now,
@@ -100,66 +100,66 @@ func NewRegistryReconcilerFactory(lister operatorlister.OperatorLister, opClient
 	}
 }
 
-func Pod(source *v1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *v1.Pod {
+func Pod(source *operatorsv1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *corev1.Pod {
 	// Ensure the catalog image is always pulled if the image is not based on a digest, measured by whether an "@" is included.
 	// See https://github.com/docker/distribution/blob/master/reference/reference.go for more info.
 	// This means recreating non-digest based catalog pods will result in the latest version of the catalog content being delivered on-cluster.
-	var pullPolicy v1.PullPolicy
+	var pullPolicy corev1.PullPolicy
 	if strings.Contains(image, "@") {
-		pullPolicy = v1.PullIfNotPresent
+		pullPolicy = corev1.PullIfNotPresent
 	} else {
-		pullPolicy = v1.PullAlways
+		pullPolicy = corev1.PullAlways
 	}
 
 	readOnlyRootFilesystem := false
 
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: source.GetName() + "-",
 			Namespace:    source.GetNamespace(),
 			Labels:       labels,
 			Annotations:  annotations,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  name,
 					Image: image,
-					Ports: []v1.ContainerPort{
+					Ports: []corev1.ContainerPort{
 						{
 							Name:          "grpc",
 							ContainerPort: 50051,
 						},
 					},
-					ReadinessProbe: &v1.Probe{
-						ProbeHandler: v1.ProbeHandler{
-							Exec: &v1.ExecAction{
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: readinessDelay,
 						TimeoutSeconds:      5,
 					},
-					LivenessProbe: &v1.Probe{
-						ProbeHandler: v1.ProbeHandler{
-							Exec: &v1.ExecAction{
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: livenessDelay,
 						TimeoutSeconds:      5,
 					},
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("10m"),
-							v1.ResourceMemory: resource.MustParse("50Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 					},
-					SecurityContext: &v1.SecurityContext{
+					SecurityContext: &corev1.SecurityContext{
 						ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 					},
 					ImagePullPolicy:          pullPolicy,
-					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			NodeSelector: map[string]string{
@@ -188,7 +188,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 
 		// Override tolerations
 		if grpcPodConfig.Tolerations != nil {
-			pod.Spec.Tolerations = make([]v1.Toleration, len(grpcPodConfig.Tolerations))
+			pod.Spec.Tolerations = make([]corev1.Toleration, len(grpcPodConfig.Tolerations))
 			for index, toleration := range grpcPodConfig.Tolerations {
 				pod.Spec.Tolerations[index] = *toleration.DeepCopy()
 			}
@@ -211,7 +211,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 }
 
 // hashPodSpec calculates a hash given a copy of the pod spec
-func hashPodSpec(spec v1.PodSpec) string {
+func hashPodSpec(spec corev1.PodSpec) string {
 	hasher := fnv.New32a()
 	hashutil.DeepHashObject(hasher, &spec)
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))

--- a/pkg/lib/operatorstatus/clusteroperatorwriter.go
+++ b/pkg/lib/operatorstatus/clusteroperatorwriter.go
@@ -7,7 +7,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -36,7 +36,7 @@ func (w *Writer) EnsureExists(name string) (existing *configv1.ClusterOperator, 
 		return
 	}
 
-	if !k8serrors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return
 	}
 

--- a/pkg/lib/operatorstatus/status.go
+++ b/pkg/lib/operatorstatus/status.go
@@ -12,7 +12,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -88,7 +88,7 @@ func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct
 
 		// create the cluster operator in an initial state if it does not exist
 		existing, err := configClient.ClusterOperators().Get(context.TODO(), name, metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info("Existing operator status not found, creating")
 			created, createErr := configClient.ClusterOperators().Create(context.TODO(), &configv1.ClusterOperator{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/lib/proxy/syncer.go
+++ b/pkg/lib/proxy/syncer.go
@@ -11,7 +11,7 @@ import (
 	listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/discovery"
 )
 
@@ -49,7 +49,7 @@ type Syncer struct {
 func (w *Syncer) QueryProxyConfig() (proxy []corev1.EnvVar, err error) {
 	global, getErr := w.lister.Get(globalProxyName)
 	if getErr != nil {
-		if !k8serrors.IsNotFound(getErr) {
+		if !apierrors.IsNotFound(getErr) {
 			err = getErr
 			return
 		}

--- a/pkg/lib/scoped/syncer.go
+++ b/pkg/lib/scoped/syncer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,7 +79,7 @@ func (s *UserDefinedServiceAccountSyncer) SyncOperatorGroup(in *v1.OperatorGroup
 	// A service account has been specified, we need to update the status.
 	sa, err := s.client.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Set OG's status condition to indicate SA is not found
 			cond := metav1.Condition{
 				Type:    v1.OperatorGroupServiceAccountCondition,

--- a/pkg/lib/scoped/token_retriever.go
+++ b/pkg/lib/scoped/token_retriever.go
@@ -7,7 +7,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,7 +54,7 @@ func getAPISecret(logger logrus.FieldLogger, kubeclient operatorclient.ClientInt
 		// corev1.ObjectReference only has Name populated.
 		secret, getErr := kubeclient.KubernetesInterface().CoreV1().Secrets(sa.GetNamespace()).Get(context.TODO(), ref.Name, metav1.GetOptions{})
 		if getErr != nil {
-			if k8serrors.IsNotFound(getErr) {
+			if apierrors.IsNotFound(getErr) {
 				logger.Warnf("skipping secret %s - %v", ref.Name, getErr)
 				continue
 			}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 )
 
@@ -246,19 +246,19 @@ func DeleteCatalogSourceStateMetric(name, namespace string) {
 	catalogSourceReady.DeleteLabelValues(namespace, name)
 }
 
-func DeleteCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion) {
+func DeleteCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion) {
 	// Delete the old CSV metrics
 	csvAbnormal.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String(), string(oldCSV.Status.Phase), string(oldCSV.Status.Reason))
 	csvSucceeded.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String())
 }
 
-func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha1.ClusterServiceVersion) {
+func EmitCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion, newCSV *operatorsv1alpha1.ClusterServiceVersion) {
 	if oldCSV == nil || newCSV == nil {
 		return
 	}
 
 	// Don't update the metric for copies
-	if newCSV.Status.Reason == olmv1alpha1.CSVReasonCopied {
+	if newCSV.Status.Reason == operatorsv1alpha1.CSVReasonCopied {
 		return
 	}
 
@@ -268,7 +268,7 @@ func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha
 	// Get the phase of the new CSV
 	newCSVPhase := string(newCSV.Status.Phase)
 	csvSucceededGauge := csvSucceeded.WithLabelValues(newCSV.Namespace, newCSV.Name, newCSV.Spec.Version.String())
-	if newCSVPhase == string(olmv1alpha1.CSVPhaseSucceeded) {
+	if newCSVPhase == string(operatorsv1alpha1.CSVPhaseSucceeded) {
 		csvSucceededGauge.Set(1)
 	} else {
 		csvSucceededGauge.Set(0)
@@ -276,7 +276,7 @@ func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha
 	}
 }
 
-func EmitSubMetric(sub *olmv1alpha1.Subscription) {
+func EmitSubMetric(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}
@@ -291,14 +291,14 @@ func EmitSubMetric(sub *olmv1alpha1.Subscription) {
 	}
 }
 
-func DeleteSubsMetric(sub *olmv1alpha1.Subscription) {
+func DeleteSubsMetric(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}
 	SubscriptionSyncCount.DeleteLabelValues(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Channel, sub.Spec.Package, string(sub.Spec.InstallPlanApproval))
 }
 
-func UpdateSubsSyncCounterStorage(sub *olmv1alpha1.Subscription) {
+func UpdateSubsSyncCounterStorage(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}

--- a/pkg/package-server/storage/reststorage.go
+++ b/pkg/package-server/storage/reststorage.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers"
 	printerstorage "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers/storage"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -76,7 +76,7 @@ func (m *PackageManifestStorage) List(ctx context.Context, options *metainternal
 
 	res, err := m.prov.List(namespace, labelSelector)
 	if err != nil {
-		return nil, k8serrors.NewInternalError(err)
+		return nil, apierrors.NewInternalError(err)
 	}
 
 	filtered := []operators.PackageManifest{}
@@ -101,7 +101,7 @@ func (m *PackageManifestStorage) Get(ctx context.Context, name string, opts *met
 	namespace := genericreq.NamespaceValue(ctx)
 	manifest, err := m.prov.Get(namespace, name)
 	if err != nil || manifest == nil {
-		return nil, k8serrors.NewNotFound(m.groupResource, name)
+		return nil, apierrors.NewNotFound(m.groupResource, name)
 	}
 	// Strip logo icons
 	for i := range manifest.Status.Channels {

--- a/test/e2e/bundle_e2e_test.go
+++ b/test/e2e/bundle_e2e_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	. "github.com/onsi/ginkgo"
@@ -73,7 +73,7 @@ var _ = Describe("Installing bundles with new object types", func() {
 			Eventually(func() error {
 				err := ctx.Ctx().Client().Create(context.Background(), &vpaCRD)
 				if err != nil {
-					if !k8serrors.IsAlreadyExists(err) {
+					if !apierrors.IsAlreadyExists(err) {
 						return err
 					}
 				}
@@ -167,7 +167,7 @@ var _ = Describe("Installing bundles with new object types", func() {
 			By("Deleting the VPA CRD")
 			Eventually(func() error {
 				err := ctx.Ctx().Client().Delete(context.Background(), &vpaCRD)
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return nil
 				}
 				return err

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -15,7 +15,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -487,7 +487,7 @@ var _ = Describe("CRD Versions", func() {
 		Eventually(func() bool {
 			sub, _ := crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.TODO(), subscription.GetName(), metav1.GetOptions{})
 			ip, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Get(context.TODO(), sub.Status.InstallPlanRef.Name, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false
 			}
 			GinkgoT().Logf("waiting for installplan to succeed...currently %s", ip.Status.Phase)

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -133,15 +133,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 		AfterEach(func() {
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &crd)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &og)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &ns)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 		})
 
 		// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2646
@@ -255,7 +255,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&unassociated), &unassociated)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &associated)
@@ -345,7 +345,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			AfterEach(func() {
 				Eventually(func() error {
 					return ctx.Ctx().Client().Delete(context.Background(), &ns)
-				}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+				}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 			})
 
 			It("can satisfy the unassociated ClusterServiceVersion's ownership requirement", func() {
@@ -777,7 +777,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	// TODO: same test but missing serviceaccount instead
@@ -837,7 +837,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 
@@ -957,7 +957,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet requirements API service", func() {
@@ -1016,7 +1016,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet permissions API service", func() {
@@ -1103,7 +1103,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet requirements native API", func() {
@@ -1152,7 +1152,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	// TODO: same test but create serviceaccount instead
@@ -1395,7 +1395,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Poll for deployment to be ready
 		Eventually(func() (bool, error) {
 			dep, err := c.GetDeployment(testNamespace, depName)
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				ctx.Ctx().Logf("deployment %s not found\n", depName)
 				return false, nil
 			} else if err != nil {
@@ -4243,7 +4243,7 @@ var _ = Describe("Disabling copied CSVs", func() {
 	AfterEach(func() {
 		Eventually(func() error {
 			err := ctx.Ctx().Client().Delete(context.Background(), &csv)
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 
@@ -4253,7 +4253,7 @@ var _ = Describe("Disabling copied CSVs", func() {
 		Eventually(func() error {
 			var namespace corev1.Namespace
 			return ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&ns), &namespace)
-		}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+		}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 	})
 
 	When("an operator is installed in AllNamespace mode", func() {
@@ -4730,7 +4730,7 @@ func awaitCSV(c versioned.Interface, namespace, name string, checker csvConditio
 	Eventually(func() (bool, error) {
 		fetched, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 			return false, err
@@ -4749,7 +4749,7 @@ func waitForDeployment(c operatorclient.ClientInterface, name string) error {
 	return wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		_, err := c.GetDeployment(testNamespace, name)
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 			return false, err
@@ -4764,7 +4764,7 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 	Eventually(func() (bool, error) {
 		ctx.Ctx().Logf("waiting for deployment %s to delete", name)
 		_, err := c.GetDeployment(testNamespace, name)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			ctx.Ctx().Logf("deleted %s", name)
 			return true, nil
 		}
@@ -4779,7 +4779,7 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 
 func csvExists(c versioned.Interface, name string) bool {
 	fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return false
 	}
 	ctx.Ctx().Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
@@ -4841,7 +4841,7 @@ func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc
 	}
 
 	_, err = c.CreateSecret(&secret)
-	if err != nil && !k8serrors.IsAlreadyExists(err) {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -4906,25 +4906,25 @@ func checkLegacyAPIResources(desc operatorsv1alpha1.APIServiceDescription, expec
 
 	// Attempt to create the legacy service
 	_, err := c.GetService(testNamespace, strings.Replace(apiServiceName, ".", "-", -1))
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret
 	_, err = c.GetSecret(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role
 	_, err = c.GetRole(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role binding
 	_, err = c.GetRoleBinding(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authDelegatorClusterRoleBinding
 	_, err = c.GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authReadingRoleBinding
 	_, err = c.GetRoleBinding("kube-system", apiServiceName+"-auth-reader")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 }

--- a/test/e2e/gc_e2e_test.go
+++ b/test/e2e/gc_e2e_test.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -113,14 +113,14 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete CRD
 				Eventually(func() bool {
 					err := kubeClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crd.GetName(), metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should delete the associated ClusterRole", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetClusterRole(cr.GetName())
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "get cluster role should eventually return \"not found\"")
 			})
 
@@ -183,14 +183,14 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete API service
 				Eventually(func() bool {
 					err := kubeClient.DeleteAPIService(apiService.GetName(), &metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should delete the associated ClusterRole", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetClusterRole(cr.GetName())
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "get cluster role should eventually return \"not found\"")
 			})
 
@@ -260,13 +260,13 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
@@ -285,32 +285,32 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// delete ownerB in the foreground (to ensure any "blocking" dependents are deleted before ownerB)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedB.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerB
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerB.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should have deleted the dependent since both the owners were deleted", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "expected dependency configmap would be properly garabage collected")
 				ctx.Ctx().Logf("dependent successfully garbage collected after both owners were deleted")
 			})
@@ -400,25 +400,25 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete subscription first
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Delete(context.Background(), subName, metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// Delete CSV
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), csvName, metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), csvName, metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
@@ -426,12 +426,12 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// confirm extra bundle objects (secret and configmap) are no longer installed on the cluster
 				Eventually(func() bool {
 					_, err := kubeClient.GetSecret(ns.GetName(), secretName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() bool {
 					_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 				ctx.Ctx().Logf("dependent successfully garbage collected after csv owner was deleted")
 			})
@@ -654,7 +654,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			It("[FLAKE] should have removed the old configmap and put the new configmap in place", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() error {

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -450,11 +450,11 @@ var _ = Describe("Install Plan", func() {
 		AfterEach(func() {
 			Expect(ctx.Ctx().Client().Delete(context.Background(), owned)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 			Expect(ctx.Ctx().Client().Delete(context.Background(), plan)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 		})
 
@@ -555,19 +555,19 @@ var _ = Describe("Install Plan", func() {
 		AfterEach(func() {
 			Expect(ctx.Ctx().Client().Delete(context.Background(), &sa)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 			Expect(ctx.Ctx().Client().Delete(context.Background(), &csv1)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 			Expect(ctx.Ctx().Client().Delete(context.Background(), &csv2)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 			Expect(ctx.Ctx().Client().Delete(context.Background(), &plan)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 		})
 
@@ -2859,7 +2859,7 @@ var _ = Describe("Install Plan", func() {
 				err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 					_, err = c.GetClusterRole(step.Resource.Name)
 					if err != nil {
-						if k8serrors.IsNotFound(err) {
+						if apierrors.IsNotFound(err) {
 							return false, nil
 						}
 						return false, err
@@ -2872,7 +2872,7 @@ var _ = Describe("Install Plan", func() {
 				err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 					_, err = c.GetClusterRoleBinding(step.Resource.Name)
 					if err != nil {
-						if k8serrors.IsNotFound(err) {
+						if apierrors.IsNotFound(err) {
 							return false, nil
 						}
 						return false, err
@@ -2967,7 +2967,7 @@ var _ = Describe("Install Plan", func() {
 			if err == nil {
 				return fmt.Errorf("The %v/%v ServiceAccount should have been deleted", ns.GetName(), serviceAccountName)
 			}
-			if !k8serrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				return err
 			}
 			return nil
@@ -4306,7 +4306,7 @@ func waitForInstallPlan(c versioned.Interface, name string, namespace string, ch
 
 	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		fetchedInstallPlan, err = c.OperatorsV1alpha1().InstallPlans(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
 		}
 

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -218,7 +218,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				log(fmt.Sprintf("Error (in %v): %v", testNamespace, fetchErr.Error()))
@@ -235,7 +235,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				log(fmt.Sprintf("Error (in %v): %v", otherNamespaceName, fetchErr.Error()))
@@ -252,7 +252,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -269,7 +269,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			createdDeployment, err := c.GetDeployment(opGroupNamespace, deploymentName)
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -387,7 +387,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			_, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(context.TODO(), operatorGroup.Name+"-edit", metav1.GetOptions{})
@@ -396,7 +396,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			_, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(context.TODO(), operatorGroup.Name+"-view", metav1.GetOptions{})
@@ -405,7 +405,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 	})
 	It("role aggregation", func() {
 
@@ -1440,7 +1440,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRole, err = c.GetClusterRole(role.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1456,7 +1456,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRoleBinding, err = c.GetClusterRoleBinding(roleBinding.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1485,7 +1485,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
@@ -1518,7 +1518,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -1549,7 +1549,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, 2*pollDuration, func() (bool, error) {
 			_, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return true, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())
@@ -1921,7 +1921,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRole, err = c.GetClusterRole(role.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1937,7 +1937,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRoleBinding, err = c.GetClusterRoleBinding(roleBinding.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1966,7 +1966,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
@@ -1999,7 +1999,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -2026,7 +2026,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, 2*pollDuration, func() (bool, error) {
 			csv, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return true, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())

--- a/test/e2e/scoped_client_test.go
+++ b/test/e2e/scoped_client_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -55,7 +55,7 @@ var _ = Describe("Scoped Client bound to a service account can be used to make A
 			// We expect the get api call to return 'Forbidden' error due to
 			// lack of permission.
 			assertFunc: func(errGot error) {
-				Expect(k8serrors.IsForbidden(errGot)).To(BeTrue())
+				Expect(apierrors.IsForbidden(errGot)).To(BeTrue())
 			},
 		}),
 		table.Entry("successfully allows API calls to be made when ServiceAccount has permission", testParameter{
@@ -66,7 +66,7 @@ var _ = Describe("Scoped Client bound to a service account can be used to make A
 				return
 			},
 			assertFunc: func(errGot error) {
-				Expect(k8serrors.IsNotFound(errGot)).To(BeTrue())
+				Expect(apierrors.IsNotFound(errGot)).To(BeTrue())
 			},
 		}),
 	}

--- a/test/e2e/setup_bare_test.go
+++ b/test/e2e/setup_bare_test.go
@@ -1,3 +1,4 @@
+//go:build bare
 // +build bare
 
 package e2e
@@ -18,7 +19,7 @@ import (
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/tools/clientcmd"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm"

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -19,7 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1210,7 +1210,7 @@ var _ = Describe("Subscription", func() {
 			}
 
 			proxy, getErr := client.Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
-			if k8serrors.IsNotFound(getErr) {
+			if apierrors.IsNotFound(getErr) {
 				return nil
 			}
 			require.NoError(GinkgoT(), getErr)
@@ -2561,7 +2561,7 @@ func init() {
 func initCatalog(t GinkgoTInterface, namespace string, c operatorclient.ClientInterface, crc versioned.Interface) error {
 	dummyCatalogConfigMap.SetNamespace(namespace)
 	if _, err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Create(context.Background(), dummyCatalogConfigMap, metav1.CreateOptions{}); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("E2E bug detected: %v", err)
 		}
 		return err
@@ -2569,7 +2569,7 @@ func initCatalog(t GinkgoTInterface, namespace string, c operatorclient.ClientIn
 
 	dummyCatalogSource.SetNamespace(namespace)
 	if _, err := crc.OperatorsV1alpha1().CatalogSources(namespace).Create(context.Background(), &dummyCatalogSource, metav1.CreateOptions{}); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("E2E bug detected: %v", err)
 		}
 		return err


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Introduce a configuration for the `importas` configuration for commonly used package imports, e.g. metav1/corev1/appsv1, when running golangci-lint runner. This is currently used in the operator-framework/rukpak repository, and helps lessen reviewer burden as we're focusing less on styling differences.

**Motivation for the change:**
Enforce package import naming for commonly imported packages to lessen the reviewer burden.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
