### PR TITLE
Address fail forward unit test failures

### DIFF
--- a/pkg/controller/registry/resolver/step_resolver_test.go
+++ b/pkg/controller/registry/resolver/step_resolver_test.go
@@ -1182,7 +1182,8 @@ func TestResolver(t *testing.T) {
 				steps: [][]*v1alpha1.Step{},
 				subs:  []*v1alpha1.Subscription{},
 				errAssert: func(t *testing.T, err error) {
-					assert.Contains(t, err.Error(), "error using catalog @existing (in namespace catsrc-namespace): csv catsrc-namespace/a.v1 in phase Failed instead of Replacing")
+					assert.Contains(t, err.Error(), "error using catalog @existing (in namespace catsrc-namespace): csv")
+					assert.Contains(t, err.Error(), "in phase Failed instead of Replacing")
 				},
 			},
 		},


### PR DESCRIPTION
The broken replacement chain unit test occasionally fails because it is
possible for either the a.v1 or a.v2 operators to cause the resolver to
fail. This commit updates the test to check that the resolver fails
because a csv is in the failed state versus checking that a specific
csv is in the failed state.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>