### PR TITLE
Update install.sh to use kubectl create

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,9 +29,9 @@ if kubectl get deployment olm-operator -n ${namespace} > /dev/null 2>&1; then
     exit 1
 fi
 
-kubectl apply -f "${url}/crds.yaml"
+kubectl create -f "${url}/crds.yaml"
 kubectl wait --for=condition=Established -f "${url}/crds.yaml"
-kubectl apply -f "${url}/olm.yaml"
+kubectl create -f "${url}/olm.yaml"
 
 # wait for deployments to be ready
 kubectl rollout status -w deployment/olm-operator --namespace="${namespace}"


### PR DESCRIPTION
The install of OLM CRDs via install.sh via apply was failing due to the
'last-applied-configuration' annotation causing the size of the CRD
annotations to be too large for the server to accept. Creating the CRDs via
kubectl create does not cause the annotation to be automatically
appended to the object, so the application goes through successfully.
Installing via create means that the install.sh script does not support updating an
existing OLM installation, but there are already checks in place to abort the
install if an existing OLM installation is detected.

Signed-off-by: Daniel Sover <dsover@redhat.com>

Closes #2767 

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
