### PR TITLE
Registry Pod Controller Flag

### DIFF
--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -1808,7 +1808,7 @@ func toManifest(t *testing.T, obj runtime.Object) string {
 
 func pod(s v1alpha1.CatalogSource) *corev1.Pod {
 	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetName(), s.GetLabels(), s.GetAnnotations(), 5, 10, 1001)
-	ownerutil.AddOwner(pod, &s, false, false)
+	ownerutil.AddOwner(pod, &s, false, true)
 	return pod
 }
 

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -105,7 +105,7 @@ func (s *configMapCatalogSourceDecorator) Pod(image string) *corev1.Pod {
 	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5, s.runAsUser)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
-	ownerutil.AddOwner(pod, s.CatalogSource, false, false)
+	ownerutil.AddOwner(pod, s.CatalogSource, false, true)
 	return pod
 }
 

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -124,7 +124,7 @@ func (s *grpcCatalogSourceDecorator) ServiceAccount() *corev1.ServiceAccount {
 
 func (s *grpcCatalogSourceDecorator) Pod(saName string) *corev1.Pod {
 	pod := Pod(s.CatalogSource, "registry-server", s.Spec.Image, saName, s.Labels(), s.Annotations(), 5, 10, s.createPodAsUser)
-	ownerutil.AddOwner(pod, s.CatalogSource, false, false)
+	ownerutil.AddOwner(pod, s.CatalogSource, false, true)
 	return pod
 }
 


### PR DESCRIPTION
Sets the controller flag on the registry pod owner references to true in an attempt to remove the need for forceful shutdown when draining nodes.
