### PR TITLE
OCPBUGS-5523: Catalog, fatal error: concurrent map read and map write

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -209,7 +209,7 @@ var (
 // protected by mutex.
 type subscriptionSyncCounter struct {
 	counters     map[string]subscriptionSyncLabelValues
-	countersLock sync.Mutex
+	countersLock sync.RWMutex
 }
 
 func newSubscriptionSyncCounter() subscriptionSyncCounter {
@@ -225,8 +225,8 @@ func (s *subscriptionSyncCounter) setValues(key string, val subscriptionSyncLabe
 }
 
 func (s *subscriptionSyncCounter) readValues(key string) (subscriptionSyncLabelValues, bool) {
-	s.countersLock.Lock()
-	defer s.countersLock.Unlock()
+	s.countersLock.RLock()
+	defer s.countersLock.RUnlock()
 	val, ok := s.counters[key]
 	return val, ok
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -200,25 +200,31 @@ var (
 		},
 	)
 
-	subscriptionSyncCounters subscriptionSync
+	subscriptionSyncCounters = newSubscriptionSyncCounter()
 )
 
-// subscriptionSyncCounters keeps a record of the Prometheus counters emitted by
+// subscriptionSyncCounter keeps a record of the Prometheus counters emitted by
 // Subscription objects. The key of a record is the Subscription name, while the value
 // is struct containing label values used in the counter. Read and Write access are
 // protected by mutex.
-type subscriptionSync struct {
+type subscriptionSyncCounter struct {
 	counters     map[string]subscriptionSyncLabelValues
 	countersLock sync.Mutex
 }
 
-func (s *subscriptionSync) setValues(key string, val subscriptionSyncLabelValues) {
+func newSubscriptionSyncCounter() subscriptionSyncCounter {
+	return subscriptionSyncCounter{
+		counters: make(map[string]subscriptionSyncLabelValues),
+	}
+}
+
+func (s *subscriptionSyncCounter) setValues(key string, val subscriptionSyncLabelValues) {
 	s.countersLock.Lock()
 	defer s.countersLock.Unlock()
 	s.counters[key] = val
 }
 
-func (s *subscriptionSync) readValues(key string) (subscriptionSyncLabelValues, bool) {
+func (s *subscriptionSyncCounter) readValues(key string) (subscriptionSyncLabelValues, bool) {
 	s.countersLock.Lock()
 	defer s.countersLock.Unlock()
 	val, ok := s.counters[key]


### PR DESCRIPTION
Protected subscriptionSyncCounters access to prevent concurrent map writes

**Description of the change:**

The metrics pkg uses a shared map var which is not protected from concurrent read/write access. This PR adds a mutex to lock and unlock before and after each map access instance. 

**Motivation for the change:**

OCPBUGS-5523
