### PR TITLE
Correct spelling typo in CSVAnormalOver30Min alert desc

### DIFF
--- a/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
+++ b/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
@@ -29,7 +29,7 @@ spec:
           namespace: "{{ "{{ $labels.namespace }}" }}"
         annotations:
           summary: CSV abnormal for over 30 minutes
-          description: Fires whenever a CSV is in the Replacing, Pending, Deleting, or Unkown phase for more than 30 minutes.
+          description: Fires whenever a CSV is in the Replacing, Pending, Deleting, or Unknown phase for more than 30 minutes.
           message: Failed to install Operator {{ printf "{{ $labels.name }}"  }} version {{ printf "{{ $labels.version }}"  }}. Phase-{{ printf "{{ $labels.phase }}" }} Reason-{{ printf "{{ $labels.reason }}" }}
   - name: olm.installplan.rules
     rules:


### PR DESCRIPTION
This PR just corrects a very minor typo in the description of the `CSVAbnormalOver30Min` alert, which shows up noticably in the console when firing.