### PR TITLE
Allow cpb to be statically compiled / exempt from FIPS compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ ENV GO111MODULE auto
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
+# Permit the cpb binary to be compiled statically. The Red Hat compiler
+# provided by ART will otherwise force FIPS compliant dynamic compilation.
+ENV GO_COMPLIANCE_EXCLUDE="*util/cpb"
+
 WORKDIR /build
 
 # copy just enough of the git repo to parse HEAD, used to record version in OLM binaries


### PR DESCRIPTION
To be FIPS compliant, all binaries shipped in OCP must be dynamically linked against openssl unless they are specifically exempted (e.g. they do not perform any cryptography). The golang builder images made available for CI by ART will enforce this requirement (overriding any attempt to statically link) unless the binary is identified in this environment variable.
