### PR TITLE
Don't sync namespaces that have no subscriptions

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1152,6 +1152,12 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		return err
 	}
 
+	// If there are no subscriptions, don't attempt to sync the namespace.
+	if len(subs) == 0 {
+		logger.Debug(fmt.Sprintf("No subscriptions were found in namespace %v", namespace))
+		return nil
+	}
+
 	ogLister := o.lister.OperatorsV1().OperatorGroupLister().OperatorGroups(namespace)
 	failForwardEnabled, err := resolver.IsFailForwardEnabled(ogLister)
 	if err != nil {


### PR DESCRIPTION
Problem: The catalog operator is logging many errors regarding missing operator groups in namespaces that have no operators installed.

Solution: If a namespace has no subscriptions in it, do not check if an operator group is present in the namespace.

Example Logs:
```
2023-10-03T18:40:22.531790646Z E1003 18:40:22.531725       1 queueinformer_operator.go:319] sync {"update" "openshift-infra"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:22.732892241Z E1003 18:40:22.732772       1 queueinformer_operator.go:319] sync {"update" "openshift-cluster-node-tuning-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:22.932286038Z E1003 18:40:22.932185       1 queueinformer_operator.go:319] sync {"update" "openshift-etcd"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:23.132380585Z E1003 18:40:23.132315       1 queueinformer_operator.go:319] sync {"update" "openshift-console"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:23.331364253Z E1003 18:40:23.331310       1 queueinformer_operator.go:319] sync {"update" "openshift-apiserver-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:23.531841128Z E1003 18:40:23.531783       1 queueinformer_operator.go:319] sync {"update" "openshift-config"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:23.731587861Z E1003 18:40:23.731523       1 queueinformer_operator.go:319] sync {"update" "openshift-dns"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:23.935364693Z E1003 18:40:23.935308       1 queueinformer_operator.go:319] sync {"update" "openshift-kube-controller-manager-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:24.131623729Z E1003 18:40:24.131432       1 queueinformer_operator.go:319] sync {"update" "openshift-kube-scheduler"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:24.332286341Z E1003 18:40:24.332188       1 queueinformer_operator.go:319] sync {"update" "openshift-ovirt-infra"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:24.532904649Z E1003 18:40:24.532854       1 queueinformer_operator.go:319] sync {"update" "openshift-ingress-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:24.735185533Z E1003 18:40:24.735124       1 queueinformer_operator.go:319] sync {"update" "openshift-kube-apiserver-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:24.931656181Z E1003 18:40:24.931571       1 queueinformer_operator.go:319] sync {"update" "openshift-kube-scheduler-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:25.133418536Z E1003 18:40:25.133310       1 queueinformer_operator.go:319] sync {"update" "openshift-ingress-canary"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:25.331763068Z E1003 18:40:25.331667       1 queueinformer_operator.go:319] sync {"update" "openshift-console-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:25.533077389Z E1003 18:40:25.532998       1 queueinformer_operator.go:319] sync {"update" "openshift-openstack-infra"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:25.733136965Z E1003 18:40:25.733072       1 queueinformer_operator.go:319] sync {"update" "kube-public"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:25.933430183Z E1003 18:40:25.933360       1 queueinformer_operator.go:319] sync {"update" "openshift-cluster-machine-approver"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:26.132186772Z E1003 18:40:26.132125       1 queueinformer_operator.go:319] sync {"update" "openshift-etcd-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:26.333601507Z E1003 18:40:26.333433       1 queueinformer_operator.go:319] sync {"update" "openshift"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:26.532490813Z E1003 18:40:26.532426       1 queueinformer_operator.go:319] sync {"update" "openshift-authentication-operator"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:26.732186081Z E1003 18:40:26.732130       1 queueinformer_operator.go:319] sync {"update" "openshift-controller-manager"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:26.933010662Z E1003 18:40:26.932946       1 queueinformer_operator.go:319] sync {"update" "openshift-insights"} failed: found 0 operatorGroups, expected 1
2023-10-03T18:40:27.133304680Z E1003 18:40:27.132522       1 queueinformer_operator.go:319] sync {"update" "openshift-kni-infra"} failed: found 0 operatorGroups, expected 1
```