### PR TITLE
OCPBUGS-672: Catalog Pod Startup Probe Timeout

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -162,8 +162,9 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name string, img string, saNam
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
-						FailureThreshold: 15,
+						FailureThreshold: 10,
 						PeriodSeconds:    10,
+						TimeoutSeconds:   5,
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{


### PR DESCRIPTION
**Description of the change:**

Updates the Startup Probe timeoutSeconds for catalog pods to be consistent with the timeouts in the readiness and liveness probes as the default of 1s can be too low in some cases. Also adjusted the failure threshold in order to maintain the ~150s startup time failure as originally designed (timeout of 5s + period of 10s = 15s per attempt * 10 failures = 150s).

**Motivation for the change:**

OCPBUGS-672
