### PR TITLE
OCPBUGS-17157:  operators/olm: record and expose informers

### DIFF
--- a/pkg/controller/operators/olm/plugins/operator_plugin.go
+++ b/pkg/controller/operators/olm/plugins/operator_plugin.go
@@ -5,15 +5,48 @@ import (
 	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	operatorsv1informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1"
+	operatorsv1alpha1informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1alpha1"
+	operatorsv2informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v2"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 	"github.com/sirupsen/logrus"
+	extensionsv1informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	appsv1informers "k8s.io/client-go/informers/apps/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	rbacv1informers "k8s.io/client-go/informers/rbac/v1"
+	"k8s.io/client-go/metadata/metadatalister"
+	"k8s.io/client-go/tools/cache"
+	apiregistrationv1informers "k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1"
 )
 
 // HostOperator is an extensible and observable operator that hosts the plug-in, i.e. which the plug-in is extending
 type HostOperator interface {
 	queueinformer.ObservableOperator
 	queueinformer.ExtensibleOperator
+	Informers() map[string]*Informers
+}
+
+// Informers exposes informer caches that the host operator has already started, for re-use by plugins.
+type Informers struct {
+	CSVInformer                operatorsv1alpha1informers.ClusterServiceVersionInformer
+	CopiedCSVInformer          cache.SharedIndexInformer
+	CopiedCSVLister            metadatalister.Lister
+	OperatorGroupInformer      operatorsv1informers.OperatorGroupInformer
+	OperatorConditionInformer  operatorsv2informers.OperatorConditionInformer
+	SubscriptionInformer       operatorsv1alpha1informers.SubscriptionInformer
+	DeploymentInformer         appsv1informers.DeploymentInformer
+	RoleInformer               rbacv1informers.RoleInformer
+	RoleBindingInformer        rbacv1informers.RoleBindingInformer
+	SecretInformer             corev1informers.SecretInformer
+	ServiceInformer            corev1informers.ServiceInformer
+	ServiceAccountInformer     corev1informers.ServiceAccountInformer
+	OLMConfigInformer          operatorsv1informers.OLMConfigInformer
+	ClusterRoleInformer        rbacv1informers.ClusterRoleInformer
+	ClusterRoleBindingInformer rbacv1informers.ClusterRoleBindingInformer
+	NamespaceInformer          corev1informers.NamespaceInformer
+	APIServiceInformer         apiregistrationv1informers.APIServiceInformer
+	CRDInformer                extensionsv1informers.CustomResourceDefinitionInformer
 }
 
 // OperatorConfig gives access to required configuration from the host operator


### PR DESCRIPTION
Plugins should re-use informers that the host started, since there's no need to double the number of watches and caches we're doing to reconcile the same set of objects in one process.
