### PR TITLE
Refactor webhook e2e

### DIFF
--- a/test/e2e/webhook_e2e_test.go
+++ b/test/e2e/webhook_e2e_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,39 +31,34 @@ const (
 )
 
 var _ = Describe("CSVs with a Webhook", func() {
-	var c operatorclient.ClientInterface
-	var crc versioned.Interface
-	var namespace *corev1.Namespace
-	var nsCleanupFunc cleanupFunc
-	var nsLabels map[string]string
+
+	var (
+		generatedNamespace corev1.Namespace
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
+		nsLabels           map[string]string
+	)
+
 	BeforeEach(func() {
 		c = newKubeClient()
 		crc = newCRClient()
-		nsLabels = map[string]string{
-			"foo": "bar",
-		}
-		namespace = &corev1.Namespace{
+		generatedNamespace = corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   genName("webhook-test-"),
-				Labels: nsLabels,
+				Name: genName("webhook-e2e-"),
+				Labels: map[string]string{
+					"foo": "bar",
+				},
 			},
 		}
-
-		var err error
-		namespace, err = c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
-		Expect(err).Should(BeNil())
-		Expect(namespace).ShouldNot(BeNil())
-
-		nsCleanupFunc = func() {
-			err := c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), namespace.GetName(), metav1.DeleteOptions{})
-			Expect(err).Should(BeNil())
-		}
+		Eventually(func() error {
+			return ctx.Ctx().Client().Create(context.Background(), &generatedNamespace)
+		}).Should(Succeed())
 	})
+
 	AfterEach(func() {
-		if nsCleanupFunc != nil {
-			nsCleanupFunc()
-		}
+		TeardownNamespace(generatedNamespace.GetName())
 	})
+
 	When("Installed in an OperatorGroup that defines a selector", func() {
 		var cleanupCSV cleanupFunc
 		var ogSelector *metav1.LabelSelector
@@ -71,8 +67,8 @@ var _ = Describe("CSVs with a Webhook", func() {
 				MatchLabels: nsLabels,
 			}
 
-			og := newOperatorGroup(namespace.Name, genName("selector-og-"), nil, ogSelector, nil, false)
-			_, err := crc.OperatorsV1().OperatorGroups(namespace.Name).Create(context.TODO(), og, metav1.CreateOptions{})
+			og := newOperatorGroup(generatedNamespace.GetName(), genName("selector-og-"), nil, ogSelector, nil, false)
+			_, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 			Expect(err).Should(BeNil())
 		})
 		AfterEach(func() {
@@ -91,12 +87,12 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -109,9 +105,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		var cleanupCSV cleanupFunc
 		var og *v1.OperatorGroup
 		BeforeEach(func() {
-			og = newOperatorGroup(namespace.Name, genName("single-namespace-og-"), nil, nil, []string{namespace.Name}, false)
+			og = newOperatorGroup(generatedNamespace.GetName(), genName("single-namespace-og-"), nil, nil, []string{generatedNamespace.GetName()}, false)
 			var err error
-			og, err = crc.OperatorsV1().OperatorGroups(namespace.Name).Create(context.TODO(), og, metav1.CreateOptions{})
+			og, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 			Expect(err).Should(BeNil())
 		})
 		AfterEach(func() {
@@ -130,12 +126,12 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -153,13 +149,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 			// Ensure that changes to the WebhookDescription within the CSV trigger an update to on cluster resources
 			changedGenerateName := webhookName + "-changed"
 			Eventually(func() error {
-				existingCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.Name).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
+				existingCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 				existingCSV.Spec.WebhookDefinitions[0].GenerateName = changedGenerateName
 
-				existingCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.Name).Update(context.TODO(), existingCSV, metav1.UpdateOptions{})
+				existingCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.TODO(), existingCSV, metav1.UpdateOptions{})
 				return err
 			}, time.Minute, 5*time.Second).Should(Succeed())
 			Eventually(func() bool {
@@ -184,39 +180,39 @@ var _ = Describe("CSVs with a Webhook", func() {
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
 				SideEffects:             &sideEffect,
 			}
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.GetName(), false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			// Get the existing secret
 			webhookSecretName := webhook.DeploymentName + "-service-cert"
-			existingSecret, err := c.KubernetesInterface().CoreV1().Secrets(namespace.GetName()).Get(context.TODO(), webhookSecretName, metav1.GetOptions{})
+			existingSecret, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).Get(context.TODO(), webhookSecretName, metav1.GetOptions{})
 			require.NoError(GinkgoT(), err)
 
 			// Modify the phase
 			Eventually(func() bool {
-				fetchedCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.GetName()).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
+				fetchedCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
 
 				fetchedCSV.Status.Phase = operatorsv1alpha1.CSVPhasePending
 
-				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.GetName()).UpdateStatus(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).UpdateStatus(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 				return err == nil
 			}).Should(BeTrue(), "Unable to set CSV phase to Pending")
 
 			// Wait for webhook-operator to succeed
-			_, err = awaitCSV(crc, namespace.GetName(), csv.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the updated secret
-			updatedSecret, err := c.KubernetesInterface().CoreV1().Secrets(namespace.GetName()).Get(context.TODO(), webhookSecretName, metav1.GetOptions{})
+			updatedSecret, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).Get(context.TODO(), webhookSecretName, metav1.GetOptions{})
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), existingSecret.GetAnnotations()[install.OLMCAHashAnnotationKey], updatedSecret.GetAnnotations()[install.OLMCAHashAnnotationKey])
@@ -233,13 +229,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 			csv.Spec.WebhookDefinitions = append(csv.Spec.WebhookDefinitions, webhook)
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
 			Expect(err).Should(BeNil())
 		})
 		It("Fails if the webhooks intercepts all resources", func() {
@@ -263,13 +259,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include all groups"))
 		})
@@ -294,13 +290,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include the OLM group"))
 		})
@@ -325,13 +321,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include MutatingWebhookConfiguration or ValidatingWebhookConfiguration resources"))
 		})
@@ -358,13 +354,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 		})
 		It("Can be installed and upgraded successfully", func() {
@@ -390,13 +386,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
-			_, err := createCSV(c, crc, csv, namespace.Name, false, false)
+			_, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 			// cleanup by upgrade
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			_, err = getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -408,10 +404,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			previousWebhookName := webhook.GenerateName
 			webhook.GenerateName = "webhook2.test.com"
 			csv.Spec.WebhookDefinitions[0] = webhook
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.GetName(), namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			_, err = getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -446,13 +442,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -461,7 +457,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			oldWebhookCABundle := actualWebhook.Webhooks[0].ClientConfig.CABundle
 
 			// Get the deployment
-			dep, err := c.KubernetesInterface().AppsV1().Deployments(namespace.Name).Get(context.TODO(), csv.Spec.WebhookDefinitions[0].DeploymentName, metav1.GetOptions{})
+			dep, err := c.KubernetesInterface().AppsV1().Deployments(generatedNamespace.GetName()).Get(context.TODO(), csv.Spec.WebhookDefinitions[0].DeploymentName, metav1.GetOptions{})
 			Expect(err).Should(BeNil())
 
 			//Store the ca sha annotation
@@ -476,9 +472,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 				return nil
 			})).Should(Succeed())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create deployment
-				dep, err = c.GetDeployment(namespace.Name, csv.Spec.WebhookDefinitions[0].DeploymentName)
+				dep, err = c.GetDeployment(generatedNamespace.GetName(), csv.Spec.WebhookDefinitions[0].DeploymentName)
 				if err != nil {
 					return false
 				}
@@ -509,8 +505,8 @@ var _ = Describe("CSVs with a Webhook", func() {
 	When("Installed in a Global OperatorGroup", func() {
 		var cleanupCSV cleanupFunc
 		BeforeEach(func() {
-			og := newOperatorGroup(namespace.Name, genName("global-og-"), nil, nil, []string{}, false)
-			og, err := crc.OperatorsV1().OperatorGroups(namespace.Name).Create(context.TODO(), og, metav1.CreateOptions{})
+			og := newOperatorGroup(generatedNamespace.GetName(), genName("global-og-"), nil, nil, []string{}, false)
+			og, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 			Expect(err).Should(BeNil())
 		})
 		AfterEach(func() {
@@ -529,13 +525,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())
@@ -588,7 +584,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			SideEffects:             &sideEffect,
 		}
 
-		csv := createCSVWithWebhook(namespace.GetName(), webhook)
+		csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 		csv.Namespace = namespace1.GetName()
 		var cleanupCSV cleanupFunc
@@ -636,6 +632,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		var cleanupCatSrc cleanupFunc
 		var cleanupSubscription cleanupFunc
 		BeforeEach(func() {
+			og := newOperatorGroup(generatedNamespace.GetName(), genName("og-"), nil, nil, []string{}, false)
+			_, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
+			Expect(err).Should(BeNil())
 
 			// Create a catalogSource which has the webhook-operator
 			sourceName := genName("catalog-")
@@ -652,7 +651,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: testNamespace,
+					Namespace: generatedNamespace.GetName(),
 				},
 				Spec: operatorsv1alpha1.CatalogSourceSpec{
 					SourceType: operatorsv1alpha1.SourceTypeGrpc,
@@ -661,7 +660,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			}
 
 			crc := newCRClient()
-			source, err := crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(context.TODO(), source, metav1.CreateOptions{})
+			source, err = crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(context.TODO(), source, metav1.CreateOptions{})
 			require.NoError(GinkgoT(), err)
 			cleanupCatSrc = func() {
 				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Delete(context.TODO(), source.GetName(), metav1.DeleteOptions{}))
@@ -673,14 +672,14 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			// Create a Subscription for the webhook-operator
 			subscriptionName := genName("sub-")
-			cleanupSubscription := createSubscriptionForCatalog(crc, testNamespace, subscriptionName, source.GetName(), packageName, channelName, "", operatorsv1alpha1.ApprovalAutomatic)
+			cleanupSubscription := createSubscriptionForCatalog(crc, source.GetNamespace(), subscriptionName, source.GetName(), packageName, channelName, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer cleanupSubscription()
 
 			// Wait for webhook-operator v2 csv to succeed
-			csv, err := awaitCSV(crc, testNamespace, "webhook-operator.v0.0.1", csvSucceededChecker)
+			csv, err := awaitCSV(crc, source.GetNamespace(), "webhook-operator.v0.0.1", csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
-			cleanupCSV = buildCSVCleanupFunc(c, crc, *csv, testNamespace, true, true)
+			cleanupCSV = buildCSVCleanupFunc(c, crc, *csv, source.GetNamespace(), true, true)
 		})
 		AfterEach(func() {
 			if cleanupCSV != nil {
@@ -700,7 +699,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 					"apiVersion": "webhook.operators.coreos.io/v1",
 					"kind":       "webhooktests",
 					"metadata": map[string]interface{}{
-						"namespace": testNamespace,
+						"namespace": generatedNamespace.GetName(),
 						"name":      "my-cr-1",
 					},
 					"spec": map[string]interface{}{
@@ -723,7 +722,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 					"apiVersion": "webhook.operators.coreos.io/v1",
 					"kind":       "webhooktests",
 					"metadata": map[string]interface{}{
-						"namespace": testNamespace,
+						"namespace": generatedNamespace.GetName(),
 						"name":      "my-cr-1",
 					},
 					"spec": map[string]interface{}{
@@ -731,12 +730,12 @@ var _ = Describe("CSVs with a Webhook", func() {
 					},
 				},
 			}
-			crCleanupFunc, err := createCR(c, validCR, "webhook.operators.coreos.io", "v1", testNamespace, "webhooktests", "my-cr-1")
+			crCleanupFunc, err := createCR(c, validCR, "webhook.operators.coreos.io", "v1", generatedNamespace.GetName(), "webhooktests", "my-cr-1")
 			defer crCleanupFunc()
 			require.NoError(GinkgoT(), err, "The valid CR should have been approved by the validating webhook")
 
 			// Check that you can get v1 of the webhooktest cr
-			v1UnstructuredObject, err := c.GetCustomResource("webhook.operators.coreos.io", "v1", testNamespace, "webhooktests", "my-cr-1")
+			v1UnstructuredObject, err := c.GetCustomResource("webhook.operators.coreos.io", "v1", generatedNamespace.GetName(), "webhooktests", "my-cr-1")
 			require.NoError(GinkgoT(), err, "Unable to get the v1 of the valid CR")
 			v1Object := v1UnstructuredObject.Object
 			v1Spec, ok := v1Object["spec"].(map[string]interface{})
@@ -750,7 +749,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			require.True(GinkgoT(), v1SpecValid, "The validating webhook should have required that the CR's spec.valid field is true")
 
 			// Check that you can get v2 of the webhooktest cr
-			v2UnstructuredObject, err := c.GetCustomResource("webhook.operators.coreos.io", "v2", testNamespace, "webhooktests", "my-cr-1")
+			v2UnstructuredObject, err := c.GetCustomResource("webhook.operators.coreos.io", "v2", generatedNamespace.GetName(), "webhooktests", "my-cr-1")
 			require.NoError(GinkgoT(), err, "Unable to get the v2 of the valid CR")
 			v2Object := v2UnstructuredObject.Object
 			v2Spec := v2Object["spec"].(map[string]interface{})
@@ -769,8 +768,8 @@ var _ = Describe("CSVs with a Webhook", func() {
 		var cleanupCSV cleanupFunc
 		BeforeEach(func() {
 			// global operator group
-			og := newOperatorGroup(namespace.Name, genName("global-og-"), nil, nil, []string{}, false)
-			og, err := crc.OperatorsV1().OperatorGroups(namespace.Name).Create(context.TODO(), og, metav1.CreateOptions{})
+			og := newOperatorGroup(generatedNamespace.GetName(), genName("global-og-"), nil, nil, []string{}, false)
+			og, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 			Expect(err).Should(BeNil())
 		})
 		AfterEach(func() {
@@ -808,13 +807,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 			ownedCRDDescs := make([]operatorsv1alpha1.CRDDescription, 0)
 
 			// create CSV
-			csv := createCSVWithWebhookAndCrds(namespace.GetName(), webhook, ownedCRDDescs)
+			csv := createCSVWithWebhookAndCrds(generatedNamespace.GetName(), webhook, ownedCRDDescs)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())
@@ -871,13 +870,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 			ownedCRDDescs = append(ownedCRDDescs, operatorsv1alpha1.CRDDescription{Name: crdA.GetName(), Version: crdA.Spec.Versions[0].Name, Kind: crdA.Spec.Names.Kind})
 
 			// create CSV
-			csv := createCSVWithWebhookAndCrdsAndInvalidInstallModes(namespace.GetName(), webhook, ownedCRDDescs)
+			csv := createCSVWithWebhookAndCrdsAndInvalidInstallModes(generatedNamespace.GetName(), webhook, ownedCRDDescs)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())


### PR DESCRIPTION
**Description of the change:**
This PR moves the webhook e2e suite to one namespace per spec

**Motivation for the change:**
CI stability

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
