### PR TITLE
 Don't generate kubeclient at runtime in testing

### DIFF
--- a/pkg/controller/operators/adoption_controller_test.go
+++ b/pkg/controller/operators/adoption_controller_test.go
@@ -180,7 +180,6 @@ var _ = Describe("Adoption Controller", func() {
 				})
 
 				Context("that has an existing installed csv", func() {
-
 					var (
 						providedCRD *apiextensionsv1.CustomResourceDefinition
 					)
@@ -227,6 +226,7 @@ var _ = Describe("Adoption Controller", func() {
 					})
 
 					Context("with an existing provided CRD", func() {
+
 						BeforeEach(func() {
 							Eventually(func() error {
 								return k8sClient.Create(ctx, providedCRD)
@@ -242,6 +242,7 @@ var _ = Describe("Adoption Controller", func() {
 						})
 
 						Context("when its component label is removed", func() {
+
 							BeforeEach(func() {
 								Eventually(func() error {
 									latest := &apiextensionsv1.CustomResourceDefinition{}

--- a/pkg/controller/operators/operator_controller_test.go
+++ b/pkg/controller/operators/operator_controller_test.go
@@ -46,10 +46,12 @@ var _ = Describe("Operator Controller", func() {
 
 	Describe("operator deletion", func() {
 		var originalUID types.UID
+
 		JustBeforeEach(func() {
 			originalUID = operator.GetUID()
 			Expect(k8sClient.Delete(ctx, operator)).To(Succeed())
 		})
+
 		Context("with components bearing its label", func() {
 			var (
 				objs      []runtime.Object
@@ -105,6 +107,7 @@ var _ = Describe("Operator Controller", func() {
 	})
 
 	Describe("component selection", func() {
+
 		BeforeEach(func() {
 			Eventually(func() (*operatorsv1.Components, error) {
 				err := k8sClient.Get(ctx, name, operator)
@@ -164,6 +167,7 @@ var _ = Describe("Operator Controller", func() {
 			})
 
 			Context("when new components are labelled", func() {
+
 				BeforeEach(func() {
 					saName := &types.NamespacedName{Namespace: namespace, Name: genName("sa-")}
 					newObjs := testobj.WithLabel(expectedKey, "",
@@ -201,6 +205,7 @@ var _ = Describe("Operator Controller", func() {
 			})
 
 			Context("when component labels are removed", func() {
+
 				BeforeEach(func() {
 					for _, obj := range testobj.StripLabel(expectedKey, objs...) {
 						Expect(k8sClient.Update(ctx, obj.(client.Object))).To(Succeed())

--- a/pkg/controller/operators/operatorcondition_controller_test.go
+++ b/pkg/controller/operators/operatorcondition_controller_test.go
@@ -51,6 +51,7 @@ var _ = Describe("OperatorCondition", func() {
 			namespace         *corev1.Namespace
 			namespacedName    types.NamespacedName
 		)
+
 		BeforeEach(func() {
 			ctx = context.Background()
 			namespace = &corev1.Namespace{
@@ -64,6 +65,7 @@ var _ = Describe("OperatorCondition", func() {
 		})
 
 		When("an operatorCondition is created that specifies an array of ServiceAccounts", func() {
+
 			BeforeEach(func() {
 				operatorCondition = &operatorsv2.OperatorCondition{
 					ObjectMeta: metav1.ObjectMeta{
@@ -150,6 +152,7 @@ var _ = Describe("OperatorCondition", func() {
 
 		When("a CSV exists that owns a deployment", func() {
 			var csv *operatorsv1alpha1.ClusterServiceVersion
+
 			BeforeEach(func() {
 				// Create a coppied csv used as an owner in the following tests.
 				// Copied CSVs are ignored by the OperatorConditionGenerator Reconciler, which we don't want to intervine in this test.
@@ -231,6 +234,7 @@ var _ = Describe("OperatorCondition", func() {
 			})
 
 			Context("and an OperatorCondition with a different name than the CSV includes that deployment in its spec.Deployments array", func() {
+
 				BeforeEach(func() {
 					operatorCondition = &operatorsv2.OperatorCondition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -266,6 +270,7 @@ var _ = Describe("OperatorCondition", func() {
 			})
 
 			Context("and an OperatorCondition with the same name as the CSV includes that deployment in its spec.Deployments array", func() {
+
 				BeforeEach(func() {
 					operatorCondition = &operatorsv2.OperatorCondition{
 						ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -47,13 +47,12 @@ const (
 
 var _ = Describe("Starting CatalogSource e2e tests", func() {
 	var (
+		ns  corev1.Namespace
 		c   operatorclient.ClientInterface
 		crc versioned.Interface
-		ns  corev1.Namespace
 	)
+
 	BeforeEach(func() {
-		c = newKubeClient()
-		crc = newCRClient()
 		namespaceName := genName("catsrc-e2e-")
 		og := operatorsv1.OperatorGroup{
 			ObjectMeta: metav1.ObjectMeta{
@@ -62,6 +61,8 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			},
 		}
 		ns = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
+		c = ctx.Ctx().KubeClient()
+		crc = ctx.Ctx().OperatorClient()
 	})
 
 	AfterEach(func() {
@@ -1105,7 +1106,6 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(csv.Spec.Replaces).To(Equal("busybox-dependency.v1.0.0"))
 	})
 	When("A catalogSource is created with correct polling interval", func() {
-
 		var source *v1alpha1.CatalogSource
 		singlePod := podCount(1)
 		sourceName := genName("catalog-")
@@ -1177,15 +1177,16 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 	})
 
 	When("A catalogSource is created with incorrect polling interval", func() {
-
 		var (
 			source     *v1alpha1.CatalogSource
 			sourceName string
 		)
+
 		const (
 			incorrectInterval = "45mError.code"
 			correctInterval   = "45m"
 		)
+
 		BeforeEach(func() {
 			sourceName = genName("catalog-")
 			source = &v1alpha1.CatalogSource{
@@ -1230,6 +1231,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			}).Should(BeTrue())
 		})
 		When("the catalogsource is updated with a valid polling interval", func() {
+
 			BeforeEach(func() {
 				Eventually(func() error {
 					catsrc, err := crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Get(context.Background(), source.GetName(), metav1.GetOptions{})
@@ -1241,6 +1243,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 					return err
 				}).Should(Succeed())
 			})
+
 			It("the catalogsource spec shows the updated polling interval, and the error message in the status is cleared", func() {
 				Eventually(func() error {
 					catsrc, err := crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Get(context.Background(), source.GetName(), metav1.GetOptions{})
@@ -1345,7 +1348,6 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 	})
 
 	When("A CatalogSource is created with an operator that has a CSV with missing metadata.ApiVersion", func() {
-
 		var (
 			magicCatalog      MagicCatalog
 			catalogSourceName string
@@ -1370,7 +1372,8 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		})
 
 		When("A Subscription is created catalogSource built with the malformed CSV", func() {
-			BeforeEach(func ()  {
+
+			BeforeEach(func() {
 				subscription = &operatorsv1alpha1.Subscription{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-sub", catalogSourceName),

--- a/test/e2e/catsrc_pod_config_e2e_test.go
+++ b/test/e2e/catsrc_pod_config_e2e_test.go
@@ -19,6 +19,7 @@ const catalogSourceLabel = "olm.catalogSource"
 var _ = By
 
 var _ = Describe("CatalogSource Grpc Pod Config", func() {
+
 	var (
 		generatedNamespace corev1.Namespace
 	)

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -9,7 +9,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 	corev1 "k8s.io/api/core/v1"
 
@@ -20,12 +22,15 @@ import (
 )
 
 var _ = Describe("CRD Versions", func() {
-
 	var (
-		ns corev1.Namespace
+		ns  corev1.Namespace
+		c   operatorclient.ClientInterface
+		crc versioned.Interface
 	)
 
 	BeforeEach(func() {
+		c = ctx.Ctx().KubeClient()
+		crc = ctx.Ctx().OperatorClient()
 		ns = SetupGeneratedTestNamespace(genName("crd-e2e-"))
 	})
 
@@ -36,8 +41,6 @@ var _ = Describe("CRD Versions", func() {
 	// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2640
 	It("[FLAKE] creates v1 CRDs with a v1 schema successfully", func() {
 		By("v1 crds with a valid openapiv3 schema should be created successfully by OLM")
-		c := newKubeClient()
-		crc := newCRClient()
 
 		mainPackageName := genName("nginx-update2-")
 		mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
@@ -114,9 +117,6 @@ var _ = Describe("CRD Versions", func() {
 	// issue:https://github.com/operator-framework/operator-lifecycle-manager/issues/2638
 	It("[FLAKE] blocks a CRD upgrade that could cause data loss", func() {
 		By("checking the storage versions in the existing CRD status and the spec of the new CRD")
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		mainPackageName := genName("nginx-update2-")
 		mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
@@ -300,9 +300,6 @@ var _ = Describe("CRD Versions", func() {
 
 	It("allows a CRD upgrade that doesn't cause data loss", func() {
 		By("manually editing the storage versions in the existing CRD status")
-
-		c := newKubeClient()
-		crc := newCRClient()
 
 		crdPlural := genName("ins-v1-")
 		crdName := crdPlural + ".cluster.com"

--- a/test/e2e/deprecated_e2e_test.go
+++ b/test/e2e/deprecated_e2e_test.go
@@ -19,7 +19,6 @@ import (
 var missingAPI = `{"apiVersion":"verticalpodautoscalers.autoscaling.k8s.io/v1","kind":"VerticalPodAutoscaler","metadata":{"name":"my.thing","namespace":"foo"}}`
 
 var _ = Describe("Not found APIs", func() {
-
 	var ns corev1.Namespace
 
 	BeforeEach(func() {

--- a/test/e2e/disabling_copied_csv_e2e_test.go
+++ b/test/e2e/disabling_copied_csv_e2e_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Disabling copied CSVs", func() {
 	})
 
 	When("Copied CSVs are disabled", func() {
+
 		BeforeEach(func() {
 			Eventually(func() error {
 				var olmConfig operatorsv1.OLMConfig
@@ -175,6 +176,7 @@ var _ = Describe("Disabling copied CSVs", func() {
 	})
 
 	When("Copied CSVs are toggled back on", func() {
+
 		BeforeEach(func() {
 			Eventually(func() error {
 				var olmConfig operatorsv1.OLMConfig

--- a/test/e2e/dynamic_resource_e2e_test.go
+++ b/test/e2e/dynamic_resource_e2e_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 var _ = Describe("Subscriptions create required objects from Catalogs", func() {
-
 	var (
 		c             operatorclient.ClientInterface
 		crc           versioned.Interface
@@ -28,8 +27,8 @@ var _ = Describe("Subscriptions create required objects from Catalogs", func() {
 	)
 
 	BeforeEach(func() {
-		c = newKubeClient()
-		crc = newCRClient()
+		c = ctx.Ctx().KubeClient()
+		crc = ctx.Ctx().OperatorClient()
 		dynamicClient = ctx.Ctx().DynamicClient()
 
 		deleteOpts = &metav1.DeleteOptions{}
@@ -42,7 +41,6 @@ var _ = Describe("Subscriptions create required objects from Catalogs", func() {
 	Context("Given a Namespace", func() {
 		When("a CatalogSource is created with a bundle that contains prometheus objects", func() {
 			Context("creating a subscription using the CatalogSource", func() {
-
 				var (
 					ns         *corev1.Namespace
 					catsrc     *v1alpha1.CatalogSource

--- a/test/e2e/fail_forward_e2e_test.go
+++ b/test/e2e/fail_forward_e2e_test.go
@@ -22,11 +22,13 @@ const (
 )
 
 var _ = Describe("Fail Forward Upgrades", func() {
+
 	var (
 		ns       corev1.Namespace
 		crclient versioned.Interface
 		c        client.Client
 	)
+
 	BeforeEach(func() {
 		crclient = newCRClient()
 		c = ctx.Ctx().Client()
@@ -51,11 +53,13 @@ var _ = Describe("Fail Forward Upgrades", func() {
 	})
 
 	When("an InstallPlan is reporting a failed state", func() {
+
 		var (
 			magicCatalog      MagicCatalog
 			catalogSourceName string
 			subscription      *operatorsv1alpha1.Subscription
 		)
+
 		BeforeEach(func() {
 			provider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(testdataDir, failForwardTestDataBaseDir, "example-operator.v0.1.0.yaml"))
 			Expect(err).To(BeNil())
@@ -188,11 +192,13 @@ var _ = Describe("Fail Forward Upgrades", func() {
 		})
 	})
 	When("a CSV resource is in a failed state", func() {
+
 		var (
 			magicCatalog      MagicCatalog
 			catalogSourceName string
 			subscription      *operatorsv1alpha1.Subscription
 		)
+
 		BeforeEach(func() {
 			provider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(testdataDir, failForwardTestDataBaseDir, "example-operator.v0.1.0.yaml"))
 			Expect(err).To(BeNil())
@@ -241,10 +247,12 @@ var _ = Describe("Fail Forward Upgrades", func() {
 			Expect(err).To(BeNil())
 
 		})
+
 		AfterEach(func() {
 			By("removing the testing catalog resources")
 			Expect(magicCatalog.UndeployCatalog(context.Background())).To(BeNil())
 		})
+
 		It("eventually reports a successful state when using skip ranges", func() {
 			By("patching the catalog with a fixed version")
 			fixedProvider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(testdataDir, "fail-forward/skip-range", "example-operator.v0.3.0.yaml"))
@@ -257,6 +265,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 			subscription, err = fetchSubscription(crclient, subscription.GetNamespace(), subscription.GetName(), subscriptionHasCurrentCSV("example-operator.v0.3.0"))
 			Expect(err).Should(BeNil())
 		})
+
 		It("eventually reports a successful state when using skips", func() {
 			By("patching the catalog with a fixed version")
 			fixedProvider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(testdataDir, "fail-forward/skips", "example-operator.v0.3.0.yaml"))
@@ -269,6 +278,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 			subscription, err = fetchSubscription(crclient, subscription.GetNamespace(), subscription.GetName(), subscriptionHasCurrentCSV("example-operator.v0.3.0"))
 			Expect(err).Should(BeNil())
 		})
+
 		It("eventually reports a successful state when using replaces", func() {
 			By("patching the catalog with a fixed version")
 			fixedProvider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(testdataDir, "fail-forward/replaces", "example-operator.v0.3.0.yaml"))

--- a/test/e2e/gc_e2e_test.go
+++ b/test/e2e/gc_e2e_test.go
@@ -128,7 +128,6 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 	})
 
 	Context("Given a ClusterRole owned by a APIService", func() {
-
 		var (
 			apiService *apiregistrationv1.APIService
 			cr         *rbacv1.ClusterRole
@@ -216,6 +215,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			propagation metav1.DeletionPropagation
 			options     metav1.DeleteOptions
 		)
+
 		BeforeEach(func() {
 
 			ownerA = newCSV("ownera", ns.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
@@ -320,6 +320,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 	})
 
 	When("a bundle with configmap and secret objects is installed", func() {
+
 		const (
 			packageName   = "busybox"
 			channelName   = "alpha"
@@ -394,6 +395,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 		})
 
 		When("the CSV is deleted", func() {
+
 			const csvName = "busybox.v2.0.0"
 
 			BeforeEach(func() {
@@ -439,6 +441,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 	})
 
 	When("a bundle with a configmap is installed", func() {
+
 		const (
 			subName       = "test-subscription"
 			configmapName = "special-config"
@@ -500,6 +503,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 		})
 
 		When("the subscription is updated to a later CSV with a configmap with the same name but new data", func() {
+
 			const (
 				upgradeChannelName = "beta"
 				newCSVname         = "busybox.v3.0.0"
@@ -552,6 +556,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 	})
 
 	When("a bundle with a new configmap is installed", func() {
+
 		const (
 			subName       = "test-subscription"
 			configmapName = "special-config"
@@ -613,6 +618,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 		})
 
 		When("the subscription is updated to a later CSV with a configmap with a new name", func() {
+
 			const (
 				upgradeChannelName    = "beta"
 				upgradedConfigMapName = "not-special-config"

--- a/test/e2e/magic_catalog_test.go
+++ b/test/e2e/magic_catalog_test.go
@@ -18,10 +18,12 @@ var _ = Describe("MagicCatalog", func() {
 		generatedNamespace corev1.Namespace
 		c                  client.Client
 	)
+
 	BeforeEach(func() {
 		c = ctx.Ctx().Client()
 		generatedNamespace = SetupGeneratedTestNamespace(genName("magic-catalog-e2e-"))
 	})
+
 	AfterEach(func() {
 		TeardownNamespace(generatedNamespace.GetName())
 	})
@@ -40,11 +42,13 @@ var _ = Describe("MagicCatalog", func() {
 		Expect(magicCatalog.DeployCatalog(context.Background())).To(BeNil())
 		Expect(magicCatalog.UndeployCatalog(context.Background())).To(BeNil())
 	})
+
 	When("an existing magic catalog exists", func() {
 		var (
 			mc          MagicCatalog
 			catalogName string
 		)
+
 		BeforeEach(func() {
 			provider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(testdataDir, "magiccatalog/fbc_initial.yaml"))
 			Expect(err).To(BeNil())
@@ -54,6 +58,7 @@ var _ = Describe("MagicCatalog", func() {
 			mc = NewMagicCatalog(c, generatedNamespace.GetName(), catalogName, provider)
 			Expect(mc.DeployCatalog(context.Background())).To(BeNil())
 		})
+
 		AfterEach(func() {
 			Expect(mc.UndeployCatalog(context.Background())).To(BeNil())
 		})

--- a/test/e2e/operator_condition_e2e_test.go
+++ b/test/e2e/operator_condition_e2e_test.go
@@ -16,10 +16,10 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv2 "github.com/operator-framework/api/pkg/operators/v2"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
 var _ = Describe("Operator Condition", func() {
-
 	var (
 		generatedNamespace corev1.Namespace
 	)
@@ -39,8 +39,8 @@ var _ = Describe("Operator Condition", func() {
 			" expected. The overrides spec in OperatorCondition can be used to override" +
 			" the conditions spec. The overrides spec will remain in place until" +
 			" they are unset.")
-		c := newKubeClient()
-		crc := newCRClient()
+		c := ctx.Ctx().KubeClient()
+		crc := ctx.Ctx().OperatorClient()
 
 		// Create a catalog for csvA, csvB, and csvD
 		pkgA := genName("a-")

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -29,9 +29,20 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
 var _ = Describe("Operator Group", func() {
+	var (
+		c   operatorclient.ClientInterface
+		crc versioned.Interface
+	)
+
+	BeforeEach(func() {
+		c = ctx.Ctx().KubeClient()
+		crc = ctx.Ctx().OperatorClient()
+	})
+
 	AfterEach(func() {
 		TearDown(testNamespace)
 	})
@@ -56,8 +67,6 @@ var _ = Describe("Operator Group", func() {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
 		}
 
-		c := newKubeClient()
-		crc := newCRClient()
 		csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
 
 		opGroupNamespace := genName(testNamespace + "-")
@@ -434,7 +443,6 @@ var _ = Describe("Operator Group", func() {
 		}
 
 		// Generate operatorGroupA - OwnNamespace
-		crc := newCRClient()
 		groupA := newOperatorGroup(nsA, genName("a"), nil, nil, []string{nsA}, false)
 		_, err := crc.OperatorsV1().OperatorGroups(nsA).Create(context.TODO(), groupA, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
@@ -626,7 +634,6 @@ var _ = Describe("Operator Group", func() {
 		}
 
 		// Generate operatorGroupA
-		crc := newCRClient()
 		groupA := newOperatorGroup(nsA, genName("a"), nil, nil, []string{nsA}, false)
 		_, err := crc.OperatorsV1().OperatorGroups(nsA).Create(context.TODO(), groupA, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
@@ -869,8 +876,6 @@ var _ = Describe("Operator Group", func() {
 
 		// Create namespaces
 		nsA, nsB, nsC, nsD, nsE := genName("a-"), genName("b-"), genName("c-"), genName("d-"), genName("e-")
-		c := newKubeClient()
-		crc := newCRClient()
 		for _, ns := range []string{nsA, nsB, nsC, nsD, nsE} {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1143,8 +1148,7 @@ var _ = Describe("Operator Group", func() {
 
 		// Create namespaces
 		nsA, nsB, nsC, nsD := genName("a-"), genName("b-"), genName("c-"), genName("d-")
-		c := newKubeClient()
-		crc := newCRClient()
+
 		for _, ns := range []string{nsA, nsB, nsC, nsD} {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1317,8 +1321,6 @@ var _ = Describe("Operator Group", func() {
 	// TODO: Test Subscription upgrade paths with + and - providedAPIs
 	It("CSV copy watching all namespaces", func() {
 
-		c := newKubeClient()
-		crc := newCRClient()
 		csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
 
 		opGroupNamespace := testNamespace
@@ -1565,8 +1567,6 @@ var _ = Describe("Operator Group", func() {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
 		}
 
-		c := newKubeClient()
-		crc := newCRClient()
 		csvName := genName("another-csv-")
 
 		newNamespaceName := genName(testNamespace + "-")
@@ -1700,8 +1700,6 @@ var _ = Describe("Operator Group", func() {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
 		}
 
-		c := newKubeClient()
-		crc := newCRClient()
 		csvName := genName("another-csv-")
 
 		newNamespaceName := genName(testNamespace + "-")
@@ -1798,8 +1796,6 @@ var _ = Describe("Operator Group", func() {
 	// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2644
 	It("[FLAKE] cleanup csvs with bad owner operator groups", func() {
 
-		c := newKubeClient()
-		crc := newCRClient()
 		csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
 
 		opGroupNamespace := testNamespace
@@ -2039,8 +2035,6 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 	})
 	It("OperatorGroupLabels", func() {
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create the namespaces that will have an OperatorGroup Label applied.
 		testNamespaceA := genName("namespace-a-")
@@ -2140,8 +2134,6 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 	})
 	It("CleanupDeletedOperatorGroupLabels", func() {
-		c := newKubeClient()
-		crc := newCRClient()
 
 		// Create the namespaces that will have an OperatorGroup Label applied.
 		testNamespaceA := genName("namespace-a-")
@@ -2205,7 +2197,6 @@ var _ = Describe("Operator Group", func() {
 	})
 
 	Context("Given a set of Namespaces", func() {
-
 		var (
 			c              operatorclient.ClientInterface
 			crc            versioned.Interface
@@ -2245,13 +2236,11 @@ var _ = Describe("Operator Group", func() {
 		})
 
 		Context("Associating these Namespaces with a label", func() {
-
 			var (
 				matchingLabel map[string]string
 			)
 
 			BeforeEach(func() {
-
 				matchingLabel = map[string]string{"foo": "bar"}
 
 				// Updating Namespace with labels
@@ -2271,7 +2260,6 @@ var _ = Describe("Operator Group", func() {
 				var operatorGroup *v1.OperatorGroup
 
 				BeforeEach(func() {
-
 					// Creating operator group
 					operatorGroup = &v1.OperatorGroup{
 						ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -361,6 +361,7 @@ var _ = Describe("Operator API", func() {
 		})
 
 		Context("when a namespace is added", func() {
+
 			var newNs *corev1.Namespace
 
 			BeforeEach(func() {
@@ -371,6 +372,7 @@ var _ = Describe("Operator API", func() {
 					return client.Create(clientCtx, newNs)
 				}).Should(Succeed())
 			})
+
 			AfterEach(func() {
 				Eventually(func() error {
 					err := client.Delete(clientCtx, newNs)
@@ -380,6 +382,7 @@ var _ = Describe("Operator API", func() {
 					return err
 				}).Should(Succeed())
 			})
+
 			It("should not adopt copied csvs", func() {
 				Consistently(func() (*operatorsv1.Operator, error) {
 					o := &operatorsv1.Operator{}

--- a/test/e2e/packagemanifest_e2e_test.go
+++ b/test/e2e/packagemanifest_e2e_test.go
@@ -23,16 +23,16 @@ import (
 )
 
 var _ = Describe("Package Manifest API lists available Operators from Catalog Sources", func() {
-
 	var (
 		crc versioned.Interface
 		pmc pmversioned.Interface
 		c   operatorclient.ClientInterface
 	)
+
 	BeforeEach(func() {
-		crc = newCRClient()
+		crc = ctx.Ctx().OperatorClient()
 		pmc = newPMClient()
-		c = newKubeClient()
+		c = ctx.Ctx().KubeClient()
 	})
 
 	AfterEach(func() {
@@ -40,7 +40,6 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 	})
 
 	Context("Given a CatalogSource created using the ConfigMap as catalog source type", func() {
-
 		var (
 			catsrcName           string
 			packageName          string
@@ -52,8 +51,8 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 			csv                  v1alpha1.ClusterServiceVersion
 			cleanupCatalogSource cleanupFunc
 		)
-		BeforeEach(func() {
 
+		BeforeEach(func() {
 			// create a simple catalogsource
 			packageName = genName("nginx")
 			alphaChannel = "alpha"
@@ -191,6 +190,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 			packageName, displayName string
 			catalogSource            *v1alpha1.CatalogSource
 		)
+
 		BeforeEach(func() {
 			sourceName := genName("catalog-")
 			packageName = "etcd-test"
@@ -248,7 +248,6 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 		When("the display name for catalog source is updated", func() {
 
 			BeforeEach(func() {
-
 				pm, err := fetchPackageManifest(pmc, testNamespace, packageName, packageManifestHasStatus)
 				Expect(err).NotTo(HaveOccurred(), "error getting package manifest")
 				Expect(pm).ShouldNot(BeNil())
@@ -264,6 +263,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 				Expect(err).NotTo(HaveOccurred(), "error updating catalogSource")
 				Expect(catalogSource.Spec.DisplayName).Should(Equal(displayName))
 			})
+
 			It("should successfully update the CatalogSource field", func() {
 
 				Eventually(func() (string, error) {

--- a/test/e2e/resource_manager_test.go
+++ b/test/e2e/resource_manager_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 var _ = Describe("ResourceManager", func() {
-
 	var generatedNamespace corev1.Namespace
 
 	BeforeEach(func() {

--- a/test/e2e/scoped_client_test.go
+++ b/test/e2e/scoped_client_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Scoped Client bound to a service account can be used to make A
 	BeforeEach(func() {
 		config = ctx.Ctx().RESTConfig()
 
-		kubeclient = newKubeClient()
+		kubeclient = ctx.Ctx().KubeClient()
 
 		logger = logrus.New()
 		logger.SetOutput(GinkgoWriter)

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -47,14 +47,16 @@ const (
 	interval = time.Millisecond * 100
 )
 
-var _ = By
-
 var _ = Describe("Subscription", func() {
 	var (
 		generatedNamespace corev1.Namespace
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
 	)
 
 	BeforeEach(func() {
+		c = ctx.Ctx().KubeClient()
+		crc = ctx.Ctx().OperatorClient()
 		generatedNamespace = SetupGeneratedTestNamespace(genName("subscription-e2e-"))
 	})
 
@@ -137,8 +139,6 @@ var _ = Describe("Subscription", func() {
 	//      A. If package is not installed, creating a subscription should install latest version
 	It("creation if not installed", func() {
 
-		c := newKubeClient()
-		crc := newCRClient()
 		defer func() {
 			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
@@ -177,8 +177,6 @@ var _ = Describe("Subscription", func() {
 	//         version
 	It("creation using existing CSV", func() {
 
-		c := newKubeClient()
-		crc := newCRClient()
 		defer func() {
 			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
@@ -296,8 +294,6 @@ var _ = Describe("Subscription", func() {
 	// If installPlanApproval is set to manual, the installplans created should be created with approval: manual
 	It("creation manual approval", func() {
 
-		c := newKubeClient()
-		crc := newCRClient()
 		defer func() {
 			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
@@ -410,8 +406,6 @@ var _ = Describe("Subscription", func() {
 		}
 
 		// Create the CatalogSource
-		c := newKubeClient()
-		crc := newCRClient()
 		catalogSourceName := genName("mock-nginx-")
 		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB})
 		defer cleanupCatalogSource()
@@ -533,8 +527,6 @@ var _ = Describe("Subscription", func() {
 		}
 
 		// Create the CatalogSource with just one version
-		c := newKubeClient()
-		crc := newCRClient()
 		catalogSourceName := genName("mock-nginx-")
 		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA})
 		defer cleanupCatalogSource()
@@ -621,8 +613,6 @@ var _ = Describe("Subscription", func() {
 		}
 
 		// Create the CatalogSource with just one version
-		c := newKubeClient()
-		crc := newCRClient()
 		catalogSourceName := genName("mock-nginx-")
 		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, generatedNamespace.GetName(), manifests, nil, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB})
 		defer cleanupCatalogSource()
@@ -716,15 +706,11 @@ var _ = Describe("Subscription", func() {
 
 	Describe("puppeting CatalogSource health status", func() {
 		var (
-			c          operatorclient.ClientInterface
-			crc        versioned.Interface
 			getOpts    metav1.GetOptions
 			deleteOpts *metav1.DeleteOptions
 		)
 
 		BeforeEach(func() {
-			c = newKubeClient()
-			crc = newCRClient()
 			getOpts = metav1.GetOptions{}
 			deleteOpts = &metav1.DeleteOptions{}
 		})
@@ -1582,13 +1568,15 @@ var _ = Describe("Subscription", func() {
 	})
 
 	Context("to an operator with dependencies from different CatalogSources with priorities", func() {
-		var kubeClient operatorclient.ClientInterface
-		var crClient versioned.Interface
-		var crd apiextensions.CustomResourceDefinition
-		var packageMain, packageDepRight, packageDepWrong registry.PackageManifest
-		var csvsMain, csvsRight, csvsWrong []operatorsv1alpha1.ClusterServiceVersion
-		var catsrcMain, catsrcDepRight, catsrcDepWrong *operatorsv1alpha1.CatalogSource
-		var cleanup, cleanupSubscription cleanupFunc
+		var (
+			kubeClient                                    operatorclient.ClientInterface
+			crClient                                      versioned.Interface
+			crd                                           apiextensions.CustomResourceDefinition
+			packageMain, packageDepRight, packageDepWrong registry.PackageManifest
+			csvsMain, csvsRight, csvsWrong                []operatorsv1alpha1.ClusterServiceVersion
+			catsrcMain, catsrcDepRight, catsrcDepWrong    *operatorsv1alpha1.CatalogSource
+			cleanup, cleanupSubscription                  cleanupFunc
+		)
 		const (
 			mainCSVName  = "csv-main"
 			rightCSVName = "csv-right"
@@ -1615,7 +1603,6 @@ var _ = Describe("Subscription", func() {
 			var catsrcCleanup1, catsrcCleanup2, catsrcCleanup3 cleanupFunc
 
 			BeforeEach(func() {
-
 				packageDepRight = registry.PackageManifest{PackageName: "PackageDependent"}
 				csv := newCSV(rightCSVName, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"),
 					[]apiextensions.CustomResourceDefinition{crd}, nil, nil)
@@ -1644,6 +1631,7 @@ var _ = Describe("Subscription", func() {
 				_, err = fetchCatalogSourceOnStatus(crClient, catsrcDepWrong.GetName(), generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 				Expect(err).ToNot(HaveOccurred())
 			})
+
 			AfterEach(func() {
 				if catsrcCleanup1 != nil {
 					catsrcCleanup1()
@@ -1657,8 +1645,8 @@ var _ = Describe("Subscription", func() {
 			})
 
 			When("creating subscription for the main package", func() {
-
 				var subscription *operatorsv1alpha1.Subscription
+
 				BeforeEach(func() {
 					// Create a subscription for packageA in catsrc
 					subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
@@ -1680,6 +1668,7 @@ var _ = Describe("Subscription", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 				})
+
 				AfterEach(func() {
 					if cleanupSubscription != nil {
 						cleanupSubscription()
@@ -1732,6 +1721,7 @@ var _ = Describe("Subscription", func() {
 				_, err = fetchCatalogSourceOnStatus(crClient, catsrcDepWrong.GetName(), generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 				Expect(err).ToNot(HaveOccurred())
 			})
+
 			AfterEach(func() {
 				if catsrcCleanup1 != nil {
 					catsrcCleanup1()
@@ -1744,6 +1734,7 @@ var _ = Describe("Subscription", func() {
 
 			When("creating subscription for the main package", func() {
 				var subscription *operatorsv1alpha1.Subscription
+
 				BeforeEach(func() {
 					// Create a subscription for packageA in catsrc
 					subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
@@ -1765,6 +1756,7 @@ var _ = Describe("Subscription", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 				})
+
 				AfterEach(func() {
 					if cleanupSubscription != nil {
 						cleanupSubscription()
@@ -1773,6 +1765,7 @@ var _ = Describe("Subscription", func() {
 						cleanup()
 					}
 				})
+
 				It("choose the dependent package from the same catsrc as the installing operator", func() {
 					// ensure correct CSVs were picked
 					Eventually(func() ([]string, error) {
@@ -1783,16 +1776,13 @@ var _ = Describe("Subscription", func() {
 						return ip.Spec.ClusterServiceVersionNames, nil
 					}).Should(ConsistOf(mainCSVName, rightCSVName))
 				})
-
 			})
-
 		})
 
 		Context("creating CatalogSources providing the same dependency with different priority value", func() {
 			var catsrcCleanup1, catsrcCleanup2, catsrcCleanup3 cleanupFunc
 
 			BeforeEach(func() {
-
 				packageDepRight = registry.PackageManifest{PackageName: "PackageDependent"}
 				csv := newCSV(rightCSVName, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"),
 					[]apiextensions.CustomResourceDefinition{crd}, nil, nil)
@@ -1823,6 +1813,7 @@ var _ = Describe("Subscription", func() {
 				_, err = fetchCatalogSourceOnStatus(crClient, catsrcDepWrong.GetName(), generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 				Expect(err).ToNot(HaveOccurred())
 			})
+
 			AfterEach(func() {
 				if catsrcCleanup1 != nil {
 					catsrcCleanup1()
@@ -1833,11 +1824,11 @@ var _ = Describe("Subscription", func() {
 				if catsrcCleanup3 != nil {
 					catsrcCleanup3()
 				}
-
 			})
 
 			When("creating subscription for the main package", func() {
 				var subscription *operatorsv1alpha1.Subscription
+
 				BeforeEach(func() {
 					// Create a subscription for packageA in catsrc
 					subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
@@ -1859,6 +1850,7 @@ var _ = Describe("Subscription", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 				})
+
 				AfterEach(func() {
 					if cleanupSubscription != nil {
 						cleanupSubscription()
@@ -1867,6 +1859,7 @@ var _ = Describe("Subscription", func() {
 						cleanup()
 					}
 				})
+
 				It("choose the dependent package from the catsrc with higher priority", func() {
 					// ensure correct CSVs were picked
 					Eventually(func() ([]string, error) {
@@ -1877,9 +1870,7 @@ var _ = Describe("Subscription", func() {
 						return ip.Spec.ClusterServiceVersionNames, nil
 					}).Should(ConsistOf(mainCSVName, rightCSVName))
 				})
-
 			})
-
 		})
 
 		Context("creating CatalogSources providing the same dependency under test and global namespaces", func() {
@@ -1916,6 +1907,7 @@ var _ = Describe("Subscription", func() {
 				_, err = fetchCatalogSourceOnStatus(crClient, catsrcDepWrong.GetName(), operatorNamespace, catalogSourceRegistryPodSynced)
 				Expect(err).ToNot(HaveOccurred())
 			})
+
 			AfterEach(func() {
 				if catsrcCleanup1 != nil {
 					catsrcCleanup1()
@@ -1926,11 +1918,11 @@ var _ = Describe("Subscription", func() {
 				if catsrcCleanup3 != nil {
 					catsrcCleanup3()
 				}
-
 			})
 
 			When("creating subscription for the main package", func() {
 				var subscription *operatorsv1alpha1.Subscription
+
 				BeforeEach(func() {
 					// Create a subscription for packageA in catsrc
 					subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
@@ -1952,6 +1944,7 @@ var _ = Describe("Subscription", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 				})
+
 				AfterEach(func() {
 					if cleanupSubscription != nil {
 						cleanupSubscription()
@@ -1960,6 +1953,7 @@ var _ = Describe("Subscription", func() {
 						cleanup()
 					}
 				})
+
 				It("choose the dependent package from the catsrc in the same namespace as the installing operator", func() {
 					// ensure correct CSVs were picked
 					Eventually(func() ([]string, error) {
@@ -1970,11 +1964,8 @@ var _ = Describe("Subscription", func() {
 						return ip.Spec.ClusterServiceVersionNames, nil
 					}).Should(ConsistOf(mainCSVName, rightCSVName))
 				})
-
 			})
-
 		})
-
 	})
 
 	// csvA owns CRD1 & csvB owns CRD2 and requires CRD1
@@ -2126,7 +2117,6 @@ var _ = Describe("Subscription", func() {
 	})
 
 	When("A subscription is created for an operator that requires an API that is not available", func() {
-
 		var (
 			c          operatorclient.ClientInterface
 			crc        versioned.Interface
@@ -2180,6 +2170,7 @@ var _ = Describe("Subscription", func() {
 		})
 
 		When("the required API is made available", func() {
+
 			BeforeEach(func() {
 				newPkg := registry.PackageManifest{
 					PackageName: "PackageB",
@@ -2194,6 +2185,7 @@ var _ = Describe("Subscription", func() {
 
 				updateInternalCatalog(GinkgoT(), c, crc, catSrcName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB}, packages)
 			})
+
 			It("the ResolutionFailed condition previously set in its status that indicated the resolution error is cleared off", func() {
 				Eventually(func() (corev1.ConditionStatus, error) {
 					sub, err := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subName, metav1.GetOptions{})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -530,7 +530,7 @@ func TearDown(namespace string) {
 	logf("test resources deleted")
 }
 
-func buildCatalogSourceCleanupFunc(crc versioned.Interface, namespace string, catalogSource *operatorsv1alpha1.CatalogSource) cleanupFunc {
+func buildCatalogSourceCleanupFunc(c operatorclient.ClientInterface, crc versioned.Interface, namespace string, catalogSource *operatorsv1alpha1.CatalogSource) cleanupFunc {
 	return func() {
 		ctx.Ctx().Logf("Deleting catalog source %s...", catalogSource.GetName())
 		err := crc.OperatorsV1alpha1().CatalogSources(namespace).Delete(context.Background(), catalogSource.GetName(), metav1.DeleteOptions{})
@@ -541,7 +541,7 @@ func buildCatalogSourceCleanupFunc(crc versioned.Interface, namespace string, ca
 				LabelSelector: "olm.catalogSource=" + catalogSource.GetName(),
 				FieldSelector: "status.phase=Running",
 			}
-			fetched, err := newKubeClient().KubernetesInterface().CoreV1().Pods(catalogSource.GetNamespace()).List(context.Background(), listOpts)
+			fetched, err := c.KubernetesInterface().CoreV1().Pods(catalogSource.GetNamespace()).List(context.Background(), listOpts)
 			if err != nil {
 				return false, err
 			}
@@ -569,7 +569,7 @@ func buildServiceAccountCleanupFunc(t GinkgoTInterface, c operatorclient.ClientI
 	}
 }
 
-func createInvalidGRPCCatalogSource(crc versioned.Interface, name, namespace string) (*operatorsv1alpha1.CatalogSource, cleanupFunc) {
+func createInvalidGRPCCatalogSource(c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string) (*operatorsv1alpha1.CatalogSource, cleanupFunc) {
 	catalogSource := &operatorsv1alpha1.CatalogSource{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       operatorsv1alpha1.CatalogSourceKind,
@@ -589,7 +589,7 @@ func createInvalidGRPCCatalogSource(crc versioned.Interface, name, namespace str
 	catalogSource, err := crc.OperatorsV1alpha1().CatalogSources(namespace).Create(context.Background(), catalogSource, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	ctx.Ctx().Logf("Catalog source %s created", name)
-	return catalogSource, buildCatalogSourceCleanupFunc(crc, namespace, catalogSource)
+	return catalogSource, buildCatalogSourceCleanupFunc(c, crc, namespace, catalogSource)
 }
 
 func createInternalCatalogSource(
@@ -628,7 +628,7 @@ func createInternalCatalogSource(
 
 	cleanupInternalCatalogSource := func() {
 		configMapCleanup()
-		buildCatalogSourceCleanupFunc(crc, namespace, catalogSource)()
+		buildCatalogSourceCleanupFunc(c, crc, namespace, catalogSource)()
 	}
 	return catalogSource, cleanupInternalCatalogSource
 }
@@ -670,7 +670,7 @@ func createInternalCatalogSourceWithPriority(c operatorclient.ClientInterface,
 
 	cleanupInternalCatalogSource := func() {
 		configMapCleanup()
-		buildCatalogSourceCleanupFunc(crc, namespace, catalogSource)()
+		buildCatalogSourceCleanupFunc(c, crc, namespace, catalogSource)()
 	}
 	return catalogSource, cleanupInternalCatalogSource
 }
@@ -713,7 +713,7 @@ func createV1CRDInternalCatalogSource(
 
 	cleanupInternalCatalogSource := func() {
 		configMapCleanup()
-		buildCatalogSourceCleanupFunc(crc, namespace, catalogSource)()
+		buildCatalogSourceCleanupFunc(c, crc, namespace, catalogSource)()
 	}
 	return catalogSource, cleanupInternalCatalogSource
 }


### PR DESCRIPTION
- Updates tests to use common Kube and Runtime clients generated at
startup time rather than having them re-generated in each test at
runtime.
- Closes #2570

Signed-off-by: Noah Sapse <nsapse@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky
- [ ] Tests that remove the `[FLAKE]` tag are no longer flaky


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
