### PR TITLE
Refactor DeterminedE2eClient to DeterminedE2EClient

### DIFF
--- a/test/e2e/util/e2e_determined_client.go
+++ b/test/e2e/util/e2e_determined_client.go
@@ -8,19 +8,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// DeterminedE2eClient wraps E2eClient calls in an Eventually assertion to keep trying
+// DeterminedE2EClient wraps E2eClient calls in an Eventually assertion to keep trying
 // or bail after some time if unsuccessful
-type DeterminedE2eClient struct {
+type DeterminedE2EClient struct {
 	*E2EKubeClient
 }
 
-func NewDeterminedClient(e2eKubeClient *E2EKubeClient) *DeterminedE2eClient {
-	return &DeterminedE2eClient{
+func NewDeterminedClient(e2eKubeClient *E2EKubeClient) *DeterminedE2EClient {
+	return &DeterminedE2EClient{
 		e2eKubeClient,
 	}
 }
 
-func (m *DeterminedE2eClient) Create(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.CreateOption) error {
+func (m *DeterminedE2EClient) Create(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.CreateOption) error {
 	m.keepTrying(func() error {
 		err := m.E2EKubeClient.Create(context, obj, options...)
 		return err
@@ -28,27 +28,27 @@ func (m *DeterminedE2eClient) Create(context context.Context, obj k8scontrollerc
 	return nil
 }
 
-func (m *DeterminedE2eClient) Update(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.UpdateOption) error {
+func (m *DeterminedE2EClient) Update(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.UpdateOption) error {
 	m.keepTrying(func() error {
 		return m.E2EKubeClient.Update(context, obj, options...)
 	})
 	return nil
 }
 
-func (m *DeterminedE2eClient) Delete(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.DeleteOption) error {
+func (m *DeterminedE2EClient) Delete(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.DeleteOption) error {
 	m.keepTrying(func() error {
 		return m.E2EKubeClient.Delete(context, obj, options...)
 	})
 	return nil
 }
 
-func (m *DeterminedE2eClient) Patch(context context.Context, obj k8scontrollerclient.Object, patch k8scontrollerclient.Patch, options ...k8scontrollerclient.PatchOption) error {
+func (m *DeterminedE2EClient) Patch(context context.Context, obj k8scontrollerclient.Object, patch k8scontrollerclient.Patch, options ...k8scontrollerclient.PatchOption) error {
 	m.keepTrying(func() error {
 		return m.E2EKubeClient.Patch(context, obj, patch, options...)
 	})
 	return nil
 }
 
-func (m *DeterminedE2eClient) keepTrying(fn func() error) {
+func (m *DeterminedE2EClient) keepTrying(fn func() error) {
 	Eventually(fn).Should(Succeed())
 }


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
