### PR TITLE
Add cluster level baseline PSA enforcement

### DIFF
--- a/test/e2e/ctx/kind-cluster-config-patch.yaml
+++ b/test/e2e/ctx/kind-cluster-config-patch.yaml
@@ -1,0 +1,10 @@
+kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    admission-control-config-file: /etc/config/cluster-level-pss.yaml
+  extraVolumes:
+    - name: accf
+      hostPath: /etc/config
+      mountPath: /etc/config
+      readOnly: false
+      pathType: "DirectoryOrCreate"

--- a/test/e2e/ctx/kind-cluster-level-pss.yaml
+++ b/test/e2e/ctx/kind-cluster-level-pss.yaml
@@ -1,0 +1,18 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: PodSecurity
+    configuration:
+      apiVersion: pod-security.admission.config.k8s.io/v1beta1
+      kind: PodSecurityConfiguration
+      defaults:
+        enforce: "baseline"
+        enforce-version: "latest"
+        audit: "restricted"
+        audit-version: "latest"
+        warn: "restricted"
+        warn-version: "latest"
+      exemptions:
+        usernames: []
+        runtimeClasses: []
+        namespaces: [kube-system]


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>


**Description of the change:**
Modifies the kind provisioner to configure cluster level baseline PSA security standard enforcement

**Motivation for the change:**
Downstream CI uses restricted enforcement. This will make it easy to reach parity with downstream CI once the restricted standard is catered for in OLM

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
