### PR TITLE
Add architecture tolerations to bundleUnpacker job

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -211,6 +211,28 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 					NodeSelector: map[string]string{
 						"kubernetes.io/os": "linux",
 					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "kubernetes.io/arch",
+							Value:    "amd64",
+							Operator: "Equal",
+						},
+						{
+							Key:      "kubernetes.io/arch",
+							Value:    "arm64",
+							Operator: "Equal",
+						},
+						{
+							Key:      "kubernetes.io/arch",
+							Value:    "ppc64le",
+							Operator: "Equal",
+						},
+						{
+							Key:      "kubernetes.io/arch",
+							Value:    "s390x",
+							Operator: "Equal",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -337,6 +337,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
+									Tolerations: []corev1.Toleration{
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "amd64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "arm64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "ppc64le",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "s390x",
+											Operator: "Equal",
+										},
+									},
 								},
 							},
 						},
@@ -541,6 +563,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									},
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
+									},
+									Tolerations: []corev1.Toleration{
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "amd64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "arm64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "ppc64le",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "s390x",
+											Operator: "Equal",
+										},
 									},
 								},
 							},
@@ -788,6 +832,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
+									Tolerations: []corev1.Toleration{
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "amd64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "arm64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "ppc64le",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "s390x",
+											Operator: "Equal",
+										},
+									},
 								},
 							},
 						},
@@ -1028,6 +1094,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
+									Tolerations: []corev1.Toleration{
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "amd64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "arm64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "ppc64le",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "s390x",
+											Operator: "Equal",
+										},
+									},
 								},
 							},
 						},
@@ -1237,6 +1325,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									},
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
+									},
+									Tolerations: []corev1.Toleration{
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "amd64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "arm64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "ppc64le",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "s390x",
+											Operator: "Equal",
+										},
 									},
 								},
 							},
@@ -1458,6 +1568,28 @@ func TestConfigMapUnpacker(t *testing.T) {
 									},
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
+									},
+									Tolerations: []corev1.Toleration{
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "amd64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "arm64",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "ppc64le",
+											Operator: "Equal",
+										},
+										{
+											Key:      "kubernetes.io/arch",
+											Value:    "s390x",
+											Operator: "Equal",
+										},
 									},
 								},
 							},


### PR DESCRIPTION
**Description of the change:**
Adds tolerations for architecture taints to the bundleUnpacker job. These tolerations allow the bundleUnpacker job to be scheduled on nodes that have taints for their architecture (eg. ARM clusters on GKE have a `kubernetes.io/arch: "arm64"` taint.
**Motivation for the change:**
The OPM image that the bundleUnpacker job uses supports `amd64`, `arm64`, `ppc64le`, and `s390x` architectures, however the job manifest doesn't tolerate the `kubernetes.io/arch` taint for these architectures, so the bundleUnpacker won't be scheduled on nodes with this taint. This fixes that issue so now the bundleUnpacker works on ARM clusters.
**Architectural changes:**
None
**Testing remarks:**
Updated the unit test.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted
