### PR TITLE
Update for new grpc library

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -488,6 +488,15 @@ func (o *Operator) syncSourceState(state grpc.SourceState) {
 	metrics.RegisterCatalogSourceState(state.Key.Name, state.Key.Namespace, state.State)
 
 	switch state.State {
+	case connectivity.Idle:
+		// If the connection is IDLE attempt to connect to attempt to bring it to a READY state
+		// A connection will transition to IDLE if:
+		// "No RPC activity on channel for IDLE_TIMEOUT (default: 5 mins) or upon receiving a GOAWAY while there are no pending RPCs."
+		// https://gitlab.uni-hannover.de/tci-gateway-module/grpc/-/blob/972e31165218b49d93e5e1f1a1e8bbcd3fa830d1/doc/connectivity-semantics-and-api.md
+		sourceConn := o.sources.Get(state.Key)
+		if sourceConn != nil && sourceConn.Conn != nil {
+			_, _ = registry.NewClientFromConn(sourceConn.Conn).HealthCheck(context.Background(), time.Second*5)
+		}
 	case connectivity.Ready:
 		o.sourceInvalidator.Invalidate(resolvercache.SourceKey(state.Key))
 		if o.namespace == state.Key.Namespace {

--- a/pkg/controller/registry/grpc/source.go
+++ b/pkg/controller/registry/grpc/source.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/operator-framework/operator-registry/pkg/client"
-
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/net/proxy"

--- a/pkg/controller/registry/grpc/source_test.go
+++ b/pkg/controller/registry/grpc/source_test.go
@@ -134,6 +134,7 @@ func TestConnectionEvents(t *testing.T) {
 				{Name: "test", Namespace: "test"}: {
 					connectivity.Connecting,
 					connectivity.Ready,
+					connectivity.Idle,
 				},
 			},
 		},
@@ -143,10 +144,12 @@ func TestConnectionEvents(t *testing.T) {
 				{Name: "test", Namespace: "test"}: {
 					connectivity.Connecting,
 					connectivity.Ready,
+					connectivity.Idle,
 				},
 				{Name: "test2", Namespace: "test2"}: {
 					connectivity.Connecting,
 					connectivity.Ready,
+					connectivity.Idle,
 				},
 			},
 		},

--- a/pkg/package-server/provider/registry.go
+++ b/pkg/package-server/provider/registry.go
@@ -226,6 +226,15 @@ func (p *RegistryProvider) syncSourceState(state registrygrpc.SourceState) {
 
 	var err error
 	switch state.State {
+	case connectivity.Idle:
+		// If the connection is IDLE attempt to connect to attempt to bring it to a READY state
+		// A connection will transition to IDLE if:
+		// "No RPC activity on channel for IDLE_TIMEOUT (default: 5 mins) or upon receiving a GOAWAY while there are no pending RPCs."
+		// https://gitlab.uni-hannover.de/tci-gateway-module/grpc/-/blob/972e31165218b49d93e5e1f1a1e8bbcd3fa830d1/doc/connectivity-semantics-and-api.md
+		sourceConn := p.sources.Get(state.Key)
+		if sourceConn != nil && sourceConn.Conn != nil {
+			_, _ = registry.NewClientFromConn(sourceConn.Conn).HealthCheck(context.Background(), time.Second*5)
+		}
 	case connectivity.Ready:
 		var client *registryClient
 		client, err = p.registryClient(key)

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -14,6 +14,7 @@ import (
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/util"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -441,9 +442,14 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Check pod created
-		initialPods, err := c.KubernetesInterface().CoreV1().Pods(ns.GetName()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.configMapResourceVersion=" + configMap.ResourceVersion})
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(initialPods.Items).To(HaveLen(1))
+		Eventually(func() int {
+			initialPods, err := c.KubernetesInterface().CoreV1().Pods(ns.GetName()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.configMapResourceVersion=" + configMap.ResourceVersion})
+			if err != nil {
+				util.Logf("warning: error listing pods: %s", err)
+				return -1
+			}
+			return len(initialPods.Items)
+		}).Should(Equal(1))
 
 		// delete the first catalog
 		cleanupSource()
@@ -1458,9 +1464,17 @@ func rescaleDeployment(c operatorclient.ClientInterface, deployment *appsv1.Depl
 }
 
 func replicateCatalogPod(c operatorclient.ClientInterface, catalog *v1alpha1.CatalogSource) *corev1.Pod {
-	initialPods, err := c.KubernetesInterface().CoreV1().Pods(catalog.GetNamespace()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.catalogSource=" + catalog.GetName()})
-	Expect(err).ToNot(HaveOccurred())
-	Expect(initialPods.Items).To(HaveLen(1))
+	var initialPods *corev1.PodList
+	var err error
+	Eventually(func() *corev1.PodList {
+		initialPods, err = c.KubernetesInterface().CoreV1().Pods(catalog.GetNamespace()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.catalogSource=" + catalog.GetName()})
+		return initialPods
+	}).Should(WithTransform(func(podList *corev1.PodList) []corev1.Pod {
+		if podList != nil {
+			return podList.Items
+		}
+		return []corev1.Pod{}
+	}, HaveLen(1)))
 
 	pod := initialPods.Items[0]
 	copied := &corev1.Pod{

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -337,11 +338,11 @@ func registryPodHealthy(address string) bool {
 }
 
 func catalogSourceRegistryPodSynced(catalog *operatorsv1alpha1.CatalogSource) bool {
-	registry := catalog.Status.RegistryServiceStatus
+	registryStatus := catalog.Status.RegistryServiceStatus
 	connState := catalog.Status.GRPCConnectionState
-	if registry != nil && connState != nil && !connState.LastConnectTime.IsZero() && connState.LastObservedState == "READY" {
-		fmt.Printf("catalog %s pod with address %s\n", catalog.GetName(), registry.Address())
-		return registryPodHealthy(registry.Address())
+	if registryStatus != nil && connState != nil && !connState.LastConnectTime.IsZero() && (connState.LastObservedState == connectivity.Ready.String() || connState.LastObservedState == connectivity.Idle.String()) {
+		fmt.Printf("catalog %s pod with address %s\n", catalog.GetName(), registryStatus.Address())
+		return registryPodHealthy(registryStatus.Address())
 	}
 	state := "NO_CONNECTION"
 	if connState != nil {


### PR DESCRIPTION
**Description of the change:**
Updates olm to use the lates operator-registry release

**Motivation for the change:**
It's a been a while, and the latest version contains the latest version of the grpc library with security fixes needed by the downstream. See https://github.com/operator-framework/operator-registry/issues/959

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
