### PR TITLE
Bump Fedora Version for Builder Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:34-x86_64 as builder
+FROM quay.io/fedora/fedora:37-x86_64 as builder
 LABEL stage=builder
 WORKDIR /build
 


### PR DESCRIPTION
Bumps the fedora version up to 37.

Signed-off-by: Daniel Franz <dfranz@redhat.com>