### PR TITLE
Update Subscription Status with Deprecation Warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/onsi/gomega v1.27.10
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/operator-framework/api v0.19.0
+	github.com/operator-framework/api v0.20.0
 	github.com/operator-framework/operator-registry v1.33.0
 	github.com/otiai10/copy v1.12.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/openshift/api v0.0.0-20221021112143-4226c2167e40 h1:PxjGCA72RtsdHWToZ
 github.com/openshift/api v0.0.0-20221021112143-4226c2167e40/go.mod h1:aQ6LDasvHMvHZXqLHnX2GRmnfTWCF/iIwz8EMTTIE9A=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c/go.mod h1:lFMO8mLHXWFzSdYvGNo8ivF9SfF6zInA8ZGw4phRnUE=
-github.com/operator-framework/api v0.19.0 h1:QU1CTJU+CufoeneA5rsNlP/uP96s8vDHWUYDFZTauzA=
-github.com/operator-framework/api v0.19.0/go.mod h1:SCCslqke6AVOJ5JM+NqNE1CHuAgJLScsL66pnPaSMXs=
+github.com/operator-framework/api v0.20.0 h1:A2YCRhr+6s0k3pRJacnwjh1Ue8BqjIGuQ2jvPg9XCB4=
+github.com/operator-framework/api v0.20.0/go.mod h1:rXPOhrQ6mMeXqCmpDgt1ALoar9ZlHL+Iy5qut9R99a4=
 github.com/operator-framework/operator-registry v1.33.0 h1:rFvYf6vLdXSUhoePhg8w1S5FHgyFraiNLXDwl47epck=
 github.com/operator-framework/operator-registry v1.33.0/go.mod h1:1V/m2m7iH/o5ROEuMxWa/yhj4ExaPGT6V/ncGS+m6Js=
 github.com/otiai10/copy v1.12.0 h1:cLMgSQnXBs1eehF0Wy/FAGsgDTDmAqFR7rQylBb1nDY=

--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -346,6 +346,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		subscription.WithAppendedReconcilers(subscription.ReconcilerFromLegacySyncHandler(op.syncSubscriptions, nil)),
 		subscription.WithRegistryReconcilerFactory(op.reconciler),
 		subscription.WithGlobalCatalogNamespace(op.namespace),
+		subscription.WithSourceProvider(resolverSourceProvider),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/operators/catalog/subscription/config.go
+++ b/pkg/controller/operators/catalog/subscription/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
+	resolverCache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 )
@@ -26,6 +27,7 @@ type syncerConfig struct {
 	reconcilers               kubestate.ReconcilerChain
 	registryReconcilerFactory reconciler.RegistryReconcilerFactory
 	globalCatalogNamespace    string
+	sourceProvider            resolverCache.SourceProvider
 }
 
 // SyncerOption is a configuration option for a subscription syncer.
@@ -125,6 +127,12 @@ func WithRegistryReconcilerFactory(r reconciler.RegistryReconcilerFactory) Synce
 func WithGlobalCatalogNamespace(namespace string) SyncerOption {
 	return func(config *syncerConfig) {
 		config.globalCatalogNamespace = namespace
+	}
+}
+
+func WithSourceProvider(provider resolverCache.SourceProvider) SyncerOption {
+	return func(config *syncerConfig) {
+		config.sourceProvider = provider
 	}
 }
 

--- a/pkg/controller/operators/catalog/subscription/syncer.go
+++ b/pkg/controller/operators/catalog/subscription/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/operator-framework/api/pkg/operators/install"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	resolverCache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
@@ -34,6 +35,7 @@ type subscriptionSyncer struct {
 	installPlanLister      listers.InstallPlanLister
 	globalCatalogNamespace string
 	notify                 kubestate.NotifyFunc
+	sourceProvider         resolverCache.SourceProvider
 }
 
 // now returns the Syncer's current time.
@@ -214,6 +216,7 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 		reconcilers:       config.reconcilers,
 		subscriptionCache: config.subscriptionInformer.GetIndexer(),
 		installPlanLister: config.lister.OperatorsV1alpha1().InstallPlanLister(),
+		sourceProvider:    config.sourceProvider,
 		notify: func(event kubestate.ResourceEvent) {
 			// Notify Subscriptions by enqueuing to the Subscription queue.
 			config.subscriptionQueue.Add(event)
@@ -234,6 +237,7 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 			catalogLister:             config.lister.OperatorsV1alpha1().CatalogSourceLister(),
 			registryReconcilerFactory: config.registryReconcilerFactory,
 			globalCatalogNamespace:    config.globalCatalogNamespace,
+			sourceProvider:            config.sourceProvider,
 		},
 	}
 	s.reconcilers = append(defaultReconcilers, s.reconcilers...)

--- a/pkg/controller/registry/resolver/cache/operators.go
+++ b/pkg/controller/registry/resolver/cache/operators.go
@@ -140,11 +140,18 @@ type OperatorSourceInfo struct {
 	StartingCSV    string
 	Catalog        SourceKey
 	DefaultChannel bool
+	Deprecations   *Deprecations
 	Subscription   *v1alpha1.Subscription
 }
 
 func (i *OperatorSourceInfo) String() string {
 	return fmt.Sprintf("%s/%s in %s/%s", i.Package, i.Channel, i.Catalog.Name, i.Catalog.Namespace)
+}
+
+type Deprecations struct {
+	Package *api.Deprecation
+	Channel *api.Deprecation
+	Bundle  *api.Deprecation
 }
 
 type Entry struct {

--- a/test/e2e/testdata/subscription/example-operator.v0.2.0-deprecations.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.2.0-deprecations.yaml
@@ -1,0 +1,41 @@
+---
+schema: olm.package
+name: packageA
+defaultChannel: stable
+---
+schema: olm.channel
+package: packageA
+name: stable
+entries:
+  - name: example-operator.v0.2.0
+    replaces: example-operator.v0.1.0
+---
+schema: olm.bundle
+name: example-operator.v0.2.0
+package: packageA
+image: quay.io/olmtest/example-operator-bundle:0.2.0
+properties:
+  - type: olm.gvk
+    value:
+      group: example.com
+      kind: TestA
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: packageA
+      version: 1.0.1
+---
+schema: olm.deprecations
+package: packageA
+entries:
+  - reference:
+      schema: olm.package
+    message: packageA has been deprecated. Please switch to packageB.
+  - reference:
+      schema: olm.channel
+      name: stable
+    message: channel "stable" has been deprecated. Please switch to a different one.
+  - reference:
+      schema: olm.bundle
+      name: example-operator.v0.2.0
+    message: bundle "example-operator.v0.2.0" has been deprecated. Please switch to a different one.

--- a/test/e2e/testdata/subscription/example-operator.v0.3.0-deprecations.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.3.0-deprecations.yaml
@@ -1,0 +1,37 @@
+---
+schema: olm.package
+name: packageA
+defaultChannel: stable
+---
+schema: olm.channel
+package: packageA
+name: stable
+entries:
+  - name: example-operator.v0.3.0
+    replaces: example-operator.v0.2.0
+---
+schema: olm.bundle
+name: example-operator.v0.3.0
+package: packageA
+image: quay.io/olmtest/example-operator-bundle:0.3.0
+properties:
+  - type: olm.gvk
+    value:
+      group: example.com
+      kind: TestA
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: packageA
+      version: 0.3.0
+---
+schema: olm.deprecations
+package: packageA
+entries:
+  - reference:
+      schema: olm.package
+    message: packageA has been deprecated. Please switch to packageB.
+  - reference:
+      schema: olm.channel
+      name: stable
+    message: channel "stable" has been deprecated. Please switch to a different one.

--- a/vendor/github.com/operator-framework/api/pkg/operators/v1alpha1/subscription_types.go
+++ b/vendor/github.com/operator-framework/api/pkg/operators/v1alpha1/subscription_types.go
@@ -117,6 +117,19 @@ const (
 
 	// SubscriptionBundleUnpackFailed indicates that the unpack job failed
 	SubscriptionBundleUnpackFailed SubscriptionConditionType = "BundleUnpackFailed"
+
+	// SubscriptionDeprecated is a roll-up condition which indicates that the Operator currently installed with this Subscription
+	//has been deprecated. It will be present when any of the three deprecation types (Package, Channel, Bundle) are present.
+	SubscriptionDeprecated SubscriptionConditionType = "Deprecated"
+
+	// SubscriptionOperatorDeprecated indicates that the Package currently installed with this Subscription has been deprecated.
+	SubscriptionPackageDeprecated SubscriptionConditionType = "PackageDeprecated"
+
+	// SubscriptionOperatorDeprecated indicates that the Channel used with this Subscription has been deprecated.
+	SubscriptionChannelDeprecated SubscriptionConditionType = "ChannelDeprecated"
+
+	// SubscriptionOperatorDeprecated indicates that the Bundle currently installed with this Subscription has been deprecated.
+	SubscriptionBundleDeprecated SubscriptionConditionType = "BundleDeprecated"
 )
 
 const (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -719,7 +719,7 @@ github.com/openshift/client-go/config/informers/externalversions/config/v1alpha1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/config/listers/config/v1alpha1
-# github.com/operator-framework/api v0.19.0
+# github.com/operator-framework/api v0.20.0
 ## explicit; go 1.19
 github.com/operator-framework/api/crds
 github.com/operator-framework/api/pkg/constraints


### PR DESCRIPTION
**Description of the change:**

Adds the `OperatorDeprecated` Condition to the status of Subscriptions when the bundle has been deprecated.

~~Doing this in the step resolver is convenient because:~~
- ~~We have ready access to the cache entries.~~
- ~~Subscription status is already updated in this area.~~
- ~~Deprecated status should be added promptly if a catalog update occurs which adds the property to a bundle.~~

Modifying the subscription status within the resolver was both problematic and risky. We've changed strategies and are now updating status during catalog state update. This carries much lower risk.

**Remaining Tasks:**
- [x] Populate cache entries with deprecation info.
- [x] Add additional deprecation condition types (package, channel, bundle).
- [x] ~~Update logic in catalog operator's `syncResolvingNamespace` to account for subs updated with only `OperatorDeprecated` and do not necessarily require InstallPlan updates in the namespace (currently it assumes all updates are new bundles).~~
- [x] Update test and/or add more tests with additional condition types (as above).
- [x] Update go.mod to use merged/released API updates to `api` and `registry`.
- [x] Squash commits where appropriate.

**Motivation for the change:**

Closes #3099 
[Brief](https://docs.google.com/document/d/1ipnf5uMiGZh5GXt2ey3oxziFx9lZv0qiFmB8g54EFwQ/edit?usp=sharing)
[RFC](https://docs.google.com/document/d/1SLgERsnNwNN7PuABdzysmxYxzD-hiyh7yuJc1m2Hy98/edit?usp=sharing)

**Architectural changes:**


