### PR TITLE
Fixes echo of the current cluster name

### DIFF
--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -22,7 +22,7 @@ if [ -n "$KIND" ]; then
   # kind will use the cluster named kind by default, so if there is only one cluster, specify it
   if [[ ${#CLUSTERS[@]} == 1 ]]; then
     KIND_FLAGS="--name ${CLUSTERS[0]}"
-    echo 'Use cluster ${CLUSTERS[0]}'
+    echo "Use cluster ${CLUSTERS[0]}"
   fi
 
   kind load docker-image quay.io/operator-framework/olm:local ${KIND_FLAGS}


### PR DESCRIPTION
**Description of the change:**

`./scripts/build_local.sh` was not printing the cluster name correctly. The output was `Use cluster ${CLUSTERS[0]}`. Now it does work as initially intended.

**Motivation for the change:**

Minor fix in dev scripts.

**Testing remarks:**

Run `make run-local` or `make build-local` or `make e2e-local-docker` and make sure that output contains something like `Use cluster kind` instead of `Use cluster ${CLUSTERS[0]}`.

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
