### PR TITLE
deploy: use Recreate strategy for Deployments

### DIFF
--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: olm-operator
 spec:
   strategy:
-    type: RollingUpdate
+    type: Recreate
   replicas: {{ .Values.olm.replicaCount }}
   selector:
     matchLabels:

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: catalog-operator
 spec:
   strategy:
-    type: RollingUpdate
+    type: Recreate
   replicas: {{ .Values.catalog.replicaCount }}
   selector:
     matchLabels:


### PR DESCRIPTION
deploy: use Recreate strategy for Deployments

Our controllers must not share runtime with controllers of previous
versions, as we expect that the set of actors on the cluster to be
coherent with respect to what they're trying to do. RollingUpdate
strategies do not guarantee this and lead to cases where previous
versions of the operators issue spurious mutating calls that the
current operator needs to un-do.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

