### PR TITLE
Retry initialization error conditions

### DIFF
--- a/pkg/lib/operatorstatus/monitor.go
+++ b/pkg/lib/operatorstatus/monitor.go
@@ -129,9 +129,18 @@ func (m *monitor) Run(stopCh <-chan struct{}) {
 	m.logger.Infof("initializing clusteroperator resource(s) for %s", m.names)
 
 	for _, name := range m.names {
-		if err := m.init(name); err != nil {
-			m.logger.Errorf("initialization error - %v", err)
-			break
+		for {
+			if err := m.init(name); err != nil {
+				m.logger.Errorf("initialization error - %v", err)
+			} else {
+				m.logger.Infof("initialized cluster resource - %s", name)
+				break
+			}
+			select {
+			case <-time.After(defaultProbeInterval):
+			case <-stopCh:
+				return
+			}
 		}
 	}
 

--- a/pkg/lib/queueinformer/queueinformer_operator_test.go
+++ b/pkg/lib/queueinformer/queueinformer_operator_test.go
@@ -78,7 +78,7 @@ func TestOperatorRunChannelClosure(t *testing.T) {
 
 			o.Run(ctx)
 
-			timeout := time.After(time.Second)
+			timeout := time.After(2 * defaultServerVersionInterval)
 			for n, ch := range map[string]<-chan struct{}{
 				"ready": o.Ready(),
 				"done":  o.Done(),


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

When the api server is flakey (e.g. during a cluster install), it is possible for some of the OLM initialization to fail. When this happens, OLM gets into a bad state (e.g. a monitoring go routine terminates) and can't recover without a restart.

There were at least two places I found where a retry mechanism is needed to handle intialization errors. This was as far as I peeled the onion. It's not an exponential backoff retry, but a 1 minute retry interval should be sufficient (no other backoffs are exponential).

**Motivation for the change:**

Downstream bug report.

**Architectural changes:**

None.

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
