### PR TITLE
Valid service from catsrc with periods in name

### DIFF
--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"strings"
 	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
@@ -72,7 +73,7 @@ func (s *grpcCatalogSourceDecorator) Annotations() map[string]string {
 func (s *grpcCatalogSourceDecorator) Service() *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.GetName(),
+			Name:      strings.ReplaceAll(s.GetName(), ".", "-"),
 			Namespace: s.GetNamespace(),
 		},
 		Spec: corev1.ServiceSpec{

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -62,6 +62,13 @@ func grpcCatalogSourceWithAnnotations(annotations map[string]string) *v1alpha1.C
 	return catsrc
 }
 
+func grpcCatalogSourceWithName(name string) *v1alpha1.CatalogSource {
+	catsrc := validGrpcCatalogSource("image", "")
+	catsrc.SetName(name)
+	catsrc.ObjectMeta.Labels["olm.catalogSource"] = name
+	return catsrc
+}
+
 func TestGrpcRegistryReconciler(t *testing.T) {
 	now := func() metav1.Time { return metav1.Date(2018, time.January, 26, 20, 40, 0, 0, time.UTC) }
 	blockOwnerDeletion := true
@@ -92,6 +99,21 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/NoExistingRegistry/CreateSuccessful",
 			in: in{
 				catsrc: validGrpcCatalogSource("test-img", ""),
+			},
+			out: out{
+				status: &v1alpha1.RegistryServiceStatus{
+					CreatedAt:        now(),
+					Protocol:         "grpc",
+					ServiceName:      "img-catalog",
+					ServiceNamespace: testNamespace,
+					Port:             "50051",
+				},
+			},
+		},
+		{
+			testName: "Grpc/NoExistingRegistry/CreateSuccessful/CatalogSourceWithPeriodInNameCreatesValidServiceName",
+			in: in{
+				catsrc: grpcCatalogSourceWithName("img.catalog"),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{


### PR DESCRIPTION
Problem: Creating a catalogSource with a period in the name is valid as the Kuberenetes API catalogSources to adhere to the following naing conventions:
- Start and end with a lower case alphanumeric character
- Consist only of alphanumeric characters, `.`, or `-`

Unfortunately, the service created by OLM for the catalogSource must adhere to the following naming conventions:
- Start and end with a lower case alphanumeric character
- Consist only of alphanumeric characters or `-`

This causes OLM to constantly recreate the catalogSource as the service it attempts to create is rejected from the Kubernetes API service due to the `.` in the name.

Solution: When naming the service, replace all instances of `.` in the name with `-`.
