### PR TITLE
Rename ClusterRoles created by OperatorGroups

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -4560,8 +4560,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 				"": {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
+							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4571,8 +4570,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
+							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4582,8 +4580,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
+							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4624,8 +4621,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "operator-group-1-admin",
+							Name: "operator-group-1-admin",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4635,8 +4631,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "operator-group-1-view",
+							Name: "operator-group-1-view",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4646,8 +4641,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "operator-group-1-edit",
+							Name: "operator-group-1-edit",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4665,8 +4659,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 				"": {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
+							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4676,8 +4669,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
+							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4687,8 +4679,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
+							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4698,8 +4689,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "operator-group-1-admin",
+							Name: "operator-group-1-admin",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4709,8 +4699,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "operator-group-1-view",
+							Name: "operator-group-1-view",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4720,8 +4709,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "operator-group-1-edit",
+							Name: "operator-group-1-edit",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4762,8 +4750,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
+							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns-bob",
@@ -4774,8 +4761,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
+							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-5",
 								"olm.owner.namespace": "operator-ns",
@@ -4787,8 +4773,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
+							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4806,8 +4791,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 				"": {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
+							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4818,8 +4802,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
+							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4829,8 +4812,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
+							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4873,8 +4855,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
+							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4884,8 +4865,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
+							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4895,8 +4875,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
+							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4913,8 +4892,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 				"": {
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
+							Name: "olm.og.operator-group-1.admin-8rdAjL0E35JMMAkOqYmoorzjpIIihfnj3DcgDU",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4924,8 +4902,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
+							Name: "olm.og.operator-group-1.edit-9lBEUxqAYE7CX7wZfFEPYutTfQTo43WarB08od",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",
@@ -4935,8 +4912,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 					&rbacv1.ClusterRole{
 						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: "",
-							Name:            "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
+							Name: "olm.og.operator-group-1.view-1l6ymczPK5SceF4d0DCtAnWZuvmKn6s8oBUxHr",
 							Labels: map[string]string{
 								"olm.owner":           "operator-group-1",
 								"olm.owner.namespace": "operator-ns",

--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -273,7 +273,7 @@ func CSVOwnerSelector(owner *operatorsv1alpha1.ClusterServiceVersion) labels.Sel
 
 // OperatorGroupOwnerSelector returns a label selector to find generated objects owned by owner
 func OperatorGroupOwnerSelector(owner *operatorsv1.OperatorGroup) labels.Selector {
-	return labels.SelectorFromSet(OwnerLabel(owner, "OperatorGroup"))
+	return labels.SelectorFromSet(OwnerLabel(owner, operatorsv1.OperatorGroupKind))
 }
 
 // AddOwner adds an owner to the ownerref list.

--- a/pkg/lib/ownerutil/util.go
+++ b/pkg/lib/ownerutil/util.go
@@ -271,6 +271,11 @@ func CSVOwnerSelector(owner *operatorsv1alpha1.ClusterServiceVersion) labels.Sel
 	return labels.SelectorFromSet(OwnerLabel(owner, operatorsv1alpha1.ClusterServiceVersionKind))
 }
 
+// OperatorGroupOwnerSelector returns a label selector to find generated objects owned by owner
+func OperatorGroupOwnerSelector(owner *operatorsv1.OperatorGroup) labels.Selector {
+	return labels.SelectorFromSet(OwnerLabel(owner, "OperatorGroup"))
+}
+
 // AddOwner adds an owner to the ownerref list.
 func AddOwner(object metav1.Object, owner Owner, blockOwnerDeletion, isController bool) {
 	// Most of the time we won't have TypeMeta on the object, so we infer it for types we know about

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -351,18 +353,28 @@ var _ = Describe("Operator Group", func() {
 				adminPolicyRules := []rbacv1.PolicyRule{
 					{Verbs: []string{"*"}, APIGroups: []string{mainCRD.Spec.Group}, Resources: []string{mainCRDPlural}},
 				}
-				require.Equal(GinkgoT(), adminPolicyRules, role.Rules)
+				if assert.Equal(GinkgoT(), adminPolicyRules, role.Rules) == false {
+					fmt.Println(cmp.Diff(adminPolicyRules, role.Rules))
+					GinkgoT().Fail()
+				}
+
 			} else if strings.HasSuffix(role.Name, "edit") {
 				editPolicyRules := []rbacv1.PolicyRule{
 					{Verbs: []string{"create", "update", "patch", "delete"}, APIGroups: []string{mainCRD.Spec.Group}, Resources: []string{mainCRDPlural}},
 				}
-				require.Equal(GinkgoT(), editPolicyRules, role.Rules)
+				if assert.Equal(GinkgoT(), editPolicyRules, role.Rules) == false {
+					fmt.Println(cmp.Diff(editPolicyRules, role.Rules))
+					GinkgoT().Fail()
+				}
 			} else if strings.HasSuffix(role.Name, "view") {
 				viewPolicyRules := []rbacv1.PolicyRule{
 					{Verbs: []string{"get"}, APIGroups: []string{"apiextensions.k8s.io"}, Resources: []string{"customresourcedefinitions"}, ResourceNames: []string{mainCRD.Name}},
 					{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{mainCRD.Spec.Group}, Resources: []string{mainCRDPlural}},
 				}
-				require.Equal(GinkgoT(), viewPolicyRules, role.Rules)
+				if assert.Equal(GinkgoT(), viewPolicyRules, role.Rules) == false {
+					fmt.Println(cmp.Diff(viewPolicyRules, role.Rules))
+					GinkgoT().Fail()
+				}
 			}
 		}
 


### PR DESCRIPTION
**Description of the change:**
When an OperatorGroup creates a ClusterRole, it's based directly on the OG name with a suffix, this causes two issues:
1. same-named OGs in different namespaces overwrite each others CRs
2. there are some very important CRs that could be overwritten by OG

Tests added.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Motivation for the change:**

The ClusterRoles created by an OperatorGroup can conflict with existing CRs and with CRs created by OGs.

**Architectural changes:**

Naming of these OG CRs change, but since they're aggregated, admins shouldn't really be using them, so the new names shouldn't matter.

There will be a need to clean up the old roles, but that could potentially be dangerous.

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
