### PR TITLE
Update unpack job pod security

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/security"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/configmap"
 	"github.com/sirupsen/logrus"
@@ -29,6 +28,7 @@ import (
 	listersoperatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/security"
 )
 
 const (

--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/security"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/configmap"
 	"github.com/sirupsen/logrus"
@@ -190,6 +191,10 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 			},
 		},
 	}
+
+	// Apply Pod security
+	security.ApplyPodSpecSecurity(&job.Spec.Template.Spec)
+
 	job.SetNamespace(cmRef.Namespace)
 	job.SetName(cmRef.Name)
 	job.SetOwnerReferences([]metav1.OwnerReference{ownerRef(cmRef)})

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -72,8 +72,10 @@ func TestConfigMapUnpacker(t *testing.T) {
 	var expectedAllowPrivilegeEscalation = false
 	var expectedRunAsNonRoot = true
 	var expectedRunAsUser int64 = 1001
+	var expectedPrivileged = false
 
 	var expectedContainerSecurityContext = &corev1.SecurityContext{
+		Privileged:               &expectedPrivileged,
 		ReadOnlyRootFilesystem:   &expectedReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &expectedAllowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -68,6 +68,27 @@ func TestConfigMapUnpacker(t *testing.T) {
 		roleBindings []*rbacv1.RoleBinding
 	}
 
+	var expectedReadOnlyRootFilesystem = false
+	var expectedAllowPrivilegeEscalation = false
+	var expectedRunAsNonRoot = true
+	var expectedRunAsUser int64 = 1001
+
+	var expectedContainerSecurityContext = &corev1.SecurityContext{
+		ReadOnlyRootFilesystem:   &expectedReadOnlyRootFilesystem,
+		AllowPrivilegeEscalation: &expectedAllowPrivilegeEscalation,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+
+	var expectedPodSecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot: &expectedRunAsNonRoot,
+		RunAsUser:    &expectedRunAsUser,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
 	tests := []struct {
 		description string
 		fields      fields
@@ -220,6 +241,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 								Spec: corev1.PodSpec{
 									RestartPolicy:    corev1.RestartPolicyNever,
 									ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-secret"}},
+									SecurityContext:  expectedPodSecurityContext,
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -243,6 +265,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -262,6 +285,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 										{
 											Name:            "pull",
@@ -284,6 +308,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -396,7 +421,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 									Name: pathHash,
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: corev1.RestartPolicyNever,
+									RestartPolicy:   corev1.RestartPolicyNever,
+									SecurityContext: expectedPodSecurityContext,
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -420,6 +446,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -439,6 +466,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 										{
 											Name:            "pull",
@@ -461,6 +489,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -614,7 +643,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 									Name: pathHash,
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: corev1.RestartPolicyNever,
+									RestartPolicy:   corev1.RestartPolicyNever,
+									SecurityContext: expectedPodSecurityContext,
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -638,6 +668,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -657,6 +688,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 										{
 											Name:            "pull",
@@ -679,6 +711,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -826,7 +859,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 									Name: pathHash,
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: corev1.RestartPolicyNever,
+									RestartPolicy:   corev1.RestartPolicyNever,
+									SecurityContext: expectedPodSecurityContext,
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -850,6 +884,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -869,6 +904,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 										{
 											Name:            "pull",
@@ -891,6 +927,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -1008,7 +1045,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 									Name: pathHash,
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: corev1.RestartPolicyNever,
+									RestartPolicy:   corev1.RestartPolicyNever,
+									SecurityContext: expectedPodSecurityContext,
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -1032,6 +1070,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1051,6 +1090,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 										{
 											Name:            "pull",
@@ -1073,6 +1113,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -1201,7 +1242,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 									Name: pathHash,
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: corev1.RestartPolicyNever,
+									RestartPolicy:   corev1.RestartPolicyNever,
+									SecurityContext: expectedPodSecurityContext,
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -1225,6 +1267,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1244,6 +1287,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 										{
 											Name:            "pull",
@@ -1266,6 +1310,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: expectedContainerSecurityContext,
 										},
 									},
 									Volumes: []corev1.Volume{

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -82,8 +82,10 @@ func TestPodContainerSecurityContext(t *testing.T) {
 	expectedAllowPrivilegeEscalation := false
 	expectedRunAsNonRoot := true
 	expectedRunAsUser := int64(1001)
+	expectedPrivileged := false
 
 	expectedContainerSecCtx := &corev1.SecurityContext{
+		Privileged:               &expectedPrivileged,
 		ReadOnlyRootFilesystem:   &expectedReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &expectedAllowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{

--- a/pkg/controller/security/security.go
+++ b/pkg/controller/security/security.go
@@ -1,32 +1,37 @@
 package security
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
 
-var readOnlyRootFilesystem = false
-var allowPrivilegeEscalation = false
-var runAsNonRoot = true
+const readOnlyRootFilesystem = false
+const allowPrivilegeEscalation = false
+const privileged = false
+const runAsNonRoot = true
 
 // See: https://github.com/operator-framework/operator-registry/blob/master/Dockerfile#L27
-var runAsUser int64 = 1001
-
-var containerSecurityContext = &corev1.SecurityContext{
-	ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
-	AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-	Capabilities: &corev1.Capabilities{
-		Drop: []corev1.Capability{"ALL"},
-	},
-}
-
-var podSecurityContext = &corev1.PodSecurityContext{
-	RunAsNonRoot: &runAsNonRoot,
-	RunAsUser:    &runAsUser,
-	SeccompProfile: &corev1.SeccompProfile{
-		Type: corev1.SeccompProfileTypeRuntimeDefault,
-	},
-}
+const runAsUser int64 = 1001
 
 // ApplyPodSpecSecurity applies the standard security profile to a pod spec
 func ApplyPodSpecSecurity(spec *corev1.PodSpec) {
+	var containerSecurityContext = &corev1.SecurityContext{
+		Privileged:               pointer.Bool(privileged),
+		ReadOnlyRootFilesystem:   pointer.Bool(readOnlyRootFilesystem),
+		AllowPrivilegeEscalation: pointer.Bool(allowPrivilegeEscalation),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+
+	var podSecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot: pointer.Bool(runAsNonRoot),
+		RunAsUser:    pointer.Int64(runAsUser),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
 	spec.SecurityContext = podSecurityContext
 	for idx := 0; idx < len(spec.Containers); idx++ {
 		spec.Containers[idx].SecurityContext = containerSecurityContext

--- a/pkg/controller/security/security.go
+++ b/pkg/controller/security/security.go
@@ -1,0 +1,37 @@
+package security
+
+import corev1 "k8s.io/api/core/v1"
+
+var readOnlyRootFilesystem = false
+var allowPrivilegeEscalation = false
+var runAsNonRoot = true
+
+// See: https://github.com/operator-framework/operator-registry/blob/master/Dockerfile#L27
+var runAsUser int64 = 1001
+
+var containerSecurityContext = &corev1.SecurityContext{
+	ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+	AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+	Capabilities: &corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
+	},
+}
+
+var podSecurityContext = &corev1.PodSecurityContext{
+	RunAsNonRoot: &runAsNonRoot,
+	RunAsUser:    &runAsUser,
+	SeccompProfile: &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
+	},
+}
+
+// ApplyPodSpecSecurity applies the standard security profile to a pod spec
+func ApplyPodSpecSecurity(spec *corev1.PodSpec) {
+	spec.SecurityContext = podSecurityContext
+	for idx := 0; idx < len(spec.Containers); idx++ {
+		spec.Containers[idx].SecurityContext = containerSecurityContext
+	}
+	for idx := 0; idx < len(spec.InitContainers); idx++ {
+		spec.InitContainers[idx].SecurityContext = containerSecurityContext
+	}
+}


### PR DESCRIPTION
**Description of the change:**
Updates the security context stanzas for the bundle unpacking job's pod and containers to be more explicit and limited

**Motivation for the change:**
https://bugzilla.redhat.com/show_bug.cgi?id=2088541

**Architectural changes:**
I've added a `security` package with a function to update a pod spec with the `standard` security settings and refactored the CatalogSource pod creation function to use it as well

**Testing remarks:**
I've updated the unit tests for the bundle unpacking job creation to pass. This also ensures that the correct security settings are in the job pod spec. I've also run the e2e tests and they passed.

**NOTE**: This PR is ready for review, though it will stay blocked until #2782 is merged - as this is a continuation of that PR

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
