### PR TITLE
OCPBUGS-17157: *: detect when all objects are labelled, restart

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -173,7 +173,7 @@ func main() {
 		olm.WithExternalClient(crClient),
 		olm.WithMetadataClient(metadataClient),
 		olm.WithOperatorClient(opClient),
-		olm.WithRestConfig(config),
+		olm.WithRestConfig(validatingConfig),
 		olm.WithConfigClient(versionedConfigClient),
 		olm.WithProtectedCopiedCSVNamespaces(*protectedCopiedCSVNamespaces),
 	)

--- a/cmd/olm/manager.go
+++ b/cmd/olm/manager.go
@@ -3,10 +3,15 @@ package main
 import (
 	"context"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,8 +56,37 @@ func Manager(ctx context.Context, debug bool) (ctrl.Manager, error) {
 		Scheme:             scheme,
 		MetricsBindAddress: "0", // TODO(njhale): Enable metrics on non-conflicting port (not 8080)
 		Cache: cache.Options{
-			DefaultLabelSelector: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
 			ByObject: map[client.Object]cache.ByObject{
+				&appsv1.Deployment{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&corev1.Service{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&apiextensionsv1.CustomResourceDefinition{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&apiregistrationv1.APIService{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&corev1.ConfigMap{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&corev1.ServiceAccount{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&rbacv1.Role{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&rbacv1.RoleBinding{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&rbacv1.ClusterRole{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&rbacv1.ClusterRoleBinding{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
 				&operatorsv1alpha1.ClusterServiceVersion{}: {
 					Label: copiedLabelDoesNotExist,
 				},

--- a/cmd/olm/manager.go
+++ b/cmd/olm/manager.go
@@ -3,11 +3,15 @@ package main
 import (
 	"context"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,6 +57,36 @@ func Manager(ctx context.Context, debug bool) (ctrl.Manager, error) {
 		MetricsBindAddress: "0", // TODO(njhale): Enable metrics on non-conflicting port (not 8080)
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
+				&appsv1.Deployment{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&corev1.Service{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&apiextensionsv1.CustomResourceDefinition{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&apiregistrationv1.APIService{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&corev1.ConfigMap{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&corev1.ServiceAccount{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&rbacv1.Role{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&rbacv1.RoleBinding{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&rbacv1.ClusterRole{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
+				&rbacv1.ClusterRoleBinding{}: {
+					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+				},
 				&corev1.Secret{}: {
 					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
 				},

--- a/cmd/olm/manager.go
+++ b/cmd/olm/manager.go
@@ -3,15 +3,10 @@ package main
 import (
 	"context"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
-	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,40 +51,8 @@ func Manager(ctx context.Context, debug bool) (ctrl.Manager, error) {
 		Scheme:             scheme,
 		MetricsBindAddress: "0", // TODO(njhale): Enable metrics on non-conflicting port (not 8080)
 		Cache: cache.Options{
+			DefaultLabelSelector: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
 			ByObject: map[client.Object]cache.ByObject{
-				&appsv1.Deployment{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&corev1.Service{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&apiextensionsv1.CustomResourceDefinition{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&apiregistrationv1.APIService{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&corev1.ConfigMap{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&corev1.ServiceAccount{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&rbacv1.Role{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&rbacv1.RoleBinding{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&rbacv1.ClusterRole{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&rbacv1.ClusterRoleBinding{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
-				&corev1.Secret{}: {
-					Label: labels.SelectorFromValidatedSet(map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
-				},
 				&operatorsv1alpha1.ClusterServiceVersion{}: {
 					Label: copiedLabelDoesNotExist,
 				},

--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -110,6 +110,10 @@ spec:
                 fieldPath: metadata.namespace
           - name: OPERATOR_NAME
             value: olm-operator
+          {{- if .Values.debug }}
+          - name: CI
+            value: "true"
+          {{- end }}
           {{- if .Values.olm.resources }}
           resources:
 {{ toYaml .Values.olm.resources | indent 12 }}

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -90,6 +90,11 @@ spec:
           - --set-workload-user-id=false
           {{ end }}
           image: {{ .Values.catalog.image.ref }}
+          {{- if .Values.debug }}
+          env:
+            - name: CI
+              value: "true"
+          {{- end }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.olm.service.internalPort }}

--- a/pkg/controller/install/apiservice.go
+++ b/pkg/controller/install/apiservice.go
@@ -61,6 +61,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateAPIService(caPEM []byte, des
 	if err := ownerutil.AddOwnerLabels(apiService, i.owner); err != nil {
 		return err
 	}
+	apiService.Labels[OLMManagedLabelKey] = OLMManagedLabelValue
 
 	// Create a service for the deployment
 	containerPort := int32(443)

--- a/pkg/controller/install/certresources.go
+++ b/pkg/controller/install/certresources.go
@@ -456,7 +456,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			Name:     "system:auth-delegator",
 		},
 	}
-	authDelegatorClusterRoleBinding.SetName(service.GetName() + "-system:auth-delegator")
+	authDelegatorClusterRoleBinding.SetName(AuthDelegatorClusterRoleBindingName(service.GetName()))
 	authDelegatorClusterRoleBinding.SetLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue})
 
 	existingAuthDelegatorClusterRoleBinding, err := i.strategyClient.GetOpLister().RbacV1().ClusterRoleBindingLister().Get(authDelegatorClusterRoleBinding.GetName())
@@ -504,7 +504,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			Name:     "extension-apiserver-authentication-reader",
 		},
 	}
-	authReaderRoleBinding.SetName(service.GetName() + "-auth-reader")
+	authReaderRoleBinding.SetName(AuthReaderRolebindingName(service.GetName()))
 	authReaderRoleBinding.SetNamespace(KubeSystem)
 	authReaderRoleBinding.SetLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue})
 
@@ -541,6 +541,14 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 	// is used by the apiserver if not hot reloading.
 	SetCAAnnotation(&depSpec, caHash)
 	return &depSpec, caPEM, nil
+}
+
+func AuthDelegatorClusterRoleBindingName(serviceName string) string {
+	return serviceName + "-system:auth-delegator"
+}
+
+func AuthReaderRolebindingName(serviceName string) string {
+	return serviceName + "-auth-reader"
 }
 
 func SetCAAnnotation(depSpec *appsv1.DeploymentSpec, caHash string) {

--- a/pkg/controller/install/certresources.go
+++ b/pkg/controller/install/certresources.go
@@ -504,7 +504,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			Name:     "extension-apiserver-authentication-reader",
 		},
 	}
-	authReaderRoleBinding.SetName(AuthReaderRolebindingName(service.GetName()))
+	authReaderRoleBinding.SetName(AuthReaderRoleBindingName(service.GetName()))
 	authReaderRoleBinding.SetNamespace(KubeSystem)
 	authReaderRoleBinding.SetLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue})
 
@@ -547,7 +547,7 @@ func AuthDelegatorClusterRoleBindingName(serviceName string) string {
 	return serviceName + "-system:auth-delegator"
 }
 
-func AuthReaderRolebindingName(serviceName string) string {
+func AuthReaderRoleBindingName(serviceName string) string {
 	return serviceName + "-auth-reader"
 }
 

--- a/pkg/controller/install/deployment.go
+++ b/pkg/controller/install/deployment.go
@@ -152,11 +152,11 @@ func (i *StrategyDeploymentInstaller) deploymentForSpec(name string, spec appsv1
 	dep.Spec.Template.SetAnnotations(annotations)
 
 	// Set custom labels before CSV owner labels
+	dep.SetLabels(specLabels)
 	if dep.Labels == nil {
 		dep.Labels = map[string]string{}
 	}
 	dep.Labels[OLMManagedLabelKey] = OLMManagedLabelValue
-	dep.SetLabels(specLabels)
 
 	ownerutil.AddNonBlockingOwner(dep, i.owner)
 	ownerutil.AddOwnerLabelsForKind(dep, i.owner, v1alpha1.ClusterServiceVersionKind)

--- a/pkg/controller/install/deployment_test.go
+++ b/pkg/controller/install/deployment_test.go
@@ -353,6 +353,7 @@ func TestInstallStrategyDeploymentCheckInstallErrors(t *testing.T) {
 			dep.Spec.Template.SetAnnotations(map[string]string{"test": "annotation"})
 			dep.Spec.RevisionHistoryLimit = &revisionHistoryLimit
 			dep.SetLabels(labels.CloneAndAddLabel(dep.ObjectMeta.GetLabels(), DeploymentSpecHashLabelKey, HashDeploymentSpec(dep.Spec)))
+			dep.Labels[OLMManagedLabelKey] = OLMManagedLabelValue
 			dep.Status.Conditions = append(dep.Status.Conditions, appsv1.DeploymentCondition{
 				Type:   appsv1.DeploymentAvailable,
 				Status: corev1.ConditionTrue,

--- a/pkg/controller/operators/adoption_controller_test.go
+++ b/pkg/controller/operators/adoption_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -350,6 +351,12 @@ var _ = Describe("Adoption Controller", func() {
 								),
 							}
 							for _, component := range components {
+								labels := component.GetLabels()
+								if labels == nil {
+									labels = map[string]string{}
+								}
+								labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
+								component.SetLabels(labels)
 								Eventually(func() error {
 									return k8sClient.Create(ctx, component)
 								}, timeout, interval).Should(Succeed())

--- a/pkg/controller/operators/labeller/filters.go
+++ b/pkg/controller/operators/labeller/filters.go
@@ -75,7 +75,7 @@ var filters = map[schema.GroupVersionResource]func(metav1.Object) bool{
 
 func Validate(ctx context.Context, logger *logrus.Logger, metadataClient metadata.Interface) (bool, error) {
 	okLock := sync.Mutex{}
-	var ok bool
+	ok := true
 	g, ctx := errgroup.WithContext(ctx)
 	allFilters := map[schema.GroupVersionResource]func(metav1.Object) bool{}
 	for gvr, filter := range filters {
@@ -124,5 +124,6 @@ func Validate(ctx context.Context, logger *logrus.Logger, metadataClient metadat
 	if err := g.Wait(); err != nil {
 		return false, err
 	}
+	logger.WithField("canFilter", ok).Info("detected ability to filter informers")
 	return ok, nil
 }

--- a/pkg/controller/operators/labeller/labels.go
+++ b/pkg/controller/operators/labeller/labels.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/sirupsen/logrus"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -40,28 +42,50 @@ func ObjectLabeler[T metav1.Object, A ApplyConfig[A]](
 	ctx context.Context,
 	logger *logrus.Logger,
 	check func(metav1.Object) bool,
+	list func(options labels.Selector) ([]T, error),
 	applyConfigFor func(name, namespace string) A,
 	apply func(namespace string, ctx context.Context, cfg A, opts metav1.ApplyOptions) (T, error),
-) queueinformer.LegacySyncHandler {
-	return func(obj interface{}) error {
-		cast, ok := obj.(T)
-		if !ok {
-			err := fmt.Errorf("wrong type %T, expected %T: %#v", obj, new(T), obj)
-			logger.WithError(err).Error("casting failed")
-			return fmt.Errorf("casting failed: %w", err)
+) func(done func() bool) queueinformer.LegacySyncHandler {
+	return func(done func() bool) queueinformer.LegacySyncHandler {
+		return func(obj interface{}) error {
+			cast, ok := obj.(T)
+			if !ok {
+				err := fmt.Errorf("wrong type %T, expected %T: %#v", obj, new(T), obj)
+				logger.WithError(err).Error("casting failed")
+				return fmt.Errorf("casting failed: %w", err)
+			}
+
+			if !check(cast) || hasLabel(cast) {
+				// if the object we're processing does not need us to label it, it's possible that every object that requires
+				// the label already has it; in which case we should exit the process, so the Pod that succeeds us can filter
+				// the informers used to drive the controller and stop having to track extraneous objects
+				items, err := list(labels.Everything())
+				if err != nil {
+					logger.WithError(err).Warn("failed to list all objects to check for labelling completion")
+					return nil
+				}
+				gvrFullyLabelled := true
+				for _, item := range items {
+					gvrFullyLabelled = gvrFullyLabelled && (!check(item) || hasLabel(item))
+				}
+				if gvrFullyLabelled {
+					allObjectsLabelled := done()
+					if allObjectsLabelled {
+						logrus.Info("detected that every object is labelled, exiting to re-start the process...")
+						os.Exit(0)
+					}
+				}
+				return nil
+			}
+
+			cfg := applyConfigFor(cast.GetName(), cast.GetNamespace())
+			cfg.WithLabels(map[string]string{
+				install.OLMManagedLabelKey: install.OLMManagedLabelValue,
+			})
+
+			_, err := apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{})
+			return err
 		}
-
-		if !check(cast) || hasLabel(cast) {
-			return nil
-		}
-
-		cfg := applyConfigFor(cast.GetName(), cast.GetNamespace())
-		cfg.WithLabels(map[string]string{
-			install.OLMManagedLabelKey: install.OLMManagedLabelValue,
-		})
-
-		_, err := apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{})
-		return err
 	}
 }
 
@@ -71,58 +95,77 @@ func ObjectPatchLabeler(
 	ctx context.Context,
 	logger *logrus.Logger,
 	check func(metav1.Object) bool,
+	list func(selector labels.Selector) (ret []*metav1.PartialObjectMetadata, err error),
 	patch func(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *apiextensionsv1.CustomResourceDefinition, err error),
-) func(
-	obj interface{},
-) error {
-	return func(obj interface{}) error {
-		cast, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			err := fmt.Errorf("wrong type %T, expected %T: %#v", obj, new(*apiextensionsv1.CustomResourceDefinition), obj)
-			logger.WithError(err).Error("casting failed")
-			return fmt.Errorf("casting failed: %w", err)
+) func(done func() bool) queueinformer.LegacySyncHandler {
+	return func(done func() bool) queueinformer.LegacySyncHandler {
+		return func(obj interface{}) error {
+			cast, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !ok {
+				err := fmt.Errorf("wrong type %T, expected %T: %#v", obj, new(*apiextensionsv1.CustomResourceDefinition), obj)
+				logger.WithError(err).Error("casting failed")
+				return fmt.Errorf("casting failed: %w", err)
+			}
+
+			if !check(cast) || hasLabel(cast) {
+				// if the object we're processing does not need us to label it, it's possible that every object that requires
+				// the label already has it; in which case we should exit the process, so the Pod that succeeds us can filter
+				// the informers used to drive the controller and stop having to track extraneous objects
+				items, err := list(labels.Everything())
+				if err != nil {
+					logger.WithError(err).Warn("failed to list all objects to check for labelling completion")
+					return nil
+				}
+				gvrFullyLabelled := true
+				for _, item := range items {
+					gvrFullyLabelled = gvrFullyLabelled && (!check(item) || hasLabel(item))
+				}
+				if gvrFullyLabelled {
+					allObjectsLabelled := done()
+					if allObjectsLabelled {
+						logrus.Fatal("detected that every object is labelled, exiting...")
+					}
+				}
+				return nil
+			}
+
+			uid := cast.GetUID()
+			rv := cast.GetResourceVersion()
+
+			// to ensure they appear in the patch as preconditions
+			previous := cast.DeepCopy()
+			previous.SetUID("")
+			previous.SetResourceVersion("")
+
+			oldData, err := json.Marshal(previous)
+			if err != nil {
+				return fmt.Errorf("failed to Marshal old data for %s/%s: %w", previous.GetNamespace(), previous.GetName(), err)
+			}
+
+			// to ensure they appear in the patch as preconditions
+			updated := cast.DeepCopy()
+			updated.SetUID(uid)
+			updated.SetResourceVersion(rv)
+			labels := updated.GetLabels()
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
+			updated.SetLabels(labels)
+
+			newData, err := json.Marshal(updated)
+			if err != nil {
+				return fmt.Errorf("failed to Marshal old data for %s/%s: %w", updated.GetNamespace(), updated.GetName(), err)
+			}
+
+			patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
+			if err != nil {
+				return fmt.Errorf("failed to create patch for %s/%s: %w", cast.GetNamespace(), cast.GetName(), err)
+			}
+
+			_, err = patch(ctx, cast.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{})
+			return err
 		}
-
-		if !check(cast) || hasLabel(cast) {
-			return nil
-		}
-
-		uid := cast.GetUID()
-		rv := cast.GetResourceVersion()
-
-		// to ensure they appear in the patch as preconditions
-		previous := cast.DeepCopy()
-		previous.SetUID("")
-		previous.SetResourceVersion("")
-
-		oldData, err := json.Marshal(previous)
-		if err != nil {
-			return fmt.Errorf("failed to Marshal old data for %s/%s: %w", previous.GetNamespace(), previous.GetName(), err)
-		}
-
-		// to ensure they appear in the patch as preconditions
-		updated := cast.DeepCopy()
-		updated.SetUID(uid)
-		updated.SetResourceVersion(rv)
-		labels := updated.GetLabels()
-		if labels == nil {
-			labels = map[string]string{}
-		}
-		labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
-		updated.SetLabels(labels)
-
-		newData, err := json.Marshal(updated)
-		if err != nil {
-			return fmt.Errorf("failed to Marshal old data for %s/%s: %w", updated.GetNamespace(), updated.GetName(), err)
-		}
-
-		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
-		if err != nil {
-			return fmt.Errorf("failed to create patch for %s/%s: %w", cast.GetNamespace(), cast.GetName(), err)
-		}
-
-		_, err = patch(ctx, cast.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		return err
 	}
 }
 

--- a/pkg/controller/operators/labeller/labels.go
+++ b/pkg/controller/operators/labeller/labels.go
@@ -123,7 +123,8 @@ func ObjectPatchLabeler(
 				if gvrFullyLabelled {
 					allObjectsLabelled := done()
 					if allObjectsLabelled {
-						logrus.Fatal("detected that every object is labelled, exiting...")
+						logrus.Info("detected that every object is labelled, exiting to re-start the process...")
+						os.Exit(0)
 					}
 				}
 				return nil

--- a/pkg/controller/operators/labeller/rbac.go
+++ b/pkg/controller/operators/labeller/rbac.go
@@ -3,6 +3,7 @@ package labeller
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
@@ -52,7 +53,8 @@ func ContentHashLabeler[T metav1.Object, A ApplyConfig[A]](
 				if gvrFullyLabelled {
 					allObjectsLabelled := done()
 					if allObjectsLabelled {
-						logrus.Fatal("detected that every object is labelled, exiting...")
+						logrus.Info("detected that every object is labelled, exiting to re-start the process...")
+						os.Exit(0)
 					}
 				}
 				return nil

--- a/pkg/controller/operators/labeller/rbac.go
+++ b/pkg/controller/operators/labeller/rbac.go
@@ -10,6 +10,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func hasHashLabel(obj metav1.Object) bool {
@@ -22,35 +23,56 @@ func ContentHashLabeler[T metav1.Object, A ApplyConfig[A]](
 	logger *logrus.Logger,
 	check func(metav1.Object) bool,
 	hasher func(object T) (string, error),
+	list func(options labels.Selector) ([]T, error),
 	applyConfigFor func(name, namespace string) A,
 	apply func(namespace string, ctx context.Context, cfg A, opts metav1.ApplyOptions) (T, error),
-) queueinformer.LegacySyncHandler {
-	return func(obj interface{}) error {
-		cast, ok := obj.(T)
-		if !ok {
-			err := fmt.Errorf("wrong type %T, expected %T: %#v", obj, new(T), obj)
-			logger.WithError(err).Error("casting failed")
-			return fmt.Errorf("casting failed: %w", err)
-		}
+) func(done func() bool) queueinformer.LegacySyncHandler {
+	return func(done func() bool) queueinformer.LegacySyncHandler {
+		return func(obj interface{}) error {
+			cast, ok := obj.(T)
+			if !ok {
+				err := fmt.Errorf("wrong type %T, expected %T: %#v", obj, new(T), obj)
+				logger.WithError(err).Error("casting failed")
+				return fmt.Errorf("casting failed: %w", err)
+			}
 
-		if _, _, ok := ownerutil.GetOwnerByKindLabel(cast, v1alpha1.ClusterServiceVersionKind); !ok {
-			return nil
-		}
+			if _, _, ok := ownerutil.GetOwnerByKindLabel(cast, v1alpha1.ClusterServiceVersionKind); !ok {
+				// if the object we're processing does not need us to label it, it's possible that every object that requires
+				// the label already has it; in which case we should exit the process, so the Pod that succeeds us can filter
+				// the informers used to drive the controller and stop having to track extraneous objects
+				items, err := list(labels.Everything())
+				if err != nil {
+					logger.WithError(err).Warn("failed to list all objects to check for labelling completion")
+					return nil
+				}
+				gvrFullyLabelled := true
+				for _, item := range items {
+					gvrFullyLabelled = gvrFullyLabelled && (!check(item) || hasLabel(item))
+				}
+				if gvrFullyLabelled {
+					allObjectsLabelled := done()
+					if allObjectsLabelled {
+						logrus.Fatal("detected that every object is labelled, exiting...")
+					}
+				}
+				return nil
+			}
 
-		if !check(cast) || hasHashLabel(cast) {
-			return nil
-		}
+			if !check(cast) || hasHashLabel(cast) {
+				return nil
+			}
 
-		hash, err := hasher(cast)
-		if err != nil {
-			return fmt.Errorf("failed to calculate hash: %w", err)
-		}
+			hash, err := hasher(cast)
+			if err != nil {
+				return fmt.Errorf("failed to calculate hash: %w", err)
+			}
 
-		cfg := applyConfigFor(cast.GetName(), cast.GetNamespace())
-		cfg.WithLabels(map[string]string{
-			resolver.ContentHashLabelKey: hash,
-		})
-		_, err = apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{})
-		return err
+			cfg := applyConfigFor(cast.GetName(), cast.GetNamespace())
+			cfg.WithLabels(map[string]string{
+				resolver.ContentHashLabelKey: hash,
+			})
+			_, err = apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{})
+			return err
+		}
 	}
 }

--- a/pkg/controller/operators/olm/apiservices.go
+++ b/pkg/controller/operators/olm/apiservices.go
@@ -180,8 +180,8 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 			logger.WithError(err).Warnf("could not retrieve auth delegator cluster role binding %s", install.AuthDelegatorClusterRoleBindingName(service.GetName()))
 			errs = append(errs, err)
 		}
-		if _, err := a.lister.RbacV1().RoleBindingLister().RoleBindings(install.KubeSystem).Get(install.AuthReaderRolebindingName(service.GetName())); err != nil {
-			logger.WithError(err).Warnf("could not retrieve role binding %s/%s", install.KubeSystem, install.AuthReaderRolebindingName(service.GetName()))
+		if _, err := a.lister.RbacV1().RoleBindingLister().RoleBindings(install.KubeSystem).Get(install.AuthReaderRoleBindingName(service.GetName())); err != nil {
+			logger.WithError(err).Warnf("could not retrieve role binding %s/%s", install.KubeSystem, install.AuthReaderRoleBindingName(service.GetName()))
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -186,7 +186,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		return nil, err
 	}
 
-	canFilter, err := labeller.Validate(ctx, config.logger, config.metadataClient)
+	canFilter, err := labeller.Validate(ctx, config.logger, config.metadataClient, config.externalClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/labeller"
@@ -102,10 +103,55 @@ type Operator struct {
 	clientFactory                clients.Factory
 	plugins                      []plugins.OperatorPlugin
 	informersByNamespace         map[string]*plugins.Informers
+	informersFiltered            bool
+
+	ruleChecker     func(*v1alpha1.ClusterServiceVersion) *install.CSVRuleChecker
+	ruleCheckerLock *sync.RWMutex
+	resyncPeriod    func() time.Duration
+	ctx             context.Context
 }
 
 func (a *Operator) Informers() map[string]*plugins.Informers {
 	return a.informersByNamespace
+}
+
+func (a *Operator) getRuleChecker() func(*v1alpha1.ClusterServiceVersion) *install.CSVRuleChecker {
+	var ruleChecker func(*v1alpha1.ClusterServiceVersion) *install.CSVRuleChecker
+	a.ruleCheckerLock.RLock()
+	ruleChecker = a.ruleChecker
+	a.ruleCheckerLock.RUnlock()
+	if ruleChecker != nil {
+		return ruleChecker
+	}
+
+	a.ruleCheckerLock.Lock()
+	defer a.ruleCheckerLock.Unlock()
+	if a.ruleChecker != nil {
+		return a.ruleChecker
+	}
+
+	sif := informers.NewSharedInformerFactoryWithOptions(a.opClient.KubernetesInterface(), a.resyncPeriod())
+	rolesLister := sif.Rbac().V1().Roles().Lister()
+	roleBindingsLister := sif.Rbac().V1().RoleBindings().Lister()
+	clusterRolesLister := sif.Rbac().V1().ClusterRoles().Lister()
+	clusterRoleBindingsLister := sif.Rbac().V1().ClusterRoleBindings().Lister()
+
+	done := make(chan struct{})
+	go func() {
+		<-a.ctx.Done()
+		done <- struct{}{}
+	}()
+	sif.Start(done)
+	sif.WaitForCacheSync(done)
+
+	a.ruleChecker = func(csv *v1alpha1.ClusterServiceVersion) *install.CSVRuleChecker {
+		return install.NewCSVRuleChecker(
+			rolesLister, roleBindingsLister,
+			clusterRolesLister, clusterRoleBindingsLister,
+			csv,
+		)
+	}
+	return a.ruleChecker
 }
 
 func NewOperator(ctx context.Context, options ...OperatorOption) (*Operator, error) {
@@ -171,6 +217,10 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		serviceAccountQuerier:        scoped.NewUserDefinedServiceAccountQuerier(config.logger, config.externalClient),
 		clientFactory:                clients.NewFactory(config.restConfig),
 		protectedCopiedCSVNamespaces: config.protectedCopiedCSVNamespaces,
+		resyncPeriod:                 config.resyncPeriod,
+		ruleCheckerLock:              &sync.RWMutex{},
+		ctx:                          ctx,
+		informersFiltered:            canFilter,
 	}
 
 	informersByNamespace := map[string]*plugins.Informers{}
@@ -447,9 +497,20 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		}
 	}
 
-	labelObjects := func(gvr schema.GroupVersionResource, informer cache.SharedIndexInformer, sync queueinformer.LegacySyncHandler) error {
+	complete := map[schema.GroupVersionResource][]bool{}
+	completeLock := &sync.Mutex{}
+
+	labelObjects := func(gvr schema.GroupVersionResource, informer cache.SharedIndexInformer, sync func(done func() bool) queueinformer.LegacySyncHandler) error {
 		if canFilter {
 			return nil
+		}
+		var idx int
+		if _, exists := complete[gvr]; exists {
+			idx = len(complete[gvr])
+			complete[gvr] = append(complete[gvr], false)
+		} else {
+			idx = 0
+			complete[gvr] = []bool{false}
 		}
 		queue := workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{
 			Name: gvr.String(),
@@ -459,7 +520,18 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 			queueinformer.WithQueue(queue),
 			queueinformer.WithLogger(op.logger),
 			queueinformer.WithInformer(informer),
-			queueinformer.WithSyncer(sync.ToSyncer()),
+			queueinformer.WithSyncer(sync(func() bool {
+				completeLock.Lock()
+				complete[gvr][idx] = true
+				allDone := true
+				for _, items := range complete {
+					for _, done := range items {
+						allDone = allDone && done
+					}
+				}
+				completeLock.Unlock()
+				return allDone
+			}).ToSyncer()),
 		)
 		if err != nil {
 			return err
@@ -475,6 +547,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 	deploymentsgvk := appsv1.SchemeGroupVersion.WithResource("deployments")
 	if err := labelObjects(deploymentsgvk, informersByNamespace[metav1.NamespaceAll].DeploymentInformer.Informer(), labeller.ObjectLabeler[*appsv1.Deployment, *appsv1applyconfigurations.DeploymentApplyConfiguration](
 		ctx, op.logger, labeller.Filter(deploymentsgvk),
+		informersByNamespace[metav1.NamespaceAll].DeploymentInformer.Lister().List,
 		appsv1applyconfigurations.Deployment,
 		func(namespace string, ctx context.Context, cfg *appsv1applyconfigurations.DeploymentApplyConfiguration, opts metav1.ApplyOptions) (*appsv1.Deployment, error) {
 			return op.opClient.KubernetesInterface().AppsV1().Deployments(namespace).Apply(ctx, cfg, opts)
@@ -547,6 +620,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 	clusterrolesgvk := rbacv1.SchemeGroupVersion.WithResource("clusterroles")
 	if err := labelObjects(clusterrolesgvk, clusterRoleInformer.Informer(), labeller.ObjectLabeler[*rbacv1.ClusterRole, *rbacv1applyconfigurations.ClusterRoleApplyConfiguration](
 		ctx, op.logger, labeller.Filter(clusterrolesgvk),
+		clusterRoleInformer.Lister().List,
 		func(name, _ string) *rbacv1applyconfigurations.ClusterRoleApplyConfiguration {
 			return rbacv1applyconfigurations.ClusterRole(name)
 		},
@@ -561,6 +635,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		func(clusterRole *rbacv1.ClusterRole) (string, error) {
 			return resolver.PolicyRuleHashLabelValue(clusterRole.Rules)
 		},
+		clusterRoleInformer.Lister().List,
 		func(name, _ string) *rbacv1applyconfigurations.ClusterRoleApplyConfiguration {
 			return rbacv1applyconfigurations.ClusterRole(name)
 		},
@@ -590,6 +665,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 	clusterrolebindingssgvk := rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings")
 	if err := labelObjects(clusterrolebindingssgvk, clusterRoleBindingInformer.Informer(), labeller.ObjectLabeler[*rbacv1.ClusterRoleBinding, *rbacv1applyconfigurations.ClusterRoleBindingApplyConfiguration](
 		ctx, op.logger, labeller.Filter(clusterrolebindingssgvk),
+		clusterRoleBindingInformer.Lister().List,
 		func(name, _ string) *rbacv1applyconfigurations.ClusterRoleBindingApplyConfiguration {
 			return rbacv1applyconfigurations.ClusterRoleBinding(name)
 		},
@@ -604,6 +680,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		func(clusterRoleBinding *rbacv1.ClusterRoleBinding) (string, error) {
 			return resolver.RoleReferenceAndSubjectHashLabelValue(clusterRoleBinding.RoleRef, clusterRoleBinding.Subjects)
 		},
+		clusterRoleBindingInformer.Lister().List,
 		func(name, _ string) *rbacv1applyconfigurations.ClusterRoleBindingApplyConfiguration {
 			return rbacv1applyconfigurations.ClusterRoleBinding(name)
 		},
@@ -614,8 +691,9 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		return nil, err
 	}
 
-	// register namespace queueinformer
-	namespaceInformer := k8sInformerFactory.Core().V1().Namespaces()
+	// register namespace queueinformer using a new informer factory - since namespaces won't have the labels
+	// that other k8s objects will
+	namespaceInformer := informers.NewSharedInformerFactory(op.opClient.KubernetesInterface(), config.resyncPeriod()).Core().V1().Namespaces()
 	informersByNamespace[metav1.NamespaceAll].NamespaceInformer = namespaceInformer
 	op.lister.CoreV1().RegisterNamespaceLister(namespaceInformer.Lister())
 	op.nsQueueSet = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "resolver")

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -136,13 +136,13 @@ func (a *Operator) getRuleChecker() func(*v1alpha1.ClusterServiceVersion) *insta
 	clusterRolesLister := sif.Rbac().V1().ClusterRoles().Lister()
 	clusterRoleBindingsLister := sif.Rbac().V1().ClusterRoleBindings().Lister()
 
-	done := make(chan struct{})
-	go func() {
-		<-a.ctx.Done()
-		done <- struct{}{}
-	}()
-	sif.Start(done)
-	sif.WaitForCacheSync(done)
+	sif.Start(a.ctx.Done())
+	sif.WaitForCacheSync(a.ctx.Done())
+
+	if a.ctx.Err() != nil {
+		a.ruleChecker = nil
+		return nil
+	}
 
 	a.ruleChecker = func(csv *v1alpha1.ClusterServiceVersion) *install.CSVRuleChecker {
 		return install.NewCSVRuleChecker(

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -504,6 +504,9 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		if canFilter {
 			return nil
 		}
+
+		// for each GVR, we may have more than one labelling controller active; each of which detects
+		// when it is done; we allocate a space in complete[gvr][idx] to hold that outcome and track it
 		var idx int
 		if _, exists := complete[gvr]; exists {
 			idx = len(complete[gvr])
@@ -521,6 +524,11 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 			queueinformer.WithLogger(op.logger),
 			queueinformer.WithInformer(informer),
 			queueinformer.WithSyncer(sync(func() bool {
+				// this function is called by the processor when it detects that it's work is done - so, for that
+				// particular labelling action on that particular GVR, all objects are in the correct state. when
+				// that action is done, we need to further know if that was the last action to be completed, as
+				// when every action we know about has been completed, we re-start the process to allow the future
+				// invocation of this process to filter informers (canFilter = true) and elide all this logic
 				completeLock.Lock()
 				complete[gvr][idx] = true
 				allDone := true

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -106,7 +106,7 @@ type Operator struct {
 	informersFiltered            bool
 
 	ruleChecker     func(*v1alpha1.ClusterServiceVersion) *install.CSVRuleChecker
-	ruleCheckerLock *sync.RWMutex
+	ruleCheckerLock sync.RWMutex
 	resyncPeriod    func() time.Duration
 	ctx             context.Context
 }
@@ -218,7 +218,7 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		clientFactory:                clients.NewFactory(config.restConfig),
 		protectedCopiedCSVNamespaces: config.protectedCopiedCSVNamespaces,
 		resyncPeriod:                 config.resyncPeriod,
-		ruleCheckerLock:              &sync.RWMutex{},
+		ruleCheckerLock:              sync.RWMutex{},
 		ctx:                          ctx,
 		informersFiltered:            canFilter,
 	}

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -383,6 +383,7 @@ func deployment(deploymentName, namespace, serviceAccountName string, templateAn
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
 			Namespace: namespace,
+			Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -432,6 +433,7 @@ func serviceAccount(name, namespace string) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 		},
 	}
 
@@ -440,6 +442,9 @@ func serviceAccount(name, namespace string) *corev1.ServiceAccount {
 
 func service(name, namespace, deploymentName string, targetPort int, ownerReferences ...metav1.OwnerReference) *corev1.Service {
 	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
+		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
@@ -461,6 +466,9 @@ func service(name, namespace, deploymentName string, targetPort int, ownerRefere
 
 func clusterRoleBinding(name, clusterRoleName, serviceAccountName, serviceAccountNamespace string) *rbacv1.ClusterRoleBinding {
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
+		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
@@ -482,6 +490,9 @@ func clusterRoleBinding(name, clusterRoleName, serviceAccountName, serviceAccoun
 
 func clusterRole(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
+		},
 		Rules: rules,
 	}
 	clusterRole.SetName(name)
@@ -491,6 +502,9 @@ func clusterRole(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
 
 func role(name, namespace string, rules []rbacv1.PolicyRule) *rbacv1.Role {
 	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
+		},
 		Rules: rules,
 	}
 	role.SetName(name)
@@ -501,6 +515,9 @@ func role(name, namespace string, rules []rbacv1.PolicyRule) *rbacv1.Role {
 
 func roleBinding(name, namespace, roleName, serviceAccountName, serviceAccountNamespace string) *rbacv1.RoleBinding {
 	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
+		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
@@ -523,6 +540,9 @@ func roleBinding(name, namespace, roleName, serviceAccountName, serviceAccountNa
 
 func tlsSecret(name, namespace string, certPEM, privPEM []byte) *corev1.Secret {
 	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
+		},
 		Data: map[string][]byte{
 			"tls.crt": certPEM,
 			"tls.key": privPEM,
@@ -846,7 +866,8 @@ func apiService(group, version, serviceName, serviceNamespace, deploymentName st
 func crd(name, version, group string) *apiextensionsv1.CustomResourceDefinition {
 	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name + "." + group,
+			Name:   name + "." + group,
+			Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Group: group,
@@ -4371,6 +4392,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 		},
 		Rules: permissions[0].Rules,
 	}
+	role.Labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
 
 	roleBinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
@@ -4397,6 +4419,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 			Name:     role.GetName(),
 		},
 	}
+	roleBinding.Labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
 
 	type initial struct {
 		operatorGroup *operatorsv1.OperatorGroup
@@ -4985,6 +5008,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 							Name:            "csv-role",
 							Namespace:       targetNamespace,
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.copiedFrom":      "operator-ns",
 								"olm.owner":           "csv1",
 								"olm.owner.namespace": "target-ns",
@@ -5006,6 +5030,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 							Name:            "csv-rolebinding",
 							Namespace:       targetNamespace,
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.copiedFrom":      "operator-ns",
 								"olm.owner":           "csv1",
 								"olm.owner.namespace": "target-ns",
@@ -5088,6 +5113,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 							Name:            "csv-role",
 							Namespace:       targetNamespace,
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.copiedFrom":      "operator-ns",
 								"olm.owner":           "csv1",
 								"olm.owner.namespace": "target-ns",
@@ -5109,6 +5135,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 							Name:            "csv-rolebinding",
 							Namespace:       targetNamespace,
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.copiedFrom":      "operator-ns",
 								"olm.owner":           "csv1",
 								"olm.owner.namespace": "target-ns",
@@ -5188,6 +5215,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "csv-role",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "csv1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "ClusterServiceVersion",
@@ -5207,6 +5235,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "csv-rolebinding",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "csv1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "ClusterServiceVersion",
@@ -5507,17 +5536,14 @@ func TestSyncOperatorGroups(t *testing.T) {
 				}
 
 				for _, csv := range csvs.Items {
-					t.Logf("%s/%s", csv.Namespace, csv.Name)
 					if csv.Status.Phase == v1alpha1.CSVPhaseInstalling {
 						simulateSuccessfulRollout(&csv)
 					}
 
-					t.Log("op.syncClusterServiceVersion")
 					if err := op.syncClusterServiceVersion(&csv); err != nil {
 						return false, fmt.Errorf("failed to syncClusterServiceVersion: %w", err)
 					}
 
-					t.Log("op.syncCopyCSV")
 					if err := op.syncCopyCSV(&csv); err != nil && !tt.ignoreCopyError {
 						return false, fmt.Errorf("failed to syncCopyCSV: %w", err)
 					}

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -4587,6 +4587,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4597,6 +4598,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4607,6 +4609,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4648,6 +4651,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "operator-group-1-admin",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4658,6 +4662,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "operator-group-1-view",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4668,6 +4673,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "operator-group-1-edit",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4686,6 +4692,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4696,6 +4703,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4706,6 +4714,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4716,6 +4725,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "operator-group-1-admin",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4726,6 +4736,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "operator-group-1-view",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4736,6 +4747,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "operator-group-1-edit",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4777,6 +4789,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns-bob",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4788,6 +4801,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-5",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4800,6 +4814,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroupKind",
@@ -4818,6 +4833,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4829,6 +4845,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4839,6 +4856,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4882,6 +4900,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4892,6 +4911,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4902,6 +4922,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4919,6 +4940,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4929,6 +4951,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",
@@ -4939,6 +4962,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
+								"olm.managed":         "true",
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
 								"olm.owner.kind":      "OperatorGroup",

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -4364,6 +4364,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 	annotatedDeployment := ownedDeployment.DeepCopy()
 	annotatedDeployment.Spec.Template.SetAnnotations(map[string]string{operatorsv1.OperatorGroupTargetsAnnotationKey: operatorNamespace + "," + targetNamespace, operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace})
 	annotatedDeployment.SetLabels(map[string]string{
+		"olm.managed":                      "true",
 		"olm.owner":                        "csv1",
 		"olm.owner.namespace":              "operator-ns",
 		"olm.owner.kind":                   "ClusterServiceVersion",
@@ -4373,6 +4374,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 	annotatedGlobalDeployment := ownedDeployment.DeepCopy()
 	annotatedGlobalDeployment.Spec.Template.SetAnnotations(map[string]string{operatorsv1.OperatorGroupTargetsAnnotationKey: "", operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace})
 	annotatedGlobalDeployment.SetLabels(map[string]string{
+		"olm.managed":                      "true",
 		"olm.owner":                        "csv1",
 		"olm.owner.namespace":              "operator-ns",
 		"olm.owner.kind":                   "ClusterServiceVersion",

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -1052,6 +1052,7 @@ func (a *Operator) ensureOpGroupClusterRole(op *operatorsv1.OperatorGroup, suffi
 	if err := ownerutil.AddOwnerLabels(clusterRole, op); err != nil {
 		return err
 	}
+	clusterRole.Labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
 
 	a.logger.Infof("creating cluster role: %s owned by operator group: %s/%s", clusterRole.GetName(), op.GetNamespace(), op.GetName())
 	_, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})

--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -3,6 +3,7 @@ package olm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -349,6 +350,9 @@ func (a *Operator) permissionStatus(strategyDetailsDeployment *v1alpha1.Strategy
 			// if we have not filtered our informers or if we were unable to detect the correct permissions, we have
 			// no choice but to page in the world and see if the user pre-created permissions for this CSV
 			ruleChecker := a.getRuleChecker()(csv)
+			if ruleChecker == nil {
+				return false, errors.New("could not create a rule checker (are we shutting down?)")
+			}
 			for _, rule := range perm.Rules {
 				dependent := v1alpha1.DependentStatus{
 					Group:   "rbac.authorization.k8s.io",

--- a/pkg/controller/operators/olm/requirements.go
+++ b/pkg/controller/operators/olm/requirements.go
@@ -424,12 +424,7 @@ func permissionsPreviouslyCreated[T, U metav1.Object](
 	}
 	roleSelectorMap := ownerutil.OwnerLabel(csv, v1alpha1.ClusterServiceVersionKind)
 	roleSelectorMap[resolver.ContentHashLabelKey] = ruleHash
-	roleSelectorSet := labels.Set{}
-	for key, value := range roleSelectorMap {
-		roleSelectorSet[key] = value
-	}
-	roleSelector := labels.SelectorFromSet(roleSelectorSet)
-	roles, err := listRoles(roleSelector)
+	roles, err := listRoles(labels.SelectorFromSet(roleSelectorMap))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/operators/olm/requirements_test.go
+++ b/pkg/controller/operators/olm/requirements_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -80,6 +81,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 						Name:      "sa",
 						Namespace: namespace,
 						UID:       types.UID("sa"),
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Kind: v1alpha1.ClusterServiceVersionKind,
@@ -92,6 +94,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "role",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -105,6 +108,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "roleBinding",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -122,7 +126,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				},
 				&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "clusterRole",
+						Name:   "clusterRole",
+						Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -133,7 +138,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "clusterRoleBinding",
+						Name:   "clusterRoleBinding",
+						Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -224,6 +230,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 						Name:      "sa",
 						Namespace: namespace,
 						UID:       types.UID("sa"),
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Kind: v1alpha1.ClusterServiceVersionKind,
@@ -236,6 +243,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "role",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -249,6 +257,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "roleBinding",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -266,7 +275,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				},
 				&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "clusterRole",
+						Name:   "clusterRole",
+						Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -277,7 +287,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "clusterRoleBinding",
+						Name:   "clusterRoleBinding",
+						Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -368,6 +379,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 						Name:      "sa",
 						Namespace: namespace,
 						UID:       types.UID("sa"),
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Kind: v1alpha1.ClusterServiceVersionKind,
@@ -380,6 +392,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "role",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -393,6 +406,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "roleBinding",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -410,7 +424,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				},
 				&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "clusterRole",
+						Name:   "clusterRole",
+						Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -421,7 +436,8 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "clusterRoleBinding",
+						Name:   "clusterRoleBinding",
+						Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -491,6 +507,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 						Name:      "sa",
 						Namespace: namespace,
 						UID:       types.UID("sa"),
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Kind: v1alpha1.ClusterServiceVersionKind,
@@ -503,6 +520,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "role",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -516,6 +534,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "roleBinding",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -770,6 +789,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 						Name:      "sa",
 						Namespace: namespace,
 						UID:       types.UID("sa"),
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Kind: v1alpha1.ClusterServiceVersionKind,
@@ -824,6 +844,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 						Name:      "sa",
 						Namespace: namespace,
 						UID:       types.UID("sa"),
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Kind: v1alpha1.SubscriptionKind, // arbitrary non-CSV kind
@@ -877,6 +898,7 @@ func TestRequirementAndPermissionStatus(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "sa",
 						Namespace: namespace,
+						Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 						UID:       types.UID("sa"),
 					},
 				},

--- a/pkg/controller/operators/openshift/suite_test.go
+++ b/pkg/controller/operators/openshift/suite_test.go
@@ -108,5 +108,5 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	close(syncCh)
-	Expect(testEnv.Stop()).To(Succeed())
+	testEnv.Stop()
 })

--- a/pkg/controller/operators/suite_test.go
+++ b/pkg/controller/operators/suite_test.go
@@ -162,8 +162,7 @@ var _ = AfterSuite(func() {
 	ctx.Done()
 
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	testEnv.Stop()
 })
 
 func newOperator(name string) *decorators.Operator {

--- a/pkg/lib/scoped/syncer.go
+++ b/pkg/lib/scoped/syncer.go
@@ -100,8 +100,8 @@ func (s *UserDefinedServiceAccountSyncer) SyncOperatorGroup(in *v1.OperatorGroup
 		return
 	}
 
-	// A service account has been specified, but likely does not have the labels we expect it to have so it will
-	// show up in our listers, so let's add that and queue again later
+	// A service account has been specified, but likely does not have the labels we require it to have to ensure it
+	// shows up in our listers, so let's add that and queue again later
 	config := corev1applyconfigurations.ServiceAccount(serviceAccountName, namespace)
 	config.Labels = map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}
 	if _, err := s.client.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Apply(context.TODO(), config, metav1.ApplyOptions{FieldManager: "operator-lifecycle-manager"}); err != nil {

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -3931,7 +3931,7 @@ func buildInstallPlanMessageCheckFunc(substring string) checkInstallPlanFunc {
 	lastTime := time.Now()
 	return func(fip *operatorsv1alpha1.InstallPlan) bool {
 		if fip.Status.Message != lastMessage {
-			ctx.Ctx().Logf("waiting %s for installplan %s/%s to have message substring %s, have message %s", time.Since(lastTime), fip.Namespace, fip.Name, substring, fip.Status.Phase)
+			ctx.Ctx().Logf("waiting %s for installplan %s/%s to have message substring %q, have message %q", time.Since(lastTime), fip.Namespace, fip.Name, substring, fip.Status.Message)
 			lastMessage = fip.Status.Message
 			lastTime = time.Now()
 		}

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -1950,6 +1950,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, nil
 		})
+		require.NoError(GinkgoT(), err)
 		require.EqualValues(GinkgoT(), append(role.Rules, rbacv1.PolicyRule{
 			Verbs:     []string{"get", "list", "watch"},
 			APIGroups: []string{""},
@@ -1966,6 +1967,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, nil
 		})
+		require.NoError(GinkgoT(), err)
 		require.EqualValues(GinkgoT(), roleBinding.Subjects, fetchedRoleBinding.Subjects)
 		require.EqualValues(GinkgoT(), roleBinding.RoleRef.Name, fetchedRoleBinding.RoleRef.Name)
 		require.EqualValues(GinkgoT(), "rbac.authorization.k8s.io", fetchedRoleBinding.RoleRef.APIGroup)

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -1420,19 +1421,31 @@ var _ = Describe("Operator Group", func() {
 				Name: role.GetName(),
 			},
 		}
-		_, err = c.CreateServiceAccount(serviceAccount)
+		serviceAccount, err = c.CreateServiceAccount(serviceAccount)
 		require.NoError(GinkgoT(), err)
 		defer func() {
+			if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+				fmt.Printf("Skipping cleanup of serviceaccount %s/%s...\n", serviceAccount.GetNamespace(), serviceAccount.GetName())
+				return
+			}
 			c.DeleteServiceAccount(serviceAccount.GetNamespace(), serviceAccount.GetName(), metav1.NewDeleteOptions(0))
 		}()
 		createdRole, err := c.CreateRole(role)
 		require.NoError(GinkgoT(), err)
 		defer func() {
+			if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+				fmt.Printf("Skipping cleanup of role %s/%s...\n", role.GetNamespace(), role.GetName())
+				return
+			}
 			c.DeleteRole(role.GetNamespace(), role.GetName(), metav1.NewDeleteOptions(0))
 		}()
 		createdRoleBinding, err := c.CreateRoleBinding(roleBinding)
 		require.NoError(GinkgoT(), err)
 		defer func() {
+			if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+				fmt.Printf("Skipping cleanup of role binding %s/%s...\n", roleBinding.GetNamespace(), roleBinding.GetName())
+				return
+			}
 			c.DeleteRoleBinding(roleBinding.GetNamespace(), roleBinding.GetName(), metav1.NewDeleteOptions(0))
 		}()
 		// Create a new NamedInstallStrategy
@@ -1448,11 +1461,13 @@ var _ = Describe("Operator Group", func() {
 
 		err = ownerutil.AddOwnerLabels(createdRole, createdCSV)
 		require.NoError(GinkgoT(), err)
+		createdRole.Labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
 		_, err = c.UpdateRole(createdRole)
 		require.NoError(GinkgoT(), err)
 
 		err = ownerutil.AddOwnerLabels(createdRoleBinding, createdCSV)
 		require.NoError(GinkgoT(), err)
+		createdRoleBinding.Labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
 		_, err = c.UpdateRoleBinding(createdRoleBinding)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for CSV to succeed")
@@ -1903,16 +1918,28 @@ var _ = Describe("Operator Group", func() {
 		_, err = c.CreateServiceAccount(serviceAccount)
 		require.NoError(GinkgoT(), err)
 		defer func() {
+			if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+				fmt.Printf("Skipping cleanup of serviceaccount %s/%s...\n", serviceAccount.GetNamespace(), serviceAccount.GetName())
+				return
+			}
 			c.DeleteServiceAccount(serviceAccount.GetNamespace(), serviceAccount.GetName(), metav1.NewDeleteOptions(0))
 		}()
 		createdRole, err := c.CreateRole(role)
 		require.NoError(GinkgoT(), err)
 		defer func() {
+			if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+				fmt.Printf("Skipping cleanup of role %s/%s...\n", role.GetNamespace(), role.GetName())
+				return
+			}
 			c.DeleteRole(role.GetNamespace(), role.GetName(), metav1.NewDeleteOptions(0))
 		}()
 		createdRoleBinding, err := c.CreateRoleBinding(roleBinding)
 		require.NoError(GinkgoT(), err)
 		defer func() {
+			if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+				fmt.Printf("Skipping cleanup of role binding %s/%s...\n", roleBinding.GetNamespace(), roleBinding.GetName())
+				return
+			}
 			c.DeleteRoleBinding(roleBinding.GetNamespace(), roleBinding.GetName(), metav1.NewDeleteOptions(0))
 		}()
 		// Create a new NamedInstallStrategy
@@ -1928,11 +1955,13 @@ var _ = Describe("Operator Group", func() {
 
 		err = ownerutil.AddOwnerLabels(createdRole, createdCSV)
 		require.NoError(GinkgoT(), err)
+		createdRole.Labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
 		_, err = c.UpdateRole(createdRole)
 		require.NoError(GinkgoT(), err)
 
 		err = ownerutil.AddOwnerLabels(createdRoleBinding, createdCSV)
 		require.NoError(GinkgoT(), err)
+		createdRoleBinding.Labels[install.OLMManagedLabelKey] = install.OLMManagedLabelValue
 		_, err = c.UpdateRoleBinding(createdRoleBinding)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for CSV to succeed")

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3,12 +3,14 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	gomegatypes "github.com/onsi/gomega/types"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -74,6 +76,7 @@ var _ = Describe("Operator API", func() {
 	It("should surface components in its status", func() {
 		o := &operatorsv1.Operator{}
 		o.SetName(genName("o-"))
+		By(fmt.Sprintf("Creating an Operator resource %s", o.GetName()))
 
 		Consistently(o).ShouldNot(ContainCopiedCSVReferences())
 
@@ -83,6 +86,10 @@ var _ = Describe("Operator API", func() {
 
 		defer func() {
 			Eventually(func() error {
+				if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+					fmt.Printf("Skipping cleanup of operator %s...\n", o.GetName())
+					return nil
+				}
 				err := client.Delete(clientCtx, o)
 				if apierrors.IsNotFound(err) {
 					return nil
@@ -116,11 +123,11 @@ var _ = Describe("Operator API", func() {
 		}))
 		defer w.Stop()
 
-		// Create namespaces ns-a and ns-b
 		nsA := &corev1.Namespace{}
 		nsA.SetName(genName("ns-a-"))
 		nsB := &corev1.Namespace{}
 		nsB.SetName(genName("ns-b-"))
+		By(fmt.Sprintf("Create namespaces ns-a: (%s) and ns-b: (%s)", nsA.GetName(), nsB.GetName()))
 
 		for _, ns := range []*corev1.Namespace{nsA, nsB} {
 			Eventually(func() error {
@@ -128,6 +135,10 @@ var _ = Describe("Operator API", func() {
 			}).Should(Succeed())
 
 			defer func(n *corev1.Namespace) {
+				if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+					fmt.Printf("Skipping cleanup of namespace %s...\n", n.GetName())
+					return
+				}
 				Eventually(func() error {
 					err := client.Delete(clientCtx, n)
 					if apierrors.IsNotFound(err) {
@@ -138,24 +149,27 @@ var _ = Describe("Operator API", func() {
 			}(ns)
 		}
 
-		// Label ns-a with o's component label
+		By(fmt.Sprintf("Label ns-a (%s) with o's (%s) component label (%s)", nsA.GetName(), o.GetName(), expectedKey))
 		setComponentLabel := func(m metav1.Object) error {
-			m.SetLabels(map[string]string{expectedKey: ""})
+			m.SetLabels(map[string]string{
+				install.OLMManagedLabelKey: install.OLMManagedLabelValue,
+				expectedKey:                "",
+			})
 			return nil
 		}
 		Eventually(Apply(nsA, setComponentLabel)).Should(Succeed())
 
-		// Ensure o's status.components.refs field eventually contains a reference to ns-a
+		By("Ensure o's status.components.refs field eventually contains a reference to ns-a")
 		By("eventually listing a single component reference")
 		componentRefEventuallyExists(w, true, getReference(scheme, nsA))
 
-		// Create ServiceAccounts sa-a and sa-b in namespaces ns-a and ns-b respectively
 		saA := &corev1.ServiceAccount{}
 		saA.SetName(genName("sa-a-"))
 		saA.SetNamespace(nsA.GetName())
 		saB := &corev1.ServiceAccount{}
 		saB.SetName(genName("sa-b-"))
 		saB.SetNamespace(nsB.GetName())
+		By(fmt.Sprintf("Create ServiceAccounts sa-a (%s/%s) and sa-b (%s/%s) in namespaces ns-a and ns-b respectively", saA.GetNamespace(), saA.GetName(), saB.GetNamespace(), saB.GetName()))
 
 		for _, sa := range []*corev1.ServiceAccount{saA, saB} {
 			Eventually(func() error {
@@ -163,6 +177,10 @@ var _ = Describe("Operator API", func() {
 			}).Should(Succeed())
 			defer func(sa *corev1.ServiceAccount) {
 				Eventually(func() error {
+					if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+						fmt.Printf("Skipping cleanup of serviceaccount %s/%s...\n", sa.GetNamespace(), sa.GetName())
+						return nil
+					}
 					err := client.Delete(clientCtx, sa)
 					if apierrors.IsNotFound(err) {
 						return nil
@@ -172,26 +190,26 @@ var _ = Describe("Operator API", func() {
 			}(sa)
 		}
 
-		// Label sa-a and sa-b with o's component label
+		By("Label sa-a and sa-b with o's component label")
 		Eventually(Apply(saA, setComponentLabel)).Should(Succeed())
 		Eventually(Apply(saB, setComponentLabel)).Should(Succeed())
 
-		// Ensure o's status.components.refs field eventually contains references to sa-a and sa-b
+		By("Ensure o's status.components.refs field eventually contains references to sa-a and sa-b")
 		By("eventually listing multiple component references")
 		componentRefEventuallyExists(w, true, getReference(scheme, saA))
 		componentRefEventuallyExists(w, true, getReference(scheme, saB))
 
-		// Remove the component label from sa-b
+		By("Remove the component label from sa-b")
 		Eventually(Apply(saB, func(m metav1.Object) error {
 			m.SetLabels(nil)
 			return nil
 		})).Should(Succeed())
 
-		// Ensure the reference to sa-b is eventually removed from o's status.components.refs field
+		By("Ensure the reference to sa-b is eventually removed from o's status.components.refs field")
 		By("removing a component's reference when it no longer bears the component label")
 		componentRefEventuallyExists(w, false, getReference(scheme, saB))
 
-		// Delete o
+		By("Delete o")
 		Eventually(func() error {
 			err := client.Delete(clientCtx, o)
 			if err != nil && !apierrors.IsNotFound(err) {
@@ -200,13 +218,13 @@ var _ = Describe("Operator API", func() {
 			return nil
 		}).Should(Succeed())
 
-		// Ensure that o is eventually recreated (because some of its components still exist).
+		By("Ensure that o is eventually recreated (because some of its components still exist).")
 		By("recreating the Operator when any components still exist")
 		Eventually(func() error {
 			return client.Get(clientCtx, types.NamespacedName{Name: o.GetName()}, o)
 		}).Should(Succeed())
 
-		// Delete ns-a
+		By("Delete ns-a")
 		Eventually(func() error {
 			err := client.Delete(clientCtx, nsA)
 			if apierrors.IsNotFound(err) {
@@ -215,11 +233,11 @@ var _ = Describe("Operator API", func() {
 			return err
 		}).Should(Succeed())
 
-		// Ensure the reference to ns-a is eventually removed from o's status.components.refs field
+		By("Ensure the reference to ns-a is eventually removed from o's status.components.refs field")
 		By("removing a component's reference when it no longer exists")
 		componentRefEventuallyExists(w, false, getReference(scheme, nsA))
 
-		// Delete o
+		By("Delete o")
 		Eventually(func() error {
 			err := client.Delete(clientCtx, o)
 			if apierrors.IsNotFound(err) {
@@ -228,7 +246,7 @@ var _ = Describe("Operator API", func() {
 			return err
 		}).Should(Succeed())
 
-		// Ensure that o is consistently not found
+		By("Ensure that o is consistently not found")
 		By("verifying the Operator is permanently deleted if it has no components")
 		Consistently(func() error {
 			err := client.Get(clientCtx, types.NamespacedName{Name: o.GetName()}, o)

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2890,9 +2890,9 @@ func fetchSubscription(crc versioned.Interface, namespace, name string, checker 
 			return false, err
 		}
 		thisState, thisCSV, thisInstallPlanRef := fetchedSubscription.Status.State, fetchedSubscription.Status.CurrentCSV, fetchedSubscription.Status.InstallPlanRef
-		if thisState != lastState || thisCSV != lastCSV || equality.Semantic.DeepEqual(thisInstallPlanRef, lastInstallPlanRef) {
+		if thisState != lastState || thisCSV != lastCSV || !equality.Semantic.DeepEqual(thisInstallPlanRef, lastInstallPlanRef) {
 			lastState, lastCSV, lastInstallPlanRef = thisState, thisCSV, thisInstallPlanRef
-			log(fmt.Sprintf("%s (%s): %s", thisState, thisCSV, thisInstallPlanRef))
+			log(fmt.Sprintf("subscription %s/%s state: %s (csv %s): installPlanRef: %#v", namespace, name, thisState, thisCSV, thisInstallPlanRef))
 		}
 		return checker(fetchedSubscription), nil
 	})

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -2904,6 +2905,11 @@ func fetchSubscription(crc versioned.Interface, namespace, name string, checker 
 
 func buildSubscriptionCleanupFunc(crc versioned.Interface, subscription *operatorsv1alpha1.Subscription) cleanupFunc {
 	return func() {
+		if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+			fmt.Printf("Skipping cleanup of install plan for subscription %s/%s...\n", subscription.GetNamespace(), subscription.GetName())
+			return
+		}
+
 		if installPlanRef := subscription.Status.InstallPlanRef; installPlanRef != nil {
 			installPlan, err := crc.OperatorsV1alpha1().InstallPlans(subscription.GetNamespace()).Get(context.Background(), installPlanRef.Name, metav1.GetOptions{})
 			if err == nil {

--- a/test/e2e/user_defined_sa_test.go
+++ b/test/e2e/user_defined_sa_test.go
@@ -83,7 +83,7 @@ var _ = Describe("User defined service account", func() {
 
 		By("We expect the InstallPlan to be in status: Failed.")
 		ipName := subscription.Status.Install.Name
-		ipPhaseCheckerFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseFailed)
+		ipPhaseCheckerFunc := buildInstallPlanMessageCheckFunc(`cannot create resource`)
 		ipGot, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, ipName, generatedNamespace.GetName(), ipPhaseCheckerFunc)
 		require.NoError(GinkgoT(), err)
 
@@ -186,12 +186,11 @@ var _ = Describe("User defined service account", func() {
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
-		By("We expect the InstallPlan to be in status: Failed.")
+		By("We expect the InstallPlan to expose the permissions error.")
 		ipNameOld := subscription.Status.InstallPlanRef.Name
-		ipPhaseCheckerFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseFailed)
-		ipGotOld, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, ipNameOld, generatedNamespace.GetName(), ipPhaseCheckerFunc)
+		ipPhaseCheckerFunc := buildInstallPlanMessageCheckFunc(`cannot create resource "clusterserviceversions" in API group "operators.coreos.com" in the namespace`)
+		_, err = fetchInstallPlanWithNamespace(GinkgoT(), crc, ipNameOld, generatedNamespace.GetName(), ipPhaseCheckerFunc)
 		require.NoError(GinkgoT(), err)
-		require.Equal(GinkgoT(), v1alpha1.InstallPlanPhaseFailed, ipGotOld.Status.Phase)
 
 		By("Grant permission now and this should trigger an retry of InstallPlan.")
 		cleanupPerm := grantPermission(GinkgoT(), c, generatedNamespace.GetName(), saName)

--- a/test/e2e/user_defined_sa_test.go
+++ b/test/e2e/user_defined_sa_test.go
@@ -81,17 +81,12 @@ var _ = Describe("User defined service account", func() {
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
-		By("We expect the InstallPlan to be in status: Failed.")
+		By("We expect the InstallPlan to be in status: Installing.")
 		ipName := subscription.Status.Install.Name
 		ipPhaseCheckerFunc := buildInstallPlanMessageCheckFunc(`cannot create resource`)
 		ipGot, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, ipName, generatedNamespace.GetName(), ipPhaseCheckerFunc)
 		require.NoError(GinkgoT(), err)
-
-		conditionGot := mustHaveCondition(GinkgoT(), ipGot, v1alpha1.InstallPlanInstalled)
-		assert.Equal(GinkgoT(), corev1.ConditionFalse, conditionGot.Status)
-		assert.Equal(GinkgoT(), v1alpha1.InstallPlanReasonComponentFailed, conditionGot.Reason)
-		assert.Contains(GinkgoT(), conditionGot.Message, fmt.Sprintf("is forbidden: User \"system:serviceaccount:%s:%s\" cannot create resource", generatedNamespace.GetName(), saName))
-
+		
 		By("Verify that all step resources are in Unknown state.")
 		for _, step := range ipGot.Status.Plan {
 			assert.Equal(GinkgoT(), v1alpha1.StepStatusUnknown, step.Status)

--- a/test/e2e/user_defined_sa_test.go
+++ b/test/e2e/user_defined_sa_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo/v2"
@@ -242,6 +243,10 @@ func newServiceAccount(client operatorclient.ClientInterface, namespace, name st
 	Expect(sa).ToNot(BeNil())
 
 	cleanup = func() {
+		if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+			fmt.Printf("Skipping cleanup of service account %s/%s...\n", sa.GetNamespace(), sa.GetName())
+			return
+		}
 		err := client.KubernetesInterface().CoreV1().ServiceAccounts(sa.GetNamespace()).Delete(context.TODO(), sa.GetName(), metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -268,6 +273,10 @@ func newOperatorGroupWithServiceAccount(client versioned.Interface, namespace, n
 	Expect(og).ToNot(BeNil())
 
 	cleanup = func() {
+		if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+			fmt.Printf("Skipping cleanup of operator group %s/%s...\n", og.GetNamespace(), og.GetName())
+			return
+		}
 		err := client.OperatorsV1().OperatorGroups(og.GetNamespace()).Delete(context.TODO(), og.GetName(), metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -538,6 +547,14 @@ func grantPermission(t GinkgoTInterface, client operatorclient.ClientInterface, 
 	require.NoError(t, err)
 
 	cleanup = func() {
+		if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+			fmt.Printf("Skipping cleanup of role %s/%s...\n", role.GetNamespace(), role.GetName())
+			fmt.Printf("Skipping cleanup of role binding %s/%s...\n", binding.GetNamespace(), binding.GetName())
+			fmt.Printf("Skipping cleanup of cluster role %s...\n", clusterrole.GetName())
+			fmt.Printf("Skipping cleanup of cluster role binding %s...\n", clusterbinding.GetName())
+			return
+		}
+
 		err := client.KubernetesInterface().RbacV1().Roles(role.GetNamespace()).Delete(context.TODO(), role.GetName(), metav1.DeleteOptions{})
 		require.NoError(t, err)
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -50,7 +50,7 @@ import (
 )
 
 const (
-	pollInterval = 1 * time.Second
+	pollInterval = 100 * time.Millisecond
 	pollDuration = 5 * time.Minute
 
 	olmConfigMap = "olm-operators" // No-longer used, how long do we keep this around?


### PR DESCRIPTION
When all of the k8s objects that need labels have them, we are good to exit the process. The next Pod that start up will detect that all labels are present and be able to filter informers going forward.
