### PR TITLE
Remove Namespace sync from OG queue informer

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -266,7 +266,6 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		queueinformer.WithLogger(op.logger),
 		queueinformer.WithQueue(ogQueue),
 		queueinformer.WithInformer(operatorGroupInformer.Informer()),
-		queueinformer.WithSyncer(queueinformer.LegacySyncHandler(op.syncResolvingNamespace).ToSyncer()),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Per Goncalves da Silva <pegoncal@redhat.com>

**Description of the change:**
A Namespace sync function was erroneously added to the OG queue informer generating some log traffic.

**Motivation for the change:**
https://bugzilla.redhat.com/show_bug.cgi?id=2079200

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky
