### PR TITLE
test/e2e: Preserve the existing environment when using exec.Command

### DIFF
--- a/test/e2e/ctx/ctx.go
+++ b/test/e2e/ctx/ctx.go
@@ -130,7 +130,7 @@ func (ctx TestContext) DumpNamespaceArtifacts(namespace string) error {
 	}
 
 	cmd := exec.Command(ctx.artifactsScriptPath)
-	cmd.Env = append(cmd.Env, envvars...)
+	cmd.Env = append(os.Environ(), envvars...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Ensure we're preserving the existing environment before running any exec.Commands. I noticed locally when running the e2e suite that the underlying bash script wasn't able to find 'oc' despite that executable being in my $PATH, and the `which oc` was outputting strange results when run in isolation. Explicitly specifying the existing environment via os.Environ() which should include the $PATH variable helped fix this pathing issue.

**Motivation for the change:**
I saw this in openshift's downstream CI for our OLM fork. We've fixed this issue in the past in other downstream repositories that use [a similar setup](https://github.com/openshift/platform-operators/pull/76).

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
