### PR TITLE
controller/operators: label ConfigMaps, don't assume they are

### DIFF
--- a/pkg/controller/operators/labeller/filters.go
+++ b/pkg/controller/operators/labeller/filters.go
@@ -59,7 +59,8 @@ func ServiceAccountFilter(isServiceAccountReferenced func(namespace, name string
 }
 
 var filters = map[schema.GroupVersionResource]func(metav1.Object) bool{
-	corev1.SchemeGroupVersion.WithResource("services"): HasOLMOwnerRef,
+	corev1.SchemeGroupVersion.WithResource("configmaps"): HasOLMOwnerRef,
+	corev1.SchemeGroupVersion.WithResource("services"):   HasOLMOwnerRef,
 	corev1.SchemeGroupVersion.WithResource("pods"): func(object metav1.Object) bool {
 		_, ok := object.GetLabels()[reconciler.CatalogSourceLabelKey]
 		return ok

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2936,9 +2936,6 @@ var (
 	dummyCatalogConfigMap = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: catalogConfigMapName,
-			Labels: map[string]string{
-				install.OLMManagedLabelKey: install.OLMManagedLabelValue,
-			},
 		},
 		Data: map[string]string{},
 	}

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -159,13 +159,21 @@ var _ = Describe("Subscription", func() {
 	It("creation if not installed", func() {
 
 		defer func() {
+			if env := os.Getenv("SKIP_CLEANUP"); env != "" {
+				fmt.Printf("Skipping cleanup of subscriptions in namespace %s\n", generatedNamespace.GetName())
+				return
+			}
 			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
+
+		By("creating a catalog")
 		require.NoError(GinkgoT(), initCatalog(GinkgoT(), generatedNamespace.GetName(), c, crc))
 
+		By(fmt.Sprintf("creating a subscription: %s/%s", generatedNamespace.GetName(), testSubscriptionName))
 		cleanup, _ := createSubscription(GinkgoT(), crc, generatedNamespace.GetName(), testSubscriptionName, testPackageName, betaChannel, operatorsv1alpha1.ApprovalAutomatic)
 		defer cleanup()
 
+		By("waiting for the subscription to have a current CSV and be at latest")
 		var currentCSV string
 		Eventually(func() bool {
 			fetched, err := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), testSubscriptionName, metav1.GetOptions{})
@@ -2928,6 +2936,9 @@ var (
 	dummyCatalogConfigMap = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: catalogConfigMapName,
+			Labels: map[string]string{
+				install.OLMManagedLabelKey: install.OLMManagedLabelValue,
+			},
 		},
 		Data: map[string]string{},
 	}
@@ -2976,6 +2987,7 @@ func initCatalog(t GinkgoTInterface, namespace string, c operatorclient.ClientIn
 		}
 		return err
 	}
+	t.Logf("created configmap %s/%s", dummyCatalogConfigMap.Namespace, dummyCatalogConfigMap.Name)
 
 	dummyCatalogSource.SetNamespace(namespace)
 	if _, err := crc.OperatorsV1alpha1().CatalogSources(namespace).Create(context.Background(), &dummyCatalogSource, metav1.CreateOptions{}); err != nil {
@@ -2984,6 +2996,7 @@ func initCatalog(t GinkgoTInterface, namespace string, c operatorclient.ClientIn
 		}
 		return err
 	}
+	t.Logf("created catalog source %s/%s", dummyCatalogSource.Namespace, dummyCatalogSource.Name)
 
 	fetched, err := fetchCatalogSourceOnStatus(crc, dummyCatalogSource.GetName(), dummyCatalogSource.GetNamespace(), catalogSourceRegistryPodSynced())
 	require.NoError(t, err)
@@ -3154,6 +3167,7 @@ func createSubscription(t GinkgoTInterface, crc versioned.Interface, namespace, 
 
 	subscription, err := crc.OperatorsV1alpha1().Subscriptions(namespace).Create(context.Background(), subscription, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
+	t.Logf("created subscription %s/%s", subscription.Namespace, subscription.Name)
 	return buildSubscriptionCleanupFunc(crc, subscription), subscription
 }
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1073,11 +1073,13 @@ func SetupGeneratedTestNamespaceWithOperatorGroup(name string, og operatorsv1.Op
 		return ctx.Ctx().E2EClient().Create(context.Background(), &ns)
 	}).Should(Succeed())
 
+	ctx.Ctx().Logf("created the %s testing namespace", ns.GetName())
+
 	Eventually(func() error {
 		return ctx.Ctx().E2EClient().Create(context.Background(), &og)
 	}).Should(Succeed())
 
-	ctx.Ctx().Logf("created the %s testing namespace", ns.GetName())
+	ctx.Ctx().Logf("created the %s/%s operator group", og.Namespace, og.Name)
 
 	return ns
 }


### PR DESCRIPTION
In the past, OLM moved to using a label selector to filter the informers that track ConfigMaps in the cluster. However, when this was done, previous ConfigMaps on the cluster that already existed were not labelled. Therefore, on old clusters there is a mix of data - ConfigMaps that OLM created and managed but has now forgotten since they are missing labels, and conformant objects with the label.

We use ConfigMaps to track whether or not Jobs should be labelled - if a Job has an OwnerReference to a ConfigMap and the ConfigMap has an OwnerReference to an OLM GVK, we know that the Job is created and managed by OLM.

During runtime, the two-hop lookup described above is done by using a ConfigMap informer, so we're light on client calls during the labelling phase of startup. However, before the recent labelling work went in, the ConfigMap informer was *already* filtered by label, so our lookups were dead-ends for the few old ConfigMaps that had never gotten labels in the past. However, on startup we use live clients to determine if there are unlabelled objects we need to handle, so we end up in a state where the live lookup can detect the errant Jobs but the informer-based labellers can't see them as needing labels.

This commit is technically a performance regression, as it reverts the unequivocal ConfigMap informer filtering - we see all ConfigMaps on the cluster during startup, but continue to filter as expected once everything has labels.

Ideally, we can come up with some policies for cleanup of things like these Jobs and ConfigMaps in the future; at a minimum all of the OLM objects should be labelled and visible to the OLM operators from here on out.
