### PR TITLE
.github: Update the golangci-lint version

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -22,4 +22,4 @@ jobs:
     - name: Run linting checks
       uses: "golangci/golangci-lint-action@v2"
       with:
-        version: "v1.43"
+        version: "v1.45.2"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 8m
   skip-dirs:
   - pkg/lib
   - pkg/api


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the .github/workflow/sanity.yaml GHA workflow and bump the golangci-lint to a version that works with Go 1.17.

**Motivation for the change:**
The sanity check is permafailing right now. See https://github.com/golangci/golangci-lint/issues/2374 for more information.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
