### PR TITLE
(psa) make workloads compatible with psa:restricted profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=builder /build/bin/olm /bin/olm
 COPY --from=builder /build/bin/catalog /bin/catalog
 COPY --from=builder /build/bin/package-server /bin/package-server
 COPY --from=builder /build/bin/cpb /bin/cpb
+USER 1001
 EXPOSE 8080
 EXPOSE 5443
 CMD ["/bin/olm"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -10,4 +10,5 @@ COPY package-server /bin/package-server
 COPY cpb /bin/cpb
 EXPOSE 8080
 EXPOSE 5443
+USER 1001
 ENTRYPOINT ["/bin/olm"]

--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -30,6 +30,7 @@ const (
 	defaultOPMImage             = "quay.io/operator-framework/upstream-opm-builder:latest"
 	defaultUtilImage            = "quay.io/operator-framework/olm:latest"
 	defaultOperatorName         = ""
+	defaultWorkLoadUserID       = int64(1001)
 )
 
 // config flags defined globally so that they appear on the test binary as well
@@ -83,6 +84,10 @@ func (o *options) run(ctx context.Context, logger *logrus.Logger) error {
 		return fmt.Errorf("error configuring client: %s", err.Error())
 	}
 
+	workloadUserID := int64(-1)
+	if o.setWorkloadUserID {
+		workloadUserID = defaultWorkLoadUserID
+	}
 	// TODO(tflannag): Use options pattern for catalog operator
 	// Create a new instance of the operator.
 	op, err := catalog.NewOperator(
@@ -98,6 +103,7 @@ func (o *options) run(ctx context.Context, logger *logrus.Logger) error {
 		k8sscheme.Scheme,
 		o.installPlanTimeout,
 		o.bundleUnpackTimeout,
+		workloadUserID,
 	)
 	if err != nil {
 		return fmt.Errorf("error configuring catalog operator: %s", err.Error())

--- a/cmd/catalog/start.go
+++ b/cmd/catalog/start.go
@@ -25,6 +25,7 @@ type options struct {
 	tlsKeyPath           string
 	tlsCertPath          string
 	clientCAPath         string
+	setWorkloadUserID    bool
 
 	installPlanTimeout  time.Duration
 	bundleUnpackTimeout time.Duration
@@ -66,6 +67,7 @@ func newRootCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.opmImage, "opmImage", defaultOPMImage, "the image to use for unpacking bundle content with opm")
 	cmd.Flags().StringVar(&o.utilImage, "util-image", defaultUtilImage, "an image containing custom olm utilities")
 	cmd.Flags().StringVar(&o.writeStatusName, "writeStatusName", defaultOperatorName, "ClusterOperator name in which to write status, set to \"\" to disable.")
+	cmd.Flags().BoolVar(&o.setWorkloadUserID, "set-workload-user-id", false, "set user ID for all workloads (registry pods/bundle unpack jobs to default 1001")
 
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "use debug log level")
 	cmd.Flags().BoolVar(&o.version, "version", false, "displays the olm version")

--- a/deploy/chart/templates/0000_50_olm_00-namespace.yaml
+++ b/deploy/chart/templates/0000_50_olm_00-namespace.yaml
@@ -2,9 +2,15 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
+  labels: 
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
 
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.operator_namespace }}
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest

--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: olm-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
       volumes: 
@@ -33,6 +37,10 @@ spec:
       {{- end }}
       containers:
         - name: olm-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
           volumeMounts:
           {{- end }}

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: catalog-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
       volumes:
@@ -33,6 +37,10 @@ spec:
       {{- end }}
       containers:
         - name: catalog-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
           volumeMounts:
           {{- end }}
@@ -76,6 +84,8 @@ spec:
           - --client-ca
           - /profile-collector-cert/tls.crt
           {{- end }}
+          - --set-workload-user-id
+          - "true"
           image: {{ .Values.catalog.image.ref }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:

--- a/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: packageserver
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if .Values.package.nodeSelector }}
       nodeSelector:
@@ -25,6 +29,10 @@ spec:
       {{- end }}
       containers:
       - name: packageserver
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
         command:
         - /bin/package-server
         - -v=4
@@ -60,10 +68,6 @@ spec:
         {{- if .Values.package.resources }}
         resources:
 {{ toYaml .Values.package.resources | indent 10 }}
-        {{- end }}
-        {{- if .Values.package.securityContext }}
-        securityContext:
-          runAsUser: {{ .Values.package.securityContext.runAsUser }}
         {{- end }}
         volumeMounts:
         - name: tmpfs

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -3,4 +3,5 @@ FROM busybox
 COPY olm catalog package-server wait cpb /bin/
 EXPOSE 8080
 EXPOSE 5443
+USER 1001
 CMD ["/bin/olm"]

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	crfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
@@ -32,6 +33,7 @@ const (
 	opmImage    = "opm-image"
 	utilImage   = "util-image"
 	bundlePath  = "bundle-path"
+	runAsUser   = 1001
 )
 
 func TestConfigMapUnpacker(t *testing.T) {
@@ -220,6 +222,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								Spec: corev1.PodSpec{
 									RestartPolicy:    corev1.RestartPolicyNever,
 									ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-secret"}},
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -243,6 +252,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -260,6 +275,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -282,6 +303,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -397,6 +424,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -420,6 +454,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -437,6 +477,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -459,6 +505,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -615,6 +667,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -638,6 +697,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -655,6 +720,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -677,6 +748,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -827,6 +904,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -850,6 +934,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -867,6 +957,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -889,6 +985,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1009,6 +1111,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -1032,6 +1141,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1049,6 +1164,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1071,6 +1192,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1202,6 +1329,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -1225,6 +1359,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1242,6 +1382,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1264,6 +1410,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1341,6 +1493,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 				WithUtilImage(utilImage),
 				WithNow(now),
 				WithUnpackTimeout(defaultUnpackDuration),
+				WithUserID(int64(runAsUser)),
 			)
 			require.NoError(t, err)
 

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -1606,7 +1606,7 @@ func NewFakeOperator(ctx context.Context, namespace string, namespaces []string,
 		}
 		applier := controllerclient.NewFakeApplier(s, "testowner")
 
-		op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, op.opClient, "test:pod", op.now, applier)
+		op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, op.opClient, "test:pod", op.now, applier, 1001)
 	}
 
 	op.RunInformers(ctx)
@@ -1758,7 +1758,7 @@ func toManifest(t *testing.T, obj runtime.Object) string {
 }
 
 func pod(s v1alpha1.CatalogSource) *corev1.Pod {
-	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetName(), s.GetLabels(), s.GetAnnotations(), 5, 10)
+	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetName(), s.GetLabels(), s.GetAnnotations(), 5, 10, 1001)
 	ownerutil.AddOwner(pod, &s, false, false)
 	return pod
 }

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -23,6 +23,7 @@ import (
 // configMapCatalogSourceDecorator wraps CatalogSource to add additional methods
 type configMapCatalogSourceDecorator struct {
 	*v1alpha1.CatalogSource
+	runAsUser int64
 }
 
 const (
@@ -101,7 +102,7 @@ func (s *configMapCatalogSourceDecorator) Service() *corev1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *corev1.Pod {
-	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5)
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5, s.runAsUser)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)
@@ -162,10 +163,11 @@ func (s *configMapCatalogSourceDecorator) RoleBinding() *rbacv1.RoleBinding {
 }
 
 type ConfigMapRegistryReconciler struct {
-	now      nowFunc
-	Lister   operatorlister.OperatorLister
-	OpClient operatorclient.ClientInterface
-	Image    string
+	now             nowFunc
+	Lister          operatorlister.OperatorLister
+	OpClient        operatorclient.ClientInterface
+	Image           string
+	createPodAsUser int64
 }
 
 var _ RegistryEnsurer = &ConfigMapRegistryReconciler{}
@@ -240,7 +242,7 @@ func (c *ConfigMapRegistryReconciler) currentPodsWithCorrectResourceVersion(sour
 
 // EnsureRegistryServer ensures that all components of registry server are up to date.
 func (c *ConfigMapRegistryReconciler) EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error {
-	source := configMapCatalogSourceDecorator{catalogSource}
+	source := configMapCatalogSourceDecorator{catalogSource, c.createPodAsUser}
 
 	image := c.Image
 	if source.Spec.SourceType == "grpc" {
@@ -389,7 +391,7 @@ func (c *ConfigMapRegistryReconciler) ensureService(source configMapCatalogSourc
 
 // CheckRegistryServer returns true if the given CatalogSource is considered healthy; false otherwise.
 func (c *ConfigMapRegistryReconciler) CheckRegistryServer(catalogSource *v1alpha1.CatalogSource) (healthy bool, err error) {
-	source := configMapCatalogSourceDecorator{catalogSource}
+	source := configMapCatalogSourceDecorator{catalogSource, c.createPodAsUser}
 
 	image := c.Image
 	if source.Spec.SourceType == "grpc" {

--- a/pkg/controller/registry/reconciler/configmap_test.go
+++ b/pkg/controller/registry/reconciler/configmap_test.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	registryImageName = "test:image"
+	runAsUser         = 1001
 	testNamespace     = "testns"
 )
 
@@ -104,6 +105,7 @@ func fakeReconcilerFactory(t *testing.T, stopc <-chan struct{}, options ...fakeR
 		OpClient:             opClientFake,
 		Lister:               lister,
 		ConfigMapServerImage: config.configMapServerImage,
+		createPodAsUser:      runAsUser,
 	}
 
 	var hasSyncedCheckFns []cache.InformerSynced
@@ -186,7 +188,7 @@ func objectsForCatalogSource(catsrc *v1alpha1.CatalogSource) []runtime.Object {
 	var objs []runtime.Object
 	switch catsrc.Spec.SourceType {
 	case v1alpha1.SourceTypeInternal, v1alpha1.SourceTypeConfigmap:
-		decorated := configMapCatalogSourceDecorator{catsrc}
+		decorated := configMapCatalogSourceDecorator{catsrc, runAsUser}
 		objs = clientfake.AddSimpleGeneratedNames(
 			clientfake.AddSimpleGeneratedName(decorated.Pod(registryImageName)),
 			decorated.Service(),
@@ -196,7 +198,7 @@ func objectsForCatalogSource(catsrc *v1alpha1.CatalogSource) []runtime.Object {
 		)
 	case v1alpha1.SourceTypeGrpc:
 		if catsrc.Spec.Image != "" {
-			decorated := grpcCatalogSourceDecorator{catsrc}
+			decorated := grpcCatalogSourceDecorator{catsrc, runAsUser}
 			objs = clientfake.AddSimpleGeneratedNames(
 				decorated.Pod(catsrc.GetName()),
 				decorated.Service(),
@@ -451,7 +453,7 @@ func TestConfigMapRegistryReconciler(t *testing.T) {
 			}
 
 			// if no error, the reconciler should create the same set of kube objects every time
-			decorated := configMapCatalogSourceDecorator{tt.in.catsrc}
+			decorated := configMapCatalogSourceDecorator{tt.in.catsrc, runAsUser}
 
 			pod := decorated.Pod(registryImageName)
 			listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{CatalogSourceLabelKey: tt.in.catsrc.GetName()}).String()}

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -331,7 +331,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			}
 
 			// Check for resource existence
-			decorated := grpcCatalogSourceDecorator{tt.in.catsrc}
+			decorated := grpcCatalogSourceDecorator{tt.in.catsrc, runAsUser}
 			pod := decorated.Pod(tt.in.catsrc.GetName())
 			service := decorated.Service()
 			sa := decorated.ServiceAccount()
@@ -421,7 +421,7 @@ func TestRegistryPodPriorityClass(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check for resource existence
-			decorated := grpcCatalogSourceDecorator{tt.in.catsrc}
+			decorated := grpcCatalogSourceDecorator{tt.in.catsrc, runAsUser}
 			pod := decorated.Pod(tt.in.catsrc.GetName())
 			listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{CatalogSourceLabelKey: tt.in.catsrc.GetName()}).String()}
 			outPods, podErr := client.KubernetesInterface().CoreV1().Pods(pod.GetNamespace()).List(context.TODO(), listOptions)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->
**Motivation for the change:**

With the introduction of [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces), the recommended best practice is to enforce the `Restricted` policy of admission (see [1] for more details).

[1] https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted


**Description of the change:**

This PR
    *) Lables the olm namespace as `enforce:restricted`
    *) Labels the operators namespace as `enforce:baseline` (to allow existing CSV deployments
    without securityContext set to deploy in the namespace, which won't be possible with
    `enforce:resticted`)
    *) updates the securityContext of olm workload pods(olm-operator, catalog-operator,
    and CatalogSource registry pods) to adhere to the `Restricted` policy.
    *) updates the bundle unpacking job to create a pod that adheres to the `Restricted` policy,
    so that bundles can be unpacked in the `Restricted` namespace

Will also close #2644 as a byproduct of the need to fix test failures 

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
