### PR TITLE
(e2e) Reduce Consistently time for catalogsource_ready metrics check

### DIFF
--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -368,7 +368,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 			AfterEach(func() {
 				cleanup()
 			})
-			It("emits metrics for the catalogSource", func() {
+			It("emits catalogsource_ready metric for the catalogSource with Value equal to 1", func() {
 				Eventually(func() []Metric {
 					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"))
 				}).Should(And(
@@ -412,7 +412,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 			AfterEach(func() {
 				cleanup()
 			})
-			It("emits metrics for the CatlogSource with a Value greater than 0", func() {
+			It("emits metrics for the CatlogSource with a Value equal to 0", func() {
 				Eventually(func() []Metric {
 					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"))
 				}).Should(And(
@@ -425,7 +425,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 				))
 				Consistently(func() []Metric {
 					return getMetricsFromPod(c, getPodWithLabel(c, "app=catalog-operator"))
-				}, "3m").Should(And(
+				}, "1m", "30s").Should(And(
 					ContainElement(LikeMetric(
 						WithFamily("catalogsource_ready"),
 						WithName(name),


### PR DESCRIPTION
This test was checking for the catalogsource_ready metrics being emitted
with a particular value, consistently for a period of time. `Consistently`
blocks for the duration of time mentioned (previously 3m). Unfortunately,
there is no way to write an `Eventually` that starts polling after an
interval, which could have been the non-blocking alternatve to using
Consistently to perform the same check.

This PR reduces the period of time the test is blocked Consistently to
1m, to reduce the test package's overall runtime.

Ref:
https://onsi.github.io/gomega/#eventually
https://onsi.github.io/gomega/#consistently

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
