### PR TITLE
OCPBUGS-4955: Set ImagePullPolicy of bundle unpacker to "IfNotPresent" for image digests

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -171,7 +171,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 						{
 							Name:            "pull",
 							Image:           bundlePath,
-							ImagePullPolicy: image.InferImagePullPolicy(c.utilImage),
+							ImagePullPolicy: image.InferImagePullPolicy(bundlePath),
 							Command:         []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -29,6 +29,7 @@ import (
 	listersoperatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/image"
 )
 
 const (
@@ -170,7 +171,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 						{
 							Name:            "pull",
 							Image:           bundlePath,
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: image.InferImagePullPolicy(c.utilImage),
 							Command:         []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -50,8 +50,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 	defaultUnpackTimeoutSeconds := int64(defaultUnpackDuration.Seconds())
 
 	// Custom timeout to override the default cmdline flag ActiveDeadlineSeconds value
-	//customAnnotationDuration := 2 * time.Minute
-	//customAnnotationTimeoutSeconds := int64(customAnnotationDuration.Seconds())
+	customAnnotationDuration := 2 * time.Minute
+	customAnnotationTimeoutSeconds := int64(customAnnotationDuration.Seconds())
 
 	type fields struct {
 		objs []runtime.Object
@@ -77,7 +77,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 		args        args
 		expected    expected
 	}{
-		/*{
+		{
 			description: "NoCatalogSource/NoConfigMap/NoJob/NotCreated/Pending",
 			fields:      fields{},
 			args: args{
@@ -397,7 +397,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 					},
 				},
 			},
-		},*/
+		},
 		{
 			description: "CatalogSourcePresent/ConfigMapPresent/JobPresent/DigestImage/Unpacked",
 			fields: fields{

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -39,6 +39,7 @@ const (
 
 func TestConfigMapUnpacker(t *testing.T) {
 	pathHash := hash(bundlePath)
+	digestHash := hash(digestPath)
 	start := metav1.Now()
 	now := func() metav1.Time {
 		return start
@@ -404,13 +405,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 				objs: []runtime.Object{
 					&batchv1.Job{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      hash(digestPath),
+							Name:      digestHash,
 							Namespace: "ns-a",
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",
 									Kind:               "ConfigMap",
-									Name:               hash(digestPath),
+									Name:               digestHash,
 									Controller:         &blockOwnerDeletion,
 									BlockOwnerDeletion: &blockOwnerDeletion,
 								},
@@ -421,7 +422,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 							BackoffLimit:          &backoffLimit,
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Name: hash(digestPath),
+									Name: digestHash,
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
@@ -436,7 +437,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 										{
 											Name:    "extract",
 											Image:   opmImage,
-											Command: []string{"opm", "alpha", "bundle", "extract", "-m", "/bundle/", "-n", "ns-a", "-c", hash(digestPath), "-z"},
+											Command: []string{"opm", "alpha", "bundle", "extract", "-m", "/bundle/", "-n", "ns-a", "-c", digestHash, "-z"},
 											Env: []corev1.EnvVar{
 												{
 													Name:  configmap.EnvContainerImage,
@@ -549,7 +550,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 					},
 					&corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      hash(digestPath),
+							Name:      digestHash,
 							Namespace: "ns-a",
 							OwnerReferences: []metav1.OwnerReference{
 								{
@@ -608,7 +609,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 							Name:      "src-a",
 						},
 					},
-					name: hash(digestPath),
+					name: digestHash,
 					bundle: &api.Bundle{
 						CsvName: "etcdoperator.v0.9.2",
 						CsvJson: csvJSON + "\n",
@@ -623,7 +624,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 				configMaps: []*corev1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      hash(digestPath),
+							Name:      digestHash,
 							Namespace: "ns-a",
 							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
@@ -647,13 +648,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 				jobs: []*batchv1.Job{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      hash(digestPath),
+							Name:      digestHash,
 							Namespace: "ns-a",
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",
 									Kind:               "ConfigMap",
-									Name:               hash(digestPath),
+									Name:               digestHash,
 									Controller:         &blockOwnerDeletion,
 									BlockOwnerDeletion: &blockOwnerDeletion,
 								},
@@ -664,7 +665,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 							BackoffLimit:          &backoffLimit,
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Name: hash(digestPath),
+									Name: digestHash,
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
@@ -679,7 +680,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 										{
 											Name:    "extract",
 											Image:   opmImage,
-											Command: []string{"opm", "alpha", "bundle", "extract", "-m", "/bundle/", "-n", "ns-a", "-c", hash(digestPath), "-z"},
+											Command: []string{"opm", "alpha", "bundle", "extract", "-m", "/bundle/", "-n", "ns-a", "-c", digestHash, "-z"},
 											Env: []corev1.EnvVar{
 												{
 													Name:  configmap.EnvContainerImage,
@@ -794,13 +795,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 				roles: []*rbacv1.Role{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      hash(digestPath),
+							Name:      digestHash,
 							Namespace: "ns-a",
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",
 									Kind:               "ConfigMap",
-									Name:               hash(digestPath),
+									Name:               digestHash,
 									Controller:         &blockOwnerDeletion,
 									BlockOwnerDeletion: &blockOwnerDeletion,
 								},
@@ -818,7 +819,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 									"configmaps",
 								},
 								ResourceNames: []string{
-									hash(digestPath),
+									digestHash,
 								},
 							},
 						},
@@ -827,13 +828,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 				roleBindings: []*rbacv1.RoleBinding{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      hash(digestPath),
+							Name:      digestHash,
 							Namespace: "ns-a",
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",
 									Kind:               "ConfigMap",
-									Name:               hash(digestPath),
+									Name:               digestHash,
 									Controller:         &blockOwnerDeletion,
 									BlockOwnerDeletion: &blockOwnerDeletion,
 								},
@@ -850,7 +851,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 						RoleRef: rbacv1.RoleRef{
 							APIGroup: "rbac.authorization.k8s.io",
 							Kind:     "Role",
-							Name:     hash(digestPath),
+							Name:     digestHash,
 						},
 					},
 				},

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -33,6 +33,7 @@ const (
 	opmImage    = "opm-image"
 	utilImage   = "util-image"
 	bundlePath  = "bundle-path"
+	digestImage = "bundle@sha256:54d626e08c1c802b305dad30b7e54a82f102390cc92c7d4db112048935236e9c"
 	runAsUser   = 1001
 )
 
@@ -398,7 +399,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 			},
 		},
 		{
-			description: "CatalogSourcePresent/ConfigMapPresent/JobPresent/Unpacked",
+			description: "CatalogSourcePresent/ConfigMapPresent/JobPresent/DigestImage/Unpacked",
 			fields: fields{
 				objs: []runtime.Object{
 					&batchv1.Job{
@@ -488,8 +489,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 										},
 										{
 											Name:            "pull",
-											Image:           bundlePath,
-											ImagePullPolicy: "Always",
+											Image:           digestImage,
+											ImagePullPolicy: "IfNotPresent",
 											Command:         []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 											VolumeMounts: []corev1.VolumeMount{
 												{
@@ -731,8 +732,8 @@ func TestConfigMapUnpacker(t *testing.T) {
 										},
 										{
 											Name:            "pull",
-											Image:           bundlePath,
-											ImagePullPolicy: "Always",
+											Image:           digestImage,
+											ImagePullPolicy: "IfNotPresent",
 											Command:         []string{"/util/cpb", "/bundle"}, // Copy bundle content to its mount
 											VolumeMounts: []corev1.VolumeMount{
 												{

--- a/pkg/lib/image/image.go
+++ b/pkg/lib/image/image.go
@@ -1,0 +1,17 @@
+package image
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func InferImagePullPolicy(image string) corev1.PullPolicy {
+	// Ensure the image is always pulled if the image is not based on a digest, measured by whether an "@" is included.
+	// See https://github.com/docker/distribution/blob/master/reference/reference.go for more info.
+	// This means recreating non-digest based pods will result in the latest version of the content being delivered on-cluster.
+	if strings.Contains(image, "@") {
+		return corev1.PullIfNotPresent
+	}
+	return corev1.PullAlways
+}

--- a/pkg/lib/image/image_test.go
+++ b/pkg/lib/image/image_test.go
@@ -1,0 +1,35 @@
+package image_test
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/image"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestInferImagePullPolicy(t *testing.T) {
+	tests := []struct {
+		description    string
+		img            string
+		expectedPolicy corev1.PullPolicy
+	}{
+		{
+			description:    "WithImageTag",
+			img:            "my-image:my-tag",
+			expectedPolicy: corev1.PullAlways,
+		},
+		{
+			description:    "WithImageDigest",
+			img:            "my-image@sha256:54d626e08c1c802b305dad30b7e54a82f102390cc92c7d4db112048935236e9c",
+			expectedPolicy: corev1.PullIfNotPresent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			policy := image.InferImagePullPolicy(tt.img)
+			require.Equal(t, tt.expectedPolicy, policy)
+		})
+	}
+}


### PR DESCRIPTION
**Description of the change:**

Captures the `imagePullPolicy` selection logic into a func, then utilizes it both in its original location as well as in the bundle unpacker. This allows users to set `imagePullPolicy` to `IfNotPresent` by supplying an image digest rather than a tag.

**Motivation for the change:**

OCPBUGS-4955

