### PR TITLE
Fix Image Update test

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -922,6 +923,32 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		Expect(err).ToNot(HaveOccurred(), "error awaiting registry pod")
 		Expect(registryPods).ShouldNot(BeNil(), "nil registry pods")
 		Expect(registryPods.Items).To(HaveLen(1), "unexpected number of registry pods found")
+
+		By("Granting the ServiceAccount used by the registry pod permissions to pull from the internal registry")
+		roleBinding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    generatedNamespace.GetName(),
+				GenerateName: "registry-v1-viewer-",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:     "ServiceAccount",
+					Name:     registryPods.Items[0].Spec.ServiceAccountName,
+					APIGroup: "",
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     "registry-viewer",
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		}
+		_, err = c.CreateRoleBinding(roleBinding)
+		Expect(err).ToNot(HaveOccurred(), "error granting registry-viewer permissions")
+		defer func() {
+			err := c.DeleteRoleBinding(roleBinding.GetNamespace(), roleBinding.GetName(), &metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+		}()
 
 		By("Create a Subscription for package")
 		subscriptionName := genName("sub-")


### PR DESCRIPTION
This change grants the serviceAccount used by the catalogSource permissions to pull from the internal registry.