### PR TITLE
Moves bundle unpack timeout into OperatorGroup

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -89,21 +89,20 @@ func objectRefToNamespacedName(ip *corev1.ObjectReference) types.NamespacedName 
 	}
 }
 
-// addBundleUnpackTimeoutIPAnnotation is a helper function that's responsible for
-// adding the "operatorframework.io/bundle-unpack-timeout" annotation to an InstallPlan
-// resource. This allows you to have more control over the bundle unpack timeout when interacting
-// with test InstallPlan resources.
-func addBundleUnpackTimeoutIPAnnotation(ctx context.Context, c k8scontrollerclient.Client, ipNN types.NamespacedName, timeout string) {
+// addBundleUnpackTimeoutOGAnnotation is a helper function that's responsible for
+// adding the "operatorframework.io/bundle-unpack-timeout" annotation to an OperatorGroup
+// resource.
+func addBundleUnpackTimeoutOGAnnotation(ctx context.Context, c k8scontrollerclient.Client, ogNN types.NamespacedName, timeout string) {
 	Eventually(func() error {
-		ip := &operatorsv1alpha1.InstallPlan{}
-		if err := c.Get(ctx, ipNN, ip); err != nil {
+		og := &operatorsv1.OperatorGroup{}
+		if err := c.Get(ctx, ogNN, og); err != nil {
 			return err
 		}
-		annotations := make(map[string]string)
+		annotations := og.GetAnnotations()
 		annotations[bundle.BundleUnpackTimeoutAnnotationKey] = timeout
-		ip.SetAnnotations(annotations)
+		og.SetAnnotations(annotations)
 
-		return c.Update(ctx, ip)
+		return c.Update(ctx, og)
 	}).Should(Succeed())
 }
 


### PR DESCRIPTION
**Description of the change:**

Moves `operatorframework.io/bundle-unpack-timeout` annotation from `InstallPlan` to `OperatorGroup`

**Motivation for the change:**

`operatorframework.io/bundle-unpack-timeout` is an internal annotation used for E2E testing.

We need to move this out of `InstallPlan` in preparation to changes in the unpacking process (see #2942): OLM will soon be creating unpack jobs before creating `InstallPlan` so we need to find a new place where we can set this annotation.


**Testing remarks:**

Updates existing E2E tests

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
