### PR TITLE
OCPBUGS-6016: UpdateStrategy RegistryPoll with nil Interval

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -749,16 +749,19 @@ func (o *Operator) syncRegistryServer(logger *logrus.Entry, in *v1alpha1.Catalog
 	logger.Debug("ensured registry server")
 
 	// requeue the catalog sync based on the polling interval, for accurate syncs of catalogs with polling enabled
-	if out.Spec.UpdateStrategy != nil {
-		if out.Spec.UpdateStrategy.RegistryPoll != nil {
-			if out.Spec.UpdateStrategy.RegistryPoll.ParsingError != "" && out.Status.Reason != v1alpha1.CatalogSourceIntervalInvalidError {
-				out.SetError(v1alpha1.CatalogSourceIntervalInvalidError, fmt.Errorf(out.Spec.UpdateStrategy.RegistryPoll.ParsingError))
-			}
-			logger.Debugf("requeuing registry server sync based on polling interval %s", out.Spec.UpdateStrategy.Interval.Duration.String())
-			resyncPeriod := reconciler.SyncRegistryUpdateInterval(out, time.Now())
-			o.catsrcQueueSet.RequeueAfter(out.GetNamespace(), out.GetName(), queueinformer.ResyncWithJitter(resyncPeriod, 0.1)())
+	if out.Spec.UpdateStrategy != nil && out.Spec.UpdateStrategy.RegistryPoll != nil {
+		if out.Spec.UpdateStrategy.Interval == nil {
+			syncError = fmt.Errorf("empty polling interval; cannot requeue registry server sync without a provided polling interval")
+			out.SetError(v1alpha1.CatalogSourceIntervalInvalidError, syncError)
 			return
 		}
+		if out.Spec.UpdateStrategy.RegistryPoll.ParsingError != "" && out.Status.Reason != v1alpha1.CatalogSourceIntervalInvalidError {
+			out.SetError(v1alpha1.CatalogSourceIntervalInvalidError, fmt.Errorf(out.Spec.UpdateStrategy.RegistryPoll.ParsingError))
+		}
+		logger.Debugf("requeuing registry server sync based on polling interval %s", out.Spec.UpdateStrategy.Interval.Duration.String())
+		resyncPeriod := reconciler.SyncRegistryUpdateInterval(out, time.Now())
+		o.catsrcQueueSet.RequeueAfter(out.GetNamespace(), out.GetName(), queueinformer.ResyncWithJitter(resyncPeriod, 0.1)())
+		return
 	}
 
 	if err := o.sources.Remove(sourceKey); err != nil {


### PR DESCRIPTION
**Description of the change:**

Adds protection against a nil-pointer panic when an UpdateStrategy with nil value for RegistryPoll Interval is supplied. Also adds a unit test to ensure that the code does not panic but instead returns an error when this situation is encountered.

**Motivation for the change:**

OCPBUGS-6016