### PR TITLE
.github,test: Rename the ARTIFACTS_DIR variable to ARTIFACT_DIR

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.17'
-      - run: make e2e-local E2E_TEST_CHUNK=${{ matrix.parallel-id }} E2E_TEST_NUM_CHUNKS=${{ strategy.job-total }} E2E_NODES=2 ARTIFACTS_DIR=./artifacts/ SKIP='\[FLAKE\]'
+      - run: make e2e-local E2E_TEST_CHUNK=${{ matrix.parallel-id }} E2E_TEST_NUM_CHUNKS=${{ strategy.job-total }} E2E_NODES=2 ARTIFACT_DIR=./artifacts/ SKIP='\[FLAKE\]'
       - name: Archive Test Artifacts # test results, failed or not, are always uploaded.
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/flaky-e2e.yml
+++ b/.github/workflows/flaky-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.17'
-      - run: make e2e-local E2E_NODES=1 TEST='\[FLAKE\]' ARTIFACTS_DIR=./artifacts/
+      - run: make e2e-local E2E_NODES=1 TEST='\[FLAKE\]' ARTIFACT_DIR=./artifacts/
       - name: Archive Test Artifacts # test results, failed or not, are always uploaded.
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/test/e2e/ctx/ctx.go
+++ b/test/e2e/ctx/ctx.go
@@ -111,7 +111,7 @@ func (ctx TestContext) NewE2EClientSession() {
 
 func (ctx TestContext) DumpNamespaceArtifacts(namespace string) error {
 	if ctx.artifactsDir == "" {
-		ctx.Logf("$ARTIFACTS_DIR is unset -- not collecting failed test case logs")
+		ctx.Logf("$ARTIFACT_DIR is unset -- not collecting failed test case logs")
 		return nil
 	}
 	ctx.Logf("collecting logs in the %s artifacts directory", ctx.artifactsDir)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -62,8 +62,8 @@ func TestEndToEnd(t *testing.T) {
 	SetDefaultConsistentlyDuration(30 * time.Second)
 	SetDefaultConsistentlyPollingInterval(1 * time.Second)
 
-	// always configure a junit report when ARTIFACTS_DIR has been set
-	if artifactsDir := os.Getenv("ARTIFACTS_DIR"); artifactsDir != "" {
+	// always configure a junit report when ARTIFACT_DIR has been set
+	if artifactsDir := os.Getenv("ARTIFACT_DIR"); artifactsDir != "" {
 		junitReporter := reporters.NewJUnitReporter(path.Join(artifactsDir, junitDir, fmt.Sprintf("junit_e2e_%02d.xml", config.GinkgoConfig.ParallelNode)))
 		RunSpecsWithDefaultAndCustomReporters(t, "End-to-end", []Reporter{junitReporter})
 	} else {


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fix the ARTIFACTS_DIR variable and rename that to the proper ARTIFACT_DIR variable so OLM can work on prow-based CI environments.

**Motivation for the change:**
Maintain consistency with the various CI platforms (e.g. prow)

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
