### PR TITLE
Fixes CI: makes golangci-lint use Go version from `go.mod`

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -19,7 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run linting checks
-      uses: "golangci/golangci-lint-action@v2"
+    - uses: actions/setup-go@v3
       with:
-        version: "v1.46.0"
+        go-version-file: "go.mod"
+    - name: Run linting checks
+      uses: "golangci/golangci-lint-action@v3"
+      with:
+        version: "v1.50.1"

--- a/pkg/controller/operators/olm/overrides/inject/inject.go
+++ b/pkg/controller/operators/olm/overrides/inject/inject.go
@@ -235,10 +235,12 @@ func InjectNodeSelectorIntoDeployment(podSpec *corev1.PodSpec, nodeSelector map[
 // with the given corev1.Affinity. Any nil top-level sub-attributes (e.g. NodeAffinity, PodAffinity, and PodAntiAffinity)
 // will be ignored. Hint: to overwrite those top-level attributes, empty them out. I.e. use the empty/default object ({})
 // e.g. NodeAffinity{}. In yaml:
-// affinity:
-//   nodeAffinity: {}
-//   podAffinity: {}
-//   podAntiAffinity: {}
+//
+//	affinity:
+//	  nodeAffinity: {}
+//	  podAffinity: {}
+//	  podAntiAffinity: {}
+//
 // will completely remove the deployment podSpec.affinity and is equivalent to
 // affinity: {}
 func OverrideDeploymentAffinity(podSpec *corev1.PodSpec, affinity *corev1.Affinity) error {


### PR DESCRIPTION
**Description of the change:**

* Makes `.github/workflows/sanity.yaml` use go version from `go.mod` for runing linter
* Updates `golangci-lint` to the version which supports Go 1.19.

Note that I did not update `golangci-lint` to the latest version as it adds more issues which need extra attention/configuration and not necessary to makeing CI work again (e.g. `loopclosure: loop variable tt captured by func literal` for [tests like this one](https://github.com/operator-framework/operator-lifecycle-manager/blob/783bebf6d4811c0b36eabaa5e58a05a000a1dbfc/pkg/controller/operators/catalog/operator_test.go#L230-L250)).

**Motivation for the change:**

Currently the sanity workflow fails due to Go 1.20 being used. This PR makes sure that we use go version specified in `go.mod` to run `golangci-lint`.


Current failure example:

```
  Running [/home/runner/golangci-lint-1.46.0-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
  
  goroutine 1 [running]:
  github.com/go-critic/go-critic/checkers.init.22()
  	github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
  
  Error: golangci-lint exit with code 2
  Ran golangci-lint in 12114ms
```

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

`sanity` should use go version from `go.mod` (1.19 at the moment) and should not fail.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted
