### PR TITLE
improve CA and certificate generation

### DIFF
--- a/pkg/controller/certs/certs.go
+++ b/pkg/controller/certs/certs.go
@@ -71,13 +71,13 @@ func GenerateCA(notAfter time.Time, organization string) (*KeyPair, error) {
 	caDetails := &x509.Certificate{
 		SerialNumber: serial,
 		Subject: pkix.Name{
+			CommonName:   fmt.Sprintf("olm-selfsigned-%x", serial),
 			Organization: []string{organization},
 		},
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
 		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		KeyUsage:              x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
 
@@ -120,12 +120,12 @@ func CreateSignedServingPair(notAfter time.Time, organization string, ca *KeyPai
 	certDetails := &x509.Certificate{
 		SerialNumber: serial,
 		Subject: pkix.Name{
+			CommonName:   hosts[0],
 			Organization: []string{organization},
 		},
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		DNSNames:              hosts,
 	}


### PR DESCRIPTION
**Motivation for the change:**
Recently during an audit on a user's cluster, it was discovered that
OLM's certificate generation functionality has a few minor shortcomings.
  1) The generated CA and server cert do not include a common name,
     which causes some tooling to have trouble tracing the cert chain.
  2) The generated CA and server cert include unnecessary key usages,
     which means those certificates can be used for more than their
     intended purposes.

**Description of the change:**
This commit resolves the above issues by ensuring the certificates
include common names and by using the minimal key usages necessary.

**Testing remarks:**
Thus far, I have only manually tested via `run-local` and verified that:
1) The generated packageserver secret contained the expected cerificates.
2) The packagemanifests API worked (thus proving the kube-apiserver can use OLM's generated CA to verify OLM's generated cert for the packageserver api service.

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
