### PR TITLE
Run community catalogSource in restricted mode

### DIFF
--- a/deploy/chart/templates/0000_50_olm_17-upstream-operators.catalogsource.yaml
+++ b/deploy/chart/templates/0000_50_olm_17-upstream-operators.catalogsource.yaml
@@ -9,6 +9,8 @@ spec:
   image: quay.io/operatorhubio/catalog:latest
   displayName: Community Operators
   publisher: OperatorHub.io
+  grpcPodConfig:
+    securityContextConfig: restricted
   updateStrategy:
     registryPoll:
       interval: 60m


### PR DESCRIPTION
Problem: The helm template that defines the community catalogSource hasn't been updated to run the catalogSource in the restricted mode, causing the associated pod not to run.

Solution: Update the helm template to configure the community catalogSource in restricted mode.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>
