### PR TITLE
Add PSA labels to e2e test namespaces

### DIFF
--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -533,12 +533,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			)
 
 			BeforeEach(func() {
-				target = corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "watched-",
-					},
-				}
-				Expect(ctx.Ctx().Client().Create(context.Background(), &target)).To(Succeed())
+				target = CreateTestNamespace(genName("watched-"))
 
 				original = operatorsv1alpha1.ClusterServiceVersion{
 					TypeMeta: metav1.TypeMeta{
@@ -1975,7 +1970,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   secondNamespaceName,
-					Labels: matchingLabel,
+					Labels: WithPodSecurityAdmissionLabels(matchingLabel),
 				},
 			}, metav1.CreateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())

--- a/test/e2e/dynamic_resource_e2e_test.go
+++ b/test/e2e/dynamic_resource_e2e_test.go
@@ -54,7 +54,8 @@ var _ = Describe("Subscriptions create required objects from Catalogs", func() {
 					var err error
 					ns, err = c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: genName("ns-"),
+							Name:   genName("ns-"),
+							Labels: PodSecurityAdmissionLabels(),
 						},
 					}, metav1.CreateOptions{})
 					Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -41,7 +41,7 @@ var (
 	collectArtifactsScriptPath = flag.String(
 		"gather-artifacts-script-path",
 		"./collect-ci-artifacts.sh",
-		"configures the relative/absolute path to the script resposible for collecting CI artifacts",
+		"configures the relative/absolute path to the script responsible for collecting CI artifacts",
 	)
 
 	testdataPath = flag.String(

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -3063,7 +3063,8 @@ var _ = Describe("Install Plan", func() {
 	It("unpacks bundle image", func() {
 		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
+				Name:   genName("ns-"),
+				Labels: PodSecurityAdmissionLabels(),
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
@@ -3157,12 +3158,9 @@ var _ = Describe("Install Plan", func() {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
 		}
 
-		ns := &corev1.Namespace{}
-		ns.SetName(genName("ns-"))
+		ns := CreateTestNamespace(genName("ns-"))
 
 		// Create a namespace an OperatorGroup
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
 		deleteOpts := &metav1.DeleteOptions{}
 		defer func() {
 			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), *deleteOpts))
@@ -3170,7 +3168,7 @@ var _ = Describe("Install Plan", func() {
 
 		og := &operatorsv1.OperatorGroup{}
 		og.SetName("og")
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
+		_, err := crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
 
 		mainPackageName := genName("nginx-")
@@ -3307,6 +3305,7 @@ var _ = Describe("Install Plan", func() {
 		BeforeEach(func() {
 			ns = &corev1.Namespace{}
 			ns.SetName(genName("ns-"))
+			ns.SetLabels(PodSecurityAdmissionLabels())
 
 			// Create a namespace
 			Eventually(func() error {
@@ -3404,6 +3403,7 @@ var _ = Describe("Install Plan", func() {
 		BeforeEach(func() {
 			ns = &corev1.Namespace{}
 			ns.SetName(genName("ns-"))
+			ns.SetLabels(PodSecurityAdmissionLabels())
 			Eventually(func() error {
 				return ctx.Ctx().Client().Create(context.Background(), ns)
 			}, timeout, interval).Should(Succeed(), "could not create Namespace")
@@ -3609,7 +3609,8 @@ var _ = Describe("Install Plan", func() {
 
 		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
+				Name:   genName("ns-"),
+				Labels: PodSecurityAdmissionLabels(),
 			},
 		}, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -3694,7 +3695,8 @@ var _ = Describe("Install Plan", func() {
 		By("creating a scoped serviceaccount specified in the operatorgroup")
 		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
+				Name:   genName("ns-"),
+				Labels: PodSecurityAdmissionLabels(),
 			},
 		}, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -3938,7 +3940,8 @@ var _ = Describe("Install Plan", func() {
 		By("creating a scoped serviceaccount specifified in the operatorgroup")
 		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
+				Name:   genName("ns-"),
+				Labels: PodSecurityAdmissionLabels(),
 			},
 		}, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Operator Group", func() {
 		_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   opGroupNamespace,
-				Labels: matchingLabel,
+				Labels: WithPodSecurityAdmissionLabels(matchingLabel),
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
@@ -89,7 +89,7 @@ var _ = Describe("Operator Group", func() {
 		otherNamespace := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   otherNamespaceName,
-				Labels: matchingLabel,
+				Labels: WithPodSecurityAdmissionLabels(matchingLabel),
 			},
 		}
 		createdOtherNamespace, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &otherNamespace, metav1.CreateOptions{})
@@ -432,7 +432,8 @@ var _ = Describe("Operator Group", func() {
 		for _, ns := range []string{nsA} {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: ns,
+					Name:   ns,
+					Labels: PodSecurityAdmissionLabels(),
 				},
 			}
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
@@ -623,7 +624,8 @@ var _ = Describe("Operator Group", func() {
 		for _, ns := range []string{nsA, nsB} {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: ns,
+					Name:   ns,
+					Labels: PodSecurityAdmissionLabels(),
 				},
 			}
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
@@ -879,7 +881,8 @@ var _ = Describe("Operator Group", func() {
 		for _, ns := range []string{nsA, nsB, nsC, nsD, nsE} {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: ns,
+					Name:   ns,
+					Labels: PodSecurityAdmissionLabels(),
 				},
 			}
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
@@ -1152,7 +1155,8 @@ var _ = Describe("Operator Group", func() {
 		for _, ns := range []string{nsA, nsB, nsC, nsD} {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: ns,
+					Name:   ns,
+					Labels: PodSecurityAdmissionLabels(),
 				},
 			}
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
@@ -1507,7 +1511,7 @@ var _ = Describe("Operator Group", func() {
 		otherNamespace := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   otherNamespaceName,
-				Labels: matchingLabel,
+				Labels: WithPodSecurityAdmissionLabels(matchingLabel),
 			},
 		}
 		_, err = c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &otherNamespace, metav1.CreateOptions{})
@@ -1573,7 +1577,8 @@ var _ = Describe("Operator Group", func() {
 
 		_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: newNamespaceName,
+				Name:   newNamespaceName,
+				Labels: PodSecurityAdmissionLabels(),
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
@@ -1709,7 +1714,8 @@ var _ = Describe("Operator Group", func() {
 
 		_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: newNamespaceName,
+				Name:   newNamespaceName,
+				Labels: PodSecurityAdmissionLabels(),
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
@@ -1988,7 +1994,7 @@ var _ = Describe("Operator Group", func() {
 		otherNamespace := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   otherNamespaceName,
-				Labels: matchingLabel,
+				Labels: WithPodSecurityAdmissionLabels(matchingLabel),
 			},
 		}
 		_, err = c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &otherNamespace, metav1.CreateOptions{})
@@ -2054,7 +2060,8 @@ var _ = Describe("Operator Group", func() {
 		for _, namespace := range testNamespaces {
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: namespace,
+					Name:   namespace,
+					Labels: PodSecurityAdmissionLabels(),
 				},
 			}, metav1.CreateOptions{})
 			require.NoError(GinkgoT(), err)
@@ -2153,7 +2160,8 @@ var _ = Describe("Operator Group", func() {
 		for _, namespace := range testNamespaces {
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: namespace,
+					Name:   namespace,
+					Labels: PodSecurityAdmissionLabels(),
 				},
 			}, metav1.CreateOptions{})
 			require.NoError(GinkgoT(), err)
@@ -2226,7 +2234,8 @@ var _ = Describe("Operator Group", func() {
 			for _, namespace := range testNamespaces {
 				_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: namespace,
+						Name:   namespace,
+						Labels: PodSecurityAdmissionLabels(),
 					},
 				}, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -2254,7 +2263,7 @@ var _ = Describe("Operator Group", func() {
 					_, err := c.KubernetesInterface().CoreV1().Namespaces().Update(context.TODO(), &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   namespace,
-							Labels: matchingLabel,
+							Labels: WithPodSecurityAdmissionLabels(matchingLabel),
 						},
 					}, metav1.UpdateOptions{})
 					Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -119,8 +119,11 @@ var _ = Describe("Operator API", func() {
 		// Create namespaces ns-a and ns-b
 		nsA := &corev1.Namespace{}
 		nsA.SetName(genName("ns-a-"))
+		nsA.SetLabels(PodSecurityAdmissionLabels())
+
 		nsB := &corev1.Namespace{}
 		nsB.SetName(genName("ns-b-"))
+		nsB.SetLabels(PodSecurityAdmissionLabels())
 
 		for _, ns := range []*corev1.Namespace{nsA, nsB} {
 			Eventually(func() error {
@@ -251,6 +254,7 @@ var _ = Describe("Operator API", func() {
 			// Subscribe to a package and await a successful install
 			ns = &corev1.Namespace{}
 			ns.SetName(genName("ns-"))
+			ns.SetLabels(PodSecurityAdmissionLabels())
 			Eventually(func() error {
 				return client.Create(clientCtx, ns)
 			}).Should(Succeed())
@@ -368,6 +372,7 @@ var _ = Describe("Operator API", func() {
 				// Subscribe to a package and await a successful install
 				newNs = &corev1.Namespace{}
 				newNs.SetName(genName("ns-"))
+				newNs.SetLabels(PodSecurityAdmissionLabels())
 				Eventually(func() error {
 					return client.Create(clientCtx, newNs)
 				}).Should(Succeed())

--- a/test/e2e/resource_manager_test.go
+++ b/test/e2e/resource_manager_test.go
@@ -31,7 +31,8 @@ var _ = Describe("ResourceManager", func() {
 		// Create a namespace
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("test-"),
+				Name:   genName("test-"),
+				Labels: PodSecurityAdmissionLabels(),
 			},
 		}
 		Expect(ctx.Ctx().E2EClient().Create(context.TODO(), ns)).To(Succeed())
@@ -46,7 +47,8 @@ var _ = Describe("ResourceManager", func() {
 		// Create a namespace
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("test-"),
+				Name:   genName("test-"),
+				Labels: PodSecurityAdmissionLabels(),
 			},
 		}
 		Expect(ctx.Ctx().E2EClient().Create(context.TODO(), ns)).To(Succeed())

--- a/test/e2e/user_defined_sa_test.go
+++ b/test/e2e/user_defined_sa_test.go
@@ -31,14 +31,7 @@ var _ = Describe("User defined service account", func() {
 	)
 
 	BeforeEach(func() {
-		generatedNamespace = corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("user-defined-sa-e2e-"),
-			},
-		}
-		Eventually(func() error {
-			return ctx.Ctx().Client().Create(context.Background(), &generatedNamespace)
-		}).Should(Succeed())
+		generatedNamespace = CreateTestNamespace(genName("user-defined-sa-e2e-"))
 
 		c = ctx.Ctx().KubeClient()
 		crc = ctx.Ctx().OperatorClient()
@@ -206,7 +199,8 @@ var _ = Describe("User defined service account", func() {
 func newNamespace(client operatorclient.ClientInterface, name string) (ns *corev1.Namespace, cleanup cleanupFunc) {
 	request := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: PodSecurityAdmissionLabels(),
 		},
 	}
 

--- a/test/e2e/webhook_e2e_test.go
+++ b/test/e2e/webhook_e2e_test.go
@@ -47,9 +47,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		generatedNamespace = corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: genName("webhook-e2e-"),
-				Labels: map[string]string{
+				Labels: WithPodSecurityAdmissionLabels(map[string]string{
 					"foo": "bar",
-				},
+				}),
 			},
 		}
 		Eventually(func() error {


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

**Description of the change:**
Enforeces baseline PSA security profile on e2e test namespaces

**Motivation for the change:**
Downstream CI is breaking due to enforcing restricted profile and PSA changes to workloads are not through yet.

**Architectural changes:**
N/A

**Testing remarks:**
N/A

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
