### PR TITLE
Multiple operatorGroup error in subscription status

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -934,9 +934,16 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		return err
 	}
 
+	// The IsFailForward method only returns an error if the number
+	// of operatorGroups is greater than 1. If we exit early here, the
+	// subscription status is not updated to reflect that resolution
+	// fails due to an unexpected number of operatorGroups.
+	// It is best to log the error if in debug mode and simply assume that
+	// it is not safe to fail forward, the error will be made apparent in
+	// the subscription status when the resolver fails.
 	failForwardEnabled, err := resolver.IsFailForwardEnabled(o.lister.OperatorsV1().OperatorGroupLister().OperatorGroups(namespace))
 	if err != nil {
-		return err
+		logger.WithError(err).Debug("assuming fail-forward is disabled")
 	}
 
 	// TODO: parallel


### PR DESCRIPTION
Problem: When reconciling subscriptions in a namespace, OLM will error
out if multiple operatorGroups exist in the namespace when deciding if
the fail-forward feature is enabled. The failure is only loged and not
surfaced in the status of the subscription.

Solution: By assuming that fail forward is disabled when more than one
operatorGroups are found in a namespace, the syncResolvingNamespace
function will attempt to find upgrades using the resolver which will
fail due to multiple operatorGroups in the namespace anyways and
portray this information in the subscription status.