### PR TITLE
Don't use $BUILDPLATFORM image for goreleaser

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:debug
+FROM gcr.io/distroless/static:debug
 LABEL stage=olm
 WORKDIR /
 # bundle unpack Jobs require cp at /bin/cp


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:** Removes the `--platform=$BUILDPLATFORM` argument

**Motivation for the change:** When specifying the platform as $BUILDPLATFORM, amd64 binaries are taken. This leads to the image not being multi-arch, but still having an amd64 busybox binary.
The [util init container](https://github.com/operator-framework/operator-lifecycle-manager/blob/67177c0c822fbe7d554669262c6b4f54bebad17f/pkg/controller/bundle/bundle_unpacker_test.go#L267) of jobs are failing with an `exec /bin/cp: exec format error`.

**Architectural changes:** None

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Further remarks: I already opened #2890 to increase multi-arch/arm64 compatibility. In case wanted, I can also incorporate this change into that PR
