### PR TITLE
Change opm image from `quay.io/operator-framework/upstream-opm-builder` to `quay.io/operator-framework/opm`

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -27,7 +27,7 @@ const (
 	defaultWakeupInterval       = 15 * time.Minute
 	defaultCatalogNamespace     = "olm"
 	defaultConfigMapServerImage = "quay.io/operator-framework/configmap-operator-registry:latest"
-	defaultOPMImage             = "quay.io/operator-framework/upstream-opm-builder:latest"
+	defaultOPMImage             = "quay.io/operator-framework/opm:latest"
 	defaultUtilImage            = "quay.io/operator-framework/olm:latest"
 	defaultOperatorName         = ""
 	defaultWorkLoadUserID       = int64(1001)

--- a/test/e2e/magic_catalog.go
+++ b/test/e2e/magic_catalog.go
@@ -257,7 +257,7 @@ func (c *MagicCatalog) makeCatalogSource() *operatorsv1alpha1.CatalogSource {
 func (c *MagicCatalog) makeCatalogSourcePod() *corev1.Pod {
 
 	const (
-		image                  = "quay.io/operator-framework/upstream-opm-builder"
+		image                  = "quay.io/operator-framework/opm"
 		readinessDelay  int32  = 5
 		livenessDelay   int32  = 10
 		volumeMountName string = "fbc-catalog"


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:** Bumping the opm image from `quay.io/operator-framework/upstream-opm-builder` to `quay.io/operator-framework/opm`

**Motivation for the change:** We are having issues with opm jobs, as we have a multi-arch cluster, where jobs are failing if ran on ARM64 nodes. The OLM seems to be using a deprecated opm image. See details in https://github.com/operator-framework/operator-lifecycle-manager/issues/2823#issuecomment-1310007214

Note: I don't completely know what I'm doing and whether the `opm` image is actually able to fully replace the `upstream-opm-builder` image. But I guess before digging down deeply into that rabbit hole, maintainers here should have a good understanding of that and evaluate that quicker than me.
Closes #2823

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
