### PR TITLE
OCPBUGS-17157: *: filter informers when preconditions are met

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/net v0.10.0
+	golang.org/x/sync v0.2.0
 	golang.org/x/time v0.3.0
 	google.golang.org/grpc v1.54.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -208,7 +209,6 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/oauth2 v0.5.0 // indirect
-	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/pkg/controller/operators/labeller/filters.go
+++ b/pkg/controller/operators/labeller/filters.go
@@ -1,0 +1,112 @@
+package labeller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/metadata"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/internal/alongside"
+)
+
+func Filter(gvr schema.GroupVersionResource) func(metav1.Object) bool {
+	if f, ok := filters[gvr]; ok {
+		return f
+	}
+	return func(object metav1.Object) bool {
+		return false
+	}
+}
+
+func JobFilter(getConfigMap func(namespace, name string) (metav1.Object, error)) func(object metav1.Object) bool {
+	return func(object metav1.Object) bool {
+		for _, ownerRef := range object.GetOwnerReferences() {
+			if ownerRef.APIVersion == corev1.SchemeGroupVersion.String() && ownerRef.Kind == "ConfigMap" {
+				cm, err := getConfigMap(object.GetNamespace(), ownerRef.Name)
+				if err != nil {
+					return false
+				}
+				return HasOLMOwnerRef(cm)
+			}
+		}
+		return false
+	}
+}
+
+var filters = map[schema.GroupVersionResource]func(metav1.Object) bool{
+	corev1.SchemeGroupVersion.WithResource("services"): HasOLMOwnerRef,
+	corev1.SchemeGroupVersion.WithResource("pods"): func(object metav1.Object) bool {
+		_, ok := object.GetLabels()[reconciler.CatalogSourceLabelKey]
+		return ok
+	},
+	corev1.SchemeGroupVersion.WithResource("serviceaccounts"): func(object metav1.Object) bool {
+		return HasOLMOwnerRef(object) || HasOLMLabel(object)
+	},
+	appsv1.SchemeGroupVersion.WithResource("deployments"):         HasOLMOwnerRef,
+	rbacv1.SchemeGroupVersion.WithResource("roles"):               HasOLMOwnerRef,
+	rbacv1.SchemeGroupVersion.WithResource("rolebindings"):        HasOLMOwnerRef,
+	rbacv1.SchemeGroupVersion.WithResource("clusterroles"):        HasOLMOwnerRef,
+	rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"): HasOLMOwnerRef,
+	apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"): func(object metav1.Object) bool {
+		for key := range object.GetAnnotations() {
+			if strings.HasPrefix(key, alongside.AnnotationPrefix) {
+				return true
+			}
+		}
+		return false
+	},
+}
+
+func Validate(ctx context.Context, logger *logrus.Logger, metadataClient metadata.Interface) (bool, error) {
+	okLock := sync.Mutex{}
+	var ok bool
+	g, ctx := errgroup.WithContext(ctx)
+	allFilters := map[schema.GroupVersionResource]func(metav1.Object) bool{}
+	for gvr, filter := range filters {
+		allFilters[gvr] = filter
+	}
+	allFilters[batchv1.SchemeGroupVersion.WithResource("jobs")] = JobFilter(func(namespace, name string) (metav1.Object, error) {
+		return metadataClient.Resource(corev1.SchemeGroupVersion.WithResource("configmaps")).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	})
+	for gvr, filter := range allFilters {
+		gvr, filter := gvr, filter
+		g.Go(func() error {
+			list, err := metadataClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to list %s: %w", gvr.String(), err)
+			}
+			var count int
+			for _, item := range list.Items {
+				if filter(&item) && !hasLabel(&item) {
+					count++
+				}
+			}
+			if count > 0 {
+				logger.WithFields(logrus.Fields{
+					"gvr":           gvr.String(),
+					"nonconforming": count,
+				}).Info("found nonconforming items")
+			}
+			okLock.Lock()
+			ok = ok && count == 0
+			okLock.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return false, err
+	}
+	return ok, nil
+}

--- a/pkg/controller/operators/labeller/labels.go
+++ b/pkg/controller/operators/labeller/labels.go
@@ -7,11 +7,8 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 	"github.com/sirupsen/logrus"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,6 +19,8 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/decorators"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 )
 
 type ApplyConfig[T any] interface {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -11,10 +12,16 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
+
+func init() {
+	log.SetLogger(zap.New())
+}
 
 var (
 	kubeConfigPath = flag.String(
@@ -125,5 +132,9 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+		fmt.Println("Skipping deprovisioning...")
+		return
+	}
 	deprovision()
 })


### PR DESCRIPTION
*: filter informers when preconditions are met

When we can detect at startup time that all of the objects we're about
to look at have the labels we're expecting, we can filter our informer
factories upfront.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

depends on #3020 
