### PR TITLE
*: use a stable hash for client-side short-circuits

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -27,3 +27,4 @@ jobs:
       uses: "golangci/golangci-lint-action@v3"
       with:
         version: "v1.51.1"
+  

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/go-semver v0.3.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/distribution/distribution v2.7.1+incompatible
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fsnotify/fsnotify v1.6.0
@@ -89,6 +88,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v23.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v23.0.3+incompatible // indirect

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -999,7 +999,7 @@ func TestSyncCatalogSources(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedObjs: []runtime.Object{
-				pod(*grpcCatalog),
+				pod(t, *grpcCatalog),
 			},
 		},
 		{
@@ -1007,7 +1007,7 @@ func TestSyncCatalogSources(t *testing.T) {
 			namespace:     "cool-namespace",
 			catalogSource: grpcCatalog,
 			k8sObjs: []runtime.Object{
-				pod(v1alpha1.CatalogSource{
+				pod(t, v1alpha1.CatalogSource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cool-catalog",
 						Namespace: "cool-namespace",
@@ -1031,7 +1031,7 @@ func TestSyncCatalogSources(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedObjs: []runtime.Object{
-				pod(*grpcCatalog),
+				pod(t, *grpcCatalog),
 			},
 		},
 		{
@@ -1110,7 +1110,7 @@ func TestSyncCatalogSources(t *testing.T) {
 				},
 			}),
 			k8sObjs: []runtime.Object{
-				pod(*grpcCatalog),
+				pod(t, *grpcCatalog),
 				service(grpcCatalog.GetName(), grpcCatalog.GetNamespace()),
 				serviceAccount(grpcCatalog.GetName(), grpcCatalog.GetNamespace(), "", objectReference("init secret")),
 			},
@@ -2119,14 +2119,17 @@ func toManifest(t *testing.T, obj runtime.Object) string {
 	return string(raw)
 }
 
-func pod(s v1alpha1.CatalogSource) *corev1.Pod {
+func pod(t *testing.T, s v1alpha1.CatalogSource) *corev1.Pod {
 	serviceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: s.GetNamespace(),
 			Name:      s.GetName(),
 		},
 	}
-	pod := reconciler.Pod(&s, "registry-server", "central-opm", "central-util", s.Spec.Image, serviceAccount, s.GetLabels(), s.GetAnnotations(), 5, 10, 1001)
+	pod, err := reconciler.Pod(&s, "registry-server", "central-opm", "central-util", s.Spec.Image, serviceAccount, s.GetLabels(), s.GetAnnotations(), 5, 10, 1001)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ownerutil.AddOwner(pod, &s, false, true)
 	return pod
 }

--- a/pkg/controller/operators/olm/apiservices.go
+++ b/pkg/controller/operators/olm/apiservices.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -414,7 +415,11 @@ func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion) (bo
 		// Create Webhook Label Selector
 		webhookLabels := ownerutil.OwnerLabel(csv, v1alpha1.ClusterServiceVersionKind)
 		webhookLabels[install.WebhookDescKey] = desc.GenerateName
-		webhookLabels[install.WebhookHashKey] = install.HashWebhookDesc(desc)
+		hash, err := hashutil.DeepHashObject(&desc)
+		if err != nil {
+			return false, err
+		}
+		webhookLabels[install.WebhookHashKey] = hash
 		webhookSelector := labels.SelectorFromSet(webhookLabels).String()
 
 		webhookCount := 0

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -35,7 +35,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "68d7885bb7", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "8SbHWyYfjbRT8lLcfdZ5ofXNdC1GE6ayztILTF", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -107,7 +107,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "5c6bb6945f", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "3DSBhZZIiOl5YIjTsZy9aRyFIXeDR8mZCGAcYA", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -167,7 +167,8 @@ func TestPodMemoryTarget(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pod := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		pod, err := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		require.NoError(t, err)
 		if diff := cmp.Diff(pod, testCase.expected); diff != "" {
 			t.Errorf("got incorrect pod: %v", diff)
 		}
@@ -201,7 +202,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "68d7885bb7", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "8SbHWyYfjbRT8lLcfdZ5ofXNdC1GE6ayztILTF", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -276,7 +277,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "667f4b9769", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "6AsUxiAHW383luxWxmVVATFBeHXKNIX0HXrP5g", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -371,7 +372,8 @@ func TestPodExtractContent(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pod := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		pod, err := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		require.NoError(t, err)
 		if diff := cmp.Diff(pod, testCase.expected); diff != "" {
 			t.Errorf("got incorrect pod: %v", diff)
 		}
@@ -421,7 +423,8 @@ func TestPodServiceAccountImagePullSecrets(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pod := Pod(catalogSource, "name", "opmImage", "utilImage", "image", testCase.serviceAccount, map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		pod, err := Pod(catalogSource, "name", "opmImage", "utilImage", "image", testCase.serviceAccount, map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		require.NoError(t, err)
 		if diff := cmp.Diff(testCase.serviceAccount.ImagePullSecrets, pod.Spec.ImagePullSecrets); diff != "" {
 			t.Errorf("got incorrect pod: %v", diff)
 		}
@@ -439,7 +442,8 @@ func TestPodNodeSelector(t *testing.T) {
 	key := "kubernetes.io/os"
 	value := "linux"
 
-	gotCatSrcPod := Pod(catsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+	gotCatSrcPod, err := Pod(catsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+	require.NoError(t, err)
 	gotCatSrcPodSelector := gotCatSrcPod.Spec.NodeSelector
 
 	if gotCatSrcPodSelector[key] != value {
@@ -487,7 +491,8 @@ func TestPullPolicy(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		p := Pod(source, "catalog", "opmImage", "utilImage", tt.image, serviceAccount("", "service-account"), nil, nil, int32(0), int32(0), int64(workloadUserID))
+		p, err := Pod(source, "catalog", "opmImage", "utilImage", tt.image, serviceAccount("", "service-account"), nil, nil, int32(0), int32(0), int64(workloadUserID))
+		require.NoError(t, err)
 		policy := p.Spec.Containers[0].ImagePullPolicy
 		if policy != tt.policy {
 			t.Fatalf("expected pull policy %s for image  %s", tt.policy, tt.image)
@@ -599,7 +604,8 @@ func TestPodContainerSecurityContext(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		outputPod := Pod(testcase.inputCatsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		outputPod, err := Pod(testcase.inputCatsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		require.NoError(t, err)
 		if testcase.expectedSecurityContext != nil {
 			require.Equal(t, testcase.expectedSecurityContext, outputPod.Spec.SecurityContext)
 		}
@@ -629,7 +635,8 @@ func TestPodAvoidsConcurrentWrite(t *testing.T) {
 		"annotation": "somethingelse",
 	}
 
-	gotPod := Pod(catsrc, "hello", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), labels, annotations, int32(0), int32(0), int64(workloadUserID))
+	gotPod, err := Pod(catsrc, "hello", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), labels, annotations, int32(0), int32(0), int64(workloadUserID))
+	require.NoError(t, err)
 
 	// check labels and annotations point to different addresses between parameters and what's in the pod
 	require.NotEqual(t, &labels, &gotPod.Labels)
@@ -858,7 +865,8 @@ func TestPodSchedulingOverrides(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pod := Pod(testCase.catalogSource, "hello", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, testCase.annotations, int32(0), int32(0), int64(workloadUserID))
+		pod, err := Pod(testCase.catalogSource, "hello", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, testCase.annotations, int32(0), int32(0), int64(workloadUserID))
+		require.NoError(t, err)
 		require.Equal(t, testCase.expectedNodeSelectors, pod.Spec.NodeSelector)
 		require.Equal(t, testCase.expectedPriorityClassName, pod.Spec.PriorityClassName)
 		require.Equal(t, testCase.expectedTolerations, pod.Spec.Tolerations)

--- a/pkg/controller/registry/resolver/rbac_test.go
+++ b/pkg/controller/registry/resolver/rbac_test.go
@@ -31,7 +31,7 @@ func TestGenerateName(t *testing.T) {
 				base: "myname",
 				o:    []string{"something"},
 			},
-			want: "myname-9c895f74f",
+			want: "myname-5L9sNXi3Y6mcOevFzYY3WOLIukKOeZwz1pfUlT",
 		},
 		{
 			name: "truncated",
@@ -39,12 +39,13 @@ func TestGenerateName(t *testing.T) {
 				base: strings.Repeat("name", 100),
 				o:    []string{"something", "else"},
 			},
-			want: "namenamenamenamenamenamenamenamenamenamenamenamename-78fd8b4d6b",
+			want: "namenamenamenamenamename-6XtefCelEzfYlFOD1fARIK5vhWVfWfGHja7H3q",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateName(tt.args.base, tt.args.o)
+			got, err := generateName(tt.args.base, tt.args.o)
+			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 			require.LessOrEqual(t, len(got), maxNameLength)
 		})
@@ -65,7 +66,8 @@ func (validKubeName) Generate(rand *rand.Rand, size int) reflect.Value {
 
 func TestGeneratesWithinRange(t *testing.T) {
 	f := func(base validKubeName, o string) bool {
-		return len(generateName(string(base), o)) <= maxNameLength
+		out, err := generateName(string(base), o)
+		return len(out) <= maxNameLength || err == nil
 	}
 	require.NoError(t, quick.Check(f, nil))
 }

--- a/pkg/lib/kubernetes/pkg/util/hash/hash.go
+++ b/pkg/lib/kubernetes/pkg/util/hash/hash.go
@@ -17,21 +17,39 @@ limitations under the License.
 package hash
 
 import (
-	"hash"
-
-	"github.com/davecgh/go-spew/spew"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math/big"
 )
 
 // DeepHashObject writes specified object to hash using the spew library
 // which follows pointers and prints actual values of the nested objects
 // ensuring the hash does not change when a pointer changes.
-func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+func DeepHashObject(obj interface{}) (string, error) {
+	// While the most accurate encoding we could do for Kubernetes objects (runtime.Object)
+	// would use the API machinery serializers, those operate over entire objects - and
+	// we often need to operate on snippets. Checking with the experts and the implementation,
+	// we can see that the serializers are a thin wrapper over json.Marshal for encoding:
+	// https://github.com/kubernetes/kubernetes/blob/8509ab82b96caa2365552efa08c8ba8baf11c5ec/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go#L216-L247
+	// Therefore, we can be confident that using json.Marshal() here will:
+	//  1. be stable & idempotent - the library sorts keys, etc.
+	//  2. be germane to our needs - only fields that serialize and are sent to the server
+	//     will be encoded
+
+	hasher := sha256.New224()
 	hasher.Reset()
-	printer := spew.ConfigState{
-		Indent:         " ",
-		SortKeys:       true,
-		DisableMethods: true,
-		SpewKeys:       true,
+	encoder := json.NewEncoder(hasher)
+	if err := encoder.Encode(obj); err != nil {
+		return "", fmt.Errorf("couldn't encode object: %w", err)
 	}
-	printer.Fprintf(hasher, "%#v", objectToWrite)
+
+	// base62(sha224(bytes)) is a useful hash and encoding for adding the contents of this
+	// to a Kubernetes identifier or other field which has length and character set requirements
+	var hash []byte
+	hash = hasher.Sum(hash)
+
+	var i big.Int
+	i.SetBytes(hash[:])
+	return i.Text(62), nil
 }


### PR DESCRIPTION
The previous approach here was to use go-spew, which, unfortunately, is not a stable and germane encoding for objects. We are encoding objects that we send to the Kubernetes API server, so features of go-spew like printing the capacity of slices are not germane. This led to hashes of otherwise identical (as far as the server was concerned) objects to be determined as hashing differently.
