### PR TITLE
Fix some of the e2e loops

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			return err
 		}).Should(Succeed())
 
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Update manifest
@@ -364,7 +364,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		Expect(err).ShouldNot(HaveOccurred())
 
 		ipList, err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
@@ -455,7 +455,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ToNot(BeNil())
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(v1alpha1.CSVPhaseSucceeded))
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -597,7 +597,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionStateAtLatestChecker())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(subscription).ShouldNot(BeNil())
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), subscription.Status.CurrentCSV, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Update the catalog's address to point at the other registry pod's cluster ip
@@ -613,7 +613,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		}).Should(Succeed())
 
 		// Wait for the replacement CSV to be installed
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), replacementCSV.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), replacementCSV.GetName(), csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -928,7 +928,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(subscription).ShouldNot(BeNil())
 
 		// Wait for csv to succeed
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		_, err = fetchCSV(crc, subscription.GetNamespace(), subscription.Status.CurrentCSV, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		registryCheckFunc := func(podList *corev1.PodList) bool {
@@ -1033,7 +1033,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(subscription).ShouldNot(BeNil())
 
 		// Wait for csv to succeed
-		csv, err := fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		csv, err := fetchCSV(crc, subscription.GetNamespace(), subscription.Status.CurrentCSV, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// check version of running csv to ensure the latest version (0.9.2) was installed onto the cluster
@@ -1144,7 +1144,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(subscription).ShouldNot(BeNil())
 
 		By("waiting for busybox v2 csv to succeed and check the replaces field")
-		csv, err := fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		csv, err := fetchCSV(crc, subscription.GetNamespace(), subscription.Status.CurrentCSV, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(csv.Spec.Replaces).To(Equal("busybox.v1.0.0"))
 
@@ -1157,7 +1157,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(subscription).ShouldNot(BeNil())
 
 		By("waiting for busybox-dependency v2 csv to succeed and check the replaces field")
-		csv, err = fetchCSV(crc, subscription.Status.CurrentCSV, subscription.GetNamespace(), csvSucceededChecker)
+		csv, err = fetchCSV(crc, subscription.GetNamespace(), subscription.Status.CurrentCSV, csvSucceededChecker)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(csv.Spec.Replaces).To(Equal("busybox-dependency.v1.0.0"))
 	})

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -10,7 +10,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
@@ -30,6 +29,7 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
@@ -745,7 +745,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
@@ -806,7 +806,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
@@ -925,7 +925,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
@@ -984,7 +984,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
@@ -1071,7 +1071,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
@@ -1120,7 +1120,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
@@ -1214,7 +1214,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			sa := corev1.ServiceAccount{}
@@ -1386,14 +1386,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return false, nil
 			}).Should(BeTrue())
 
-			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Delete CRD
 			cleanupCRD()
 
 			// Wait for CSV failure
-			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
+			fetchedCSV, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Recreate the CRD
@@ -1402,7 +1402,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupCRD()
 
 			// Wait for CSV success again
-			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("create requirements met API service", func() {
@@ -1555,11 +1555,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 		})
@@ -1657,7 +1657,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				<-deleted
 			}()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
@@ -1706,7 +1706,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return nil
 			})).Should(Succeed())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create deployment
 				dep, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 				if err != nil {
@@ -1737,7 +1737,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for CSV success
-			fetchedCSV, err = fetchCSV(crc, csv.GetName(), generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			fetchedCSV, err = fetchCSV(crc, generatedNamespace.GetName(), csv.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create an APIService
 				apiService, err := c.GetAPIService(apiServiceName)
 				if err != nil {
@@ -1821,7 +1821,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			_, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
@@ -1897,7 +1897,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV2()
 
-			_, err = fetchCSV(crc, csv2.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv2.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
@@ -1948,9 +1948,8 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
 
 			// Should eventually GC the CSV
-			Eventually(func() bool {
-				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
-			}).Should(BeFalse())
+			err = waitForCsvToDelete(generatedNamespace.GetName(), csv.Name, crc)
+			Expect(err).ShouldNot(HaveOccurred())
 
 			// Rename the initial CSV
 			csv.SetName("csv-hat-3")
@@ -1960,7 +1959,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetched, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOwnerConflict))
+			fetched, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOwnerConflict))
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(fetched.Status.Phase).Should(Equal(operatorsv1alpha1.CSVPhaseFailed))
 		})
@@ -2079,7 +2078,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
@@ -2153,7 +2152,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			_, err = createCSV(c, crc, csv2, secondNamespaceName, false, true)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, err = fetchCSV(crc, csv2.Name, secondNamespaceName, csvFailedChecker)
+			_, err = fetchCSV(crc, secondNamespaceName, csv2.Name, csvFailedChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("orphaned API service clean up", func() {
@@ -2281,7 +2280,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
@@ -2352,7 +2351,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
@@ -2467,7 +2466,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
@@ -2540,7 +2539,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvNew.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have updated existing deployment
@@ -2550,12 +2549,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
 
 			// Should eventually GC the CSV
-			Eventually(func() bool {
-				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
-			}).Should(BeFalse())
+			err = waitForCsvToDelete(generatedNamespace.GetName(), csv.Name, crc)
+			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvNew.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 		})
@@ -2658,7 +2656,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
@@ -2729,11 +2727,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvNew.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvNew.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
@@ -2741,13 +2739,12 @@ var _ = Describe("ClusterServiceVersion", func() {
 			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name, c)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should eventually GC the CSV
-			Eventually(func() bool {
-				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
-			}).Should(BeFalse())
+			err = waitForCsvToDelete(generatedNamespace.GetName(), csv.Name, crc)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("update multiple intermediates", func() {
 
@@ -2848,7 +2845,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
@@ -2919,11 +2916,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvNew.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvNew.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
@@ -2931,13 +2928,12 @@ var _ = Describe("ClusterServiceVersion", func() {
 			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name, c)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should eventually GC the CSV
-			Eventually(func() bool {
-				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
-			}).Should(BeFalse())
+			err = waitForCsvToDelete(generatedNamespace.GetName(), csv.Name, crc)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("update in place", func() {
 
@@ -3039,7 +3035,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
@@ -3085,7 +3081,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}).Should(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			depUpdated, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
@@ -3210,7 +3206,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
@@ -3289,11 +3285,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvNew.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvNew.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
@@ -3301,7 +3297,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name, c)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Create updated deployment strategy
@@ -3368,11 +3364,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err = fetchCSV(crc, csvNew2.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, generatedNamespace.GetName(), csvNew2.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err = fetchCSV(crc, csvNew2.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			sameCSV, err = fetchCSV(crc, generatedNamespace.GetName(), csvNew2.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
@@ -3380,13 +3376,12 @@ var _ = Describe("ClusterServiceVersion", func() {
 			depNew, err = c.GetDeployment(generatedNamespace.GetName(), strategyNew2.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name, c)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should clean up the CSV
-			Eventually(func() bool {
-				return csvExists(generatedNamespace.GetName(), crc, csvNew.Name)
-			}).Should(BeFalse())
+			err = waitForCsvToDelete(generatedNamespace.GetName(), csvNew.Name, crc)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("update modify deployment name", func() {
@@ -3491,7 +3486,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployments
@@ -3519,7 +3514,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch the current csv
-			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Update csv with same strategy with different deployment's name
@@ -3530,11 +3525,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for new deployment to exist
-			err = waitForDeployment(generatedNamespace.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
+			_, err = waitForDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name, c)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created new deployment and deleted old
@@ -3547,7 +3542,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew2).ShouldNot(BeNil())
 
-			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name, c)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("update deployment spec in an existing CSV for a hotfix", func() {
@@ -3651,7 +3646,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
@@ -3672,7 +3667,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Fetch the current csv
-			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Update csv with modified deployment spec
@@ -3685,14 +3680,20 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}).Should(Succeed())
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 
 				// Should have updated existing deployment
 				depUpdated, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(depUpdated).ShouldNot(BeNil())
+				if err != nil {
+					return false
+				}
+				if depUpdated == nil {
+					return false
+				}
 				// container name has been updated and differs from initial CSV spec and updated CSV spec
-				Expect(depUpdated.Spec.Template.Spec.Containers[0].Name).ShouldNot(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
+				if depUpdated.Spec.Template.Spec.Containers[0].Name == strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name {
+					return false
+				}
 
 				// Check for success
 				return csvSucceededChecker(csv)
@@ -3891,7 +3892,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return false
 			}
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvCheckPhaseAndRequirementStatus)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvCheckPhaseAndRequirementStatus)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(fetchedCSV.Status.RequirementStatus).Should(ContainElement(notServedStatus))
@@ -3971,7 +3972,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			checkLegacyAPIResources(generatedNamespace.GetName(), owned[0], true, c)
@@ -4051,7 +4052,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			checkLegacyAPIResources(generatedNamespace.GetName(), owned[0], false, c)
@@ -4166,7 +4167,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Check that the APIService caBundles are equal
@@ -4432,89 +4433,110 @@ var csvFailedChecker = buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseFailed
 var csvAnyChecker = buildCSVConditionChecker(operatorsv1alpha1.CSVPhasePending, operatorsv1alpha1.CSVPhaseSucceeded, operatorsv1alpha1.CSVPhaseReplacing, operatorsv1alpha1.CSVPhaseDeleting, operatorsv1alpha1.CSVPhaseFailed)
 var csvCopiedChecker = buildCSVReasonChecker(operatorsv1alpha1.CSVReasonCopied)
 
-func fetchCSV(c versioned.Interface, name, namespace string, checker csvConditionChecker) (*operatorsv1alpha1.ClusterServiceVersion, error) {
-	var fetchedCSV *operatorsv1alpha1.ClusterServiceVersion
-	var err error
+func fetchCSV(c versioned.Interface, namespace, name string, checker csvConditionChecker) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+	var lastPhase operatorsv1alpha1.ClusterServiceVersionPhase
+	var lastReason operatorsv1alpha1.ConditionReason
+	var lastMessage string
+	lastTime := time.Now()
+	var csv *operatorsv1alpha1.ClusterServiceVersion
 
 	ctx.Ctx().Logf("waiting for CSV %s/%s to reach condition", namespace, name)
-	Eventually(func() (bool, error) {
-		fetchedCSV, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	err := wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		var err error
+		csv, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			return false, err
+			ctx.Ctx().Logf("error getting csv %s/%s: %v", namespace, name, err)
+			return false, nil
 		}
-		return checker(fetchedCSV), nil
-	}).Should(BeTrue())
+		phase, reason, message := csv.Status.Phase, csv.Status.Reason, csv.Status.Message
+		if phase != lastPhase || reason != lastReason || message != lastMessage {
+			ctx.Ctx().Logf("waited %s for csv %s/%s - %s (%s): %s", time.Since(lastTime), namespace, name, phase, reason, message)
+			lastPhase, lastReason, lastMessage = phase, reason, message
+			lastTime = time.Now()
+		}
+		return checker(csv), nil
+	})
 
-	if err != nil {
-		ctx.Ctx().Logf("CSV %s/%s never got correct status: %#v", namespace, name, fetchedCSV.Status)
+	// Only want to return `csv` if there was no (timeout) error
+	if err == nil {
+		return csv, nil
 	}
-	return fetchedCSV, err
+	return nil, err
 }
 
-func awaitCSV(c versioned.Interface, namespace, name string, checker csvConditionChecker) (*operatorsv1alpha1.ClusterServiceVersion, error) {
-	var fetched *operatorsv1alpha1.ClusterServiceVersion
-	var err error
+func waitForDeployment(namespace, name string, c operatorclient.ClientInterface) (*appsv1.Deployment, error) {
+	var fetched *appsv1.Deployment
 
-	Eventually(func() (bool, error) {
-		fetched, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	ctx.Ctx().Logf("waiting for deployment %s/%s to be created", namespace, name)
+	err := wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		var err error
+		fetched, err = c.GetDeployment(namespace, name)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		ctx.Ctx().Logf("%s - %s (%s): %s", name, fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
-		return checker(fetched), nil
-	}).Should(BeTrue())
-
-	if err != nil {
-		ctx.Ctx().Logf("never got correct status: %#v", fetched.Status)
-	}
-	return fetched, err
-}
-
-func waitForDeployment(namespace string, c operatorclient.ClientInterface, name string) error {
-	return wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-		_, err := c.GetDeployment(namespace, name)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
+			ctx.Ctx().Logf("error getting deployment %s/%s: %v", namespace, name, err)
+			return false, nil
 		}
 		return true, nil
 	})
+
+	return fetched, err
 }
 
-func waitForDeploymentToDelete(namespace string, c operatorclient.ClientInterface, name string) error {
-	var err error
+func waitForDeploymentToDelete(namespace, name string, c operatorclient.ClientInterface) error {
+	var lastReplicas, lastUpdated, lastReady, lastAvailable, lastUnavailable int32
+	lastTime := time.Now()
 
-	Eventually(func() (bool, error) {
-		ctx.Ctx().Logf("waiting for deployment %s to delete", name)
-		_, err := c.GetDeployment(namespace, name)
+	ctx.Ctx().Logf("waiting for deployment %s/%s to delete", namespace, name)
+	err := wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		dep, err := c.GetDeployment(namespace, name)
 		if apierrors.IsNotFound(err) {
-			ctx.Ctx().Logf("deleted %s", name)
+			ctx.Ctx().Logf("deployment %s/%s deleted", namespace, name)
 			return true, nil
 		}
 		if err != nil {
-			ctx.Ctx().Logf("err trying to delete %s: %s", name, err)
-			return false, err
+			ctx.Ctx().Logf("error getting deployment %s/%s: %v", namespace, name, err)
+		}
+		if dep != nil {
+			replicas, updated, ready, available, unavailable := dep.Status.Replicas, dep.Status.UpdatedReplicas, dep.Status.ReadyReplicas, dep.Status.AvailableReplicas, dep.Status.UnavailableReplicas
+			if replicas != lastReplicas || updated != lastUpdated || ready != lastReady || available != lastAvailable || unavailable != lastUnavailable {
+				ctx.Ctx().Logf("waited %s for deployment %s/%s status: rep: %v upd: %v rdy: %v ava: %v una: %v", time.Since(lastTime), replicas, updated, ready, available, unavailable)
+				lastReplicas, lastUpdated, lastReady, lastAvailable, lastUnavailable = replicas, updated, ready, available, unavailable
+				lastTime = time.Now()
+			}
 		}
 		return false, nil
-	}).Should(BeTrue())
+	})
+
 	return err
 }
 
-func csvExists(namespace string, c versioned.Interface, name string) bool {
-	fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return false
-	}
-	ctx.Ctx().Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
-	if err != nil {
-		return true
-	}
-	return true
+func waitForCsvToDelete(namespace, name string, c versioned.Interface) error {
+	var lastPhase operatorsv1alpha1.ClusterServiceVersionPhase
+	var lastReason operatorsv1alpha1.ConditionReason
+	var lastMessage string
+	lastTime := time.Now()
+
+	ctx.Ctx().Logf("waiting for csv %s/%s to delete", namespace, name)
+	err := wait.Poll(pollInterval, pollDuration, func() (bool, error) {
+		csv, err := c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			ctx.Ctx().Logf("csv %s/%s deleted", namespace, name)
+			return true, nil
+		}
+		if err != nil {
+			ctx.Ctx().Logf("error getting csv %s/%s: %v", namespace, name, err)
+		}
+		if csv != nil {
+			phase, reason, message := csv.Status.Phase, csv.Status.Reason, csv.Status.Message
+			if phase != lastPhase || reason != lastReason || message != lastMessage {
+				ctx.Ctx().Logf("waited %s for csv %s/%s status: %s (%s): %s", time.Since(lastTime), namespace, name, phase, reason, message)
+				lastPhase, lastReason, lastMessage = phase, reason, message
+				lastTime = time.Now()
+			}
+		}
+		return false, nil
+	})
+
+	return err
 }
 
 func deleteLegacyAPIResources(namespace string, desc operatorsv1alpha1.APIServiceDescription, c operatorclient.ClientInterface) {

--- a/test/e2e/csv_e2e_test.go
+++ b/test/e2e/csv_e2e_test.go
@@ -4444,7 +4444,7 @@ func fetchCSV(c versioned.Interface, namespace, name string, checker csvConditio
 	err := wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		var err error
 		csv, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		if err != nil {
+		if err != nil || csv == nil {
 			ctx.Ctx().Logf("error getting csv %s/%s: %v", namespace, name, err)
 			return false, nil
 		}

--- a/test/e2e/fail_forward_e2e_test.go
+++ b/test/e2e/fail_forward_e2e_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 			originalInstallPlanRef = subscription.Status.InstallPlanRef
 
 			By("waiting for the v0.1.0 CSV to report a succeeded phase")
-			_, err = fetchCSV(crclient, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+			_, err = fetchCSV(crclient, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("updating the catalog with a v0.2.0 bundle that has an invalid CSV")
@@ -358,7 +358,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 			Expect(err).Should(BeNil())
 
 			By("waiting for the v0.1.0 CSV to report a succeeded phase")
-			_, err = fetchCSV(crclient, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+			_, err = fetchCSV(crclient, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("updating the catalog with a broken v0.2.0 csv")
@@ -374,7 +374,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 			Expect(err).Should(BeNil())
 
 			By("waiting for the bad CSV to report a failed state")
-			_, err = fetchCSV(crclient, subscription.Status.CurrentCSV, generatedNamespace.GetName(), csvFailedChecker)
+			_, err = fetchCSV(crclient, generatedNamespace.GetName(), subscription.Status.CurrentCSV, csvFailedChecker)
 			Expect(err).To(BeNil())
 
 		})

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -812,7 +812,7 @@ var _ = Describe("Install Plan", func() {
 		require.Equal(GinkgoT(), dependentCSV.GetName(), dependentSubscription.Status.CurrentCSV)
 
 		// Verify CSV is created
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), dependentCSV.GetName(), csvAnyChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), dependentCSV.GetName(), csvAnyChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update dependent subscription in catalog and wait for csv to update
@@ -840,7 +840,7 @@ var _ = Describe("Install Plan", func() {
 		require.NotEqual(GinkgoT(), fetchedInstallPlan.GetName(), fetchedUpdatedDepInstallPlan.GetName())
 
 		// Wait for csv to update
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedDependentCSV.GetName(), csvAnyChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), updatedDependentCSV.GetName(), csvAnyChecker)
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -1414,7 +1414,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), generatedNamespace.GetName(), csvAnyChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), mainBetaCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			GinkgoT().Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
@@ -1638,7 +1638,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), mainBetaCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Ensure CRD versions are accurate
@@ -1678,7 +1678,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err = fetchCSV(crc, mainDeltaCSV.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, generatedNamespace.GetName(), mainDeltaCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Ensure CRD versions are accurate
@@ -1818,7 +1818,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Update CatalogSource with a new CSV with more permissions
@@ -1884,7 +1884,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// If the CSV is succeeded, we successfully rolled out the RBAC changes
@@ -2016,7 +2016,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Update CatalogSource with a new CSV with more permissions
@@ -2076,7 +2076,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			newSecrets, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
@@ -2232,7 +2232,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			csv, err := awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			csv, err := fetchCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			addedEnvVar := corev1.EnvVar{Name: "EXAMPLE", Value: "value"}
@@ -2273,7 +2273,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Should have the updated env var
@@ -2321,7 +2321,7 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Should have created deployment and stomped on the env changes
@@ -2478,7 +2478,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvAnyChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			mainManifests = []registry.PackageManifest{
@@ -2502,7 +2502,7 @@ var _ = Describe("Install Plan", func() {
 			require.NotEqual(GinkgoT(), fetchedInstallPlan.GetName(), fetchedUpdatedInstallPlan.GetName())
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), betaCSV.GetName(), csvAnyChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), betaCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the CRD to see if it is updated
@@ -2678,7 +2678,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvAnyChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the CRD to see if it is updated
@@ -3190,7 +3190,7 @@ var _ = Describe("Install Plan", func() {
 		require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 		// Verify CSV is created
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Make sure to clean up the installed CRD

--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 				cleanupCSV, err = createCSV(c, crc, failingCSV, generatedNamespace.GetName(), false, false)
 				Expect(err).ToNot(HaveOccurred())
 
-				_, err = fetchCSV(crc, failingCSV.Name, generatedNamespace.GetName(), csvFailedChecker)
+				_, err = fetchCSV(crc, generatedNamespace.GetName(), failingCSV.Name, csvFailedChecker)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -136,7 +136,7 @@ var _ = Describe("Metrics are generated for OLM managed resources", func() {
 				var err error
 				_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+				_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/test/e2e/operator_condition_e2e_test.go
+++ b/test/e2e/operator_condition_e2e_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Operator Condition", func() {
 		defer cleanupSub()
 
 		// Await csvA's success
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Get the OperatorCondition for csvA and report that it is not upgradeable
@@ -121,7 +121,7 @@ var _ = Describe("Operator Condition", func() {
 		require.NoError(GinkgoT(), err)
 
 		// csvB will be in Pending phase due to csvA reports Upgradeable=False condition
-		fetchedCSV, err := fetchCSV(crc, csvB.GetName(), generatedNamespace.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
+		fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csvB.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), fetchedCSV.Status.Phase, operatorsv1alpha1.CSVPhasePending)
 
@@ -146,7 +146,7 @@ var _ = Describe("Operator Condition", func() {
 		}, pollInterval, pollDuration).Should(Succeed())
 
 		// Await csvB's success
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Get the OperatorCondition for csvB and purposedly change ObservedGeneration
@@ -180,7 +180,7 @@ var _ = Describe("Operator Condition", func() {
 		require.NoError(GinkgoT(), err)
 
 		// CSVD will be in Pending status due to overrides in csvB's condition
-		fetchedCSV, err = fetchCSV(crc, csvD.GetName(), generatedNamespace.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
+		fetchedCSV, err = fetchCSV(crc, generatedNamespace.GetName(), csvD.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), fetchedCSV.Status.Phase, operatorsv1alpha1.CSVPhasePending)
 
@@ -198,7 +198,7 @@ var _ = Describe("Operator Condition", func() {
 		require.NoError(GinkgoT(), err)
 
 		require.NoError(GinkgoT(), err)
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvD.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvD.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 	})
 })

--- a/test/e2e/operator_groups_e2e_test.go
+++ b/test/e2e/operator_groups_e2e_test.go
@@ -392,7 +392,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err, "could not update csv installmodes")
 
 		// Ensure CSV fails
-		_, err = fetchCSV(crc, csvName, opGroupNamespace, csvFailedChecker)
+		_, err = fetchCSV(crc, opGroupNamespace, csvName, csvFailedChecker)
 		require.NoError(GinkgoT(), err, "csv did not transition to failed as expected")
 
 		// ensure deletion cleans up copied CSV
@@ -490,7 +490,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 		defer cleanupCRD()
 
-		_, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
+		_, err = fetchCSV(crc, nsA, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		depName := genName("hat-server")
@@ -562,7 +562,7 @@ var _ = Describe("Operator Group", func() {
 		defer cleanupCSV()
 
 		GinkgoT().Logf("Fetch the APIService CSV %s/%s", nsA, depName)
-		_, err = fetchCSV(crc, csvB.GetName(), nsA, csvSucceededChecker)
+		_, err = fetchCSV(crc, nsA, csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		GinkgoT().Logf("Ensure clusterroles created and aggregated for access provided APIs")
@@ -700,7 +700,7 @@ var _ = Describe("Operator Group", func() {
 		failedWithUnsupportedOperatorGroup := func(csv *v1alpha1.ClusterServiceVersion) bool {
 			return csvFailedChecker(csv) && csv.Status.Reason == v1alpha1.CSVReasonUnsupportedOperatorGroup
 		}
-		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
+		csvA, err = fetchCSV(crc, nsA, csvA.GetName(), failedWithUnsupportedOperatorGroup)
 		require.NoError(GinkgoT(), err)
 
 		// Update csvA to have OwnNamespace supported=true
@@ -731,7 +731,7 @@ var _ = Describe("Operator Group", func() {
 		defer cleanupCRD()
 
 		// Ensure csvA transitions to Succeeded
-		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
+		csvA, err = fetchCSV(crc, nsA, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update operatorGroupA's target namespaces to select namespaceB
@@ -742,7 +742,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Failed with reason "UnsupportedOperatorGroup"
-		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
+		csvA, err = fetchCSV(crc, nsA, csvA.GetName(), failedWithUnsupportedOperatorGroup)
 		require.NoError(GinkgoT(), err)
 
 		// Update csvA to have SingleNamespace supported=true
@@ -768,7 +768,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Succeeded
-		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
+		csvA, err = fetchCSV(crc, nsA, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update operatorGroupA's target namespaces to select namespaceA and namespaceB
@@ -779,7 +779,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Failed with reason "UnsupportedOperatorGroup"
-		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
+		csvA, err = fetchCSV(crc, nsA, csvA.GetName(), failedWithUnsupportedOperatorGroup)
 		require.NoError(GinkgoT(), err)
 
 		// Update csvA to have MultiNamespace supported=true
@@ -805,7 +805,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Succeeded
-		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
+		csvA, err = fetchCSV(crc, nsA, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update operatorGroupA's target namespaces to select all namespaces
@@ -816,7 +816,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Failed with reason "UnsupportedOperatorGroup"
-		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, failedWithUnsupportedOperatorGroup)
+		csvA, err = fetchCSV(crc, nsA, csvA.GetName(), failedWithUnsupportedOperatorGroup)
 		require.NoError(GinkgoT(), err)
 
 		// Update csvA to have AllNamespaces supported=true
@@ -842,7 +842,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA transitions to Pending
-		csvA, err = fetchCSV(crc, csvA.GetName(), nsA, csvSucceededChecker)
+		csvA, err = fetchCSV(crc, nsA, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 	})
 	It("intersection", func() {
@@ -975,11 +975,11 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subD)
 
 		// Await csvD's success
-		_, err = awaitCSV(crc, nsD, csvD.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, nsD, csvD.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Await csvD's copy in namespaceE
-		_, err = awaitCSV(crc, nsE, csvD.GetName(), csvCopiedChecker)
+		_, err = fetchCSV(crc, nsE, csvD.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Await annotation on groupD
@@ -998,7 +998,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subD2)
 
 		// Await csvD2's failure
-		csvD2, err := awaitCSV(crc, nsA, csvD.GetName(), csvFailedChecker)
+		csvD2, err := fetchCSV(crc, nsA, csvD.GetName(), csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.CSVReasonInterOperatorGroupOwnerConflict, csvD2.Status.Reason)
 
@@ -1010,7 +1010,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), awaitAnnotations(GinkgoT(), q, map[string]string{}))
 
 		// Ensure csvD is still successful
-		_, err = awaitCSV(crc, nsD, csvD.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, nsD, csvD.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Create subscription for csvA in namespaceA
@@ -1022,7 +1022,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subA)
 
 		// Await csvA's success
-		_, err = awaitCSV(crc, nsA, csvA.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, nsA, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure clusterroles created and aggregated for access provided APIs
@@ -1061,7 +1061,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), awaitAnnotations(GinkgoT(), q, map[string]string{v1.OperatorGroupProvidedAPIsAnnotationKey: kvgA}))
 
 		// Wait for csvA to have a CSV with copied status in namespace D
-		csvAinNsD, err := awaitCSV(crc, nsD, csvA.GetName(), csvCopiedChecker)
+		csvAinNsD, err := fetchCSV(crc, nsD, csvA.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// trigger a resync of operatorgropuD
@@ -1073,7 +1073,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Ensure csvA retains the operatorgroup annotations for operatorgroupA
-		csvAinNsD, err = awaitCSV(crc, nsD, csvA.GetName(), csvCopiedChecker)
+		csvAinNsD, err = fetchCSV(crc, nsD, csvA.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		require.Equal(GinkgoT(), groupA.GetName(), csvAinNsD.Annotations[v1.OperatorGroupAnnotationKey])
@@ -1081,7 +1081,7 @@ var _ = Describe("Operator Group", func() {
 		require.Equal(GinkgoT(), nsA, csvAinNsD.Labels[v1alpha1.CopiedLabelKey])
 
 		// Await csvA's copy in namespaceC
-		_, err = awaitCSV(crc, nsC, csvA.GetName(), csvCopiedChecker)
+		_, err = fetchCSV(crc, nsC, csvA.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Create subscription for csvB in namespaceB
@@ -1093,7 +1093,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subB)
 
 		// Await csvB's failure
-		fetchedB, err := awaitCSV(crc, nsB, csvB.GetName(), csvFailedChecker)
+		fetchedB, err := fetchCSV(crc, nsB, csvB.GetName(), csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.CSVReasonInterOperatorGroupOwnerConflict, fetchedB.Status.Reason)
 
@@ -1115,14 +1115,14 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), awaitAnnotations(GinkgoT(), q, map[string]string{v1.OperatorGroupProvidedAPIsAnnotationKey: ""}))
 
 		// Ensure csvA's deployment is deleted
-		require.NoError(GinkgoT(), waitForDeploymentToDelete(generatedNamespace.GetName(), c, pkgAStable))
+		require.NoError(GinkgoT(), waitForDeploymentToDelete(generatedNamespace.GetName(), pkgAStable, c))
 
 		// Await csvB's success
-		_, err = awaitCSV(crc, nsB, csvB.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, nsB, csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Await csvB's copy in namespace C
-		_, err = awaitCSV(crc, nsC, csvB.GetName(), csvCopiedChecker)
+		_, err = fetchCSV(crc, nsC, csvB.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure annotations exist on group B
@@ -1238,7 +1238,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subA)
 
 		// Await csvA's failure
-		fetchedCSVA, err := awaitCSV(crc, nsB, csvA.GetName(), csvFailedChecker)
+		fetchedCSVA, err := fetchCSV(crc, nsB, csvA.GetName(), csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.CSVReasonInterOperatorGroupOwnerConflict, fetchedCSVA.Status.Reason)
 
@@ -1264,7 +1264,7 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subAC)
 
 		// Await csvA's success
-		_, err = awaitCSV(crc, nsC, csvA.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, nsC, csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure operatorGroupC has KindA.version.group in its providedAPIs annotation
@@ -1290,15 +1290,15 @@ var _ = Describe("Operator Group", func() {
 		require.NotNil(GinkgoT(), subB)
 
 		// Await csvB's success
-		_, err = awaitCSV(crc, nsB, csvB.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, nsB, csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Await copied csvBs
-		_, err = awaitCSV(crc, nsA, csvB.GetName(), csvCopiedChecker)
+		_, err = fetchCSV(crc, nsA, csvB.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
-		_, err = awaitCSV(crc, nsC, csvB.GetName(), csvCopiedChecker)
+		_, err = fetchCSV(crc, nsC, csvB.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
-		_, err = awaitCSV(crc, nsD, csvB.GetName(), csvCopiedChecker)
+		_, err = fetchCSV(crc, nsD, csvB.GetName(), csvCopiedChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure operatorGroupB has KindB.version.group in its providedAPIs annotation
@@ -1323,7 +1323,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Wait for csvA in namespaceC to fail with status "InterOperatorGroupOwnerConflict"
-		fetchedCSVA, err = awaitCSV(crc, nsC, csvA.GetName(), csvFailedChecker)
+		fetchedCSVA, err = fetchCSV(crc, nsC, csvA.GetName(), csvFailedChecker)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.CSVReasonInterOperatorGroupOwnerConflict, fetchedCSVA.Status.Reason)
 
@@ -1474,7 +1474,7 @@ var _ = Describe("Operator Group", func() {
 		_, err = c.UpdateRoleBinding(createdRoleBinding)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for CSV to succeed")
-		_, err = fetchCSV(crc, createdCSV.GetName(), opGroupNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, opGroupNamespace, createdCSV.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for roles to be promoted to clusterroles")
 		var fetchedRole *rbacv1.ClusterRole
@@ -1967,7 +1967,7 @@ var _ = Describe("Operator Group", func() {
 		_, err = c.UpdateRoleBinding(createdRoleBinding)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for CSV to succeed")
-		_, err = fetchCSV(crc, createdCSV.GetName(), opGroupNamespace, csvSucceededChecker)
+		_, err = fetchCSV(crc, opGroupNamespace, createdCSV.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("wait for roles to be promoted to clusterroles")
 		var fetchedRole *rbacv1.ClusterRole

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Subscription", func() {
 			return false
 		}, 5*time.Minute, 10*time.Second).Should(BeTrue())
 
-		csv, err := fetchCSV(crc, currentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+		csv, err := fetchCSV(crc, generatedNamespace.GetName(), currentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 
 		// Check for the olm.package property as a proxy for
@@ -211,7 +211,7 @@ var _ = Describe("Subscription", func() {
 		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), testSubscriptionName, subscriptionStateAtLatestChecker())
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 	})
 	It("skip range", func() {
@@ -296,14 +296,14 @@ var _ = Describe("Subscription", func() {
 		defer subscriptionCleanup()
 
 		// Wait for csv to install
-		firstCSV, err := awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
+		firstCSV, err := fetchCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update catalog with a new csv in the channel with a skip range
 		updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensionsv1.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{updatedCSV}, updatedManifests)
 
 		// Wait for csv to update
-		finalCSV, err := awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+		finalCSV, err := fetchCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure we set the replacement field based on the registry data
@@ -368,7 +368,7 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
-		_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -494,7 +494,7 @@ var _ = Describe("Subscription", func() {
 		_, err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Update(context.Background(), fetchedInstallPlan, metav1.UpdateOptions{})
 		require.NoError(GinkgoT(), err)
 
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Wait for the subscription to begin upgrading to csvB
@@ -512,7 +512,7 @@ var _ = Describe("Subscription", func() {
 		_, err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Update(context.Background(), upgradeInstallPlan, metav1.UpdateOptions{})
 		require.NoError(GinkgoT(), err)
 
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Ensure that 2 installplans were created
@@ -563,7 +563,7 @@ var _ = Describe("Subscription", func() {
 		require.NotNil(GinkgoT(), subscription)
 
 		// Wait for csvA to be installed
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Set up async watches that will fail the test if csvB doesn't get created in between csvA and csvC
@@ -572,7 +572,7 @@ var _ = Describe("Subscription", func() {
 			defer GinkgoRecover()
 			wg.Add(1)
 			defer wg.Done()
-			_, err := awaitCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvReplacingChecker)
+			_, err := fetchCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvReplacingChecker)
 			require.NoError(GinkgoT(), err)
 		}(GinkgoT())
 		// Update the catalog to include multiple updates
@@ -592,17 +592,15 @@ var _ = Describe("Subscription", func() {
 		wg.Wait()
 
 		// Wait for csvC to be installed
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvC.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvC.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Should eventually GC the CSVs
-		Eventually(func() bool {
-			return csvExists(generatedNamespace.GetName(), crc, csvA.Name)
-		}).Should(BeFalse())
+		err = waitForCsvToDelete(generatedNamespace.GetName(), csvA.Name, crc)
+		Expect(err).ShouldNot(HaveOccurred())
 
-		Eventually(func() bool {
-			return csvExists(generatedNamespace.GetName(), crc, csvB.Name)
-		}).Should(BeFalse())
+		err = waitForCsvToDelete(generatedNamespace.GetName(), csvB.Name, crc)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// TODO: check installplans, subscription status, etc
 	})
@@ -645,7 +643,7 @@ var _ = Describe("Subscription", func() {
 		createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, catalogSourceName, packageName, stableChannel, csvB.GetName(), operatorsv1alpha1.ApprovalAutomatic)
 
 		// Wait for csvB to be installed
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker())
@@ -701,7 +699,7 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Wait for csvA to be installed
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Wait for the subscription to begin upgrading to csvB
@@ -719,7 +717,7 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Wait for csvB to be installed
-		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -1366,7 +1364,7 @@ var _ = Describe("Subscription", func() {
 		expected = append(expected, proxyEnv...)
 
 		Eventually(func() error {
-			csv, err := fetchCSV(crClient, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+			csv, err := fetchCSV(crClient, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 			if err != nil {
 				return err
 			}
@@ -1420,7 +1418,7 @@ var _ = Describe("Subscription", func() {
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
-		csv, err := fetchCSV(crClient, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseInstalling, operatorsv1alpha1.CSVPhaseSucceeded))
+		csv, err := fetchCSV(crClient, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseInstalling, operatorsv1alpha1.CSVPhaseSucceeded))
 		require.NoError(GinkgoT(), err)
 
 		Eventually(func() error {
@@ -1705,7 +1703,7 @@ var _ = Describe("Subscription", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(subscription).ToNot(BeNil())
 
-					_, err = fetchCSV(crClient, mainCSVName, generatedNamespace.GetName(), csvSucceededChecker)
+					_, err = fetchCSV(crClient, generatedNamespace.GetName(), mainCSVName, csvSucceededChecker)
 					Expect(err).ToNot(HaveOccurred())
 
 				})
@@ -1793,7 +1791,7 @@ var _ = Describe("Subscription", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(subscription).ToNot(BeNil())
 
-					_, err = fetchCSV(crClient, mainCSVName, generatedNamespace.GetName(), csvSucceededChecker)
+					_, err = fetchCSV(crClient, generatedNamespace.GetName(), mainCSVName, csvSucceededChecker)
 					Expect(err).ToNot(HaveOccurred())
 
 				})
@@ -1887,7 +1885,7 @@ var _ = Describe("Subscription", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(subscription).ToNot(BeNil())
 
-					_, err = fetchCSV(crClient, mainCSVName, generatedNamespace.GetName(), csvSucceededChecker)
+					_, err = fetchCSV(crClient, generatedNamespace.GetName(), mainCSVName, csvSucceededChecker)
 					Expect(err).ToNot(HaveOccurred())
 
 				})
@@ -1981,7 +1979,7 @@ var _ = Describe("Subscription", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(subscription).ToNot(BeNil())
 
-					_, err = fetchCSV(crClient, mainCSVName, generatedNamespace.GetName(), csvSucceededChecker)
+					_, err = fetchCSV(crClient, generatedNamespace.GetName(), mainCSVName, csvSucceededChecker)
 					Expect(err).ToNot(HaveOccurred())
 
 				})
@@ -2095,9 +2093,9 @@ var _ = Describe("Subscription", func() {
 		_, err = fetchInstallPlanWithNamespace(GinkgoT(), crClient, subscription.Status.InstallPlanRef.Name, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		// Fetch CSVs A and B
-		_, err = fetchCSV(crClient, csvA.Name, generatedNamespace.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crClient, generatedNamespace.GetName(), csvA.Name, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
-		_, err = fetchCSV(crClient, csvB.Name, generatedNamespace.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crClient, generatedNamespace.GetName(), csvB.Name, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update PackageManifest
@@ -2125,7 +2123,7 @@ var _ = Describe("Subscription", func() {
 		_, err = crClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), csvNewA.Name, metav1.GetOptions{})
 		require.Error(GinkgoT(), err)
 		// Ensure csvA still exists
-		_, err = fetchCSV(crClient, csvA.Name, generatedNamespace.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crClient, generatedNamespace.GetName(), csvA.Name, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update packagemanifest again
@@ -2150,10 +2148,10 @@ var _ = Describe("Subscription", func() {
 		_, err = fetchSubscription(crClient, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(subscription.Status.InstallPlanRef.Name))
 		require.NoError(GinkgoT(), err)
 		// Ensure csvNewA is installed
-		_, err = fetchCSV(crClient, csvNewA.Name, generatedNamespace.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crClient, generatedNamespace.GetName(), csvNewA.Name, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 		// Ensure csvNewB is installed
-		_, err = fetchCSV(crClient, csvNewB.Name, generatedNamespace.GetName(), csvSucceededChecker)
+		_, err = fetchCSV(crClient, generatedNamespace.GetName(), csvNewB.Name, csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -2451,7 +2449,7 @@ var _ = Describe("Subscription", func() {
 			Expect(err).Should(BeNil())
 
 			By("waiting for the v0.1.0 CSV to report a succeeded phase")
-			_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -2675,7 +2673,7 @@ properties:
 			Expect(err).Should(BeNil())
 
 			By("waiting for the v0.1.0 CSV to report a succeeded phase")
-			_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("checking if old unpack conditions on subscription are removed")
@@ -2711,7 +2709,7 @@ properties:
 			Expect(err).Should(BeNil())
 
 			By("waiting for the v0.1.0 CSV to report a succeeded phase")
-			_, err = fetchCSV(crc, subscription.Status.CurrentCSV, generatedNamespace.GetName(), buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), subscription.Status.CurrentCSV, buildCSVConditionChecker(operatorsv1alpha1.CSVPhaseSucceeded))
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("patching operator group to enable unpack retries")
@@ -3382,6 +3380,8 @@ func updateInternalCatalog(t GinkgoTInterface, c operatorclient.ClientInterface,
 	require.NoError(t, err)
 
 	// wait for catalog to update
+	var lastState string
+	lastTime := time.Now()
 	_, err = fetchCatalogSourceOnStatus(crc, catalogSourceName, namespace, func(catalog *operatorsv1alpha1.CatalogSource) bool {
 		before := fetchedInitialCatalog.Status.ConfigMapResource
 		after := catalog.Status.ConfigMapResource
@@ -3390,7 +3390,11 @@ func updateInternalCatalog(t GinkgoTInterface, c operatorclient.ClientInterface,
 			fmt.Println("catalog updated")
 			return true
 		}
-		fmt.Printf("waiting for catalog pod %v to be available (after catalog update) - %s\n", catalog.GetName(), catalog.Status.GRPCConnectionState.LastObservedState)
+		if catalog.Status.GRPCConnectionState.LastObservedState != lastState {
+			fmt.Printf("waited %s for catalog pod %v to be available (after catalog update) - %s\n", time.Since(lastTime), catalog.GetName(), catalog.Status.GRPCConnectionState.LastObservedState)
+			lastState = catalog.Status.GRPCConnectionState.LastObservedState
+			lastTime = time.Now()
+		}
 		return false
 	})
 	require.NoError(t, err)

--- a/test/e2e/webhook_e2e_test.go
+++ b/test/e2e/webhook_e2e_test.go
@@ -97,7 +97,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -139,7 +139,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -194,7 +194,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			// Get the existing secret
@@ -216,7 +216,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			}).Should(BeTrue(), "Unable to set CSV phase to Pending")
 
 			// Wait for webhook-operator to succeed
-			_, err = awaitCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the updated secret
@@ -243,7 +243,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvFailedChecker)
 			Expect(err).Should(BeNil())
 		})
 		It("Fails if the webhooks intercepts all resources", func() {
@@ -273,7 +273,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include all groups"))
 		})
@@ -304,7 +304,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include the OLM group"))
 		})
@@ -335,7 +335,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include MutatingWebhookConfiguration or ValidatingWebhookConfiguration resources"))
 		})
@@ -368,7 +368,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 		})
 		It("Can be installed and upgraded successfully", func() {
@@ -400,7 +400,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			Expect(err).Should(BeNil())
 			// cleanup by upgrade
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			_, err = getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -415,16 +415,15 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			_, err = getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())
 
 			// Make sure old resources are cleaned up.
-			Eventually(func() bool {
-				return csvExists(generatedNamespace.GetName(), crc, csv.Spec.Replaces)
-			}).Should(BeFalse())
+			err = waitForCsvToDelete(generatedNamespace.GetName(), csv.Spec.Replaces, crc)
+			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait until previous webhook is cleaned up
 			Eventually(func() (bool, error) {
@@ -456,7 +455,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -480,7 +479,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 				return nil
 			})).Should(Succeed())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create deployment
 				dep, err = c.GetDeployment(generatedNamespace.GetName(), csv.Spec.WebhookDefinitions[0].DeploymentName)
 				if err != nil {
@@ -542,7 +541,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())
@@ -606,7 +605,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 		defer cleanupCSV()
 
 		Eventually(func() (err error) {
-			_, err = fetchCSV(crc, csv.Name, namespace1.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, namespace1.Name, csv.Name, csvSucceededChecker)
 			return
 		}).Should(Succeed())
 
@@ -618,7 +617,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 		defer cleanupCSV()
 
 		Eventually(func() (err error) {
-			_, err = fetchCSV(crc, csv.Name, namespace2.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, namespace2.Name, csv.Name, csvSucceededChecker)
 			return
 		}).Should(Succeed())
 
@@ -690,8 +689,11 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupSubscription := createSubscriptionForCatalog(crc, source.GetNamespace(), subscriptionName, source.GetName(), packageName, channelName, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer cleanupSubscription()
 
+			_, err = fetchSubscription(crc, source.GetNamespace(), subscriptionName, subscriptionHasInstallPlanChecker())
+			require.NoError(GinkgoT(), err)
+
 			// Wait for webhook-operator v2 csv to succeed
-			csv, err := awaitCSV(crc, source.GetNamespace(), csvName, csvSucceededChecker)
+			csv, err := fetchCSV(crc, source.GetNamespace(), csvName, csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			cleanupCSV = buildCSVCleanupFunc(c, crc, *csv, source.GetNamespace(), true, true)
@@ -852,7 +854,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())
@@ -915,7 +917,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())


### PR DESCRIPTION
Some of the e2e loops are a bit flakey, make them more robust
* Retry on certain errors
* Use Eventually() consistently (avoid wait.Poll())
* Clarify logging
* Reduce some logging
* Change csvExists() to waitForCsvToDelete(), as that's how it's used
* Change awaitCSV() to fetchCSV()

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
