### PR TITLE
[WIP] refactor operator group cluster role name

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -298,18 +298,6 @@ func NewFakeOperator(ctx context.Context, options ...fakeOperatorOption) (*Opera
 	k8sClientFake.Resources = apiResourcesForObjects(append(config.extObjs, config.regObjs...))
 	k8sClientFake.PrependReactor("*", "*", clienttesting.ReactionFunc(func(action clienttesting.Action) (bool, runtime.Object, error) {
 		*config.actionLog = append(*config.actionLog, action)
-		switch action.GetVerb() {
-		case "create":
-			a := action.(clienttesting.CreateAction)
-			m := a.GetObject().(metav1.Object)
-
-			// create a name if generateName is set
-			if m.GetGenerateName() != "" {
-				m.SetName(m.GetGenerateName() + "xxxxx")
-				m.SetGenerateName("")
-				return false, a.GetObject(), nil
-			}
-		}
 		return false, nil, nil
 	}))
 	apiextensionsFake := apiextensionsfake.NewSimpleClientset(config.extObjs...)
@@ -4566,7 +4554,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-xxxxx",
+							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4577,7 +4565,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-xxxxx",
+							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4588,7 +4576,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-xxxxx",
+							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4670,7 +4658,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-xxxxx",
+							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4681,7 +4669,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-xxxxx",
+							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4692,7 +4680,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-xxxxx",
+							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4766,7 +4754,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-xxxxx",
+							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4777,7 +4765,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-xxxxx",
+							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4788,7 +4776,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-xxxxx",
+							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4806,7 +4794,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-xxxxx",
+							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4817,7 +4805,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-xxxxx",
+							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4828,7 +4816,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-xxxxx",
+							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -298,6 +298,18 @@ func NewFakeOperator(ctx context.Context, options ...fakeOperatorOption) (*Opera
 	k8sClientFake.Resources = apiResourcesForObjects(append(config.extObjs, config.regObjs...))
 	k8sClientFake.PrependReactor("*", "*", clienttesting.ReactionFunc(func(action clienttesting.Action) (bool, runtime.Object, error) {
 		*config.actionLog = append(*config.actionLog, action)
+		switch action.GetVerb() {
+		case "create":
+			a := action.(clienttesting.CreateAction)
+			m := a.GetObject().(metav1.Object)
+
+			// create a name if generateName is set
+			if m.GetGenerateName() != "" {
+				m.SetName(m.GetGenerateName() + "xxxxx")
+				m.SetGenerateName("")
+				return false, a.GetObject(), nil
+			}
+		}
 		return false, nil, nil
 	}))
 	apiextensionsFake := apiextensionsfake.NewSimpleClientset(config.extObjs...)
@@ -4554,7 +4566,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.admin-d2ededg",
+							Name:            "olm.og.operator-group-1.admin-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4565,7 +4577,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.edit-d2ededg",
+							Name:            "olm.og.operator-group-1.edit-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4576,7 +4588,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.view-d2ededg",
+							Name:            "olm.og.operator-group-1.view-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4589,7 +4601,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 		},
 		{
 			// check that even if cluster roles exist without the naming convention, we create the new ones and leave the old ones unchanged
-			name:          "MatchingNamespace/NoCSVs/UpdatesOldClusterRoles",
+			name:          "MatchingNamespace/NoCSVs/KeepOldClusterRoles",
 			expectedEqual: true,
 			initial: initial{
 				operatorGroup: &operatorsv1.OperatorGroup{
@@ -4658,7 +4670,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.admin-d2ededg",
+							Name:            "olm.og.operator-group-1.admin-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4669,7 +4681,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.edit-d2ededg",
+							Name:            "olm.og.operator-group-1.edit-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4680,7 +4692,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.view-d2ededg",
+							Name:            "olm.og.operator-group-1.view-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4754,7 +4766,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.admin-xxxxx",
+							Name:            "olm.og.operator-group-1.admin-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4765,7 +4777,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.edit-yyyyy",
+							Name:            "olm.og.operator-group-1.edit-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4776,7 +4788,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.view-zzzzz",
+							Name:            "olm.og.operator-group-1.view-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4794,7 +4806,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.admin-xxxxx",
+							Name:            "olm.og.operator-group-1.admin-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4805,7 +4817,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.edit-yyyyy",
+							Name:            "olm.og.operator-group-1.edit-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4816,7 +4828,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "",
-							Name:            "olm.operatorgroup.view-zzzzz",
+							Name:            "olm.og.operator-group-1.view-xxxxx",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -4725,6 +4725,116 @@ func TestSyncOperatorGroups(t *testing.T) {
 			}},
 		},
 		{
+			// ensure that ownership labels are fixed but user labels are preserved
+			name:          "MatchingNamespace/NoCSVs/ClusterRoleOwnershipLabels",
+			expectedEqual: true,
+			initial: initial{
+				operatorGroup: &operatorsv1.OperatorGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "operator-group-1",
+						Namespace: operatorNamespace},
+					Spec: operatorsv1.OperatorGroupSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "app-a"},
+						},
+					},
+				},
+				k8sObjs: []runtime.Object{
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: operatorNamespace,
+						},
+					},
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   targetNamespace,
+							Labels: map[string]string{"app": "app-a"},
+						},
+					},
+					&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "",
+							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
+							Labels: map[string]string{
+								"olm.owner":           "operator-group-1",
+								"olm.owner.namespace": "operator-ns-bob",
+								"olm.owner.kind":      "OperatorGroup",
+								"not.an.olm.label":    "true",
+							},
+						},
+					},
+					&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "",
+							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
+							Labels: map[string]string{
+								"olm.owner":           "operator-group-5",
+								"olm.owner.namespace": "operator-ns",
+								"olm.owner.kind":      "OperatorGroup",
+								"not.an.olm.label":    "false",
+								"another.olm.label":   "or maybe not",
+							},
+						},
+					},
+					&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "",
+							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
+							Labels: map[string]string{
+								"olm.owner":           "operator-group-1",
+								"olm.owner.namespace": "operator-ns",
+								"olm.owner.kind":      "OperatorGroupKind",
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: operatorsv1.OperatorGroupStatus{
+				Namespaces:  []string{targetNamespace},
+				LastUpdated: &now,
+			},
+			final: final{objects: map[string][]runtime.Object{
+				"": {
+					&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "",
+							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
+							Labels: map[string]string{
+								"olm.owner":           "operator-group-1",
+								"olm.owner.namespace": "operator-ns",
+								"olm.owner.kind":      "OperatorGroup",
+								"not.an.olm.label":    "true",
+							},
+						},
+					},
+					&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "",
+							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
+							Labels: map[string]string{
+								"olm.owner":           "operator-group-1",
+								"olm.owner.namespace": "operator-ns",
+								"olm.owner.kind":      "OperatorGroup",
+							},
+						},
+					},
+					&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "",
+							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
+							Labels: map[string]string{
+								"olm.owner":           "operator-group-1",
+								"olm.owner.namespace": "operator-ns",
+								"olm.owner.kind":      "OperatorGroup",
+								"not.an.olm.label":    "false",
+								"another.olm.label":   "or maybe not",
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
 			// if a cluster role exists with the correct name, use that
 			name:          "MatchingNamespace/NoCSVs/DoesNotUpdateClusterRoles",
 			expectedEqual: true,

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -1030,7 +1032,7 @@ func (a *Operator) ensureOpGroupClusterRole(op *operatorsv1.OperatorGroup, suffi
 		}
 
 		// ensure that the labels and aggregation rules are correct
-		if labels.Equals(existingRole.Labels, cp.Labels) && reflect.DeepEqual(existingRole.AggregationRule, aggregationRule) {
+		if labels.Equals(existingRole.Labels, cp.Labels) && equality.Semantic.DeepEqual(existingRole.AggregationRule, aggregationRule) {
 			return nil
 		}
 

--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -2,6 +2,7 @@ package ownerutil
 
 import (
 	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"

--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -2,7 +2,6 @@ package ownerutil
 
 import (
 	"fmt"
-
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -269,6 +268,11 @@ func AdoptableLabels(labels map[string]string, checkName bool, targets ...Owner)
 // CSVOwnerSelector returns a label selector to find generated objects owned by owner
 func CSVOwnerSelector(owner *operatorsv1alpha1.ClusterServiceVersion) labels.Selector {
 	return labels.SelectorFromSet(OwnerLabel(owner, operatorsv1alpha1.ClusterServiceVersionKind))
+}
+
+// OperatorGroupOwnerSelector returns a label selector to find generated objects owned by owner
+func OperatorGroupOwnerSelector(owner *operatorsv1.OperatorGroup) labels.Selector {
+	return labels.SelectorFromSet(OwnerLabel(owner, "OperatorGroup"))
 }
 
 // AddOwner adds an owner to the ownerref list.


### PR DESCRIPTION
**Description of the change:**
In its current implementation, OLM creates three cluster roles for and operator-group: <operator-group name>-admin, <operator-group name>-view, and <operator-group name>-edit.

**Motivation for the change:**
[OCPBUGS-14698](https://issues.redhat.com/browse/OCPBUGS-14698)

**Architectural changes:**

The cluster role name format was changed to: `olm.operatorgroup.{admin|edit | view}`

**Testing remarks:**

When this hits a running cluster, it will abandon the currently existing cluster roles in favor of new ones that respect the new format. This means that additional migration information will need to be provided in documentation.

The unit tests check that the appropriate cluster roles are created whether or not there is a currently existing. E2e tests responsible for the cluster role creation were also updated for the new format.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
