### PR TITLE
Workaround server-side apply not working

### DIFF
--- a/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -54,6 +54,7 @@ spec:
         imagePullPolicy: {{ .Values.package.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.package.service.internalPort }}
+          protocol: TCP
         livenessProbe:
           httpGet:
             scheme: HTTPS


### PR DESCRIPTION
**Description of the change:**

Explicitly set container port protocol to `TCP`.

NB: This should have been fixed already while upgrading to k8s 1.20 (see https://github.com/kubernetes/kubernetes/issues/92332 and probably https://github.com/kubernetes/kubernetes/commit/d3e641e84ec9e5a9e551ef394509f65c6e6782b6). Is there some tooling issue?

**Motivation for the change:**

Fixes:

```
error calculating structured merge diff:
error building typed value from config resource:
.spec.install.spec.deployments[0].spec.template.spec.containers[0].ports: element 0: associative list with keys has an element that omits key field "protocol" (and doesn't have default value)
```

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted

