### PR TITLE
Fix default E2E_INSTALL_NS value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ ifneq (all,$(E2E_TEST_CHUNK))
 TEST := $(shell go run ./test/e2e/split/... -chunks $(E2E_TEST_NUM_CHUNKS) -print-chunk $(E2E_TEST_CHUNK) ./test/e2e)
 endif
 E2E_OPTS ?= $(if $(E2E_SEED),-seed '$(E2E_SEED)') $(if $(SKIP), -skip '$(SKIP)') $(if $(TEST),-focus '$(TEST)') $(if $(ARTIFACT_DIR), -junit-report '$(ARTIFACT_DIR)junit_e2e.xml') -flake-attempts $(E2E_FLAKE_ATTEMPTS) -nodes $(E2E_NODES) -timeout $(E2E_TIMEOUT) -v -randomize-suites -race -trace -progress
-E2E_INSTALL_NS ?= operator-lifecycle-manager
+E2E_INSTALL_NS ?= olm
 E2E_TEST_NS ?= operators
 
 e2e:


### PR DESCRIPTION
The e2e tests assume that OLM is installed in the
operator-lifecycle-manager namespace if E2E_INSTALL_NS is not set. OLM
is typically installed in the olm namespace.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>
