### PR TITLE
Fix finalizer processing

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -5832,6 +5832,9 @@ func RequireObjectsInCache(t *testing.T, lister operatorlister.OperatorLister, n
 			fetched, err = lister.RbacV1().RoleBindingLister().RoleBindings(namespace).Get(o.GetName())
 		case *v1alpha1.ClusterServiceVersion:
 			fetched, err = lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(namespace).Get(o.GetName())
+			// We don't care about finalizers
+			object.(*v1alpha1.ClusterServiceVersion).Finalizers = nil
+			fetched.(*v1alpha1.ClusterServiceVersion).Finalizers = nil
 		case *operatorsv1.OperatorGroup:
 			fetched, err = lister.OperatorsV1().OperatorGroupLister().OperatorGroups(namespace).Get(o.GetName())
 		default:
@@ -5885,6 +5888,8 @@ func CheckObjectsInNamespace(t *testing.T, opClient operatorclient.ClientInterfa
 			// and this will still check that the final state is correct
 			object.(*v1alpha1.ClusterServiceVersion).Status.Conditions = nil
 			fetched.(*v1alpha1.ClusterServiceVersion).Status.Conditions = nil
+			object.(*v1alpha1.ClusterServiceVersion).Finalizers = nil
+			fetched.(*v1alpha1.ClusterServiceVersion).Finalizers = nil
 		case *operatorsv1.OperatorGroup:
 			name = o.GetName()
 			fetched, err = client.OperatorsV1().OperatorGroups(namespace).Get(context.TODO(), o.GetName(), metav1.GetOptions{})

--- a/pkg/controller/operators/operatorconditiongenerator_controller.go
+++ b/pkg/controller/operators/operatorconditiongenerator_controller.go
@@ -2,20 +2,15 @@ package operators
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -100,10 +95,6 @@ func (r *OperatorConditionGeneratorReconciler) Reconcile(ctx context.Context, re
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err, ok := r.processFinalizer(ctx, in); !ok {
-		return ctrl.Result{}, err
-	}
-
 	operatorCondition := &operatorsv2.OperatorCondition{
 		ObjectMeta: metav1.ObjectMeta{
 			// For now, only generate an OperatorCondition with the same name as the csv.
@@ -178,113 +169,4 @@ func (r *OperatorConditionGeneratorReconciler) ensureOperatorCondition(operatorC
 	existingOperatorCondition.Spec.Deployments = operatorCondition.Spec.Deployments
 	existingOperatorCondition.Spec.ServiceAccounts = operatorCondition.Spec.ServiceAccounts
 	return r.Client.Update(context.TODO(), existingOperatorCondition)
-}
-
-// Return values, err, ok; ok == true: continue Reconcile, ok == false: exit Reconcile
-func (r *OperatorConditionGeneratorReconciler) processFinalizer(ctx context.Context, csv *operatorsv1alpha1.ClusterServiceVersion) (error, bool) {
-	myFinalizerName := "operators.coreos.com/csv-cleanup"
-	log := r.log.WithValues("name", csv.GetName()).WithValues("namespace", csv.GetNamespace())
-
-	if csv.ObjectMeta.DeletionTimestamp.IsZero() {
-		// CSV is not being deleted, add finalizer if not present
-		if !controllerutil.ContainsFinalizer(csv, myFinalizerName) {
-			patch := csv.DeepCopy()
-			controllerutil.AddFinalizer(patch, myFinalizerName)
-			if err := r.Client.Patch(ctx, patch, client.MergeFrom(csv)); err != nil {
-				log.Error(err, "Adding finalizer")
-				return err, false
-			}
-		}
-		return nil, true
-	}
-
-	if !controllerutil.ContainsFinalizer(csv, myFinalizerName) {
-		// Finalizer has been removed; stop reconciliation as the CSV is being deleted
-		return nil, false
-	}
-
-	// CSV is being deleted and the finalizer still present; do any clean up
-	ownerSelector := ownerutil.CSVOwnerSelector(csv)
-	listOptions := client.ListOptions{
-		LabelSelector: ownerSelector,
-	}
-	deleteOptions := client.DeleteAllOfOptions{
-		ListOptions: listOptions,
-	}
-	// Look for resources owned by this CSV, and delete them.
-	log.WithValues("selector", ownerSelector).Info("Cleaning up resources after CSV deletion")
-	var errs []error
-
-	err := r.Client.DeleteAllOf(ctx, &rbacv1.ClusterRoleBinding{}, &deleteOptions)
-	if client.IgnoreNotFound(err) != nil {
-		log.Error(err, "Deleting ClusterRoleBindings on CSV delete")
-		errs = append(errs, err)
-	}
-
-	err = r.Client.DeleteAllOf(ctx, &rbacv1.ClusterRole{}, &deleteOptions)
-	if client.IgnoreNotFound(err) != nil {
-		log.Error(err, "Deleting ClusterRoles on CSV delete")
-		errs = append(errs, err)
-	}
-
-	err = r.Client.DeleteAllOf(ctx, &admissionregistrationv1.MutatingWebhookConfiguration{}, &deleteOptions)
-	if client.IgnoreNotFound(err) != nil {
-		log.Error(err, "Deleting MutatingWebhookConfigurations on CSV delete")
-		errs = append(errs, err)
-	}
-
-	err = r.Client.DeleteAllOf(ctx, &admissionregistrationv1.ValidatingWebhookConfiguration{}, &deleteOptions)
-	if client.IgnoreNotFound(err) != nil {
-		log.Error(err, "Deleting ValidatingWebhookConfigurations on CSV delete")
-		errs = append(errs, err)
-	}
-
-	// Make sure things are deleted
-	crbList := &rbacv1.ClusterRoleBindingList{}
-	err = r.Client.List(ctx, crbList, &listOptions)
-	if err != nil {
-		errs = append(errs, err)
-	} else if len(crbList.Items) != 0 {
-		errs = append(errs, fmt.Errorf("waiting for ClusterRoleBindings to delete"))
-	}
-
-	crList := &rbacv1.ClusterRoleList{}
-	err = r.Client.List(ctx, crList, &listOptions)
-	if err != nil {
-		errs = append(errs, err)
-	} else if len(crList.Items) != 0 {
-		errs = append(errs, fmt.Errorf("waiting for ClusterRoles to delete"))
-	}
-
-	mwcList := &admissionregistrationv1.MutatingWebhookConfigurationList{}
-	err = r.Client.List(ctx, mwcList, &listOptions)
-	if err != nil {
-		errs = append(errs, err)
-	} else if len(mwcList.Items) != 0 {
-		errs = append(errs, fmt.Errorf("waiting for MutatingWebhookConfigurations to delete"))
-	}
-
-	vwcList := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
-	err = r.Client.List(ctx, vwcList, &listOptions)
-	if err != nil {
-		errs = append(errs, err)
-	} else if len(vwcList.Items) != 0 {
-		errs = append(errs, fmt.Errorf("waiting for ValidatingWebhookConfigurations to delete"))
-	}
-
-	// Return any errors
-	if err := utilerrors.NewAggregate(errs); err != nil {
-		return err, false
-	}
-
-	// If no errors, remove our finalizer from the CSV and update
-	patch := csv.DeepCopy()
-	controllerutil.RemoveFinalizer(patch, myFinalizerName)
-	if err := r.Client.Patch(ctx, patch, client.MergeFrom(csv)); err != nil {
-		log.Error(err, "Removing finalizer")
-		return err, false
-	}
-
-	// Stop reconciliation as the csv is being deleted
-	return nil, false
 }

--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -2925,7 +2925,7 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			return true
-		}, pollDuration*2, pollInterval).Should(BeTrue())
+		}, pollDuration, pollInterval).Should(BeTrue())
 		By("Cleaning up the test")
 	})
 


### PR DESCRIPTION
**Description of the change:**

Handle CSV deletion during sync.

**Motivation for the change:**

There are two reconcilers for the CSV, one is controller-runtime based,
the other is based on queueinformer. A finalizer was added to the CSV
and it's handled by the controller-runtime reconciler.

However, the queueinformer-based reconciler may take a while to do its
processing such that the CSV may be deleted and the finalizer run via
the controller-runtime reconciler. (This still takes <1s.)

This causes problems when CSV being synced is deleted. The queueinformer
attempts to sync RBAC to the stale CSV. The proper (BIG/risky) fix is to
consolidate the two reconcilers. A less risky fix is to query the lister
cache to see if the CSV has been deleted (or has a DeletionTimestamp),
and not do the RBAC updates if that's the case.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Architectural changes:**

None.

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
