### PR TITLE
Makefile: Add a build-local target for building the OLM related images locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,10 +279,13 @@ uninstall:
 	- kubectl delete clusterroles.rbac.authorization.k8s.io "system:controller:operator-lifecycle-manager"
 	- kubectl delete clusterrolebindings.rbac.authorization.k8s.io "olm-operator-binding-openshift-operator-lifecycle-manager"
 
-.PHONY: run-local
-run-local: build-linux build-wait build-util-linux
+.PHONY: build-local
+build-local: build-linux build-wait build-util-linux
 	rm -rf build
 	. ./scripts/build_local.sh
+
+.PHONY: run-local
+run-local: build-local
 	mkdir -p build/resources
 	. ./scripts/package_release.sh 1.0.0 build/resources doc/install/local-values.yaml
 	. ./scripts/install_local.sh $(LOCAL_NAMESPACE) build/resources


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the Makefile and separate out the local container image building process from the run-local into it's own dedicated target. Add the build-local target as a prequisite target to the run-local target.

**Motivation for the change:**
Make it easier to quickly deploy changes to the OLM binaries locally when OLM is already installed on a dev cluster.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
