### PR TITLE
Use generated namespaces in e2e tests

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -49,7 +49,7 @@ const (
 
 var _ = Describe("Starting CatalogSource e2e tests", func() {
 	var (
-		ns                  corev1.Namespace
+		generatedNamespace  corev1.Namespace
 		c                   operatorclient.ClientInterface
 		crc                 versioned.Interface
 		packageserverClient *packageserverclientset.Clientset
@@ -67,14 +67,14 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 				Namespace: namespaceName,
 			},
 		}
-		ns = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
 		c = ctx.Ctx().KubeClient()
 		crc = ctx.Ctx().OperatorClient()
 		packageserverClient = packageserverclientset.NewForConfigOrDie(ctx.Ctx().RESTConfig())
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	It("loading between restarts", func() {
@@ -93,7 +93,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		}
 
 		crd := newCRD(genName("ins-"))
-		csv := newCSV(packageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
+		csv := newCSV(packageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
 
 		defer func() {
 			Eventually(func() error {
@@ -105,11 +105,11 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		}()
 
 		catalogSourceName := genName("mock-ocs-")
-		_, cleanupSource := createInternalCatalogSource(c, crc, catalogSourceName, ns.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
+		_, cleanupSource := createInternalCatalogSource(c, crc, catalogSourceName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
 		defer cleanupSource()
 
 		// ensure the mock catalog exists and has been synced by the catalog operator
-		catalogSource, err := fetchCatalogSourceOnStatus(crc, catalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+		catalogSource, err := fetchCatalogSourceOnStatus(crc, catalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// get catalog operator deployment
@@ -125,7 +125,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 
 		// check for last synced update to catalogsource
 		By("Checking for catalogsource lastSync updates")
-		_, err = fetchCatalogSourceOnStatus(crc, catalogSourceName, ns.GetName(), func(cs *v1alpha1.CatalogSource) bool {
+		_, err = fetchCatalogSourceOnStatus(crc, catalogSourceName, generatedNamespace.GetName(), func(cs *v1alpha1.CatalogSource) bool {
 			before := catalogSource.Status.GRPCConnectionState
 			after := cs.Status.GRPCConnectionState
 			if after != nil && after.LastConnectTime.After(before.LastConnectTime.Time) {
@@ -147,8 +147,8 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		stableChannel := "stable"
 
 		mainCRD := newCRD(genName("ins-"))
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, nil)
-		replacementCSV := newCSV(mainPackageReplacement, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, nil)
+		replacementCSV := newCSV(mainPackageReplacement, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, nil)
 
 		defer func() {
 			Eventually(func() error {
@@ -194,9 +194,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 
 		// Create Subscription
 		subscriptionName := genName("sub-")
-		createSubscriptionForCatalogWithSpec(GinkgoT(), crc, ns.GetName(), subscriptionName, subscriptionSpec)
+		createSubscriptionForCatalogWithSpec(GinkgoT(), crc, generatedNamespace.GetName(), subscriptionName, subscriptionSpec)
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ToNot(BeNil())
 
@@ -204,17 +204,17 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		requiresApprovalChecker := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseRequiresApproval)
 
 		Eventually(func() error {
-			fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), requiresApprovalChecker)
+			fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), requiresApprovalChecker)
 			if err != nil {
 				return err
 			}
 
 			fetchedInstallPlan.Spec.Approved = true
-			_, err = crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Update(context.Background(), fetchedInstallPlan, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Update(context.Background(), fetchedInstallPlan, metav1.UpdateOptions{})
 			return err
 		}).Should(Succeed())
 
-		_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Update manifest
@@ -235,7 +235,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		fetchedUpdatedCatalog, err := fetchCatalogSourceOnStatus(crc, cs.GetName(), cs.GetNamespace(), catalogSourceRegistryPodSynced())
 		Expect(err).ShouldNot(HaveOccurred())
 
-		subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionStateUpgradePendingChecker())
+		subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateUpgradePendingChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
 
@@ -256,8 +256,8 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		stableChannel := "stable"
 
 		dependentCRD := newCRD(genName("ins-"))
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-		dependentCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+		dependentCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 		defer func() {
 			Eventually(func() error {
@@ -295,25 +295,25 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		}
 
 		// Create the initial catalogsource
-		createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
+		createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
 
 		// Attempt to get the catalog source before creating install plan
-		fetchedInitialCatalog, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+		fetchedInitialCatalog, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Get initial configmap
-		configMap, err := c.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), fetchedInitialCatalog.Spec.ConfigMap, metav1.GetOptions{})
+		configMap, err := c.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Get(context.Background(), fetchedInitialCatalog.Spec.ConfigMap, metav1.GetOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Check pod created
-		initialPods, err := c.KubernetesInterface().CoreV1().Pods(ns.GetName()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.configMapResourceVersion=" + configMap.ResourceVersion})
+		initialPods, err := c.KubernetesInterface().CoreV1().Pods(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.configMapResourceVersion=" + configMap.ResourceVersion})
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(initialPods.Items).To(HaveLen(1))
 
 		// Update catalog configmap
-		updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV}, append(mainManifests, dependentManifests...))
+		updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV}, append(mainManifests, dependentManifests...))
 
-		fetchedUpdatedCatalog, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), func(catalog *v1alpha1.CatalogSource) bool {
+		fetchedUpdatedCatalog, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), func(catalog *v1alpha1.CatalogSource) bool {
 			before := fetchedInitialCatalog.Status.ConfigMapResource
 			after := catalog.Status.ConfigMapResource
 			if after != nil && before.LastUpdateTime.Before(&after.LastUpdateTime) &&
@@ -330,7 +330,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Eventually(func() (types.UID, error) {
 			var err error
 			// Get updated configmap
-			updatedConfigMap, err = c.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), fetchedInitialCatalog.Spec.ConfigMap, metav1.GetOptions{})
+			updatedConfigMap, err = c.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Get(context.Background(), fetchedInitialCatalog.Spec.ConfigMap, metav1.GetOptions{})
 			if err != nil {
 				return "", err
 			}
@@ -347,27 +347,27 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		// Await 1 CatalogSource registry pod matching the updated labels
 		singlePod := podCount(1)
 		selector := labels.SelectorFromSet(map[string]string{"olm.catalogSource": mainCatalogName, "olm.configMapResourceVersion": updatedConfigMap.GetResourceVersion()})
-		podList, err := awaitPods(GinkgoT(), c, ns.GetName(), selector.String(), singlePod)
+		podList, err := awaitPods(GinkgoT(), c, generatedNamespace.GetName(), selector.String(), singlePod)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(podList.Items).To(HaveLen(1), "expected pod list not of length 1")
 
 		// Await 1 CatalogSource registry pod matching the updated labels
 		selector = labels.SelectorFromSet(map[string]string{"olm.catalogSource": mainCatalogName})
-		podList, err = awaitPods(GinkgoT(), c, ns.GetName(), selector.String(), singlePod)
+		podList, err = awaitPods(GinkgoT(), c, generatedNamespace.GetName(), selector.String(), singlePod)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(podList.Items).To(HaveLen(1), "expected pod list not of length 1")
 
 		// Create Subscription
 		subscriptionName := genName("sub-")
-		createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, fetchedUpdatedCatalog.GetName(), mainPackageName, stableChannel, "", v1alpha1.ApprovalAutomatic)
+		createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, fetchedUpdatedCatalog.GetName(), mainPackageName, stableChannel, "", v1alpha1.ApprovalAutomatic)
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, ns.GetName(), buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		Expect(err).ShouldNot(HaveOccurred())
 
-		ipList, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).List(context.Background(), metav1.ListOptions{})
+		ipList, err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
 		ipCount := 0
 		for _, ip := range ipList.Items {
 			if ownerutil.IsOwnedBy(&ip, subscription) {
@@ -389,8 +389,8 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		stableChannel := "stable"
 
 		dependentCRD := newCRD(genName("ins-"))
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-		dependentCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+		dependentCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 		defer func() {
 			Eventually(func() error {
@@ -428,17 +428,17 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		}
 
 		// Create the initial catalogsource
-		_, cleanupSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, nil, []v1alpha1.ClusterServiceVersion{mainCSV})
 
 		// Attempt to get the catalog source before creating install plan
-		fetchedInitialCatalog, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+		fetchedInitialCatalog, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		Expect(err).ShouldNot(HaveOccurred())
 		// Get initial configmap
-		configMap, err := c.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), fetchedInitialCatalog.Spec.ConfigMap, metav1.GetOptions{})
+		configMap, err := c.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Get(context.Background(), fetchedInitialCatalog.Spec.ConfigMap, metav1.GetOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Check pod created
-		initialPods, err := c.KubernetesInterface().CoreV1().Pods(ns.GetName()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.configMapResourceVersion=" + configMap.ResourceVersion})
+		initialPods, err := c.KubernetesInterface().CoreV1().Pods(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.configMapResourceVersion=" + configMap.ResourceVersion})
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(initialPods.Items).To(HaveLen(1))
 
@@ -446,16 +446,16 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		cleanupSource()
 
 		// create a catalog with the same name
-		createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), append(mainManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV})
+		createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), append(mainManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV})
 
 		// Create Subscription
 		subscriptionName := genName("sub-")
-		createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", v1alpha1.ApprovalAutomatic)
+		createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", v1alpha1.ApprovalAutomatic)
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ToNot(BeNil())
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, ns.GetName(), buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -482,9 +482,9 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		stableChannel := "stable"
 
 		dependentCRD := newCRD(genName("ins-"))
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-		replacementCSV := newCSV(mainPackageReplacement, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-		dependentCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+		replacementCSV := newCSV(mainPackageReplacement, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+		dependentCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 		defer func() {
 			Eventually(func() error {
@@ -536,13 +536,13 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		}
 
 		// Create ConfigMap CatalogSources
-		createInternalCatalogSource(c, crc, mainSourceName, ns.GetName(), append(mainManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV})
-		createInternalCatalogSource(c, crc, replacementSourceName, ns.GetName(), append(replacementManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{replacementCSV, mainCSV, dependentCSV})
+		createInternalCatalogSource(c, crc, mainSourceName, generatedNamespace.GetName(), append(mainManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{mainCSV, dependentCSV})
+		createInternalCatalogSource(c, crc, replacementSourceName, generatedNamespace.GetName(), append(replacementManifests, dependentManifests...), []apiextensions.CustomResourceDefinition{dependentCRD}, []v1alpha1.ClusterServiceVersion{replacementCSV, mainCSV, dependentCSV})
 
 		// Wait for ConfigMap CatalogSources to be ready
-		mainSource, err := fetchCatalogSourceOnStatus(crc, mainSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+		mainSource, err := fetchCatalogSourceOnStatus(crc, mainSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		Expect(err).ShouldNot(HaveOccurred())
-		replacementSource, err := fetchCatalogSourceOnStatus(crc, replacementSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+		replacementSource, err := fetchCatalogSourceOnStatus(crc, replacementSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Replicate catalog pods with no OwnerReferences
@@ -561,7 +561,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      addressSourceName,
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
@@ -572,10 +572,10 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			},
 		}
 
-		addressSource, err = crc.OperatorsV1alpha1().CatalogSources(ns.GetName()).Create(context.Background(), addressSource, metav1.CreateOptions{})
+		addressSource, err = crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Create(context.Background(), addressSource, metav1.CreateOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 		defer func() {
-			err := crc.OperatorsV1alpha1().CatalogSources(ns.GetName()).Delete(context.Background(), addressSourceName, metav1.DeleteOptions{})
+			err := crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Delete(context.Background(), addressSourceName, metav1.DeleteOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 		}()
 
@@ -584,36 +584,36 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(err).ToNot(HaveOccurred(), "catalog source did not become ready")
 
 		// Delete CatalogSources
-		err = crc.OperatorsV1alpha1().CatalogSources(ns.GetName()).Delete(context.Background(), mainSourceName, metav1.DeleteOptions{})
+		err = crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Delete(context.Background(), mainSourceName, metav1.DeleteOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
-		err = crc.OperatorsV1alpha1().CatalogSources(ns.GetName()).Delete(context.Background(), replacementSourceName, metav1.DeleteOptions{})
+		err = crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Delete(context.Background(), replacementSourceName, metav1.DeleteOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Create Subscription
 		subscriptionName := genName("sub-")
-		cleanupSubscription := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, addressSourceName, mainPackageName, stableChannel, "", v1alpha1.ApprovalAutomatic)
+		cleanupSubscription := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, addressSourceName, mainPackageName, stableChannel, "", v1alpha1.ApprovalAutomatic)
 		defer cleanupSubscription()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, ns.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Update the catalog's address to point at the other registry pod's cluster ip
 		Eventually(func() error {
-			addressSource, err = crc.OperatorsV1alpha1().CatalogSources(ns.GetName()).Get(context.Background(), addressSourceName, metav1.GetOptions{})
+			addressSource, err = crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Get(context.Background(), addressSourceName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
 			addressSource.Spec.Address = net.JoinHostPort(replacementCopy.Status.PodIP, "50051")
-			_, err = crc.OperatorsV1alpha1().CatalogSources(ns.GetName()).Update(context.Background(), addressSource, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Update(context.Background(), addressSource, metav1.UpdateOptions{})
 			return err
 		}).Should(Succeed())
 
 		// Wait for the replacement CSV to be installed
-		_, err = awaitCSV(crc, ns.GetName(), replacementCSV.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), replacementCSV.GetName(), csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -630,7 +630,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		stableChannel := "stable"
 		sourceName := genName("catalog-")
 		crd := newCRD(genName("ins-"))
-		csv := newCSV(packageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
+		csv := newCSV(packageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
 		manifests := []registry.PackageManifest{
 			{
 				PackageName: packageName,
@@ -650,13 +650,13 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			}).Should(Succeed())
 		}()
 
-		_, cleanupSource := createInternalCatalogSource(c, crc, sourceName, ns.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
+		_, cleanupSource := createInternalCatalogSource(c, crc, sourceName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv})
 		defer cleanupSource()
 
 		// Wait for a new registry pod to be created
 		selector := labels.SelectorFromSet(map[string]string{"olm.catalogSource": sourceName})
 		singlePod := podCount(1)
-		registryPods, err := awaitPods(GinkgoT(), c, ns.GetName(), selector.String(), singlePod)
+		registryPods, err := awaitPods(GinkgoT(), c, generatedNamespace.GetName(), selector.String(), singlePod)
 		Expect(err).ShouldNot(HaveOccurred(), "error awaiting registry pod")
 		Expect(registryPods).ToNot(BeNil(), "nil registry pods")
 		Expect(registryPods.Items).To(HaveLen(1), "unexpected number of registry pods found")
@@ -667,7 +667,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		// Delete the registry pod
 		Eventually(func() error {
 			backgroundDeletion := metav1.DeletePropagationBackground
-			return c.KubernetesInterface().CoreV1().Pods(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{PropagationPolicy: &backgroundDeletion}, metav1.ListOptions{LabelSelector: selector.String()})
+			return c.KubernetesInterface().CoreV1().Pods(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{PropagationPolicy: &backgroundDeletion}, metav1.ListOptions{LabelSelector: selector.String()})
 		}).Should(Succeed())
 
 		// Wait for a new registry pod to be created
@@ -683,7 +683,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			ctx.Ctx().Logf("waiting for %v to not be empty and not contain %s", uids, uid)
 			return len(pods.Items) > 0
 		}
-		registryPods, err = awaitPods(GinkgoT(), c, ns.GetName(), selector.String(), unionPodsCheck(singlePod, notUID))
+		registryPods, err = awaitPods(GinkgoT(), c, generatedNamespace.GetName(), selector.String(), unionPodsCheck(singlePod, notUID))
 		Expect(err).ShouldNot(HaveOccurred(), "error waiting for replacement registry pod")
 		Expect(registryPods).ToNot(BeNil(), "nil replacement registry pods")
 		Expect(registryPods.Items).To(HaveLen(1), "unexpected number of replacement registry pods found")
@@ -704,7 +704,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("catalog-"),
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
@@ -732,7 +732,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		// Delete the registry pod
 		Eventually(func() error {
 			backgroundDeletion := metav1.DeletePropagationBackground
-			return c.KubernetesInterface().CoreV1().Pods(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{PropagationPolicy: &backgroundDeletion}, metav1.ListOptions{LabelSelector: selector.String()})
+			return c.KubernetesInterface().CoreV1().Pods(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{PropagationPolicy: &backgroundDeletion}, metav1.ListOptions{LabelSelector: selector.String()})
 		}).Should(Succeed())
 
 		// Wait for a new registry pod to be created
@@ -748,7 +748,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			ctx.Ctx().Logf("waiting for %v to not be empty and not contain %s", uids, uid)
 			return len(pods.Items) > 0
 		}
-		registryPods, err = awaitPods(GinkgoT(), c, ns.GetName(), selector.String(), unionPodsCheck(singlePod, notUID))
+		registryPods, err = awaitPods(GinkgoT(), c, generatedNamespace.GetName(), selector.String(), unionPodsCheck(singlePod, notUID))
 		Expect(err).ShouldNot(HaveOccurred(), "error waiting for replacement registry pod")
 		Expect(registryPods).ShouldNot(BeNil(), "nil replacement registry pods")
 		Expect(registryPods.Items).To(HaveLen(1), "unexpected number of replacement registry pods found")
@@ -764,7 +764,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("catalog-"),
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
@@ -825,18 +825,18 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		var registryURL string
 		var registryAuth string
 		if local {
-			registryURL, err = createDockerRegistry(c, ns.GetName())
+			registryURL, err = createDockerRegistry(c, generatedNamespace.GetName())
 			Expect(err).NotTo(HaveOccurred(), "error creating container registry: %s", err)
-			defer deleteDockerRegistry(c, ns.GetName())
+			defer deleteDockerRegistry(c, generatedNamespace.GetName())
 
 			// ensure registry pod is ready before attempting port-forwarding
-			_ = awaitPod(GinkgoT(), c, ns.GetName(), registryName, podReady)
+			_ = awaitPod(GinkgoT(), c, generatedNamespace.GetName(), registryName, podReady)
 
-			err = registryPortForward(ns.GetName())
+			err = registryPortForward(generatedNamespace.GetName())
 			Expect(err).NotTo(HaveOccurred(), "port-forwarding local registry: %s", err)
 		} else {
-			registryURL = fmt.Sprintf("%s/%s", openshiftregistryFQDN, ns.GetName())
-			registryAuth, err = openshiftRegistryAuth(c, ns.GetName())
+			registryURL = fmt.Sprintf("%s/%s", openshiftregistryFQDN, generatedNamespace.GetName())
+			registryAuth, err = openshiftRegistryAuth(c, generatedNamespace.GetName())
 			Expect(err).NotTo(HaveOccurred(), "error getting openshift registry authentication: %s", err)
 		}
 
@@ -852,15 +852,15 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Expect(err).NotTo(HaveOccurred(), "error copying old registry file: %s", err)
 		} else {
 			skopeoArgs := skopeoCopyCmd(testImage, tag, catsrcImage, "old", registryAuth)
-			err = createSkopeoPod(c, skopeoArgs, ns.GetName())
+			err = createSkopeoPod(c, skopeoArgs, generatedNamespace.GetName())
 			Expect(err).NotTo(HaveOccurred(), "error creating skopeo pod: %s", err)
 
 			// wait for skopeo pod to exit successfully
-			awaitPod(GinkgoT(), c, ns.GetName(), skopeo, func(pod *corev1.Pod) bool {
+			awaitPod(GinkgoT(), c, generatedNamespace.GetName(), skopeo, func(pod *corev1.Pod) bool {
 				return pod.Status.Phase == corev1.PodSucceeded
 			})
 
-			err = deleteSkopeoPod(c, ns.GetName())
+			err = deleteSkopeoPod(c, generatedNamespace.GetName())
 			Expect(err).NotTo(HaveOccurred(), "error deleting skopeo pod: %s", err)
 		}
 
@@ -882,7 +882,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      sourceName,
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Labels:    map[string]string{"olm.catalogSource": sourceName},
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
@@ -923,7 +923,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		defer cleanupSubscription()
 
 		// Wait for the Subscription to succeed
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
 
@@ -947,15 +947,15 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Expect(err).NotTo(HaveOccurred(), "error copying new registry file: %s", err)
 		} else {
 			skopeoArgs := skopeoCopyCmd(testImage, tag, catsrcImage, "new", registryAuth)
-			err = createSkopeoPod(c, skopeoArgs, ns.GetName())
+			err = createSkopeoPod(c, skopeoArgs, generatedNamespace.GetName())
 			Expect(err).NotTo(HaveOccurred(), "error creating skopeo pod: %s", err)
 
 			// wait for skopeo pod to exit successfully
-			awaitPod(GinkgoT(), c, ns.GetName(), skopeo, func(pod *corev1.Pod) bool {
+			awaitPod(GinkgoT(), c, generatedNamespace.GetName(), skopeo, func(pod *corev1.Pod) bool {
 				return pod.Status.Phase == corev1.PodSucceeded
 			})
 
-			err = deleteSkopeoPod(c, ns.GetName())
+			err = deleteSkopeoPod(c, generatedNamespace.GetName())
 			Expect(err).NotTo(HaveOccurred(), "error deleting skopeo pod: %s", err)
 		}
 
@@ -1028,7 +1028,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			return sub.Status.InstalledCSV == "busybox.v2.0.0"
 		}
 		// Wait for the Subscription to succeed
-		subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subChecker)
+		subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
 
@@ -1070,7 +1070,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      sourceName,
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType: v1alpha1.SourceTypeGrpc,
@@ -1097,7 +1097,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		defer cleanupSubscription()
 
 		By("waiting for the Subscription to succeed")
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
 		Expect(subscription.Status.InstalledCSV).To(Equal("busybox.v1.0.0"))
@@ -1114,7 +1114,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(dependencySubscriptionName).ToNot(BeEmpty())
 
 		By("waiting for the Subscription to succeed")
-		subscription, err = fetchSubscription(crc, ns.GetName(), dependencySubscriptionName, subscriptionStateAtLatestChecker())
+		subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), dependencySubscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
 		Expect(subscription.Status.InstalledCSV).To(Equal("busybox-dependency.v1.0.0"))
@@ -1139,7 +1139,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		subChecker := func(sub *v1alpha1.Subscription) bool {
 			return sub.Status.InstalledCSV == "busybox.v2.0.0"
 		}
-		subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subChecker)
+		subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
 
@@ -1152,7 +1152,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		subChecker = func(sub *v1alpha1.Subscription) bool {
 			return sub.Status.InstalledCSV == "busybox-dependency.v2.0.0"
 		}
-		subscription, err = fetchSubscription(crc, ns.GetName(), dependencySubscriptionName, subChecker)
+		subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), dependencySubscriptionName, subChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
 
@@ -1174,7 +1174,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: testNamespace,
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -1255,7 +1255,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: testNamespace,
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -1337,7 +1337,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      sourceName,
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Labels:    map[string]string{"olm.catalogSource": sourceName},
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
@@ -1427,13 +1427,13 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Expect(err).To(BeNil())
 
 			catalogSourceName = genName("cat-bad-csv")
-			magicCatalog = NewMagicCatalog(c, ns.GetName(), catalogSourceName, provider)
+			magicCatalog = NewMagicCatalog(c, generatedNamespace.GetName(), catalogSourceName, provider)
 			Expect(magicCatalog.DeployCatalog(context.Background())).To(BeNil())
 
 		})
 
 		AfterEach(func() {
-			TeardownNamespace(ns.GetName())
+			TeardownNamespace(generatedNamespace.GetName())
 		})
 
 		When("A Subscription is created catalogSource built with the malformed CSV", func() {
@@ -1442,11 +1442,11 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 				subscription = &operatorsv1alpha1.Subscription{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-sub", catalogSourceName),
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: &operatorsv1alpha1.SubscriptionSpec{
 						CatalogSource:          catalogSourceName,
-						CatalogSourceNamespace: ns.GetName(),
+						CatalogSourceNamespace: generatedNamespace.GetName(),
 						Channel:                "stable",
 						Package:                "packageA",
 					},
@@ -1456,7 +1456,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 
 			It("fails with a BundleUnpackFailed error condition, and a message that highlights the missing field in the CSV", func() {
 				Eventually(func(g Gomega) string {
-					fetchedSubscription, err := crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subscription.GetName(), metav1.GetOptions{})
+					fetchedSubscription, err := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subscription.GetName(), metav1.GetOptions{})
 					g.Expect(err).NotTo(HaveOccurred())
 
 					// expect the message that API missing
@@ -1471,7 +1471,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			var err error
 			testNS := &corev1.Namespace{}
 			Eventually(func() error {
-				testNS, err = c.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), ns.GetName(), metav1.GetOptions{})
+				testNS, err = c.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), generatedNamespace.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -1502,7 +1502,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      sourceName,
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 						Labels:    map[string]string{"olm.catalogSource": sourceName},
 					},
 					Spec: v1alpha1.CatalogSourceSpec{
@@ -1521,7 +1521,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			})
 			It("The registry pod fails to become come up because of lack of permission", func() {
 				Eventually(func() (bool, error) {
-					podList, err := c.KubernetesInterface().CoreV1().Pods(ns.GetName()).List(context.TODO(), metav1.ListOptions{})
+					podList, err := c.KubernetesInterface().CoreV1().Pods(generatedNamespace.GetName()).List(context.TODO(), metav1.ListOptions{})
 					if err != nil {
 						return false, err
 					}
@@ -1542,7 +1542,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			var err error
 			testNS := &corev1.Namespace{}
 			Eventually(func() error {
-				testNS, err = c.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), ns.GetName(), metav1.GetOptions{})
+				testNS, err = c.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), generatedNamespace.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -1573,7 +1573,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      sourceName,
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 						Labels:    map[string]string{"olm.catalogSource": sourceName},
 					},
 					Spec: v1alpha1.CatalogSourceSpec{
@@ -1592,7 +1592,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			})
 			It("The registry pod comes up successfully", func() {
 				Eventually(func() (bool, error) {
-					podList, err := c.KubernetesInterface().CoreV1().Pods(ns.GetName()).List(context.TODO(), metav1.ListOptions{})
+					podList, err := c.KubernetesInterface().CoreV1().Pods(generatedNamespace.GetName()).List(context.TODO(), metav1.ListOptions{})
 					if err != nil {
 						return false, err
 					}

--- a/test/e2e/catalog_exclusion_test.go
+++ b/test/e2e/catalog_exclusion_test.go
@@ -21,7 +21,7 @@ const magicCatalogDir = "magiccatalog"
 
 var _ = Describe("Global Catalog Exclusion", func() {
 	var (
-		testNamespace       corev1.Namespace
+		generatedNamespace  corev1.Namespace
 		determinedE2eClient *util.DeterminedE2EClient
 		operatorGroup       operatorsv1.OperatorGroup
 		localCatalog        *MagicCatalog
@@ -42,7 +42,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 				TargetNamespaces: []string{e2eTestNamespace},
 			},
 		}
-		testNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(e2eTestNamespace, operatorGroup)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(e2eTestNamespace, operatorGroup)
 
 		By("creating a broken catalog in the global namespace")
 		globalCatalog := &v1alpha1.CatalogSource{
@@ -66,7 +66,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 		var err error = nil
 
 		fbcPath := filepath.Join(testdataDir, magicCatalogDir, "fbc_initial.yaml")
-		localCatalog, err = NewMagicCatalogFromFile(determinedE2eClient, testNamespace.GetName(), localCatalogName, fbcPath)
+		localCatalog, err = NewMagicCatalogFromFile(determinedE2eClient, generatedNamespace.GetName(), localCatalogName, fbcPath)
 		Expect(err).To(Succeed())
 
 		// deploy catalog blocks until the catalog has reached a ready state or fails
@@ -79,7 +79,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(testNamespace.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	When("a subscription referring to the local catalog is created", func() {
@@ -88,7 +88,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 		BeforeEach(func() {
 			subscription = &v1alpha1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      genName("local-subscription-"),
 				},
 				Spec: &v1alpha1.SubscriptionSpec{

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -38,9 +38,9 @@ import (
 
 var _ = Describe("ClusterServiceVersion", func() {
 	var (
-		ns  corev1.Namespace
-		c   operatorclient.ClientInterface
-		crc versioned.Interface
+		generatedNamespace corev1.Namespace
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
 	)
 
 	BeforeEach(func() {
@@ -49,14 +49,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	Context("OwnNamespace OperatorGroup", func() {
 
 		BeforeEach(func() {
 			nsName := genName("csv-e2e-")
-			ns = SetupGeneratedTestNamespace(nsName, nsName)
+			generatedNamespace = SetupGeneratedTestNamespace(nsName, nsName)
 		})
 
 		When("a CustomResourceDefinition was installed alongside a ClusterServiceVersion", func() {
@@ -73,7 +73,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: apifullname,
 						Annotations: map[string]string{
-							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", ns.GetName()),
+							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", generatedNamespace.GetName()),
 						},
 					},
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -112,7 +112,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				associated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "associated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -170,7 +170,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				unassociated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "unassociated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -194,7 +194,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				associated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "associated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -229,7 +229,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				unassociated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "unassociated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -294,7 +294,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: apifullname,
 						Annotations: map[string]string{
-							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", ns.GetName()),
+							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", generatedNamespace.GetName()),
 						},
 					},
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -327,7 +327,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				associated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "associated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -351,7 +351,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				unassociated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "unassociated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -401,9 +401,8 @@ var _ = Describe("ClusterServiceVersion", func() {
 	})
 
 	Context("AllNamespaces OperatorGroup", func() {
-
 		BeforeEach(func() {
-			ns = SetupGeneratedTestNamespace(genName("csv-e2e-"))
+			generatedNamespace = SetupGeneratedTestNamespace(genName("csv-e2e-"))
 		})
 
 		When("a csv exists specifying two replicas with one max unavailable", func() {
@@ -419,7 +418,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				csv = operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "test-csv",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
@@ -508,7 +507,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			It("remains in phase Succeeded when only one pod is available", func() {
 				Eventually(func() int32 {
-					dep, err := c.GetDeployment(ns.GetName(), "deployment")
+					dep, err := c.GetDeployment(generatedNamespace.GetName(), "deployment")
 					if err != nil || dep == nil {
 						return 0
 					}
@@ -548,7 +547,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "csv-",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						InstallStrategy: newNginxInstallStrategy(genName("csv-"), nil, nil),
@@ -613,7 +612,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				cm = corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "cm-",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 					},
 				}
 				Expect(ctx.Ctx().Client().Create(context.Background(), &cm)).To(Succeed())
@@ -621,7 +620,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				sa = corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "sa-",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Name:       cm.GetName(),
@@ -641,7 +640,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "csv-",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
@@ -744,16 +743,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -805,16 +804,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -924,16 +923,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCRD()
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -983,16 +982,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -1070,16 +1069,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -1119,16 +1118,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -1213,16 +1212,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create CSV first, knowing it will fail
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			sa := corev1.ServiceAccount{}
 			sa.SetName(saName)
-			sa.SetNamespace(ns.GetName())
+			sa.SetNamespace(generatedNamespace.GetName())
 			sa.SetOwnerReferences([]metav1.OwnerReference{{
 				Name:       fetchedCSV.GetName(),
 				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
@@ -1281,7 +1280,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			role.SetName(genName("dep-"))
-			role.SetNamespace(ns.GetName())
+			role.SetNamespace(generatedNamespace.GetName())
 			_, err = c.CreateRole(&role)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
 
@@ -1301,7 +1300,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			roleBinding.SetName(genName("dep-"))
-			roleBinding.SetNamespace(ns.GetName())
+			roleBinding.SetNamespace(generatedNamespace.GetName())
 			_, err = c.CreateRoleBinding(&roleBinding)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
 
@@ -1371,7 +1370,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			ctx.Ctx().Logf("checking for deployment")
 			// Poll for deployment to be ready
 			Eventually(func() (bool, error) {
-				dep, err := c.GetDeployment(ns.GetName(), depName)
+				dep, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				if apierrors.IsNotFound(err) {
 					ctx.Ctx().Logf("deployment %s not found\n", depName)
 					return false, nil
@@ -1389,14 +1388,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return false, nil
 			}).Should(BeTrue())
 
-			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Delete CRD
 			cleanupCRD()
 
 			// Wait for CSV failure
-			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Recreate the CRD
@@ -1405,14 +1404,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupCRD()
 
 			// Wait for CSV success again
-			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("create requirements met API service", func() {
 
 			sa := corev1.ServiceAccount{}
 			sa.SetName(genName("sa-"))
-			sa.SetNamespace(ns.GetName())
+			sa.SetNamespace(generatedNamespace.GetName())
 			_, err := c.CreateServiceAccount(&sa)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create ServiceAccount")
 
@@ -1498,7 +1497,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			role.SetName(genName("dep-"))
-			role.SetNamespace(ns.GetName())
+			role.SetNamespace(generatedNamespace.GetName())
 			_, err = c.CreateRole(&role)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
 
@@ -1518,7 +1517,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			roleBinding.SetName(genName("dep-"))
-			roleBinding.SetNamespace(ns.GetName())
+			roleBinding.SetNamespace(generatedNamespace.GetName())
 			_, err = c.CreateRoleBinding(&roleBinding)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
 
@@ -1554,15 +1553,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 		})
@@ -1633,7 +1632,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			csv.SetName(depName)
 
 			// Create the APIService CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer func() {
 				watcher, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + apiServiceName})
@@ -1660,11 +1659,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 				<-deleted
 			}()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
-			dep, err := c.GetDeployment(ns.GetName(), depName)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 			// Should create APIService
@@ -1673,20 +1672,20 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should create Service
 			serviceName := fmt.Sprintf("%s-service", depName)
-			_, err = c.GetService(ns.GetName(), serviceName)
+			_, err = c.GetService(generatedNamespace.GetName(), serviceName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 			// Should create certificate Secret
 			secretName := fmt.Sprintf("%s-cert", serviceName)
-			_, err = c.GetSecret(ns.GetName(), secretName)
+			_, err = c.GetSecret(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 			// Should create a Role for the Secret
-			_, err = c.GetRole(ns.GetName(), secretName)
+			_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 			// Should create a RoleBinding for the Secret
-			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			_, err = c.GetRoleBinding(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 			// Should create a system:auth-delegator Cluster RoleBinding
@@ -1709,9 +1708,9 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return nil
 			})).Should(Succeed())
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create deployment
-				dep, err = c.GetDeployment(ns.GetName(), depName)
+				dep, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 				if err != nil {
 					return false
 				}
@@ -1740,7 +1739,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for CSV success
-			fetchedCSV, err = fetchCSV(crc, csv.GetName(), ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			fetchedCSV, err = fetchCSV(crc, csv.GetName(), generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create an APIService
 				apiService, err := c.GetAPIService(apiServiceName)
 				if err != nil {
@@ -1821,14 +1820,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 			csv.SetName("csv-hat-1")
 
 			// Create the APIService CSV
-			_, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
-			_, err = c.GetDeployment(ns.GetName(), depName)
+			_, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 			// Should create APIService
@@ -1837,20 +1836,20 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should create Service
 			serviceName := fmt.Sprintf("%s-service", depName)
-			_, err = c.GetService(ns.GetName(), serviceName)
+			_, err = c.GetService(generatedNamespace.GetName(), serviceName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 			// Should create certificate Secret
 			secretName := fmt.Sprintf("%s-cert", serviceName)
-			_, err = c.GetSecret(ns.GetName(), secretName)
+			_, err = c.GetSecret(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 			// Should create a Role for the Secret
-			_, err = c.GetRole(ns.GetName(), secretName)
+			_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 			// Should create a RoleBinding for the Secret
-			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			_, err = c.GetRoleBinding(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 			// Should create a system:auth-delegator Cluster RoleBinding
@@ -1896,15 +1895,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			csv2.SetName("csv-hat-2")
 
 			// Create CSV2 to replace CSV
-			cleanupCSV2, err := createCSV(c, crc, csv2, ns.GetName(), false, true)
+			cleanupCSV2, err := createCSV(c, crc, csv2, generatedNamespace.GetName(), false, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV2()
 
-			_, err = fetchCSV(crc, csv2.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv2.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
-			_, err = c.GetDeployment(ns.GetName(), depName)
+			_, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 			// Should create APIService
@@ -1913,27 +1912,27 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should create Service
 			Eventually(func() error {
-				_, err := c.GetService(ns.GetName(), serviceName)
+				_, err := c.GetService(generatedNamespace.GetName(), serviceName)
 				return err
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			// Should create certificate Secret
 			secretName = fmt.Sprintf("%s-cert", serviceName)
 			Eventually(func() error {
-				_, err = c.GetSecret(ns.GetName(), secretName)
+				_, err = c.GetSecret(generatedNamespace.GetName(), secretName)
 				return err
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			// Should create a Role for the Secret
-			_, err = c.GetRole(ns.GetName(), secretName)
+			_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 			Eventually(func() error {
-				_, err = c.GetRole(ns.GetName(), secretName)
+				_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 				return err
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			// Should create a RoleBinding for the Secret
 			Eventually(func() error {
-				_, err = c.GetRoleBinding(ns.GetName(), secretName)
+				_, err = c.GetRoleBinding(generatedNamespace.GetName(), secretName)
 				return err
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
@@ -1952,25 +1951,25 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should eventually GC the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csv.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
 			}).Should(BeFalse())
 
 			// Rename the initial CSV
 			csv.SetName("csv-hat-3")
 
 			// Recreate the old CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, true)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetched, err := fetchCSV(crc, csv.Name, ns.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOwnerConflict))
+			fetched, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOwnerConflict))
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(fetched.Status.Phase).Should(Equal(operatorsv1alpha1.CSVPhaseFailed))
 		})
 		It("create same CSV with owned API service multi namespace", func() {
 
 			// Create new namespace in a new operator group
-			secondNamespaceName := genName(ns.GetName() + "-")
+			secondNamespaceName := genName(generatedNamespace.GetName() + "-")
 			matchingLabel := map[string]string{"inGroup": secondNamespaceName}
 
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
@@ -2078,15 +2077,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			csv.SetName("csv-hat-1")
 
 			// Create the initial CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
-			_, err = c.GetDeployment(ns.GetName(), depName)
+			_, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 			// Should create APIService
@@ -2095,20 +2094,20 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should create Service
 			serviceName := fmt.Sprintf("%s-service", depName)
-			_, err = c.GetService(ns.GetName(), serviceName)
+			_, err = c.GetService(generatedNamespace.GetName(), serviceName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 			// Should create certificate Secret
 			secretName := fmt.Sprintf("%s-cert", serviceName)
-			_, err = c.GetSecret(ns.GetName(), secretName)
+			_, err = c.GetSecret(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 			// Should create a Role for the Secret
-			_, err = c.GetRole(ns.GetName(), secretName)
+			_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 			// Should create a RoleBinding for the Secret
-			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			_, err = c.GetRoleBinding(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 			// Should create a system:auth-delegator Cluster RoleBinding
@@ -2216,7 +2215,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			orphanedAPISvc, err = c.GetAPIService(apiServiceName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
-			newLabels = map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": ns.GetName()}
+			newLabels = map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": generatedNamespace.GetName()}
 			orphanedAPISvc.SetLabels(newLabels)
 			_, err = c.UpdateAPIService(orphanedAPISvc)
 			Expect(err).ShouldNot(HaveOccurred(), "error updating APIService")
@@ -2279,16 +2278,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create the CSV and make sure to clean it up
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -2350,23 +2349,23 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create the CSV and make sure to clean it up
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
 			// Make sure that the deployment labels are correct
 			labels := dep.GetLabels()
 			Expect(labels["olm.owner"]).Should(Equal(csv.GetName()))
-			Expect(labels["olm.owner.namespace"]).Should(Equal(ns.GetName()))
+			Expect(labels["olm.owner.namespace"]).Should(Equal(generatedNamespace.GetName()))
 			Expect(labels["application"]).Should(Equal("nginx"))
 			Expect(labels["application.type"]).Should(Equal("proxy"))
 		})
@@ -2466,15 +2465,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Don't need to cleanup this CSV, it will be deleted by the upgrade process
-			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -2538,27 +2537,27 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have updated existing deployment
-			depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depUpdated, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depUpdated).ShouldNot(BeNil())
 			Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
 
 			// Should eventually GC the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csv.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
 			}).Should(BeFalse())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 		})
@@ -2657,15 +2656,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// don't need to clean up this CSV, it will be deleted by the upgrade process
-			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -2727,29 +2726,29 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 			// Should have created new deployment and deleted old
-			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should eventually GC the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csv.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
 			}).Should(BeFalse())
 		})
 		It("update multiple intermediates", func() {
@@ -2847,15 +2846,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// don't need to clean up this CSV, it will be deleted by the upgrade process
-			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -2917,29 +2916,29 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 			// Should have created new deployment and deleted old
-			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should eventually GC the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csv.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
 			}).Should(BeFalse())
 		})
 		It("update in place", func() {
@@ -3037,16 +3036,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, true)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -3074,12 +3073,12 @@ var _ = Describe("ClusterServiceVersion", func() {
 			fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
 
 			// Update CSV directly
-			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// wait for deployment spec to be updated
 			Eventually(func() (string, error) {
-				fetched, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+				fetched, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 				if err != nil {
 					return "", err
 				}
@@ -3088,10 +3087,10 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}).Should(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depUpdated, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depUpdated).ShouldNot(BeNil())
 
@@ -3209,15 +3208,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// CSV will be deleted by the upgrade process later
-			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -3288,23 +3287,23 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create newly updated CSV
-			_, err = createCSV(c, crc, csvNew, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csvNew, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 			// Should have created new deployment and deleted old one
-			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Create updated deployment strategy
@@ -3366,29 +3365,29 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create newly updated CSV
-			cleanupNewCSV, err := createCSV(c, crc, csvNew2, ns.GetName(), true, false)
+			cleanupNewCSV, err := createCSV(c, crc, csvNew2, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err = fetchCSV(crc, csvNew2.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, csvNew2.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err = fetchCSV(crc, csvNew2.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err = fetchCSV(crc, csvNew2.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 			// Should have created new deployment and deleted old one
-			depNew, err = c.GetDeployment(ns.GetName(), strategyNew2.DeploymentSpecs[0].Name)
+			depNew, err = c.GetDeployment(generatedNamespace.GetName(), strategyNew2.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should clean up the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csvNew.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csvNew.Name)
 			}).Should(BeFalse())
 		})
 
@@ -3489,19 +3488,19 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployments
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
-			dep2, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[1].Name)
+			dep2, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[1].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep2).ShouldNot(BeNil())
 
@@ -3522,35 +3521,35 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch the current csv
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Update csv with same strategy with different deployment's name
 			fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
 
 			// Update the current csv with the new csv
-			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for new deployment to exist
-			err = waitForDeployment(ns.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
+			err = waitForDeployment(generatedNamespace.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created new deployment and deleted old
-			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
 
 			// Make sure the unchanged deployment still exists
-			depNew2, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[1].Name)
+			depNew2, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[1].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew2).ShouldNot(BeNil())
 
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("update deployment spec in an existing CSV for a hotfix", func() {
@@ -3649,16 +3648,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -3675,7 +3674,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Fetch the current csv
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Update csv with modified deployment spec
@@ -3683,15 +3682,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			Eventually(func() error {
 				// Update the current csv
-				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 				return err
 			}).Should(Succeed())
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 
 				// Should have updated existing deployment
-				depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+				depUpdated, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(depUpdated).ShouldNot(BeNil())
 				// container name has been updated and differs from initial CSV spec and updated CSV spec
@@ -3739,7 +3738,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					},
 				},
 			}
-			csv.SetNamespace(ns.GetName())
+			csv.SetNamespace(generatedNamespace.GetName())
 			csv.SetName(genName("csv-"))
 
 			clientCtx := context.Background()
@@ -3751,7 +3750,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Watch latest events from test namespace for CSV
 			listOpts.ResourceVersion = events.ResourceVersion
-			w, err := c.KubernetesInterface().CoreV1().Events(ns.GetName()).Watch(context.Background(), listOpts)
+			w, err := c.KubernetesInterface().CoreV1().Events(generatedNamespace.GetName()).Watch(context.Background(), listOpts)
 			Expect(err).ToNot(HaveOccurred())
 			defer w.Stop()
 
@@ -3871,7 +3870,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
@@ -3894,7 +3893,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return false
 			}
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvCheckPhaseAndRequirementStatus)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvCheckPhaseAndRequirementStatus)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(fetchedCSV.Status.RequirementStatus).Should(ContainElement(notServedStatus))
@@ -3965,19 +3964,19 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			csv.SetName("csv-hat-1")
-			csv.SetNamespace(ns.GetName())
+			csv.SetNamespace(generatedNamespace.GetName())
 
-			createLegacyAPIResources(ns.GetName(), &csv, owned[0], c)
+			createLegacyAPIResources(generatedNamespace.GetName(), &csv, owned[0], c)
 
 			// Create the APIService CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			checkLegacyAPIResources(ns.GetName(), owned[0], true, c)
+			checkLegacyAPIResources(generatedNamespace.GetName(), owned[0], true, c)
 		})
 
 		It("API service resource not migrated if not adoptable", func() {
@@ -4045,22 +4044,22 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			csv.SetName("csv-hat-1")
-			csv.SetNamespace(ns.GetName())
+			csv.SetNamespace(generatedNamespace.GetName())
 
-			createLegacyAPIResources(ns.GetName(), nil, owned[0], c)
+			createLegacyAPIResources(generatedNamespace.GetName(), nil, owned[0], c)
 
 			// Create the APIService CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			checkLegacyAPIResources(ns.GetName(), owned[0], false, c)
+			checkLegacyAPIResources(generatedNamespace.GetName(), owned[0], false, c)
 
 			// Cleanup the resources created for this test that were not cleaned up.
-			deleteLegacyAPIResources(ns.GetName(), owned[0], c)
+			deleteLegacyAPIResources(generatedNamespace.GetName(), owned[0], c)
 		})
 
 		It("multiple API services on a single pod", func() {
@@ -4162,14 +4161,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			csv.SetName("csv-hat-1")
-			csv.SetNamespace(ns.GetName())
+			csv.SetNamespace(generatedNamespace.GetName())
 
 			// Create the APIService CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Check that the APIService caBundles are equal

--- a/test/e2e/deprecated_e2e_test.go
+++ b/test/e2e/deprecated_e2e_test.go
@@ -19,7 +19,7 @@ import (
 var missingAPI = `{"apiVersion":"verticalpodautoscalers.autoscaling.k8s.io/v1","kind":"VerticalPodAutoscaler","metadata":{"name":"my.thing","namespace":"foo"}}`
 
 var _ = Describe("Not found APIs", func() {
-	var ns corev1.Namespace
+	var generatedNamespace corev1.Namespace
 
 	BeforeEach(func() {
 		namespaceName := genName("deprecated-e2e-")
@@ -29,14 +29,14 @@ var _ = Describe("Not found APIs", func() {
 				Namespace: namespaceName,
 			},
 		}
-		ns = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
 
-		csv := newCSV("test-csv", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+		csv := newCSV("test-csv", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 		Expect(ctx.Ctx().Client().Create(context.TODO(), &csv)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	Context("objects with APIs that are not on-cluster are created in the installplan", func() {
@@ -45,7 +45,7 @@ var _ = Describe("Not found APIs", func() {
 				ip := &operatorsv1alpha1.InstallPlan{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-plan-api",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.InstallPlanSpec{
 						Approval:                   operatorsv1alpha1.ApprovalAutomatic,

--- a/test/e2e/disabling_copied_csv_e2e_test.go
+++ b/test/e2e/disabling_copied_csv_e2e_test.go
@@ -28,21 +28,21 @@ const (
 
 var _ = Describe("Disabling copied CSVs", func() {
 	var (
-		ns                              corev1.Namespace
+		generatedNamespace              corev1.Namespace
 		csv                             operatorsv1alpha1.ClusterServiceVersion
 		nonTerminatingNamespaceSelector = fields.ParseSelectorOrDie("status.phase!=Terminating")
 		protectedCopiedCSVNamespaces    = map[string]struct{}{}
 	)
 
 	BeforeEach(func() {
-		nsname := genName("csv-toggle-test-")
+		nsname := genName("disabling-copied-csv-e2e-")
 		og := operatorsv1.OperatorGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-operatorgroup", nsname),
 				Namespace: nsname,
 			},
 		}
-		ns = SetupGeneratedTestNamespaceWithOperatorGroup(nsname, og)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(nsname, og)
 
 		csv = operatorsv1alpha1.ClusterServiceVersion{
 			ObjectMeta: metav1.ObjectMeta{
@@ -67,7 +67,7 @@ var _ = Describe("Disabling copied CSVs", func() {
 		Eventually(func() error {
 			return client.IgnoreNotFound(ctx.Ctx().Client().Delete(context.Background(), &csv))
 		}).Should(Succeed())
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	When("an operator is installed in AllNamespace mode", func() {

--- a/test/e2e/gc_e2e_test.go
+++ b/test/e2e/gc_e2e_test.go
@@ -25,9 +25,9 @@ import (
 
 var _ = Describe("Garbage collection for dependent resources", func() {
 	var (
-		kubeClient     operatorclient.ClientInterface
-		operatorClient versioned.Interface
-		ns             corev1.Namespace
+		kubeClient         operatorclient.ClientInterface
+		operatorClient     versioned.Interface
+		generatedNamespace corev1.Namespace
 	)
 
 	BeforeEach(func() {
@@ -35,11 +35,11 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 		operatorClient = ctx.Ctx().OperatorClient()
 
 		namespaceName := genName("gc-e2e-")
-		ns = SetupGeneratedTestNamespace(namespaceName, namespaceName)
+		generatedNamespace = SetupGeneratedTestNamespace(namespaceName, namespaceName)
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	Context("Given a ClusterRole owned by a CustomResourceDefinition", func() {
@@ -218,18 +218,18 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 
 		BeforeEach(func() {
 
-			ownerA = newCSV("ownera", ns.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
-			ownerB = newCSV("ownerb", ns.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
+			ownerA = newCSV("ownera", generatedNamespace.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
+			ownerB = newCSV("ownerb", generatedNamespace.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
 
 			// create all owners
 			var err error
 			Eventually(func() error {
-				fetchedA, err = operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Create(context.Background(), &ownerA, metav1.CreateOptions{})
+				fetchedA, err = operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Create(context.Background(), &ownerA, metav1.CreateOptions{})
 				return err
 			}).Should(Succeed())
 
 			Eventually(func() error {
-				fetchedB, err = operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Create(context.Background(), &ownerB, metav1.CreateOptions{})
+				fetchedB, err = operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Create(context.Background(), &ownerB, metav1.CreateOptions{})
 				return err
 			}).Should(Succeed())
 
@@ -246,7 +246,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 
 			// create ConfigMap dependent
 			Eventually(func() error {
-				_, err = kubeClient.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Create(context.Background(), dependent, metav1.CreateOptions{})
+				_, err = kubeClient.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Create(context.Background(), dependent, metav1.CreateOptions{})
 				return err
 			}).Should(Succeed(), "dependent could not be created")
 
@@ -259,20 +259,20 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
+					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should not have deleted the dependent since ownerB CSV is still present", func() {
 				Eventually(func() error {
-					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
+					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
 					return err
 				}).Should(Succeed(), "dependent deleted after one of the owner was deleted")
 				ctx.Ctx().Logf("dependent still exists after one owner was deleted")
@@ -284,32 +284,32 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
+					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// delete ownerB in the foreground (to ensure any "blocking" dependents are deleted before ownerB)
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedB.GetName(), options)
+					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.Background(), fetchedB.GetName(), options)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerB
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerB.GetName(), metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), ownerB.GetName(), metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should have deleted the dependent since both the owners were deleted", func() {
 				Eventually(func() bool {
-					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
+					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "expected dependency configmap would be properly garabage collected")
 				ctx.Ctx().Logf("dependent successfully garbage collected after both owners were deleted")
@@ -344,7 +344,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -374,25 +374,25 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			_ = createSubscriptionForCatalog(operatorClient, source.GetNamespace(), subName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
 
 			// Wait for the Subscription to succeed
-			sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker())
+			sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker())
 			Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 			installPlanRef = sub.Status.InstallPlanRef.Name
 
 			// Wait for the installplan to complete (5 minute timeout)
-			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 			Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 			ctx.Ctx().Logf("install plan %s completed", installPlanRef)
 
 			// confirm extra bundle objects (secret and configmap) are installed
 			Eventually(func() error {
-				_, err := kubeClient.GetSecret(ns.GetName(), secretName)
+				_, err := kubeClient.GetSecret(generatedNamespace.GetName(), secretName)
 				return err
 			}).Should(Succeed(), "expected no error getting secret object associated with CSV")
 
 			Eventually(func() error {
-				_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+				_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 				return err
 			}).Should(Succeed(), "expected no error getting configmap object associated with CSV")
 		})
@@ -404,25 +404,25 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				// Delete subscription first
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Delete(context.Background(), subName, metav1.DeleteOptions{})
+					err := operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Delete(context.Background(), subName, metav1.DeleteOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// Delete CSV
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), csvName, metav1.DeleteOptions{})
+					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.Background(), csvName, metav1.DeleteOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), csvName, metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), csvName, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
@@ -430,12 +430,12 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			It("OLM should delete the associated configmap and secret", func() {
 				// confirm extra bundle objects (secret and configmap) are no longer installed on the cluster
 				Eventually(func() bool {
-					_, err := kubeClient.GetSecret(ns.GetName(), secretName)
+					_, err := kubeClient.GetSecret(generatedNamespace.GetName(), secretName)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() bool {
-					_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+					_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 				ctx.Ctx().Logf("dependent successfully garbage collected after csv owner was deleted")
@@ -467,7 +467,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -493,17 +493,17 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			_ = createSubscriptionForCatalog(operatorClient, source.GetNamespace(), subName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
 
 			// Wait for the Subscription to succeed
-			sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker())
+			sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker())
 			Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 			installPlanRef = sub.Status.InstallPlanRef.Name
 
 			// Wait for the installplan to complete (5 minute timeout)
-			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 			Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 			Eventually(func() error {
-				_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+				_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 				return err
 			}).Should(Succeed(), "expected no error getting configmap object associated with CSV")
 		})
@@ -519,36 +519,36 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				Eventually(func() error {
 					// update subscription first
-					sub, err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
+					sub, err := operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
 					if err != nil {
 						return fmt.Errorf("could not get subscription")
 					}
 					// update channel on sub
 					sub.Spec.Channel = upgradeChannelName
-					_, err = operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Update(context.Background(), sub, metav1.UpdateOptions{})
+					_, err = operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Update(context.Background(), sub, metav1.UpdateOptions{})
 					return err
 				}).Should(Succeed(), "could not update subscription")
 
 				// Wait for the Subscription to succeed
-				sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker())
+				sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker())
 				Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 				installPlanRef = sub.Status.InstallPlanRef.Name
 
 				// Wait for the installplan to complete (5 minute timeout)
-				_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+				_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 				Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 				// Ensure the new csv is installed
 				Eventually(func() error {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), newCSVname, metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), newCSVname, metav1.GetOptions{})
 					return err
 				}).Should(BeNil())
 			})
 
 			It("OLM should have upgraded associated configmap in place", func() {
 				Eventually(func() (string, error) {
-					cfg, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+					cfg, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 					if err != nil {
 						return "", err
 					}
@@ -585,7 +585,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -611,17 +611,17 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			_ = createSubscriptionForCatalog(operatorClient, source.GetNamespace(), subName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
 
 			// Wait for the Subscription to succeed
-			sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker())
+			sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker())
 			Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 			installPlanRef = sub.Status.InstallPlanRef.Name
 
 			// Wait for the installplan to complete (5 minute timeout)
-			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 			Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 			Eventually(func() error {
-				_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+				_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 				return err
 			}).Should(Succeed(), "expected no error getting configmap object associated with CSV")
 		})
@@ -638,29 +638,29 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				Eventually(func() error {
 					// update subscription first
-					sub, err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
+					sub, err := operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
 					if err != nil {
 						return fmt.Errorf("could not get subscription")
 					}
 					// update channel on sub
 					sub.Spec.Channel = upgradeChannelName
-					_, err = operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Update(context.Background(), sub, metav1.UpdateOptions{})
+					_, err = operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Update(context.Background(), sub, metav1.UpdateOptions{})
 					return err
 				}).Should(Succeed(), "could not update subscription")
 
 				// Wait for the Subscription to succeed
-				sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker())
+				sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker())
 				Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 				installPlanRef = sub.Status.InstallPlanRef.Name
 
 				// Wait for the installplan to complete (5 minute timeout)
-				_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+				_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 				Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 				// Ensure the new csv is installed
 				Eventually(func() error {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), newCSVname, metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), newCSVname, metav1.GetOptions{})
 					return err
 				}).Should(BeNil())
 			})
@@ -668,12 +668,12 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			// flake issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2626
 			It("[FLAKE] should have removed the old configmap and put the new configmap in place", func() {
 				Eventually(func() bool {
-					_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+					_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() error {
-					_, err := kubeClient.GetConfigMap(ns.GetName(), upgradedConfigMapName)
+					_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), upgradedConfigMapName)
 					return err
 				}).Should(BeNil())
 				ctx.Ctx().Logf("dependent successfully updated after csv owner was updated")

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -56,9 +56,9 @@ const (
 
 var _ = Describe("Install Plan", func() {
 	var (
-		c   operatorclient.ClientInterface
-		crc versioned.Interface
-		ns  corev1.Namespace
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
+		generatedNamespace corev1.Namespace
 	)
 
 	BeforeEach(func() {
@@ -69,13 +69,13 @@ var _ = Describe("Install Plan", func() {
 				Namespace: namespaceName,
 			},
 		}
-		ns = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
 		c = ctx.Ctx().KubeClient()
 		crc = ctx.Ctx().OperatorClient()
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	When("an InstallPlan step contains a deprecated resource version", func() {
@@ -111,10 +111,10 @@ var _ = Describe("Install Plan", func() {
 
 			Expect(ctx.Ctx().Client().Create(context.Background(), deprecatedCRD)).To(Succeed())
 
-			csv = newCSV(genName("test-csv-"), ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			csv = newCSV(genName("test-csv-"), generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
 
-			deprecated, err = util.DecodeFile(filepath.Join(testdataDir, deprecatedCRDDir, "deprecated.cr.yaml"), &unstructured.Unstructured{}, util.WithNamespace(ns.GetName()))
+			deprecated, err = util.DecodeFile(filepath.Join(testdataDir, deprecatedCRDDir, "deprecated.cr.yaml"), &unstructured.Unstructured{}, util.WithNamespace(generatedNamespace.GetName()))
 			Expect(err).NotTo(HaveOccurred())
 
 			scheme := runtime.NewScheme()
@@ -126,7 +126,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan = operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      genName("test-plan-"),
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -175,7 +175,7 @@ var _ = Describe("Install Plan", func() {
 		It("creates an Event surfacing the deprecation warning", func() {
 			Eventually(func() ([]corev1.Event, error) {
 				var events corev1.EventList
-				if err := ctx.Ctx().Client().List(context.Background(), &events, client.InNamespace(ns.GetName())); err != nil {
+				if err := ctx.Ctx().Client().List(context.Background(), &events, client.InNamespace(generatedNamespace.GetName())); err != nil {
 					return nil, err
 				}
 				var result []corev1.Event
@@ -197,7 +197,7 @@ var _ = Describe("Install Plan", func() {
 				InvolvedObject: corev1.ObjectReference{
 					APIVersion: operatorsv1alpha1.InstallPlanAPIVersion,
 					Kind:       operatorsv1alpha1.InstallPlanKind,
-					Namespace:  ns.GetName(),
+					Namespace:  generatedNamespace.GetName(),
 					Name:       plan.GetName(),
 					FieldPath:  "status.plan[0]",
 				},
@@ -223,7 +223,7 @@ var _ = Describe("Install Plan", func() {
 		)
 
 		BeforeEach(func() {
-			csv := newCSV("test-csv", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			csv := newCSV("test-csv", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
 
 			crd = apiextensionsv1.CustomResourceDefinition{
@@ -266,7 +266,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan := operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-plan",
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -312,7 +312,7 @@ var _ = Describe("Install Plan", func() {
 				return crd.GetAnnotations(), nil
 			}).Should(HaveKeyWithValue(
 				HavePrefix("operatorframework.io/installed-alongside-"),
-				fmt.Sprintf("%s/test-csv", ns.GetName()),
+				fmt.Sprintf("%s/test-csv", generatedNamespace.GetName()),
 			))
 		})
 
@@ -323,12 +323,12 @@ var _ = Describe("Install Plan", func() {
 			)
 
 			BeforeEach(func() {
-				csv = newCSV("test-csv-two", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+				csv = newCSV("test-csv-two", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 				Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
 
 				plan = operatorsv1alpha1.InstallPlan{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 						Name:      "test-plan-two",
 					},
 					Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -382,11 +382,11 @@ var _ = Describe("Install Plan", func() {
 				}).Should(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
 						"Key":   HavePrefix("operatorframework.io/installed-alongside-"),
-						"Value": Equal(fmt.Sprintf("%s/test-csv", ns.GetName())),
+						"Value": Equal(fmt.Sprintf("%s/test-csv", generatedNamespace.GetName())),
 					}),
 					MatchFields(IgnoreExtras, Fields{
 						"Key":   HavePrefix("operatorframework.io/installed-alongside-"),
-						"Value": Equal(fmt.Sprintf("%s/test-csv-two", ns.GetName())),
+						"Value": Equal(fmt.Sprintf("%s/test-csv-two", generatedNamespace.GetName())),
 					}),
 				))
 			})
@@ -407,7 +407,7 @@ var _ = Describe("Install Plan", func() {
 			// during a test.
 			owned = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-owned",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "operators.coreos.com/v1alpha1",
@@ -425,7 +425,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan = &operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-plan",
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -474,7 +474,7 @@ var _ = Describe("Install Plan", func() {
 		})
 
 		It("succeeds if there is no error on a later attempt", func() {
-			owner := newCSV("test-owner", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			owner := newCSV("test-owner", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &owner)).To(Succeed())
 			Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 				return plan, ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(plan), plan)
@@ -490,14 +490,14 @@ var _ = Describe("Install Plan", func() {
 		)
 
 		BeforeEach(func() {
-			csv1 = newCSV("test-csv-old", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			csv1 = newCSV("test-csv-old", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &csv1)).To(Succeed())
-			csv2 = newCSV("test-csv-new", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			csv2 = newCSV("test-csv-new", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &csv2)).To(Succeed())
 
 			sa = corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-serviceaccount",
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -516,7 +516,7 @@ var _ = Describe("Install Plan", func() {
 			var manifest bytes.Buffer
 			Expect(k8sjson.NewSerializer(k8sjson.DefaultMetaFactory, scheme, scheme, false).Encode(&corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-serviceaccount",
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -530,7 +530,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan = operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-plan",
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -612,7 +612,7 @@ var _ = Describe("Install Plan", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-service",
 				},
 				Spec: corev1.ServiceSpec{
@@ -640,7 +640,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan := &operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-plan",
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -692,11 +692,11 @@ var _ = Describe("Install Plan", func() {
 		stableChannel := "stable"
 
 		dependentCRD := newCRD(genName("ins-"))
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-		dependentCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+		dependentCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 		defer func() {
-			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
 
 		dependentCatalogName := genName("mock-ocs-dependent-")
@@ -731,48 +731,48 @@ var _ = Describe("Install Plan", func() {
 		}()
 
 		// Create the catalog sources
-		require.NotEqual(GinkgoT(), "", ns.GetName())
-		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, ns.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
+		require.NotEqual(GinkgoT(), "", generatedNamespace.GetName())
+		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, generatedNamespace.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
 		defer cleanupDependentCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+		_, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		require.NoError(GinkgoT(), err)
 
-		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		require.NoError(GinkgoT(), err)
 
 		// Create expected install plan step sources
 		expectedStepSources := map[registry.ResourceKey]registry.ResourceKey{
-			{Name: dependentCRD.Name, Kind: "CustomResourceDefinition"}:                                                                               {Name: dependentCatalogName, Namespace: ns.GetName()},
-			{Name: dependentPackageStable, Kind: operatorsv1alpha1.ClusterServiceVersionKind}:                                                         {Name: dependentCatalogName, Namespace: ns.GetName()},
-			{Name: mainPackageStable, Kind: operatorsv1alpha1.ClusterServiceVersionKind}:                                                              {Name: mainCatalogName, Namespace: ns.GetName()},
-			{Name: strings.Join([]string{dependentPackageStable, dependentCatalogName, ns.GetName()}, "-"), Kind: operatorsv1alpha1.SubscriptionKind}: {Name: dependentCatalogName, Namespace: ns.GetName()},
+			{Name: dependentCRD.Name, Kind: "CustomResourceDefinition"}:                                                                                               {Name: dependentCatalogName, Namespace: generatedNamespace.GetName()},
+			{Name: dependentPackageStable, Kind: operatorsv1alpha1.ClusterServiceVersionKind}:                                                                         {Name: dependentCatalogName, Namespace: generatedNamespace.GetName()},
+			{Name: mainPackageStable, Kind: operatorsv1alpha1.ClusterServiceVersionKind}:                                                                              {Name: mainCatalogName, Namespace: generatedNamespace.GetName()},
+			{Name: strings.Join([]string{dependentPackageStable, dependentCatalogName, generatedNamespace.GetName()}, "-"), Kind: operatorsv1alpha1.SubscriptionKind}: {Name: dependentCatalogName, Namespace: generatedNamespace.GetName()},
 		}
 
 		subscriptionName := genName("sub-nginx-")
-		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Wait for InstallPlan to be status: Complete before checking resource presence
-		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		log(fmt.Sprintf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
 
 		require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 		// Fetch installplan again to check for unnecessary control loops
-		fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), ns.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
+		fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), generatedNamespace.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 			// Don't compare object meta as labels can be applied by the operator controller.
 			Expect(equality.Semantic.DeepEqual(fetchedInstallPlan.Spec, fip.Spec)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 			Expect(equality.Semantic.DeepEqual(fetchedInstallPlan.Status, fip.Status)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
@@ -806,18 +806,18 @@ var _ = Describe("Install Plan", func() {
 		log("All expected resources resolved")
 
 		// Verify that the dependent subscription is in a good state
-		dependentSubscription, err := fetchSubscription(crc, ns.GetName(), strings.Join([]string{dependentPackageStable, dependentCatalogName, ns.GetName()}, "-"), subscriptionStateAtLatestChecker())
+		dependentSubscription, err := fetchSubscription(crc, generatedNamespace.GetName(), strings.Join([]string{dependentPackageStable, dependentCatalogName, generatedNamespace.GetName()}, "-"), subscriptionStateAtLatestChecker())
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), dependentSubscription)
 		require.NotNil(GinkgoT(), dependentSubscription.Status.InstallPlanRef)
 		require.Equal(GinkgoT(), dependentCSV.GetName(), dependentSubscription.Status.CurrentCSV)
 
 		// Verify CSV is created
-		_, err = awaitCSV(crc, ns.GetName(), dependentCSV.GetName(), csvAnyChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), dependentCSV.GetName(), csvAnyChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update dependent subscription in catalog and wait for csv to update
-		updatedDependentCSV := newCSV(dependentPackageStable+"-v2", ns.GetName(), dependentPackageStable, semver.MustParse("0.1.1"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		updatedDependentCSV := newCSV(dependentPackageStable+"-v2", generatedNamespace.GetName(), dependentPackageStable, semver.MustParse("0.1.1"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 		dependentManifests = []registry.PackageManifest{
 			{
 				PackageName: dependentPackageName,
@@ -828,20 +828,20 @@ var _ = Describe("Install Plan", func() {
 			},
 		}
 
-		updateInternalCatalog(GinkgoT(), c, crc, dependentCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV, updatedDependentCSV}, dependentManifests)
+		updateInternalCatalog(GinkgoT(), c, crc, dependentCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV, updatedDependentCSV}, dependentManifests)
 
 		// Wait for subscription to update
-		updatedDepSubscription, err := fetchSubscription(crc, ns.GetName(), strings.Join([]string{dependentPackageStable, dependentCatalogName, ns.GetName()}, "-"), subscriptionHasCurrentCSV(updatedDependentCSV.GetName()))
+		updatedDepSubscription, err := fetchSubscription(crc, generatedNamespace.GetName(), strings.Join([]string{dependentPackageStable, dependentCatalogName, generatedNamespace.GetName()}, "-"), subscriptionHasCurrentCSV(updatedDependentCSV.GetName()))
 		require.NoError(GinkgoT(), err)
 
 		// Verify installplan created and installed
-		fetchedUpdatedDepInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedDepSubscription.Status.InstallPlanRef.Name, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedUpdatedDepInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedDepSubscription.Status.InstallPlanRef.Name, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		log(fmt.Sprintf("Install plan %s fetched with status %s", fetchedUpdatedDepInstallPlan.GetName(), fetchedUpdatedDepInstallPlan.Status.Phase))
 		require.NotEqual(GinkgoT(), fetchedInstallPlan.GetName(), fetchedUpdatedDepInstallPlan.GetName())
 
 		// Wait for csv to update
-		_, err = awaitCSV(crc, ns.GetName(), updatedDependentCSV.GetName(), csvAnyChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedDependentCSV.GetName(), csvAnyChecker)
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -884,10 +884,10 @@ var _ = Describe("Install Plan", func() {
 			dependentCRD := newCRD(genName("ins-"))
 
 			// Create new CSVs
-			mainStableCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-			mainBetaCSV := newCSV(mainPackageBeta, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-			dependentStableCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
-			dependentBetaCSV := newCSV(dependentPackageBeta, ns.GetName(), dependentPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+			mainStableCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+			mainBetaCSV := newCSV(mainPackageBeta, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+			dependentStableCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+			dependentBetaCSV := newCSV(dependentPackageBeta, generatedNamespace.GetName(), dependentPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 			// Defer CRD clean up
 			defer func() {
@@ -900,16 +900,16 @@ var _ = Describe("Install Plan", func() {
 			}()
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-" + strings.ToLower(K8sSafeCurrentTestDescription()) + "-")
-			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{dependentCRD, mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainStableCSV, mainBetaCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{dependentCRD, mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainStableCSV, mainBetaCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			expectedSteps := map[registry.ResourceKey]struct{}{
@@ -921,30 +921,30 @@ var _ = Describe("Install Plan", func() {
 			cleanupCRD, err := createCRD(c, dependentCRD)
 			require.NoError(GinkgoT(), err)
 			defer cleanupCRD()
-			cleanupCSV, err := createCSV(c, crc, dependentBetaCSV, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, dependentBetaCSV, generatedNamespace.GetName(), true, false)
 			require.NoError(GinkgoT(), err)
 			defer cleanupCSV()
 			GinkgoT().Log("Dependent CRD and preexisting CSV created")
 
 			subscriptionName := genName("sub-nginx-")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Fetch installplan again to check for unnecessary control loops
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), ns.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), generatedNamespace.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
@@ -1295,8 +1295,8 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create new CSVs
-			mainStableCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
-			mainBetaCSV := newCSV(mainPackageBeta, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
+			mainStableCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
+			mainBetaCSV := newCSV(mainPackageBeta, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
 
 			// Defer CRD clean up
 			defer func() {
@@ -1319,7 +1319,7 @@ var _ = Describe("Install Plan", func() {
 					"apiVersion": "cluster.com/v1alpha1",
 					"kind":       tt.oldCRD.Spec.Names.Kind,
 					"metadata": map[string]interface{}{
-						"namespace": ns.GetName(),
+						"namespace": generatedNamespace.GetName(),
 						"name":      "my-cr-1",
 					},
 					"spec": map[string]interface{}{
@@ -1330,18 +1330,18 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-")
-			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-alpha-")
-			cleanupSubscription := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			cleanupSubscription := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer cleanupSubscription()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
@@ -1349,7 +1349,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Wait for InstallPlan to be status: Complete or failed before checking resource presence
 			completeOrFailedFunc := buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed)
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), completeOrFailedFunc)
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), completeOrFailedFunc)
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
@@ -1378,44 +1378,44 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), 0, len(expectedSteps), "Actual resource steps do not match expected")
 
 			// Create initial CR
-			cleanupCR, err := createCR(c, existingCR, "cluster.com", "v1alpha1", ns.GetName(), tt.oldCRD.Spec.Names.Plural, "my-cr-1")
+			cleanupCR, err := createCR(c, existingCR, "cluster.com", "v1alpha1", generatedNamespace.GetName(), tt.oldCRD.Spec.Names.Plural, "my-cr-1")
 			require.NoError(GinkgoT(), err)
 			defer cleanupCR()
 
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, ns.GetName(), []apiextensions.CustomResourceDefinition{*tt.newCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{*tt.newCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			// Update the subscription resource to point to the beta CSV
 			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+				subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 				require.NoError(GinkgoT(), err)
 				require.NotNil(GinkgoT(), subscription)
 
 				subscription.Spec.Channel = betaChannel
-				subscription, err = crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).Update(context.Background(), subscription, metav1.UpdateOptions{})
+				subscription, err = crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Update(context.Background(), subscription, metav1.UpdateOptions{})
 
 				return err
 			})
 
 			// Wait for subscription to have a new installplan
-			subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
 			installPlanName = subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(tt.expectedPhase))
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(tt.expectedPhase))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), ns.GetName(), csvAnyChecker)
+			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), generatedNamespace.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			GinkgoT().Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
@@ -1550,9 +1550,9 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create new CSVs
-			mainStableCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
-			mainBetaCSV := newCSV(mainPackageBeta, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, nil, nil)
-			mainDeltaCSV := newCSV(mainPackageDelta, ns.GetName(), mainPackageBeta, semver.MustParse("0.3.0"), []apiextensions.CustomResourceDefinition{*tt.newCRD}, nil, nil)
+			mainStableCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
+			mainBetaCSV := newCSV(mainPackageBeta, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, nil, nil)
+			mainDeltaCSV := newCSV(mainPackageDelta, generatedNamespace.GetName(), mainPackageBeta, semver.MustParse("0.3.0"), []apiextensions.CustomResourceDefinition{*tt.newCRD}, nil, nil)
 
 			// Defer CRD clean up
 			defer func() {
@@ -1578,19 +1578,19 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-")
-			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-")
 
 			// this subscription will be cleaned up below without the clean up function
-			createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
@@ -1598,7 +1598,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Wait for InstallPlan to be status: Complete or failed before checking resource presence
 			completeOrFailedFunc := buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed)
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), completeOrFailedFunc)
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), completeOrFailedFunc)
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
@@ -1621,25 +1621,25 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, ns.GetName(), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
-			subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(installPlanName))
+			subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(installPlanName))
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
 			installPlanName = subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Ensure CRD versions are accurate
@@ -1661,25 +1661,25 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, ns.GetName(), []apiextensions.CustomResourceDefinition{*tt.newCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV, mainDeltaCSV}, mainManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{*tt.newCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV, mainDeltaCSV}, mainManifests)
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
-			subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(installPlanName))
+			subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(installPlanName))
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
 			installPlanName = subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err = fetchCSV(crc, mainDeltaCSV.GetName(), ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, mainDeltaCSV.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Ensure CRD versions are accurate
@@ -1706,7 +1706,7 @@ var _ = Describe("Install Plan", func() {
 		It("AmplifyPermissions", func() {
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			// Build initial catalog
@@ -1774,7 +1774,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog sources
 			mainNamedStrategy := newNginxInstallStrategy(genName("dep-"), permissions, clusterPermissions)
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
 			mainCatalogName := genName("mock-ocs-amplify-")
 			mainManifests := []registry.PackageManifest{
 				{
@@ -1793,18 +1793,18 @@ var _ = Describe("Install Plan", func() {
 				}).Should(Succeed())
 			}()
 
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-update-perms1")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -1813,13 +1813,13 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Update CatalogSource with a new CSV with more permissions
@@ -1860,7 +1860,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog sources
 			updatedNamedStrategy := newNginxInstallStrategy(genName("dep-"), updatedPermissions, updatedClusterPermissions)
-			updatedCSV := newCSV(mainPackageStable+"-next", ns.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &updatedNamedStrategy)
+			updatedCSV := newCSV(mainPackageStable+"-next", generatedNamespace.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &updatedNamedStrategy)
 			updatedManifests := []registry.PackageManifest{
 				{
 					PackageName: mainPackageName,
@@ -1872,20 +1872,20 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Update catalog with updated CSV with more permissions
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
 
-			_, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			_, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 
 			updatedInstallPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// If the CSV is succeeded, we successfully rolled out the RBAC changes
@@ -1893,7 +1893,7 @@ var _ = Describe("Install Plan", func() {
 		It("AttenuatePermissions", func() {
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			// Build initial catalog
@@ -1972,7 +1972,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog sources
 			mainNamedStrategy := newNginxInstallStrategy(genName("dep-"), permissions, clusterPermissions)
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
 			mainCatalogName := genName("mock-ocs-main-update-perms1-")
 			mainManifests := []registry.PackageManifest{
 				{
@@ -1991,18 +1991,18 @@ var _ = Describe("Install Plan", func() {
 				}).Should(Succeed())
 			}()
 
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-update-perms1")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -2011,13 +2011,13 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Update CatalogSource with a new CSV with more permissions
@@ -2046,12 +2046,12 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			oldSecrets, err := c.KubernetesInterface().CoreV1().Secrets(ns.GetName()).List(context.Background(), metav1.ListOptions{})
+			oldSecrets, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
 			require.NoError(GinkgoT(), err, "error listing secrets")
 
 			// Create the catalog sources
 			updatedNamedStrategy := newNginxInstallStrategy(genName("dep-"), updatedPermissions, updatedClusterPermissions)
-			updatedCSV := newCSV(mainPackageStable+"-next", ns.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &updatedNamedStrategy)
+			updatedCSV := newCSV(mainPackageStable+"-next", generatedNamespace.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &updatedNamedStrategy)
 			updatedManifests := []registry.PackageManifest{
 				{
 					PackageName: mainPackageName,
@@ -2063,24 +2063,24 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Update catalog with updated CSV with more permissions
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
 
 			// Wait for subscription to update its status
-			_, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			_, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 
 			updatedInstallPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
-			newSecrets, err := c.KubernetesInterface().CoreV1().Secrets(ns.GetName()).List(context.Background(), metav1.ListOptions{})
+			newSecrets, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
 			require.NoError(GinkgoT(), err, "error listing secrets")
 
 			// Assert that the number of secrets is not increased from updating service account as part of the install plan,
@@ -2093,7 +2093,7 @@ var _ = Describe("Install Plan", func() {
 			err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 				res, err := c.KubernetesInterface().AuthorizationV1().SubjectAccessReviews().Create(context.Background(), &authorizationv1.SubjectAccessReview{
 					Spec: authorizationv1.SubjectAccessReviewSpec{
-						User: "system:serviceaccount:" + ns.GetName() + ":" + serviceAccountName,
+						User: "system:serviceaccount:" + generatedNamespace.GetName() + ":" + serviceAccountName,
 						ResourceAttributes: &authorizationv1.ResourceAttributes{
 							Group:    "cluster.com",
 							Version:  "v1alpha1",
@@ -2118,7 +2118,7 @@ var _ = Describe("Install Plan", func() {
 		It("StopOnCSVModifications", func() {
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			// Build initial catalog
@@ -2188,7 +2188,7 @@ var _ = Describe("Install Plan", func() {
 			// Create the catalog sources
 			deploymentName := genName("dep-")
 			mainNamedStrategy := newNginxInstallStrategy(deploymentName, permissions, clusterPermissions)
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
 			mainCatalogName := genName("mock-ocs-stomper-")
 			mainManifests := []registry.PackageManifest{
 				{
@@ -2207,18 +2207,18 @@ var _ = Describe("Install Plan", func() {
 				}).Should(Succeed())
 			}()
 
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-stompy-")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -2227,13 +2227,13 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			csv, err := awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			csv, err := awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			addedEnvVar := corev1.EnvVar{Name: "EXAMPLE", Value: "value"}
@@ -2270,16 +2270,16 @@ var _ = Describe("Install Plan", func() {
 				StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
 				StrategySpec: modifiedDetails,
 			}
-			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.Background(), csv, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.Background(), csv, metav1.UpdateOptions{})
 			require.NoError(GinkgoT(), err)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), csv.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Should have the updated env var
 			err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-				dep, err := c.GetDeployment(ns.GetName(), deploymentName)
+				dep, err := c.GetDeployment(generatedNamespace.GetName(), deploymentName)
 				if err != nil {
 					return false, nil
 				}
@@ -2297,7 +2297,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog sources
 			// Updated csv has the same deployment strategy as main
-			updatedCSV := newCSV(mainPackageStable+"-next", ns.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &mainNamedStrategy)
+			updatedCSV := newCSV(mainPackageStable+"-next", generatedNamespace.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &mainNamedStrategy)
 			updatedManifests := []registry.PackageManifest{
 				{
 					PackageName: mainPackageName,
@@ -2309,24 +2309,24 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Update catalog with updated CSV with more permissions
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
 
-			_, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			_, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 
 			updatedInstallPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Should have created deployment and stomped on the env changes
-			updatedDep, err := c.GetDeployment(ns.GetName(), deploymentName)
+			updatedDep, err := c.GetDeployment(generatedNamespace.GetName(), deploymentName)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), updatedDep)
 
@@ -2416,8 +2416,8 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, nil)
-			betaCSV := newCSV(mainPackageBeta, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{updatedCRD}, nil, nil)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, nil)
+			betaCSV := newCSV(mainPackageBeta, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{updatedCRD}, nil, nil)
 
 			// Defer CRD clean up
 			defer func() {
@@ -2430,7 +2430,7 @@ var _ = Describe("Install Plan", func() {
 			}()
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			mainCatalogName := genName("mock-ocs-main-update-")
@@ -2447,17 +2447,17 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create the catalog sources
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-update-")
-			createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -2466,20 +2466,20 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Fetch installplan again to check for unnecessary control loops
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), ns.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), generatedNamespace.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
 			require.NoError(GinkgoT(), err)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			mainManifests = []registry.PackageManifest{
@@ -2492,18 +2492,18 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, betaCSV}, mainManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, betaCSV}, mainManifests)
 			// Wait for subscription to update
-			updatedSubscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			updatedSubscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 
 			// Verify installplan created and installed
-			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedSubscription.Status.InstallPlanRef.Name, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedSubscription.Status.InstallPlanRef.Name, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 			require.NotEqual(GinkgoT(), fetchedInstallPlan.GetName(), fetchedUpdatedInstallPlan.GetName())
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), betaCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), betaCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the CRD to see if it is updated
@@ -2535,7 +2535,7 @@ var _ = Describe("Install Plan", func() {
 		It("UpdatePreexistingCRDFailed", func() {
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			mainPackageName := genName("nginx-update2-")
@@ -2630,7 +2630,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 			defer cleanupCRD()
 
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
 
 			mainCatalogName := genName("mock-ocs-main-update2-")
 
@@ -2646,18 +2646,18 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create the catalog sources
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-update2-")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -2666,20 +2666,20 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Fetch installplan again to check for unnecessary control loops
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), ns.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), generatedNamespace.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
 			require.NoError(GinkgoT(), err)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the CRD to see if it is updated
@@ -2780,33 +2780,33 @@ var _ = Describe("Install Plan", func() {
 		namedStrategy := newNginxInstallStrategy(genName("dep-"), permissions, clusterPermissions)
 
 		// Create new CSVs
-		stableCSV := newCSV(stableCSVName, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &namedStrategy)
+		stableCSV := newCSV(stableCSVName, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &namedStrategy)
 
 		defer func() {
-			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
 
 		// Create CatalogSource
 		mainCatalogSourceName := genName("nginx-catalog")
-		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, ns.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{stableCSV})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{stableCSV})
 		defer cleanupCatalogSource()
 
 		// Attempt to get CatalogSource
-		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("sub-nginx-")
-		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogSourceName, packageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogSourceName, packageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Attempt to get InstallPlan
-		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseFailed, operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseFailed, operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		require.NotEqual(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseFailed, fetchedInstallPlan.Status.Phase, "InstallPlan failed")
 
@@ -2934,8 +2934,8 @@ var _ = Describe("Install Plan", func() {
 				}
 			}
 		}()
-		GinkgoT().Logf("Deleting CSV '%v' in namespace %v", stableCSVName, ns.GetName())
-		require.NoError(GinkgoT(), crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+		GinkgoT().Logf("Deleting CSV '%v' in namespace %v", stableCSVName, generatedNamespace.GetName())
+		require.NoError(GinkgoT(), crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		select {
 		case <-done:
 			break
@@ -2947,9 +2947,9 @@ var _ = Describe("Install Plan", func() {
 		require.Emptyf(GinkgoT(), createdClusterRoleBindingNames, "unexpected cluster role binding remain: %v", createdClusterRoleBindingNames)
 
 		Eventually(func() error {
-			_, err := c.GetServiceAccount(ns.GetName(), serviceAccountName)
+			_, err := c.GetServiceAccount(generatedNamespace.GetName(), serviceAccountName)
 			if err == nil {
-				return fmt.Errorf("The %v/%v ServiceAccount should have been deleted", ns.GetName(), serviceAccountName)
+				return fmt.Errorf("The %v/%v ServiceAccount should have been deleted", generatedNamespace.GetName(), serviceAccountName)
 			}
 			if !apierrors.IsNotFound(err) {
 				return err
@@ -3021,7 +3021,7 @@ var _ = Describe("Install Plan", func() {
 		packageName := genName("nginx-")
 		stableChannel := "stable"
 		packageNameStable := packageName + "-" + stableChannel
-		csv := newCSV(packageNameStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
+		csv := newCSV(packageNameStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
 
 		// Create PackageManifests
 		manifests := []registry.PackageManifest{
@@ -3036,25 +3036,25 @@ var _ = Describe("Install Plan", func() {
 
 		// Create the CatalogSource
 		catalogSourceName := genName("mock-nginx-")
-		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, ns.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csv})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csv})
 		defer cleanupCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err := fetchCatalogSourceOnStatus(crc, catalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced())
+		_, err := fetchCatalogSourceOnStatus(crc, catalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("sub-nginx-")
-		cleanupSubscription := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, catalogSourceName, packageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		cleanupSubscription := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, catalogSourceName, packageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer cleanupSubscription()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Wait for InstallPlan to be status: Complete before checking resource presence
-		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
+		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
@@ -3085,12 +3085,12 @@ var _ = Describe("Install Plan", func() {
 		require.NoError(GinkgoT(), err)
 		deleteOpts := &metav1.DeleteOptions{}
 		defer func() {
-			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), *deleteOpts))
+			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), generatedNamespace.GetName(), *deleteOpts))
 		}()
 
 		og := &operatorsv1.OperatorGroup{}
 		og.SetName("og")
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
+		_, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
 
 		mainPackageName := genName("nginx-")
@@ -3102,11 +3102,11 @@ var _ = Describe("Install Plan", func() {
 		stableChannel := "stable"
 
 		dependentCRD := newCRD(genName("ins-"))
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-		dependentCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+		dependentCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 		defer func() {
-			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
 
 		dependentCatalogName := genName("mock-ocs-dependent-")
@@ -3141,11 +3141,11 @@ var _ = Describe("Install Plan", func() {
 		}()
 
 		// Create the dependent catalog source
-		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, ns.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
+		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, generatedNamespace.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
 		defer cleanupDependentCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		dependentCatalogSource, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+		dependentCatalogSource, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		require.NoError(GinkgoT(), err)
 
 		// Create the alt dependent catalog sources
@@ -3170,11 +3170,11 @@ var _ = Describe("Install Plan", func() {
 				}
 				addressSource.SetName(genName("alt-dep-"))
 
-				_, err := crc.OperatorsV1alpha1().CatalogSources(ns.GetName()).Create(context.Background(), addressSource, metav1.CreateOptions{})
+				_, err := crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Create(context.Background(), addressSource, metav1.CreateOptions{})
 				require.NoError(GinkgoT(), err)
 
 				// Attempt to get the catalog source before creating install plan
-				_, err = fetchCatalogSourceOnStatus(crc, addressSource.GetName(), ns.GetName(), catalogSourceRegistryPodSynced())
+				_, err = fetchCatalogSourceOnStatus(crc, addressSource.GetName(), generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 				require.NoError(GinkgoT(), err)
 				wg.Done()
 			}(i)
@@ -3182,32 +3182,32 @@ var _ = Describe("Install Plan", func() {
 		wg.Wait()
 
 		// Create the main catalog source
-		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced())
+		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("sub-nginx-")
-		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Wait for InstallPlan to be status: Complete before checking resource presence
-		fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		log(fmt.Sprintf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
 
 		require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 		// Verify CSV is created
-		_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Make sure to clean up the installed CRD
@@ -3216,7 +3216,7 @@ var _ = Describe("Install Plan", func() {
 		}()
 
 		// ensure there is only one installplan
-		ips, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).List(context.Background(), metav1.ListOptions{})
+		ips, err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), 1, len(ips.Items), "If this test fails it should be taken seriously and not treated as a flake. \n%v", ips.Items)
 	})
@@ -3238,22 +3238,22 @@ var _ = Describe("Install Plan", func() {
 
 			// Create InstallPlan
 			installPlanName = "ip"
-			ip := newInstallPlanWithDummySteps(installPlanName, ns.GetName(), operatorsv1alpha1.InstallPlanPhaseInstalling)
-			outIP, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Create(context.Background(), ip, metav1.CreateOptions{})
+			ip := newInstallPlanWithDummySteps(installPlanName, generatedNamespace.GetName(), operatorsv1alpha1.InstallPlanPhaseInstalling)
+			outIP, err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Create(context.Background(), ip, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(outIP).NotTo(BeNil())
 
 			// The status gets ignored on create so we need to update it else the InstallPlan sync ignores
 			// InstallPlans without any steps or bundle lookups
 			outIP.Status = ip.Status
-			_, err = crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).UpdateStatus(context.Background(), outIP, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).UpdateStatus(context.Background(), outIP, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
-			err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Delete(context.Background(), installPlanName, metav1.DeleteOptions{})
+			err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Delete(context.Background(), installPlanName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), metav1.DeleteOptions{})
+			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), generatedNamespace.GetName(), metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -3265,7 +3265,7 @@ var _ = Describe("Install Plan", func() {
 				Message: "no operator group found that is managing this namespace"}
 
 			Eventually(func() bool {
-				fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
+				fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
 				if err != nil || fetchedInstallPlan == nil {
 					return false
 				}
@@ -3279,10 +3279,10 @@ var _ = Describe("Install Plan", func() {
 			og := &operatorsv1.OperatorGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "og",
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 				},
 				Spec: operatorsv1.OperatorGroupSpec{
-					TargetNamespaces: []string{ns.GetName()},
+					TargetNamespaces: []string{generatedNamespace.GetName()},
 				},
 			}
 			Eventually(func() error {
@@ -3298,11 +3298,11 @@ var _ = Describe("Install Plan", func() {
 				},
 				1*time.Minute,
 				interval,
-			).Should(ContainElement(ns.GetName()))
+			).Should(ContainElement(generatedNamespace.GetName()))
 
 			// check that the condition has been cleared up
 			Eventually(func() (bool, error) {
-				fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
+				fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
 				if err != nil {
 					return false, err
 				}
@@ -3320,26 +3320,10 @@ var _ = Describe("Install Plan", func() {
 	It("compresses installplan step resource manifests to configmap references", func() {
 		// Test ensures that all steps for index-based catalogs are references to configmaps. This avoids the problem
 		// of installplans growing beyond the etcd size limit when manifests are written to the ip status.
-
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		og := &operatorsv1.OperatorGroup{}
-		og.SetName("og")
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		deleteOpts := &metav1.DeleteOptions{}
-		defer c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), *deleteOpts)
-
 		catsrc := &operatorsv1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("kiali-"),
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Labels:    map[string]string{"olm.catalogSource": "kaili-catalog"},
 			},
 			Spec: operatorsv1alpha1.CatalogSourceSpec{
@@ -3350,7 +3334,7 @@ var _ = Describe("Install Plan", func() {
 				},
 			},
 		}
-		catsrc, err = crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Create(context.Background(), catsrc, metav1.CreateOptions{})
+		catsrc, err := crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Create(context.Background(), catsrc, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// Wait for the CatalogSource to be ready
@@ -3407,27 +3391,17 @@ var _ = Describe("Install Plan", func() {
 	})
 
 	It("limits installed resources if the scoped serviceaccount has no permissions", func() {
-
-		By("creating a scoped serviceaccount specified in the operatorgroup")
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		defer c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), metav1.DeleteOptions{})
-
 		// create SA
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("sa-"),
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 			},
 		}
-		_, err = c.KubernetesInterface().CoreV1().ServiceAccounts(ns.GetName()).Create(context.Background(), sa, metav1.CreateOptions{})
+		_, err := c.KubernetesInterface().CoreV1().ServiceAccounts(generatedNamespace.GetName()).Create(context.Background(), sa, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		// Create token secret for the serviceaccount
-		_, cleanupSE := newTokenSecret(c, ns.GetName(), sa.GetName())
+		_, cleanupSE := newTokenSecret(c, generatedNamespace.GetName(), sa.GetName())
 		defer cleanupSE()
 
 		// role has no explicit permissions
@@ -3462,24 +3436,22 @@ var _ = Describe("Install Plan", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer c.KubernetesInterface().RbacV1().ClusterRoles().Delete(context.Background(), role.GetName(), metav1.DeleteOptions{})
 
-		// create operator group referencing the SA
-		og := &operatorsv1.OperatorGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      genName("og-"),
-				Namespace: ns.GetName(),
-			},
-			Spec: operatorsv1.OperatorGroupSpec{
-				ServiceAccountName: sa.GetName(),
-			},
-		}
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		// Update the existing OG to use the ServiceAccount
+		Eventually(func() error {
+			existingOG, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Get(context.Background(), fmt.Sprintf("%s-operatorgroup", generatedNamespace.GetName()), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			existingOG.Spec.ServiceAccountName = sa.GetName()
+			_, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Update(context.Background(), existingOG, metav1.UpdateOptions{})
+			return err
+		}).Should(Succeed())
 
 		// Wait for the OperatorGroup to be synced and have a status.ServiceAccountRef
 		// before moving on. Otherwise the catalog operator treats it as an invalid OperatorGroup
 		// and the InstallPlan is resynced
 		Eventually(func() (*corev1.ObjectReference, error) {
-			outOG, err := crc.OperatorsV1().OperatorGroups(ns.GetName()).Get(context.Background(), og.Name, metav1.GetOptions{})
+			outOG, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Get(context.Background(), fmt.Sprintf("%s-operatorgroup", generatedNamespace.GetName()), metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -3534,7 +3506,7 @@ var _ = Describe("Install Plan", func() {
 		By("using the OLM client to create the CRD")
 		plan := &operatorsv1alpha1.InstallPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      genName("ip-"),
 			},
 			Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -3576,7 +3548,7 @@ var _ = Describe("Install Plan", func() {
 		// delete installplan, then create one with an additional resource that the SA does not have permissions to create
 		// expect installplan to fail
 		By("failing to install resources that are not explicitly allowed in the SA")
-		err = crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Delete(context.Background(), plan.GetName(), metav1.DeleteOptions{})
+		err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Delete(context.Background(), plan.GetName(), metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		service := &corev1.Service{
@@ -3585,7 +3557,7 @@ var _ = Describe("Install Plan", func() {
 				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      "test-service",
 			},
 			Spec: corev1.ServiceSpec{
@@ -3604,7 +3576,7 @@ var _ = Describe("Install Plan", func() {
 
 		newPlan := &operatorsv1alpha1.InstallPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      genName("ip-"),
 			},
 			Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -3645,33 +3617,21 @@ var _ = Describe("Install Plan", func() {
 		}).Should(HavePhase(operatorsv1alpha1.InstallPlanPhaseFailed))
 
 		Expect(client.IgnoreNotFound(ctx.Ctx().Client().Delete(context.Background(), &crd))).To(Succeed())
-		Eventually(func() error {
-			return client.IgnoreNotFound(ctx.Ctx().Client().Delete(context.Background(), ns))
-		}, timeout, interval).Should(Succeed(), "could not delete Namespace")
 	})
 
 	It("uses the correct client when installing resources from an installplan", func() {
-
 		By("creating a scoped serviceaccount specifified in the operatorgroup")
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		defer c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), metav1.DeleteOptions{})
-
 		// create SA
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("sa-"),
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 			},
 		}
-		_, err = c.KubernetesInterface().CoreV1().ServiceAccounts(ns.GetName()).Create(context.Background(), sa, metav1.CreateOptions{})
+		_, err := c.KubernetesInterface().CoreV1().ServiceAccounts(generatedNamespace.GetName()).Create(context.Background(), sa, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		// Create token secret for the serviceaccount
-		_, cleanupSE := newTokenSecret(c, ns.GetName(), sa.GetName())
+		_, cleanupSE := newTokenSecret(c, generatedNamespace.GetName(), sa.GetName())
 		defer cleanupSE()
 
 		// see https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/scoped-operator-install.md
@@ -3731,24 +3691,22 @@ var _ = Describe("Install Plan", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer c.KubernetesInterface().RbacV1().ClusterRoles().Delete(context.Background(), role.GetName(), metav1.DeleteOptions{})
 
-		// create operator group referencing the SA
-		og := &operatorsv1.OperatorGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      genName("og-"),
-				Namespace: ns.GetName(),
-			},
-			Spec: operatorsv1.OperatorGroupSpec{
-				ServiceAccountName: sa.GetName(),
-			},
-		}
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		// Update the existing OG to use the ServiceAccount
+		Eventually(func() error {
+			existingOG, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Get(context.Background(), fmt.Sprintf("%s-operatorgroup", generatedNamespace.GetName()), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			existingOG.Spec.ServiceAccountName = sa.GetName()
+			_, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Update(context.Background(), existingOG, metav1.UpdateOptions{})
+			return err
+		}).Should(Succeed())
 
 		// Wait for the OperatorGroup to be synced and have a status.ServiceAccountRef
 		// before moving on. Otherwise the catalog operator treats it as an invalid OperatorGroup
 		// and the InstallPlan is resynced
 		Eventually(func() (*corev1.ObjectReference, error) {
-			outOG, err := crc.OperatorsV1().OperatorGroups(ns.GetName()).Get(context.Background(), og.Name, metav1.GetOptions{})
+			outOG, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Get(context.Background(), fmt.Sprintf("%s-operatorgroup", generatedNamespace.GetName()), metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -3790,7 +3748,7 @@ var _ = Describe("Install Plan", func() {
 				},
 			},
 		}
-		csv := newCSV("stable", ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
+		csv := newCSV("stable", generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
 
 		// Defer CRD clean up
 		defer func() {
@@ -3811,7 +3769,7 @@ var _ = Describe("Install Plan", func() {
 
 		plan := &operatorsv1alpha1.InstallPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      genName("ip-"),
 			},
 			Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -3861,12 +3819,12 @@ var _ = Describe("Install Plan", func() {
 
 		// delete installplan, and create one with just a CSV resource which should succeed
 		By("installing additional resources that are allowed in the SA")
-		err = crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Delete(context.Background(), plan.GetName(), metav1.DeleteOptions{})
+		err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Delete(context.Background(), plan.GetName(), metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		newPlan := &operatorsv1alpha1.InstallPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      genName("ip-"),
 			},
 			Spec: operatorsv1alpha1.InstallPlanSpec{


### PR DESCRIPTION
This commit updates the OLM e2e test framework to create the test namespace if it does not already exist.