### PR TITLE
reconcile clusteroperator status more frequently

### DIFF
--- a/pkg/lib/operatorstatus/status.go
+++ b/pkg/lib/operatorstatus/status.go
@@ -228,7 +228,7 @@ func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct
 		// if we've reported success, we can sleep longer, otherwise we want to keep watching for
 		// successful
 		if successfulSyncs > 0 {
-			time.Sleep(5 * time.Minute)
+			time.Sleep(25 * time.Second)
 		}
 
 	}, 5*time.Second, stopCh)


### PR DESCRIPTION
Needed for openshift/cluster-kube-apiserver-operator#1423.

If status is modified, the operator must set status to proper values. This ensures that accidents cannot permanently reset status and gives a clear indication that the operator is "live". This came up as important when operators were NOT live, during cert rotations and we had no indication of problems.

Ideally this should happen on every sync (e.g. move this logic to its own crontroller loop, as it was done for the `operator-lifecycle-manager` ) but setting the backoff interval on sucess small enough to avoid triggering the future stale condition controller from flagging these conditions as stale / `Unknown` should be sufficient as a quick fix.