### PR TITLE
Specify exact verbs that OLM requires

### DIFF
--- a/deploy/chart/templates/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/deploy/chart/templates/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
-  verbs: ["*"]
+  verbs: ["watch", "list", "get", "create", "update", "patch", "delete", "deletecollection", "escalate", "bind"]
 - nonResourceURLs: ["*"]
   verbs: ["*"]
 ---


### PR DESCRIPTION
This will specifically allow OLM to avoid the "use" verb for SCCs that it wasn't configured to work with on OpenShift clusters.
