### PR TITLE
Improve condition check for installplan

### DIFF
--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -328,7 +328,7 @@ var _ = Describe("Subscription", func() {
 		subscriptionCleanup, _ := createSubscription(GinkgoT(), crc, generatedNamespace.GetName(), "manual-subscription", testPackageName, stableChannel, operatorsv1alpha1.ApprovalManual)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), "manual-subscription", subscriptionStateUpgradePendingChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), "manual-subscription", subscriptionHasCondition(operatorsv1alpha1.SubscriptionInstallPlanPending, corev1.ConditionTrue, string(operatorsv1alpha1.InstallPlanPhaseRequiresApproval), ""))
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 


### PR DESCRIPTION
This test is currently flakey because it will occasionally delete the installplan before the subscription has been properly linked up. This results in a state where the subscription has an `InstallPlanRef` but the referenced install plan does not exist. Additionally, a new installplan will not be created automatically when this happens.

Long-term, a finalizer should be added to the installplan to prevent a user from getting their subscription into a limbo state by deleting an installplan rapidly. I will add details to #3143 to capture this.