### PR TITLE
[chore] Update github.com/emicklei/go-restful/v3 to v3.10.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
+	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
-github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.10.2 h1:hIovbnmBTLjHXkqEBUz3HGpXZdM7ZrE9fJIZIqlJLqE=
+github.com/emicklei/go-restful/v3 v3.10.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=

--- a/vendor/github.com/emicklei/go-restful/v3/CHANGES.md
+++ b/vendor/github.com/emicklei/go-restful/v3/CHANGES.md
@@ -1,5 +1,10 @@
 # Change history of go-restful
 
+## [v3.10.2] - 2023-03-09
+
+- introduced MergePathStrategy to be able to revert behaviour of path concatenation to 3.9.0
+  see comment in Readme how to customize this behaviour.
+
 ## [v3.10.1] - 2022-11-19
 
 - fix broken 3.10.0 by using path package for joining paths

--- a/vendor/github.com/emicklei/go-restful/v3/README.md
+++ b/vendor/github.com/emicklei/go-restful/v3/README.md
@@ -96,6 +96,10 @@ There are several hooks to customize the behavior of the go-restful package.
 - Compression
 - Encoders for other serializers
 - Use [jsoniter](https://github.com/json-iterator/go) by building this package using a build tag, e.g. `go build -tags=jsoniter .` 
+- Use the variable `MergePathStrategy` to change the behaviour of composing the Route path given a root path and a local route path	
+	- versions >= 3.10.1 has set the value to `PathJoinStrategy` that fixes a reported [security issue](https://github.com/advisories/GHSA-r48q-9g5r-8q2h) but may cause your services not to work correctly anymore.
+	- versions <= 3.9 had the behaviour that can be restored in newer versions by setting the value to `TrimSlashStrategy`.
+	- you can set value to a custom implementation (must implement MergePathStrategyFunc)
 
 ## Resources
 

--- a/vendor/github.com/emicklei/go-restful/v3/route_builder.go
+++ b/vendor/github.com/emicklei/go-restful/v3/route_builder.go
@@ -353,8 +353,28 @@ func (b *RouteBuilder) Build() Route {
 	return route
 }
 
-func concatPath(path1, path2 string) string {
-	return path.Join(path1, path2)
+type MergePathStrategyFunc func(rootPath, routePath string) string
+
+var (
+	// behavior >= 3.10
+	PathJoinStrategy = func(rootPath, routePath string) string {
+		return path.Join(rootPath, routePath)
+	}
+
+	// behavior <= 3.9
+	TrimSlashStrategy = func(rootPath, routePath string) string {
+		return strings.TrimRight(rootPath, "/") + "/" + strings.TrimLeft(routePath, "/")
+	}
+
+	// MergePathStrategy is the active strategy for merging a Route path when building the routing of all WebServices.
+	// The value is set to PathJoinStrategy
+	// PathJoinStrategy is a strategy that is more strict [Security - PRISMA-2022-0227]
+	MergePathStrategy = PathJoinStrategy
+)
+
+// merge two paths using the current (package global) merge path strategy.
+func concatPath(rootPath, routePath string) string {
+	return MergePathStrategy(rootPath, routePath)
 }
 
 var anonymousFuncCount int32

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -227,7 +227,7 @@ github.com/docker/go-metrics
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/emicklei/go-restful/v3 v3.10.1
+# github.com/emicklei/go-restful/v3 v3.10.2
 ## explicit; go 1.13
 github.com/emicklei/go-restful/v3
 github.com/emicklei/go-restful/v3/log


### PR DESCRIPTION
Fixes path join issue

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->
