### PR TITLE
OCPBUGS-17157: pkg/controller: label RBAC with content hash

### DIFF
--- a/pkg/controller/operators/labeller/filters.go
+++ b/pkg/controller/operators/labeller/filters.go
@@ -21,6 +21,10 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/internal/alongside"
 )
 
+func ContentHashFilter(object metav1.Object) bool {
+	return HasOLMOwnerRef(object) && !hasHashLabel(object)
+}
+
 func Filter(gvr schema.GroupVersionResource) func(metav1.Object) bool {
 	if f, ok := filters[gvr]; ok {
 		return f
@@ -80,6 +84,18 @@ func Validate(ctx context.Context, logger *logrus.Logger, metadataClient metadat
 	allFilters[batchv1.SchemeGroupVersion.WithResource("jobs")] = JobFilter(func(namespace, name string) (metav1.Object, error) {
 		return metadataClient.Resource(corev1.SchemeGroupVersion.WithResource("configmaps")).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	})
+
+	for _, gvr := range []schema.GroupVersionResource{
+		rbacv1.SchemeGroupVersion.WithResource("roles"),
+		rbacv1.SchemeGroupVersion.WithResource("rolebindings"),
+		rbacv1.SchemeGroupVersion.WithResource("clusterroles"),
+		rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"),
+	} {
+		previous := allFilters[gvr]
+		allFilters[gvr] = func(object metav1.Object) bool {
+			return previous != nil && previous(object) && ContentHashFilter(object)
+		}
+	}
 	for gvr, filter := range allFilters {
 		gvr, filter := gvr, filter
 		g.Go(func() error {

--- a/pkg/controller/operators/labeller/rbac.go
+++ b/pkg/controller/operators/labeller/rbac.go
@@ -1,0 +1,56 @@
+package labeller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func hasHashLabel(obj metav1.Object) bool {
+	_, ok := obj.GetLabels()[resolver.ContentHashLabelKey]
+	return ok
+}
+
+func ContentHashLabeler[T metav1.Object, A ApplyConfig[A]](
+	ctx context.Context,
+	logger *logrus.Logger,
+	check func(metav1.Object) bool,
+	hasher func(object T) (string, error),
+	applyConfigFor func(name, namespace string) A,
+	apply func(namespace string, ctx context.Context, cfg A, opts metav1.ApplyOptions) (T, error),
+) queueinformer.LegacySyncHandler {
+	return func(obj interface{}) error {
+		cast, ok := obj.(T)
+		if !ok {
+			err := fmt.Errorf("wrong type %T, expected %T: %#v", obj, new(T), obj)
+			logger.WithError(err).Error("casting failed")
+			return fmt.Errorf("casting failed: %w", err)
+		}
+
+		if _, _, ok := ownerutil.GetOwnerByKindLabel(cast, v1alpha1.ClusterServiceVersionKind); !ok {
+			return nil
+		}
+
+		if !check(cast) || hasHashLabel(cast) {
+			return nil
+		}
+
+		hash, err := hasher(cast)
+		if err != nil {
+			return fmt.Errorf("failed to calculate hash: %w", err)
+		}
+
+		cfg := applyConfigFor(cast.GetName(), cast.GetNamespace())
+		cfg.WithLabels(map[string]string{
+			resolver.ContentHashLabelKey: hash,
+		})
+		_, err = apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{})
+		return err
+	}
+}

--- a/pkg/package-server/provider/registry_test.go
+++ b/pkg/package-server/provider/registry_test.go
@@ -787,7 +787,7 @@ func TestRegistryProviderList(t *testing.T) {
 			globalNS:         "ns",
 			requestNamespace: "wisconsin",
 			expectedErr:      "",
-			expected:         &operators.PackageManifestList{Items: []operators.PackageManifest{}},
+			expected:         &operators.PackageManifestList{},
 		},
 		{
 			name:     "PackagesFound",
@@ -1230,7 +1230,6 @@ func TestRegistryProviderList(t *testing.T) {
 			} else {
 				require.Nil(t, err)
 			}
-
 			require.Equal(t, len(test.expected.Items), len(packageManifestList.Items))
 			require.ElementsMatch(t, test.expected.Items, packageManifestList.Items)
 		})


### PR DESCRIPTION
When a CSV is processed, it is assumed that the InstallPlan has already run, or that a user that's creating a CSV as their entrypoint into the system has otherwise met all the preconditions for the CSV to exist.

As part of validating these preconditions, the CSV logic today uses cluster-scoped listers for all RBAC resources. sets up an in-memory authorizer for these, and queries the CSV install strategie's permissions against those.

We would like to restrict the amount of memory OLM uses, and part of that is not caching the world. For the above approach to work, all RBAC objects fulfilling CSV permission preconditions would need to be labelled. In the case that a user is creating a CSV manually, this will not be the case.

We can use the SubjectAccessReview API to check for the presence of permissions without caching the world, but since a PolicyRule has slices of verbs, resources, subjects, etc and the SAR endpoint accepts but one of each, there will be (in the general case) a combinatorical explosion of calls to issue enough SARs to cover the full set of permissions.

Therefore, we need to limit the amount of times we take that action. A simple optimization is to check for permissions created directly by OLM, as that's by far the most common entrypoint into the system (a user creates a Subscription, that triggers an InstallPlan, which creates the RBAC).

As OLM chose to name the RBAC objects with random strings of characters, it's not possible to look at a list of permissions in a CSV and know which resources OLM would have created. Therefore, this PR adds a label to all relevant RBAC resources with the hash of their content. We already have the name of the CSV, but since CSV content is ostensibly mutable, this is not enough.
