### PR TITLE
OCPBUGS-17157: queueinformer: don't double register informers

### DIFF
--- a/pkg/lib/queueinformer/queueinformer_operator.go
+++ b/pkg/lib/queueinformer/queueinformer_operator.go
@@ -141,6 +141,12 @@ func (o *operator) RegisterInformer(informer cache.SharedIndexInformer) error {
 }
 
 func (o *operator) registerInformer(informer cache.SharedIndexInformer) {
+	// never double-register an informer
+	for i := range o.informers {
+		if o.informers[i] == informer {
+			return
+		}
+	}
 	o.informers = append(o.informers, informer)
 	o.addHasSynced(informer.HasSynced)
 }


### PR DESCRIPTION
The abstraction here doesn't let you re-use an informer without also causing it to be re-registered and re-started, which is invalid.
