### PR TITLE
labellers: use unique field managers

### DIFF
--- a/pkg/controller/operators/labeller/labels.go
+++ b/pkg/controller/operators/labeller/labels.go
@@ -84,7 +84,7 @@ func ObjectLabeler[T metav1.Object, A ApplyConfig[A]](
 				install.OLMManagedLabelKey: install.OLMManagedLabelValue,
 			})
 
-			_, err := apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{FieldManager: "olm"})
+			_, err := apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{FieldManager: "olm-ownership-labeller"})
 			return err
 		}
 	}
@@ -166,7 +166,7 @@ func ObjectPatchLabeler(
 				return fmt.Errorf("failed to create patch for %s/%s: %w", cast.GetNamespace(), cast.GetName(), err)
 			}
 
-			_, err = patch(ctx, cast.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "olm"})
+			_, err = patch(ctx, cast.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "olm-ownership-labeller"})
 			return err
 		}
 	}

--- a/pkg/controller/operators/labeller/rbac.go
+++ b/pkg/controller/operators/labeller/rbac.go
@@ -68,7 +68,7 @@ func ContentHashLabeler[T metav1.Object, A ApplyConfig[A]](
 			cfg.WithLabels(map[string]string{
 				resolver.ContentHashLabelKey: hash,
 			})
-			_, err = apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{FieldManager: "olm"})
+			_, err = apply(cast.GetNamespace(), ctx, cfg, metav1.ApplyOptions{FieldManager: "olm-hash-labeller"})
 			return err
 		}
 	}


### PR DESCRIPTION
It seems like using the same field manager for two distinct fields leads to the label set oscillating between the two states instead of converging to the union of both requests.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
