### PR TITLE
Fix default sync interval

### DIFF
--- a/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -47,6 +47,10 @@ spec:
         {{- if .Values.debug }}
         - --debug
         {{- end }}
+        {{- if .Values.package.interval }}
+        - --interval
+        - {{ .Values.package.interval }}
+        {{- end }}
         {{- if .Values.package.commandArgs }}
         - {{ .Values.package.commandArgs }}
         {{- end }}

--- a/test/e2e/e2e-bare-values.yaml
+++ b/test/e2e/e2e-bare-values.yaml
@@ -28,6 +28,7 @@ package:
   service:
     internalPort: 5443
   commandArgs: -test.coverprofile=/tmp/catalog-coverage.cov
+  interval: 1h
 
 e2e:
   image:

--- a/test/e2e/e2e-values.yaml
+++ b/test/e2e/e2e-values.yaml
@@ -24,6 +24,7 @@ package:
     pullPolicy: IfNotPresent
   service:
     internalPort: 5443
+  interval: 1h
 
 e2e:
   image:


### PR DESCRIPTION
The sync default sync interval was changed to 12 hours, but there is also a CLI option that also configures the sync interval.

The OLMConfig reconcile code did not properly handle the value coming in via the CLI, and changing the sync interval from the default without an OLMConfig value specified.

The CLI option now changes the default sync interval, when the OLMConfig is not present. The 12h default sync interval is used when neither the CLI nor the OLMConfig is specified. The OLMConfig reconcile code now uses the CLI option as the default.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
