### PR TITLE
registry/reconciler: allow current pods to be not ready

### DIFF
--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -437,11 +437,15 @@ func (c *GrpcRegistryReconciler) createUpdatePod(source grpcCatalogSourceDecorat
 func imageChanged(updatePod *corev1.Pod, servingPods []*corev1.Pod) bool {
 	updatedCatalogSourcePodImageID := imageID(updatePod)
 	if updatedCatalogSourcePodImageID == "" {
-		logrus.WithField("CatalogSource", updatePod.GetName()).Warn("pod status unknown, cannot get the pod's imageID")
+		logrus.WithField("CatalogSource", updatePod.GetName()).Warn("pod status unknown, cannot get the updated pod's imageID")
 		return false
 	}
 	for _, servingPod := range servingPods {
 		servingCatalogSourcePodImageID := imageID(servingPod)
+		if servingCatalogSourcePodImageID == "" {
+			logrus.WithField("CatalogSource", servingPod.GetName()).Warn("pod status unknown, cannot get the current pod's imageID")
+			return false
+		}
 		if updatedCatalogSourcePodImageID != servingCatalogSourcePodImageID {
 			logrus.WithField("CatalogSource", servingPod.GetName()).Infof("catalog image changed: serving pod %s update pod %s", servingCatalogSourcePodImageID, updatedCatalogSourcePodImageID)
 			return true


### PR DESCRIPTION
A good chunk of this logic is fatally flawed - it would be much more simple to manage a Deployment and use server-side apply to ensure that the current server state always matched the desired state, but that would be a large refactor and who knows how many other things are loosely coupled here. This is the smallest change that allows for the current serving pod to not yet have a running catalog server.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
