### PR TITLE
Update e2e catalogSources to run in restricted mode

### DIFF
--- a/test/e2e/bundle_e2e_test.go
+++ b/test/e2e/bundle_e2e_test.go
@@ -102,6 +102,9 @@ var _ = Describe("Installing bundles with new object types", func() {
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
 					Image:      imageName,
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Restricted,
+					},
 				},
 			}
 

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -562,6 +562,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
 				Address:    net.JoinHostPort(mainCopy.Status.PodIP, "50051"),
+				GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+					SecurityContextConfig: v1alpha1.Restricted,
+				},
 			},
 		}
 
@@ -702,6 +705,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
 				Image:      communityOperatorsImage,
+				GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+					SecurityContextConfig: v1alpha1.Restricted,
+				},
 			},
 		}
 
@@ -830,6 +836,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
 				Image:      image,
+				GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+					SecurityContextConfig: v1alpha1.Restricted,
+				},
 				UpdateStrategy: &v1alpha1.UpdateStrategy{
 					RegistryPoll: &v1alpha1.RegistryPoll{
 						// Using RawInterval rather than Interval due to this issue:
@@ -1014,6 +1023,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
 				Image:      catSrcImage + ":1.0.0-with-ListBundles-method",
+				GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+					SecurityContextConfig: v1alpha1.Restricted,
+				},
 			},
 		}
 
@@ -1117,6 +1129,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
 					Image:      "quay.io/olmtest/catsrc-update-test:new",
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Restricted,
+					},
 					UpdateStrategy: &v1alpha1.UpdateStrategy{
 						RegistryPoll: &v1alpha1.RegistryPoll{
 							RawInterval: "45s",
@@ -1195,6 +1210,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
 					Image:      "quay.io/olmtest/catsrc-update-test:new",
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Restricted,
+					},
 					UpdateStrategy: &v1alpha1.UpdateStrategy{
 						RegistryPoll: &v1alpha1.RegistryPoll{
 							RawInterval: incorrectInterval,
@@ -1274,6 +1292,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
 				Image:      "quay.io/olmtest/catsrc-update-test:old",
+				GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+					SecurityContextConfig: v1alpha1.Restricted,
+				},
 			},
 		}
 
@@ -1511,11 +1532,11 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 						Labels:    map[string]string{"olm.catalogSource": sourceName},
 					},
 					Spec: v1alpha1.CatalogSourceSpec{
+						SourceType: v1alpha1.SourceTypeGrpc,
+						Image:      "quay.io/olmtest/old-opm-catsrc:v1.21.0",
 						GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 							SecurityContextConfig: operatorsv1alpha1.Legacy,
 						},
-						SourceType: v1alpha1.SourceTypeGrpc,
-						Image:      "quay.io/olmtest/old-opm-catsrc:v1.21.0",
 					},
 				}
 

--- a/test/e2e/catalog_exclusion_test.go
+++ b/test/e2e/catalog_exclusion_test.go
@@ -54,6 +54,9 @@ var _ = Describe("Global Catalog Exclusion", func() {
 				DisplayName: "Broken Global Catalog Source",
 				SourceType:  v1alpha1.SourceTypeGrpc,
 				Address:     "1.1.1.1:1337", // points to non-existing service
+				GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+					SecurityContextConfig: v1alpha1.Restricted,
+				},
 			},
 		}
 		_ = determinedE2eClient.Create(context.Background(), globalCatalog)

--- a/test/e2e/catsrc_pod_config_e2e_test.go
+++ b/test/e2e/catsrc_pod_config_e2e_test.go
@@ -56,6 +56,9 @@ var _ = Describe("CatalogSource Grpc Pod Config", func() {
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
 					Image:      "repo/image:tag",
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Restricted,
+					},
 				},
 			}
 		})
@@ -78,7 +81,8 @@ var _ = Describe("CatalogSource Grpc Pod Config", func() {
 
 			// create catalog source
 			catalogSource.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
-				PriorityClassName: &overridenPriorityClassName,
+				PriorityClassName:     &overridenPriorityClassName,
+				SecurityContextConfig: v1alpha1.Restricted,
 			}
 			mustCreateCatalogSource(client, catalogSource)
 
@@ -95,7 +99,8 @@ var _ = Describe("CatalogSource Grpc Pod Config", func() {
 
 			// create catalog source
 			catalogSource.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
-				PriorityClassName: &overridenPriorityClassName,
+				PriorityClassName:     &overridenPriorityClassName,
+				SecurityContextConfig: v1alpha1.Restricted,
 			}
 			mustCreateCatalogSource(client, catalogSource)
 
@@ -115,7 +120,8 @@ var _ = Describe("CatalogSource Grpc Pod Config", func() {
 
 			// create catalog source
 			catalogSource.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
-				NodeSelector: overridenNodeSelector,
+				NodeSelector:          overridenNodeSelector,
+				SecurityContextConfig: v1alpha1.Restricted,
 			}
 			mustCreateCatalogSource(client, catalogSource)
 
@@ -145,7 +151,8 @@ var _ = Describe("CatalogSource Grpc Pod Config", func() {
 
 			// create catalog source
 			catalogSource.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
-				Tolerations: overriddenTolerations,
+				Tolerations:           overriddenTolerations,
+				SecurityContextConfig: v1alpha1.Restricted,
 			}
 			mustCreateCatalogSource(client, catalogSource)
 

--- a/test/e2e/dynamic_resource_e2e_test.go
+++ b/test/e2e/dynamic_resource_e2e_test.go
@@ -68,6 +68,9 @@ var _ = Describe("Subscriptions create required objects from Catalogs", func() {
 						Spec: v1alpha1.CatalogSourceSpec{
 							Image:      "quay.io/olmtest/catsrc_dynamic_resources:e2e-test",
 							SourceType: v1alpha1.SourceTypeGrpc,
+							GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+								SecurityContextConfig: v1alpha1.Restricted,
+							},
 						},
 					}
 

--- a/test/e2e/gc_e2e_test.go
+++ b/test/e2e/gc_e2e_test.go
@@ -350,6 +350,9 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
 					Image:      imageName,
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Restricted,
+					},
 				},
 			}
 
@@ -470,6 +473,9 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
 					Image:      imageName,
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Restricted,
+					},
 				},
 			}
 
@@ -585,6 +591,9 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
 					Image:      imageName,
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Restricted,
+					},
 				},
 			}
 

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -3089,6 +3089,9 @@ var _ = Describe("Install Plan", func() {
 			Spec: operatorsv1alpha1.CatalogSourceSpec{
 				Image:      "quay.io/operator-framework/ci-index:latest",
 				SourceType: operatorsv1alpha1.SourceTypeGrpc,
+				GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+					SecurityContextConfig: operatorsv1alpha1.Restricted,
+				},
 			},
 		}
 		catsrc, err = crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Create(context.Background(), catsrc, metav1.CreateOptions{})
@@ -3245,6 +3248,9 @@ var _ = Describe("Install Plan", func() {
 					Spec: operatorsv1alpha1.CatalogSourceSpec{
 						SourceType: operatorsv1alpha1.SourceTypeGrpc,
 						Address:    dependentCatalogSource.Status.RegistryServiceStatus.Address(),
+						GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+							SecurityContextConfig: operatorsv1alpha1.Restricted,
+						},
 					},
 				}
 				addressSource.SetName(genName("alt-dep-"))
@@ -3419,6 +3425,9 @@ var _ = Describe("Install Plan", func() {
 				Spec: operatorsv1alpha1.CatalogSourceSpec{
 					Image:      "localhost:0/not/exist:catsrc",
 					SourceType: operatorsv1alpha1.SourceTypeGrpc,
+					GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+						SecurityContextConfig: operatorsv1alpha1.Restricted,
+					},
 				},
 			}
 			Eventually(func() error {
@@ -3633,6 +3642,9 @@ var _ = Describe("Install Plan", func() {
 			Spec: operatorsv1alpha1.CatalogSourceSpec{
 				Image:      "quay.io/operator-framework/ci-index:latest",
 				SourceType: operatorsv1alpha1.SourceTypeGrpc,
+				GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+					SecurityContextConfig: operatorsv1alpha1.Restricted,
+				},
 			},
 		}
 		catsrc, err = crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Create(context.Background(), catsrc, metav1.CreateOptions{})

--- a/test/e2e/magic_catalog.go
+++ b/test/e2e/magic_catalog.go
@@ -247,6 +247,9 @@ func (c *MagicCatalog) makeCatalogSource() *operatorsv1alpha1.CatalogSource {
 		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: operatorsv1alpha1.SourceTypeGrpc,
 			Address:    fmt.Sprintf("%s.%s.svc:50051", c.serviceName, c.namespace),
+			GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+				SecurityContextConfig: operatorsv1alpha1.Restricted,
+			},
 		},
 	}
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -267,6 +267,9 @@ var _ = Describe("Operator API", func() {
 				Spec: operatorsv1alpha1.CatalogSourceSpec{
 					SourceType: operatorsv1alpha1.SourceTypeGrpc,
 					Image:      "quay.io/operator-framework/ci-index:latest",
+					GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+						SecurityContextConfig: operatorsv1alpha1.Restricted,
+					},
 				},
 			}
 			cs.SetNamespace(ns.GetName())

--- a/test/e2e/packagemanifest_e2e_test.go
+++ b/test/e2e/packagemanifest_e2e_test.go
@@ -227,6 +227,9 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 					SourceType:  v1alpha1.SourceTypeGrpc,
 					Image:       image,
 					DisplayName: displayName,
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Restricted,
+					},
 				},
 			}
 

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -773,6 +773,9 @@ var _ = Describe("Subscription", func() {
 						},
 						Spec: operatorsv1alpha1.CatalogSourceSpec{
 							SourceType: "goose",
+							GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+								SecurityContextConfig: operatorsv1alpha1.Restricted,
+							},
 						},
 					}
 
@@ -832,6 +835,9 @@ var _ = Describe("Subscription", func() {
 						},
 						Spec: operatorsv1alpha1.CatalogSourceSpec{
 							SourceType: operatorsv1alpha1.SourceTypeGrpc,
+							GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+								SecurityContextConfig: operatorsv1alpha1.Restricted,
+							},
 						},
 					}
 
@@ -889,6 +895,9 @@ var _ = Describe("Subscription", func() {
 						},
 						Spec: operatorsv1alpha1.CatalogSourceSpec{
 							SourceType: operatorsv1alpha1.SourceTypeInternal,
+							GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+								SecurityContextConfig: operatorsv1alpha1.Restricted,
+							},
 						},
 					}
 
@@ -942,6 +951,9 @@ var _ = Describe("Subscription", func() {
 						},
 						Spec: operatorsv1alpha1.CatalogSourceSpec{
 							SourceType: operatorsv1alpha1.SourceTypeInternal,
+							GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+								SecurityContextConfig: operatorsv1alpha1.Restricted,
+							},
 						},
 					}
 
@@ -2528,6 +2540,9 @@ var (
 		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: "internal",
 			ConfigMap:  catalogConfigMapName,
+			GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+				SecurityContextConfig: operatorsv1alpha1.Restricted,
+			},
 		},
 	}
 )

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -582,6 +582,9 @@ func createInvalidGRPCCatalogSource(c operatorclient.ClientInterface, crc versio
 		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: "grpc",
 			Image:      "localhost:0/not/exists:catsrc",
+			GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+				SecurityContextConfig: operatorsv1alpha1.Restricted,
+			},
 		},
 	}
 
@@ -616,6 +619,9 @@ func createInternalCatalogSource(
 		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: "internal",
 			ConfigMap:  configMap.GetName(),
+			GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+				SecurityContextConfig: operatorsv1alpha1.Restricted,
+			},
 		},
 	}
 
@@ -657,6 +663,9 @@ func createInternalCatalogSourceWithPriority(c operatorclient.ClientInterface,
 			SourceType: "internal",
 			ConfigMap:  configMap.GetName(),
 			Priority:   priority,
+			GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+				SecurityContextConfig: operatorsv1alpha1.Restricted,
+			},
 		},
 	}
 	catalogSource.SetNamespace(namespace)
@@ -700,6 +709,9 @@ func createV1CRDInternalCatalogSource(
 		Spec: operatorsv1alpha1.CatalogSourceSpec{
 			SourceType: "internal",
 			ConfigMap:  configMap.GetName(),
+			GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+				SecurityContextConfig: operatorsv1alpha1.Restricted,
+			},
 		},
 	}
 	catalogSource.SetNamespace(namespace)

--- a/test/e2e/webhook_e2e_test.go
+++ b/test/e2e/webhook_e2e_test.go
@@ -669,6 +669,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 				Spec: operatorsv1alpha1.CatalogSourceSpec{
 					SourceType: operatorsv1alpha1.SourceTypeGrpc,
 					Image:      catSrcImage + ":0.0.3",
+					GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+						SecurityContextConfig: operatorsv1alpha1.Restricted,
+					},
 				},
 			}
 


### PR DESCRIPTION
With the recent changes to default to legacy mode, some distributions of OLM are unable to run as the catalogSources are running in legacy mode in restricted namespaces.

This commit configures the catalogSource pods in the e2e suite to run in restricted mode.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>