### PR TITLE
(chore) deprecate io/ioutil usage for io & os packages

### DIFF
--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -1353,7 +1353,7 @@ func TestCompetingCRDOwnersExist(t *testing.T) {
 
 func TestValidateExistingCRs(t *testing.T) {
 	unstructuredForFile := func(file string) *unstructured.Unstructured {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		require.NoError(t, err)
 		dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 		k8sFile := &unstructured.Unstructured{}
@@ -1362,7 +1362,7 @@ func TestValidateExistingCRs(t *testing.T) {
 	}
 
 	unversionedCRDForV1beta1File := func(file string) *apiextensions.CustomResourceDefinition {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		require.NoError(t, err)
 		dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 		k8sFile := &apiextensionsv1beta1.CustomResourceDefinition{}
@@ -1744,7 +1744,7 @@ func objectReference(name string) *corev1.ObjectReference {
 }
 
 func yamlFromFilePath(t *testing.T, fileName string) string {
-	yaml, err := ioutil.ReadFile(fileName)
+	yaml, err := os.ReadFile(fileName)
 	require.NoError(t, err)
 
 	return string(yaml)

--- a/pkg/lib/filemonitor/cabundle_updater.go
+++ b/pkg/lib/filemonitor/cabundle_updater.go
@@ -2,7 +2,7 @@ package filemonitor
 
 import (
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
@@ -16,7 +16,7 @@ type certPoolStore struct {
 }
 
 func NewCertPoolStore(clientCAPath string) (*certPoolStore, error) {
-	pem, err := ioutil.ReadFile(clientCAPath)
+	pem, err := os.ReadFile(clientCAPath)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func NewCertPoolStore(clientCAPath string) (*certPoolStore, error) {
 }
 
 func (c *certPoolStore) storeCABundle(clientCAPath string) error {
-	pem, err := ioutil.ReadFile(clientCAPath)
+	pem, err := os.ReadFile(clientCAPath)
 	if err == nil {
 		c.mutex.Lock()
 		defer c.mutex.Unlock()

--- a/pkg/lib/filemonitor/cert_updater_test.go
+++ b/pkg/lib/filemonitor/cert_updater_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"html"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -88,7 +87,7 @@ func TestOLMGetCertRotationFn(t *testing.T) {
 		}
 	}()
 
-	caCert, err := ioutil.ReadFile(caCrt)
+	caCert, err := os.ReadFile(caCrt)
 	require.NoError(t, err)
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)

--- a/pkg/package-server/storage/subresources.go
+++ b/pkg/package-server/storage/subresources.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -68,7 +68,7 @@ func (s *LogoStorage) Connect(ctx context.Context, name string, options runtime.
 				etag := `"` + strings.Join([]string{name, pkgChannel.Name, pkgChannel.CurrentCSV}, ".") + `"`
 
 				reader := base64.NewDecoder(base64.StdEncoding, strings.NewReader(data))
-				imgBytes, _ := ioutil.ReadAll(reader)
+				imgBytes, _ := io.ReadAll(reader)
 
 				return imgBytes, mimeType, etag
 			}

--- a/test/e2e/ctx/provisioner_kind.go
+++ b/test/e2e/ctx/provisioner_kind.go
@@ -7,7 +7,6 @@ import (
 	"encoding/csv"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func (kl kindLogAdapter) V(level log.Level) log.InfoLogger {
 }
 
 func Provision(ctx *TestContext) (func(), error) {
-	dir, err := ioutil.TempDir("", "kind.")
+	dir, err := os.MkdirTemp("", "kind.")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %s", err.Error())
 	}

--- a/test/e2e/setup_bare_test.go
+++ b/test/e2e/setup_bare_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -65,7 +64,7 @@ func TestMain(m *testing.M) {
 
 	testNamespace = *namespace
 	if testNamespace == "" {
-		testNamespaceBytes, err := ioutil.ReadFile("e2e.namespace")
+		testNamespaceBytes, err := os.ReadFile("e2e.namespace")
 		if err != nil || testNamespaceBytes == nil {
 			panic("no namespace set")
 		}

--- a/test/e2e/split/main.go
+++ b/test/e2e/split/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -106,7 +105,7 @@ func findDescribes(logger logrus.FieldLogger, dir string) ([]string, error) {
 		return nil, err
 	}
 	for _, match := range matches {
-		b, err := ioutil.ReadFile(match)
+		b, err := os.ReadFile(match)
 		if err != nil {
 			return nil, err
 		}

--- a/util/cpb/main.go
+++ b/util/cpb/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -118,7 +117,7 @@ func getMetadata() (m *metadata, err error) {
 		m.annotationsFile = path
 
 		// Unmarshal metadata
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("couldn't get content of annotations.yaml file: %s", path)
 		}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
golangci-lint is barfing about use of the deprecated ioutils package.  Updating impacted modules to use io or os supported methods instead, which match in signature and functionality.

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
