### PR TITLE
Option to skip the local role lift for the global operator group

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -476,7 +476,7 @@ func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersi
 	logger := a.logger.WithField("opgroup", operatorGroup.GetName()).WithField("csv", csv.GetName())
 
 	// if OperatorGroup is global (all namespaces) we generate cluster roles / cluster role bindings instead
-	if len(targetNamespaces) == 1 && targetNamespaces[0] == corev1.NamespaceAll {
+	if len(targetNamespaces) == 1 && targetNamespaces[0] == corev1.NamespaceAll && csv.Annotations["olm.skipLocalRoleLiftForGlobalOperatorGroup"] != "yes" {
 		logger.Debug("opgroup is global")
 
 		// synthesize cluster permissions to verify rbac


### PR DESCRIPTION
**Note**
It's just a draft which can be a starting point for the further discussion.

**Description of the change:**
Ability to skip the lifting of the local roles to the cluster level for the global operator group if a special annotation is set on CSV.

**Motivation for the change:**
The operators are forced to migrate to `AllNamespaces` installmode when they start to use the conversion webhook. This may be undesirable for some of the operators, especially for those which were designed to not be the cluster level operators. The allnamespaces installmode has a very inconvenient side effect of lifting the local permissions specified in CSV to the cluster level. This may give excessive permissions to the operator.

**Architectural changes:**
The default behavior is the same as before, the new annotation can be applied optionally to those operators which wish to opt out of the local roles lifting.

**Testing remarks:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted
