### PR TITLE
fix(openshift): use env var instead of clusterversion status

### DIFF
--- a/pkg/controller/operators/openshift/helpers_test.go
+++ b/pkg/controller/operators/openshift/helpers_test.go
@@ -221,22 +221,13 @@ func TestIncompatibleOperators(t *testing.T) {
 	}
 	for _, tt := range []struct {
 		description string
-		cv          configv1.ClusterVersion
+		version     string
 		in          skews
 		expect      expect
 	}{
 		{
 			description: "Compatible",
-			cv: configv1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "version",
-				},
-				Status: configv1.ClusterVersionStatus{
-					Desired: configv1.Release{
-						Version: "1.0.0",
-					},
-				},
-			},
+			version:     "1.0.0",
 			in: skews{
 				{
 					name:                "almond",
@@ -261,16 +252,7 @@ func TestIncompatibleOperators(t *testing.T) {
 		},
 		{
 			description: "Incompatible",
-			cv: configv1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "version",
-				},
-				Status: configv1.ClusterVersionStatus{
-					Desired: configv1.Release{
-						Version: "1.0.0",
-					},
-				},
-			},
+			version:     "1.0.0",
 			in: skews{
 				{
 					name:                "almond",
@@ -331,16 +313,7 @@ func TestIncompatibleOperators(t *testing.T) {
 		},
 		{
 			description: "Mixed",
-			cv: configv1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "version",
-				},
-				Status: configv1.ClusterVersionStatus{
-					Desired: configv1.Release{
-						Version: "1.0.0",
-					},
-				},
-			},
+			version:     "1.0.0",
 			in: skews{
 				{
 					name:                "almond",
@@ -376,16 +349,7 @@ func TestIncompatibleOperators(t *testing.T) {
 		},
 		{
 			description: "Mixed/BadVersion",
-			cv: configv1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "version",
-				},
-				Status: configv1.ClusterVersionStatus{
-					Desired: configv1.Release{
-						Version: "1.0.0",
-					},
-				},
-			},
+			version:     "1.0.0",
 			in: skews{
 				{
 					name:                "almond",
@@ -424,16 +388,7 @@ func TestIncompatibleOperators(t *testing.T) {
 		},
 		{
 			description: "EmptyVersion",
-			cv: configv1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "version",
-				},
-				Status: configv1.ClusterVersionStatus{
-					Desired: configv1.Release{
-						Version: "", // This should result in an transient error
-					},
-				},
-			},
+			version:     "", // This should result in an transient error
 			in: skews{
 				{
 					name:                "almond",
@@ -453,16 +408,7 @@ func TestIncompatibleOperators(t *testing.T) {
 		},
 		{
 			description: "ClusterZ",
-			cv: configv1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "version",
-				},
-				Status: configv1.ClusterVersionStatus{
-					Desired: configv1.Release{
-						Version: "1.0.1", // Next Y-stream is 1.1.0, NOT 1.1.1
-					},
-				},
-			},
+			version:     "1.0.1", // Next Y-stream is 1.1.0, NOT 1.1.1
 			in: skews{
 				{
 					name:                "beech",
@@ -477,16 +423,7 @@ func TestIncompatibleOperators(t *testing.T) {
 		},
 		{
 			description: "ClusterPre",
-			cv: configv1.ClusterVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "version",
-				},
-				Status: configv1.ClusterVersionStatus{
-					Desired: configv1.Release{
-						Version: "1.1.0-pre", // Next Y-stream is 1.1.0, NOT 1.2.0
-					},
-				},
-			},
+			version:     "1.1.0-pre", // Next Y-stream is 1.1.0, NOT 1.2.0
 			in: skews{
 				{
 					name:                "almond",
@@ -501,7 +438,9 @@ func TestIncompatibleOperators(t *testing.T) {
 		},
 	} {
 		t.Run(tt.description, func(t *testing.T) {
-			objs := []client.Object{tt.cv.DeepCopy()}
+			objs := []client.Object{}
+
+			resetCurrentReleaseTo(tt.version)
 
 			for _, s := range tt.in {
 				csv := &operatorsv1alpha1.ClusterServiceVersion{}

--- a/pkg/controller/operators/openshift/options.go
+++ b/pkg/controller/operators/openshift/options.go
@@ -163,7 +163,6 @@ func WithOLMOperator() ReconcilerOption {
 
 		enqueue := handler.EnqueueRequestsFromMapFunc(config.mapClusterOperator)
 
-		name := "version"
 		originalCSV := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 			csv, ok := obj.(*operatorsv1alpha1.ClusterServiceVersion)
 			if !ok {
@@ -174,8 +173,7 @@ func WithOLMOperator() ReconcilerOption {
 			return !csv.IsCopied() // Keep original CSVs only
 		})
 		config.TweakBuilder = func(bldr *builder.Builder) *builder.Builder {
-			return bldr.Watches(&source.Kind{Type: &operatorsv1alpha1.ClusterServiceVersion{}}, enqueue, builder.WithPredicates(originalCSV)).
-				Watches(&source.Kind{Type: &configv1.ClusterVersion{}}, enqueue, builder.WithPredicates(watchName(&name)))
+			return bldr.Watches(&source.Kind{Type: &operatorsv1alpha1.ClusterServiceVersion{}}, enqueue, builder.WithPredicates(originalCSV))
 		}
 	}
 }


### PR DESCRIPTION
**Description of the change:**
Introducing some code that Nick wrote a fix for prior to him leaving Red Hat. Here are his comments:

Get the current OpenShift release version from the OPENSHIFT_RELEASE
environment variable since the behavior of the original source --
the ClusterVersion desired release status field -- has changed.

> **Note**: This is for a high priority bug fix downstream.

**Reviewer Checklist**
- [X] Implementation matches the proposed design, or proposal is updated to match implementation
- [X] Sufficient unit test coverage
- [X] Sufficient end-to-end test coverage
- [X] Bug fixes are accompanied by regression test(s)
- [X] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [X] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [X] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [X] Docs updated or added to `/doc`
- [X] Commit messages sensible and descriptive
- [X] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [X] Code is properly formatted
