### PR TITLE
(e2e-fix) do not check for updated csv that is likely to be GC'd

### DIFF
--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -2021,16 +2021,10 @@ var _ = Describe("Operator Group", func() {
 			fetchedCSV.Annotations[v1.OperatorGroupNamespaceAnnotationKey] = fetchedCSV.GetNamespace()
 			_, updateErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 			if updateErr != nil {
+				GinkgoT().Logf("Error updating copied CSV (in %v): %v", otherNamespaceName, updateErr.Error())
 				return false, updateErr
 			}
-			updatedCSV, updatedfetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
-			if updatedfetchErr != nil {
-				return false, updatedfetchErr
-			}
-			if updatedCSV.Annotations[v1.OperatorGroupNamespaceAnnotationKey] == fetchedCSV.GetNamespace() {
-				return true, nil
-			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("Done updating copied CSV with bad annotation OperatorGroup, waiting for CSV to be gc'd")


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

In the test `Operator Group cleanup csvs with bad namespace annotation`, the polling
logic that updates a copied csv with a bad annotation was checking to see if the
update was successful. However, once the copied csv is given a bad annotation, the CSV
is GC'd, and if the collection happens immediately, the polling logic fails. This fix
removes the logic that attempts to check the updated CSV, and instead relies on the
updateErr being nil to assert that the update was successful.

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
