### PR TITLE
retry unpacking jobs on failure

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -1673,7 +1673,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			res, err := unpacker.UnpackBundle(tt.args.lookup, tt.args.annotationTimeout)
+			res, err := unpacker.UnpackBundle(tt.args.lookup, tt.args.annotationTimeout, 0)
 			require.Equal(t, tt.expected.err, err)
 
 			if tt.expected.res == nil {

--- a/pkg/controller/bundle/bundlefakes/fake_unpacker.go
+++ b/pkg/controller/bundle/bundlefakes/fake_unpacker.go
@@ -28,7 +28,7 @@ type FakeUnpacker struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeUnpacker) UnpackBundle(arg1 *v1alpha1.BundleLookup, arg2 time.Duration) (*bundle.BundleUnpackResult, error) {
+func (fake *FakeUnpacker) UnpackBundle(arg1 *v1alpha1.BundleLookup, arg2, arg3 time.Duration) (*bundle.BundleUnpackResult, error) {
 	fake.unpackBundleMutex.Lock()
 	ret, specificReturn := fake.unpackBundleReturnsOnCall[len(fake.unpackBundleArgsForCall)]
 	fake.unpackBundleArgsForCall = append(fake.unpackBundleArgsForCall, struct {

--- a/pkg/controller/bundle/bundlefakes/fake_unpacker.go
+++ b/pkg/controller/bundle/bundlefakes/fake_unpacker.go
@@ -10,11 +10,12 @@ import (
 )
 
 type FakeUnpacker struct {
-	UnpackBundleStub        func(*v1alpha1.BundleLookup, time.Duration) (*bundle.BundleUnpackResult, error)
+	UnpackBundleStub        func(*v1alpha1.BundleLookup, time.Duration, time.Duration) (*bundle.BundleUnpackResult, error)
 	unpackBundleMutex       sync.RWMutex
 	unpackBundleArgsForCall []struct {
 		arg1 *v1alpha1.BundleLookup
 		arg2 time.Duration
+		arg3 time.Duration
 	}
 	unpackBundleReturns struct {
 		result1 *bundle.BundleUnpackResult
@@ -28,17 +29,18 @@ type FakeUnpacker struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeUnpacker) UnpackBundle(arg1 *v1alpha1.BundleLookup, arg2, arg3 time.Duration) (*bundle.BundleUnpackResult, error) {
+func (fake *FakeUnpacker) UnpackBundle(arg1 *v1alpha1.BundleLookup, arg2 time.Duration, arg3 time.Duration) (*bundle.BundleUnpackResult, error) {
 	fake.unpackBundleMutex.Lock()
 	ret, specificReturn := fake.unpackBundleReturnsOnCall[len(fake.unpackBundleArgsForCall)]
 	fake.unpackBundleArgsForCall = append(fake.unpackBundleArgsForCall, struct {
 		arg1 *v1alpha1.BundleLookup
 		arg2 time.Duration
-	}{arg1, arg2})
-	fake.recordInvocation("UnpackBundle", []interface{}{arg1, arg2})
+		arg3 time.Duration
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UnpackBundle", []interface{}{arg1, arg2, arg3})
 	fake.unpackBundleMutex.Unlock()
 	if fake.UnpackBundleStub != nil {
-		return fake.UnpackBundleStub(arg1, arg2)
+		return fake.UnpackBundleStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -53,17 +55,17 @@ func (fake *FakeUnpacker) UnpackBundleCallCount() int {
 	return len(fake.unpackBundleArgsForCall)
 }
 
-func (fake *FakeUnpacker) UnpackBundleCalls(stub func(*v1alpha1.BundleLookup, time.Duration) (*bundle.BundleUnpackResult, error)) {
+func (fake *FakeUnpacker) UnpackBundleCalls(stub func(*v1alpha1.BundleLookup, time.Duration, time.Duration) (*bundle.BundleUnpackResult, error)) {
 	fake.unpackBundleMutex.Lock()
 	defer fake.unpackBundleMutex.Unlock()
 	fake.UnpackBundleStub = stub
 }
 
-func (fake *FakeUnpacker) UnpackBundleArgsForCall(i int) (*v1alpha1.BundleLookup, time.Duration) {
+func (fake *FakeUnpacker) UnpackBundleArgsForCall(i int) (*v1alpha1.BundleLookup, time.Duration, time.Duration) {
 	fake.unpackBundleMutex.RLock()
 	defer fake.unpackBundleMutex.RUnlock()
 	argsForCall := fake.unpackBundleArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeUnpacker) UnpackBundleReturns(result1 *bundle.BundleUnpackResult, result2 error) {

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1112,6 +1112,11 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		return err
 	}
 
+	minUnpackRetryInterval, err := bundle.OperatorGroupBundleUnpackRetryInterval(ogLister)
+	if err != nil {
+		return err
+	}
+
 	// TODO: parallel
 	maxGeneration := 0
 	subscriptionUpdated := false
@@ -1207,7 +1212,7 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		logger.Debug("unpacking bundles")
 
 		var unpacked bool
-		unpacked, steps, bundleLookups, err = o.unpackBundles(namespace, steps, bundleLookups, unpackTimeout)
+		unpacked, steps, bundleLookups, err = o.unpackBundles(namespace, steps, bundleLookups, unpackTimeout, minUnpackRetryInterval)
 		if err != nil {
 			// If the error was fatal capture and fail
 			if olmerrors.IsFatal(err) {
@@ -1664,7 +1669,7 @@ type UnpackedBundleReference struct {
 	Properties             string `json:"properties"`
 }
 
-func (o *Operator) unpackBundles(namespace string, installPlanSteps []*v1alpha1.Step, bundleLookups []v1alpha1.BundleLookup, unpackTimeout time.Duration) (bool, []*v1alpha1.Step, []v1alpha1.BundleLookup, error) {
+func (o *Operator) unpackBundles(namespace string, installPlanSteps []*v1alpha1.Step, bundleLookups []v1alpha1.BundleLookup, unpackTimeout, minUnpackRetryInterval time.Duration) (bool, []*v1alpha1.Step, []v1alpha1.BundleLookup, error) {
 	unpacked := true
 
 	outBundleLookups := make([]v1alpha1.BundleLookup, len(bundleLookups))
@@ -1679,7 +1684,7 @@ func (o *Operator) unpackBundles(namespace string, installPlanSteps []*v1alpha1.
 	var errs []error
 	for i := 0; i < len(outBundleLookups); i++ {
 		lookup := outBundleLookups[i]
-		res, err := o.bundleUnpacker.UnpackBundle(&lookup, unpackTimeout)
+		res, err := o.bundleUnpacker.UnpackBundle(&lookup, unpackTimeout, minUnpackRetryInterval)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1669,7 +1669,7 @@ type UnpackedBundleReference struct {
 	Properties             string `json:"properties"`
 }
 
-func (o *Operator) unpackBundles(namespace string, installPlanSteps []*v1alpha1.Step, bundleLookups []v1alpha1.BundleLookup, unpackTimeout, minUnpackRetryInterval time.Duration) (bool, []*v1alpha1.Step, []v1alpha1.BundleLookup, error) {
+func (o *Operator) unpackBundles(namespace string, installPlanSteps []*v1alpha1.Step, bundleLookups []v1alpha1.BundleLookup, unpackTimeout, unpackRetryInterval time.Duration) (bool, []*v1alpha1.Step, []v1alpha1.BundleLookup, error) {
 	unpacked := true
 
 	outBundleLookups := make([]v1alpha1.BundleLookup, len(bundleLookups))
@@ -1684,7 +1684,7 @@ func (o *Operator) unpackBundles(namespace string, installPlanSteps []*v1alpha1.
 	var errs []error
 	for i := 0; i < len(outBundleLookups); i++ {
 		lookup := outBundleLookups[i]
-		res, err := o.bundleUnpacker.UnpackBundle(&lookup, unpackTimeout, minUnpackRetryInterval)
+		res, err := o.bundleUnpacker.UnpackBundle(&lookup, unpackTimeout, unpackRetryInterval)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/pkg/controller/operators/catalog/subscriptions_test.go
@@ -1172,7 +1172,7 @@ func TestSyncSubscriptions(t *testing.T) {
 			defer cancel()
 
 			fakeBundleUnpacker := &bundlefakes.FakeUnpacker{
-				UnpackBundleStub: func(lookup *v1alpha1.BundleLookup, timeout time.Duration) (*bundle.BundleUnpackResult, error) {
+				UnpackBundleStub: func(lookup *v1alpha1.BundleLookup, timeout, retryInterval time.Duration) (*bundle.BundleUnpackResult, error) {
 					return &bundle.BundleUnpackResult{BundleLookup: lookup.DeepCopy()}, tt.fields.unpackBundleErr
 				},
 			}

--- a/test/e2e/fbc_provider.go
+++ b/test/e2e/fbc_provider.go
@@ -31,3 +31,9 @@ func NewFileBasedFiledBasedCatalogProvider(path string) (FileBasedCatalogProvide
 func (f *fileBasedFileBasedCatalogProvider) GetCatalog() string {
 	return f.fbc
 }
+
+func NewRawFileBasedCatalogProvider(data string) (FileBasedCatalogProvider, error) {
+	return &fileBasedFileBasedCatalogProvider{
+		fbc: string(data),
+	}, nil
+}

--- a/test/e2e/registry.go
+++ b/test/e2e/registry.go
@@ -54,6 +54,7 @@ func createDockerRegistry(client operatorclient.ClientInterface, namespace strin
 					Port: int32(5000),
 				},
 			},
+			Type: corev1.ServiceTypeNodePort,
 		},
 	}
 

--- a/test/e2e/registry.go
+++ b/test/e2e/registry.go
@@ -54,7 +54,6 @@ func createDockerRegistry(client operatorclient.ClientInterface, namespace strin
 					Port: int32(5000),
 				},
 			},
-			Type: corev1.ServiceTypeNodePort,
 		},
 	}
 

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2526,6 +2526,11 @@ var _ = Describe("Subscription", func() {
 	})
 	When("bundle unpack retries are enabled", func() {
 		It("should retry failing unpack jobs", func() {
+			if ok, err := inKind(c); ok && err == nil {
+				Skip("This spec fails when run using KIND cluster. See https://github.com/operator-framework/operator-lifecycle-manager/issues/2420 for more details")
+			} else if err != nil {
+				Skip("Could not determine whether running in a kind cluster. Skipping.")
+			}
 			By("Ensuring a registry to host bundle images")
 			local, err := Local(c)
 			Expect(err).NotTo(HaveOccurred(), "cannot determine if test running locally or on CI: %s", err)
@@ -2581,20 +2586,14 @@ var _ = Describe("Subscription", func() {
 				}
 			}
 
-			// testImage is the name of the image used throughout the test - the image overwritten by skopeo
-			// the tag is generated randomly and appended to the end of the testImage
+			// The remote image to be copied onto the local registry
 			srcImage := "quay.io/olmtest/example-operator-bundle:"
 			srcTag := "0.1.0"
-			bundleImage := fmt.Sprint(registryURL, "/unpack-retry-bundle", ":")
+
+			// on-cluster image ref
+			bundleImage := registryURL + "/unpack-retry-bundle:"
 			bundleTag := genName("x")
-			//// hash hashes data with sha256 and returns the hex string.
-			//func hash(data string) string {
-			//	// A SHA256 hash is 64 characters, which is within the 253 character limit for kube resource names
-			//	h := fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
-			//
-			//	// Make the hash 63 characters instead to comply with the 63 character limit for labels
-			//	return fmt.Sprintf(h[:len(h)-1])
-			//}
+
 			unpackRetryCatalog := fmt.Sprintf(`
 schema: olm.package
 name: unpack-retry-package

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -94,13 +94,25 @@ func objectRefToNamespacedName(ip *corev1.ObjectReference) types.NamespacedName 
 // adding the "operatorframework.io/bundle-unpack-timeout" annotation to an OperatorGroup
 // resource.
 func addBundleUnpackTimeoutOGAnnotation(ctx context.Context, c k8scontrollerclient.Client, ogNN types.NamespacedName, timeout string) {
+	setOGAnnotation(ctx, c, ogNN, bundle.BundleUnpackTimeoutAnnotationKey, timeout)
+}
+
+func setBundleUnpackRetryMinimumIntervalAnnotation(ctx context.Context, c k8scontrollerclient.Client, ogNN types.NamespacedName, interval string) {
+	setOGAnnotation(ctx, c, ogNN, bundle.BundleUnpackRetryMinimumIntervalAnnotationKey, interval)
+}
+
+func setOGAnnotation(ctx context.Context, c k8scontrollerclient.Client, ogNN types.NamespacedName, key, value string) {
 	Eventually(func() error {
 		og := &operatorsv1.OperatorGroup{}
 		if err := c.Get(ctx, ogNN, og); err != nil {
 			return err
 		}
 		annotations := og.GetAnnotations()
-		annotations[bundle.BundleUnpackTimeoutAnnotationKey] = timeout
+		if len(value) == 0 {
+			delete(annotations, key)
+		} else {
+			annotations[key] = value
+		}
 		og.SetAnnotations(annotations)
 
 		return c.Update(ctx, og)


### PR DESCRIPTION
**Description of the change:**
Recreate failed bundle unpack jobs to allow for automatic retries on unpacking failure.

**Motivation for the change:**
Bundle unpack jobs may fail due to network or configuration issues in the cluster that may be transient or resolved with user intervention. Since unpack jobs have deterministic names referencing the bundle they correspond to, recovery from unpack failures requires manual intervention for deleting the associated unpack jobs.

This PR automates recreation of failed unpack jobs indefinitely with a minimum guaranteed interval between jobs if specified by a new operatorGroup annotation.
