### PR TITLE
(manifests): populate pod security configs dynamically

### DIFF
--- a/deploy/chart/templates/0000_50_olm_00-namespace.yaml
+++ b/deploy/chart/templates/0000_50_olm_00-namespace.yaml
@@ -3,8 +3,10 @@ kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
   labels: 
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: latest
+    {{- if .Values.namespace_psa }}
+    pod-security.kubernetes.io/enforce: {{ .Values.namespace_psa.enforceLevel }}
+    pod-security.kubernetes.io/enforce-version: {{ .Values.namespace_psa.enforceVersion }}
+    {{- end }}
 
 ---
 apiVersion: v1
@@ -12,5 +14,7 @@ kind: Namespace
 metadata:
   name: {{ .Values.operator_namespace }}
   labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/enforce-version: latest
+    {{- if .Values.operator_namespace_psa }}
+    pod-security.kubernetes.io/enforce: {{ .Values.operator_namespace_psa.enforceLevel }}
+    pod-security.kubernetes.io/enforce-version: {{ .Values.operator_namespace_psa.enforceVersion }}
+    {{- end }}

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -84,8 +84,11 @@ spec:
           - --client-ca
           - /profile-collector-cert/tls.crt
           {{- end }}
-          - --set-workload-user-id
-          - "true"
+          {{- if eq .Values.catalog.setWorkloadUserID true }}
+          - --set-workload-user-id=true
+          {{- else }}
+          - --set-workload-user-id=false
+          {{ end }}
           image: {{ .Values.catalog.image.ref }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,7 +1,15 @@
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: operator-lifecycle-manager
+# see https://kubernetes.io/docs/concepts/security/pod-security-admission/ for more details
+namespace_psa: 
+  enforceLevel: restricted
+  enforceVersion: latest
 catalog_namespace: operator-lifecycle-manager
 operator_namespace: operators
+# see https://kubernetes.io/docs/concepts/security/pod-security-admission/ for more details
+operator_namespace_psa: 
+  enforceLevel: baseline
+  enforceVersion: latest
 minKubeVersion: 1.11.0
 writeStatusName: '""'
 imagestream: false
@@ -25,6 +33,7 @@ olm:
      memory: 160Mi
 
 catalog:
+  setWorkloadUserID: true
   replicaCount: 1
   commandArgs: --configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
   image:

--- a/deploy/upstream/values.yaml
+++ b/deploy/upstream/values.yaml
@@ -1,8 +1,16 @@
 installType: upstream
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: olm
+# see https://kubernetes.io/docs/concepts/security/pod-security-admission/ for more details
+namespace_psa: 
+  enforceLevel: restricted
+  enforceVersion: latest
 catalog_namespace: olm
 operator_namespace: operators
+# see https://kubernetes.io/docs/concepts/security/pod-security-admission/ for more details
+operator_namespace_psa: 
+  enforceLevel: baseline
+  enforceVersion: latest
 imagestream: false
 writeStatusName: '""'
 writePackageServerStatusName: ""
@@ -14,6 +22,7 @@ olm:
   service:
     internalPort: 8080
 catalog:
+  setWorkloadUserID: true
   replicaCount: 1
   image:
     ref: quay.io/operator-framework/olm@sha256:e74b2ac57963c7f3ba19122a8c31c9f2a0deb3c0c5cac9e5323ccffd0ca198ed


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This PR:
* introduces a chart value that decides if the --set-workload-user-id flag to true
or false for the catalog-operator container
* introduces chart values to fill in the psa enforce level/version for the namespaces
Closes #2827

Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>



<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
