### PR TITLE
OCPBUGS-29729: Default to 'restricted' for CatalogSource Pod

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -206,9 +206,13 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 		},
 	}
 
-	if source.Spec.GrpcPodConfig != nil && source.Spec.GrpcPodConfig.SecurityContextConfig == operatorsv1alpha1.Restricted {
-		addSecurityContext(pod, runAsUser)
+	// Ensure a security context exists by creating it if not specified
+	if source.Spec.GrpcPodConfig == nil {
+		source.Spec.GrpcPodConfig = &operatorsv1alpha1.GrpcPodConfig{}
 	}
+
+	// Enforce 'restricted' defaults, even if not explicitly set by the user
+	addSecurityContext(pod, runAsUser)
 
 	// Override scheduling options if specified
 	if source.Spec.GrpcPodConfig != nil {

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -602,6 +602,55 @@ func TestPodContainerSecurityContext(t *testing.T) {
 			expectedContainerSecurityContext: nil,
 			expectedSecurityContext:          nil,
 		},
+		{
+			title: "NoSpecDefined/PodContainsDefaultSecurityConfigForPSARestricted",
+			inputCatsrc: &v1alpha1.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-restricted",
+					Namespace: "testns",
+				},
+			},
+			expectedContainerSecurityContext: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem:   pointer.Bool(false),
+				AllowPrivilegeEscalation: pointer.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+			},
+			expectedSecurityContext: &corev1.PodSecurityContext{
+				RunAsUser:    pointer.Int64(workloadUserID),
+				RunAsNonRoot: pointer.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+		},
+		{
+			title: "SpecDefined/GRPCPodConfigDefined/NoSecurityContextConfig/PodContainsDefaultSecurityConfigForPSARestricted",
+			inputCatsrc: &v1alpha1.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grpc-no-security",
+					Namespace: "testns",
+				},
+				Spec: v1alpha1.CatalogSourceSpec{
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{},
+				},
+			},
+			expectedContainerSecurityContext: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem:   pointer.Bool(false),
+				AllowPrivilegeEscalation: pointer.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+			},
+			expectedSecurityContext: &corev1.PodSecurityContext{
+				RunAsUser:    pointer.Int64(workloadUserID),
+				RunAsNonRoot: pointer.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+		},
 	}
 	for _, testcase := range testcases {
 		outputPod, err := Pod(testcase.inputCatsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))


### PR DESCRIPTION
Updates the behavior of CatalogSource Pod creation to adhere to Pod Security Standards by defaulting the SecurityContext to 'restricted' if not explicitly set by the user. Previously, the default behavior was to apply a 'legacy' security context, which could lead to Pods failing to start in namespaces enforcing the 'restricted' policy.

**Description of the change:**

- Modifying the default SecurityContext assignment in the CatalogSource Pod creation process.
- Ensuring the Pod's SecurityContext respects the 'restricted' settings when `.spec.grpcPodConfig.securityContextConfig` is not specified.
- Adding unit tests to validate the new default behavior and ensure backward compatibility.


**Motivation for the change:**
Bug fix, see bug report.

**Architectural changes:**
None

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted
