### PR TITLE
Snapshot Fix for Deprecation Info

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -346,7 +346,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		subscription.WithAppendedReconcilers(subscription.ReconcilerFromLegacySyncHandler(op.syncSubscriptions, nil)),
 		subscription.WithRegistryReconcilerFactory(op.reconciler),
 		subscription.WithGlobalCatalogNamespace(op.namespace),
-		subscription.WithSourceProvider(resolverSourceProvider),
+		subscription.WithSourceProvider(op.sourceInvalidator),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When initially implemented, in order to retrieve deprecation metadata the subscription resolver was modified to add an optional sourceProvider and we incorrectly used the aggregate `OperatorGroupToggleSourceProvider`. This resulted in errors when taking snapshots from namespaces in which no `OperatorGroups` were present. 

To fix, we just use the `RegistrySourceProvider` directly instead of the aggregate which is what we actually needed in the first place. This results in silencing the errors mentioned above and also resolves an issue where the deprecation info will not be added to `Subscription` status when the `CatalogSource`'s namespace does not contain an `OperatorGroup`.