### PR TITLE
Introduce protectedCopiedCSVNamespaces flag

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -60,6 +60,9 @@ var (
 	tlsKeyPath = pflag.String(
 		"tls-key", "", "Path to use for private key (requires tls-cert)")
 
+	protectedCopiedCSVNamespaces = pflag.String("protectedCopiedCSVNamespaces",
+		"", "A comma-delimited set of namespaces where global Copied CSVs will always appear, even if Copied CSVs are disabled")
+
 	tlsCertPath = pflag.String(
 		"tls-cert", "", "Path to use for certificate key (requires tls-key)")
 
@@ -162,6 +165,7 @@ func main() {
 		olm.WithOperatorClient(opClient),
 		olm.WithRestConfig(config),
 		olm.WithConfigClient(versionedConfigClient),
+		olm.WithProtectedCopiedCSVNamespaces(*protectedCopiedCSVNamespaces),
 	)
 	if err != nil {
 		logger.WithError(err).Fatal("error configuring operator")

--- a/pkg/controller/operators/olm/config.go
+++ b/pkg/controller/operators/olm/config.go
@@ -1,6 +1,7 @@
 package olm
 
 import (
+	"strings"
 	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
@@ -21,18 +22,19 @@ import (
 type OperatorOption func(*operatorConfig)
 
 type operatorConfig struct {
-	resyncPeriod      func() time.Duration
-	operatorNamespace string
-	watchedNamespaces []string
-	clock             utilclock.Clock
-	logger            *logrus.Logger
-	operatorClient    operatorclient.ClientInterface
-	externalClient    versioned.Interface
-	strategyResolver  install.StrategyResolverInterface
-	apiReconciler     APIIntersectionReconciler
-	apiLabeler        labeler.Labeler
-	restConfig        *rest.Config
-	configClient      configv1client.Interface
+	protectedCopiedCSVNamespaces map[string]struct{}
+	resyncPeriod                 func() time.Duration
+	operatorNamespace            string
+	watchedNamespaces            []string
+	clock                        utilclock.Clock
+	logger                       *logrus.Logger
+	operatorClient               operatorclient.ClientInterface
+	externalClient               versioned.Interface
+	strategyResolver             install.StrategyResolverInterface
+	apiReconciler                APIIntersectionReconciler
+	apiLabeler                   labeler.Labeler
+	restConfig                   *rest.Config
+	configClient                 configv1client.Interface
 }
 
 func (o *operatorConfig) apply(options []OperatorOption) {
@@ -77,14 +79,15 @@ func (o *operatorConfig) validate() (err error) {
 
 func defaultOperatorConfig() *operatorConfig {
 	return &operatorConfig{
-		resyncPeriod:      queueinformer.ResyncWithJitter(30*time.Second, 0.2),
-		operatorNamespace: "default",
-		watchedNamespaces: []string{metav1.NamespaceAll},
-		clock:             utilclock.RealClock{},
-		logger:            logrus.New(),
-		strategyResolver:  &install.StrategyResolver{},
-		apiReconciler:     APIIntersectionReconcileFunc(ReconcileAPIIntersection),
-		apiLabeler:        labeler.Func(LabelSetsFor),
+		resyncPeriod:                 queueinformer.ResyncWithJitter(30*time.Second, 0.2),
+		operatorNamespace:            "default",
+		watchedNamespaces:            []string{metav1.NamespaceAll},
+		clock:                        utilclock.RealClock{},
+		logger:                       logrus.New(),
+		strategyResolver:             &install.StrategyResolver{},
+		apiReconciler:                APIIntersectionReconcileFunc(ReconcileAPIIntersection),
+		apiLabeler:                   labeler.Func(LabelSetsFor),
+		protectedCopiedCSVNamespaces: map[string]struct{}{},
 	}
 }
 
@@ -109,6 +112,18 @@ func WithWatchedNamespaces(namespaces ...string) OperatorOption {
 func WithLogger(logger *logrus.Logger) OperatorOption {
 	return func(config *operatorConfig) {
 		config.logger = logger
+	}
+}
+
+func WithProtectedCopiedCSVNamespaces(namespaces string) OperatorOption {
+	return func(config *operatorConfig) {
+		if namespaces == "" {
+			return
+		}
+
+		for _, ns := range strings.Split(namespaces, ",") {
+			config.protectedCopiedCSVNamespaces[ns] = struct{}{}
+		}
 	}
 }
 


### PR DESCRIPTION
**Description of the change:**

Introduce a runtime flag that prevents OLM from deleting Copied CSVs in a given set of namespaces.

**Motivation for the change:**

**Problem:** Users rely on Copied CSVs in order to understand which
operators are available in a given namespace. When installing All
Namespace operators, a Copied CSV is created in every namespace which
can place a huge performance strain on clusters with many namespaces.
OLM introduced the ability to disable Copied CSVs for All Namespace mode
operators  in an effort to resolve the performance issues on large clusters,
unfortunately removing the ability for users to identify which operators are
available in a given namespace.

**Solution:** The protectedCopiedCSVNamespaces runtime flag can be used to
prevent Copied CSVs from being deleted even when Copied CSVs are
disabled. An admin can then provide users with the proper RBAC to view
which operators are running in All Namespace mode.
**Architectural changes:**

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
