### PR TITLE
Updates `syncResolvingNamespace` tests

### DIFF
--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -25,14 +25,11 @@ func TestSyncSubscriptions(t *testing.T) {
 	testNamespace := "testNamespace"
 
 	type fields struct {
-		clientOptions     []clientfake.Option
-		sourcesLastUpdate metav1.Time
-		resolveSteps      []*v1alpha1.Step
-		resolveSubs       []*v1alpha1.Subscription
-		bundleLookups     []v1alpha1.BundleLookup
-		resolveErr        error
-		existingOLMObjs   []runtime.Object
-		existingObjects   []runtime.Object
+		clientOptions        []clientfake.Option
+		resolveSteps         []*v1alpha1.Step
+		resolveSubs          []*v1alpha1.Subscription
+		resolveBundleLookups []v1alpha1.BundleLookup
+		existingOLMObjs      []runtime.Object
 	}
 	type args struct {
 		obj interface{}
@@ -378,7 +375,7 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 					},
 				},
-				bundleLookups: []v1alpha1.BundleLookup{
+				resolveBundleLookups: []v1alpha1.BundleLookup{
 					{
 						Path:       "bundle-path-a",
 						Identifier: "bundle-a",
@@ -1016,7 +1013,7 @@ func TestSyncSubscriptions(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 
-			o, err := NewFakeOperator(ctx, testNamespace, []string{testNamespace}, withClock(clockFake), withClientObjs(tt.fields.existingOLMObjs...), withK8sObjs(tt.fields.existingObjects...), withFakeClientOptions(tt.fields.clientOptions...))
+			o, err := NewFakeOperator(ctx, testNamespace, []string{testNamespace}, withClock(clockFake), withClientObjs(tt.fields.existingOLMObjs...), withFakeClientOptions(tt.fields.clientOptions...))
 			require.NoError(t, err)
 
 			o.reconciler = &fakes.FakeRegistryReconcilerFactory{
@@ -1029,10 +1026,9 @@ func TestSyncSubscriptions(t *testing.T) {
 				},
 			}
 
-			o.sourcesLastUpdate.Set(tt.fields.sourcesLastUpdate.Time)
 			o.resolver = &fakes.FakeStepResolver{
 				ResolveStepsStub: func(string) ([]*v1alpha1.Step, []v1alpha1.BundleLookup, []*v1alpha1.Subscription, error) {
-					return tt.fields.resolveSteps, tt.fields.bundleLookups, tt.fields.resolveSubs, tt.fields.resolveErr
+					return tt.fields.resolveSteps, tt.fields.resolveBundleLookups, tt.fields.resolveSubs, nil
 				},
 			}
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

* Makes `TestSyncResolvingNamespace` check the resulting subscription
* Removes unused fields from `TestSyncSubscriptions`

**Motivation for the change:**

I was looking into whether `State` of the `Subscription` changes or not in case of resolution errors and noticed that `TestSyncResolvingNamespace` doesn't validate output sub.

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

None

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

None

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
