### PR TITLE
packagemanifests: do not list deprecated channel entries

### DIFF
--- a/pkg/package-server/provider/registry_test.go
+++ b/pkg/package-server/provider/registry_test.go
@@ -65,6 +65,11 @@ func server() {
 	if err := loader.Populate(); err != nil {
 		logrus.Fatal(err)
 	}
+	const bundlePath = "localhost:5000/etcdoperator:v0.6.0"
+	if _, err := db.Exec(`UPDATE operatorbundle SET bundlePath=? WHERE name="etcdoperator.v0.6.0"`, bundlePath); err != nil {
+		logrus.Fatal(err)
+	}
+	load.DeprecateBundle(bundlePath)
 	if err := db.Close(); err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/package-server/provider/testdata/manifests/etcd/0.6.0/etcdcluster.crd.yaml
+++ b/pkg/package-server/provider/testdata/manifests/etcd/0.6.0/etcdcluster.crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdclusters.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  version: v1beta2
+  scope: Namespaced
+  names:
+    plural: etcdclusters
+    singular: etcdcluster
+    kind: EtcdCluster
+    listKind: EtcdClusterList
+    shortNames:
+      - etcdclus
+      - etcd

--- a/pkg/package-server/provider/testdata/manifests/etcd/0.6.0/etcdoperator.clusterserviceversion.yaml
+++ b/pkg/package-server/provider/testdata/manifests/etcd/0.6.0/etcdoperator.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: etcdoperator.v0.6.1
+  name: etcdoperator.v0.6.0
   namespace: placeholder
   annotations:		
     tectonic-visibility: ocs		
@@ -29,9 +29,8 @@ spec:
     **Backups included**
     Coming soon, the ability to schedule backups to happen on or off cluster.
   keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
-  version: 0.6.1
+  version: 0.6.0
   maturity: alpha
-  replaces: etcdoperator.v0.6.0
   maintainers:
   - name: CoreOS, Inc
     email: support@coreos.com
@@ -39,7 +38,7 @@ spec:
   provider:
     name: CoreOS, Inc
   labels:
-    alm-status-descriptors: etcdoperator.v0.6.1
+    alm-status-descriptors: etcdoperator.v0.6.0
     alm-owner-etcd: etcdoperator
     operated-by: etcdoperator
   selector:


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Ignore bundles with property `olm.deprecated` when listing channel entries in the packagemanifests API.

**Motivation for the change:**
Follow up to #2893, which added the channel entry listing to the packagemanifests API. This is necessary to avoid misleading users about the set of bundles that available to install.

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [x] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [x] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
