### PR TITLE
Dump cache to logs on resolution failed

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -997,6 +997,7 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		// not-satisfiable error
 		if _, ok := err.(solver.NotSatisfiable); ok {
 			logger.WithError(err).Debug("resolution failed")
+			o.resolver.DumpCache(namespace)
 			_, updateErr := o.updateSubscriptionStatuses(
 				o.setSubsCond(subs, v1alpha1.SubscriptionCondition{
 					Type:    v1alpha1.SubscriptionResolutionFailed,

--- a/pkg/controller/registry/resolver/instrumented_resolver.go
+++ b/pkg/controller/registry/resolver/instrumented_resolver.go
@@ -32,3 +32,7 @@ func (ir *InstrumentedResolver) ResolveSteps(namespace string) ([]*v1alpha1.Step
 	}
 	return steps, lookups, subs, err
 }
+
+func (ir *InstrumentedResolver) DumpCache(namespace string) {
+	ir.resolver.DumpCache(namespace)
+}

--- a/pkg/controller/registry/resolver/step_resolver.go
+++ b/pkg/controller/registry/resolver/step_resolver.go
@@ -28,6 +28,7 @@ var initHooks []stepResolverInitHook
 
 type StepResolver interface {
 	ResolveSteps(namespace string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error)
+	DumpCache(namespace string)
 }
 
 type OperatorStepResolver struct {
@@ -83,6 +84,12 @@ func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versio
 		}
 	}
 	return stepResolver
+}
+
+// DumpCache writes out the content of the cache to logs
+// this is useful for debugging resolution errors
+func (r *OperatorStepResolver) DumpCache(namespace string) {
+	r.resolver.DumpCache([]string{namespace, r.globalCatalogNamespace})
 }
 
 func (r *OperatorStepResolver) ResolveSteps(namespace string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Dump cache contents to log in case of resolution failure

**Motivation for the change:**
From time to time we're running into strange resolution errors that we suspect might be related to cache issues. This adds extra logging to give support extra data points when debugging

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**
Tested manually locally

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
