### PR TITLE
RoleBinding SSA

### DIFF
--- a/pkg/controller/install/certresources_test.go
+++ b/pkg/controller/install/certresources_test.go
@@ -309,7 +309,19 @@ func TestInstallCertRequirementsForDeployment(t *testing.T) {
 				authReaderRoleBinding.SetNamespace(KubeSystem)
 				authReaderRoleBinding.SetLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue})
 
-				mockOpClient.EXPECT().UpdateRoleBinding(authReaderRoleBinding).Return(authReaderRoleBinding, nil)
+				authReaderRoleBindingApplyConfig := rbacv1ac.RoleBinding(AuthReaderRoleBindingName(service.GetName()), KubeSystem).
+					WithLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue}).
+					WithSubjects(rbacv1ac.Subject().
+						WithKind("ServiceAccount").
+						WithAPIGroup("").
+						WithName(args.depSpec.Template.Spec.ServiceAccountName).
+						WithNamespace(namespace)).
+					WithRoleRef(rbacv1ac.RoleRef().
+						WithAPIGroup("rbac.authorization.k8s.io").
+						WithKind("Role").
+						WithName("extension-apiserver-authentication-reader"))
+
+				mockOpClient.EXPECT().ApplyRoleBinding(authReaderRoleBindingApplyConfig, metav1.ApplyOptions{Force: true, FieldManager: "olm.install"}).Return(authReaderRoleBinding, nil)
 			},
 			state: fakeState{
 				existingService: &corev1.Service{
@@ -569,7 +581,19 @@ func TestInstallCertRequirementsForDeployment(t *testing.T) {
 				authReaderRoleBinding.SetNamespace(KubeSystem)
 				authReaderRoleBinding.SetLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue})
 
-				mockOpClient.EXPECT().UpdateRoleBinding(authReaderRoleBinding).Return(authReaderRoleBinding, nil)
+				authReaderRoleBindingApplyConfig := rbacv1ac.RoleBinding(AuthReaderRoleBindingName(service.GetName()), KubeSystem).
+					WithLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue}).
+					WithSubjects(rbacv1ac.Subject().
+						WithKind("ServiceAccount").
+						WithAPIGroup("").
+						WithName(args.depSpec.Template.Spec.ServiceAccountName).
+						WithNamespace(namespace)).
+					WithRoleRef(rbacv1ac.RoleRef().
+						WithAPIGroup("rbac.authorization.k8s.io").
+						WithKind("Role").
+						WithName("extension-apiserver-authentication-reader"))
+
+				mockOpClient.EXPECT().ApplyRoleBinding(authReaderRoleBindingApplyConfig, metav1.ApplyOptions{Force: true, FieldManager: "olm.install"}).Return(authReaderRoleBinding, nil)
 			},
 			state: fakeState{
 				existingService: &corev1.Service{
@@ -831,7 +855,19 @@ func TestInstallCertRequirementsForDeployment(t *testing.T) {
 				authReaderRoleBinding.SetNamespace(KubeSystem)
 				authReaderRoleBinding.SetLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue})
 
-				mockOpClient.EXPECT().UpdateRoleBinding(authReaderRoleBinding).Return(authReaderRoleBinding, nil)
+				authReaderRoleBindingApplyConfig := rbacv1ac.RoleBinding(AuthReaderRoleBindingName(service.GetName()), KubeSystem).
+					WithLabels(map[string]string{OLMManagedLabelKey: OLMManagedLabelValue}).
+					WithSubjects(rbacv1ac.Subject().
+						WithKind("ServiceAccount").
+						WithAPIGroup("").
+						WithName(args.depSpec.Template.Spec.ServiceAccountName).
+						WithNamespace(namespace)).
+					WithRoleRef(rbacv1ac.RoleRef().
+						WithAPIGroup("rbac.authorization.k8s.io").
+						WithKind("Role").
+						WithName("extension-apiserver-authentication-reader"))
+
+				mockOpClient.EXPECT().ApplyRoleBinding(authReaderRoleBindingApplyConfig, metav1.ApplyOptions{Force: true, FieldManager: "olm.install"}).Return(authReaderRoleBinding, nil)
 			},
 			state: fakeState{
 				existingService: nil,

--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -1511,6 +1511,7 @@ func TestTransitionCSV(t *testing.T) {
 					// Note: Ideally we would not pre-create these objects, but fake client does not support
 					// creation through SSA, see issue here: https://github.com/kubernetes/kubernetes/issues/115598
 					// Once resolved, these objects and others in this file may be removed.
+					roleBinding("a1-service-auth-reader", "kube-system", "extension-apiserver-authentication-reader", "sa", namespace),
 					service("a1-service", namespace, "a1", 80),
 					clusterRoleBinding("a1-service-system:auth-delegator", "system:auth-delegator", "sa", namespace),
 				},
@@ -5990,8 +5991,9 @@ func TestCARotation(t *testing.T) {
 					), defaultTemplateAnnotations), apis("a1.v1.a1Kind"), nil),
 				},
 				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1,a1Kind.v1.a1")},
-				// The service and clusterRoleBinding have been added here as a workaround to fake client not supporting SSA
+				// The rolebinding, service, and clusterRoleBinding have been added here as a workaround to fake client not supporting SSA
 				objs: []runtime.Object{
+					roleBinding("a1-service-auth-reader", "kube-system", "extension-apiserver-authentication-reader", "sa", namespace),
 					service("a1-service", namespace, "a1", 80, ownerReference),
 					clusterRoleBinding("a1-service-system:auth-delegator", "system:auth-delegator", "sa", namespace),
 				},

--- a/pkg/lib/operatorclient/client.go
+++ b/pkg/lib/operatorclient/client.go
@@ -94,6 +94,7 @@ type RoleClient interface {
 
 // RoleBindingClient contains methods for manipulating RoleBindings.
 type RoleBindingClient interface {
+	ApplyRoleBinding(applyConfig *rbacv1ac.RoleBindingApplyConfiguration, applyOptions metav1.ApplyOptions) (*rbacv1.RoleBinding, error)
 	CreateRoleBinding(*rbacv1.RoleBinding) (*rbacv1.RoleBinding, error)
 	GetRoleBinding(namespace, name string) (*rbacv1.RoleBinding, error)
 	UpdateRoleBinding(modified *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error)

--- a/pkg/lib/operatorclient/operatorclientmocks/mock_client.go
+++ b/pkg/lib/operatorclient/operatorclientmocks/mock_client.go
@@ -89,6 +89,21 @@ func (mr *MockClientInterfaceMockRecorder) ApplyClusterRoleBinding(applyConfig, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyClusterRoleBinding", reflect.TypeOf((*MockClientInterface)(nil).ApplyClusterRoleBinding), applyConfig, applyOptions)
 }
 
+// ApplyRoleBinding mocks base method.
+func (m *MockClientInterface) ApplyRoleBinding(applyConfig *v14.RoleBindingApplyConfiguration, applyOptions v12.ApplyOptions) (*v11.RoleBinding, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyRoleBinding", applyConfig, applyOptions)
+	ret0, _ := ret[0].(*v11.RoleBinding)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyRoleBinding indicates an expected call of ApplyRoleBinding.
+func (mr *MockClientInterfaceMockRecorder) ApplyRoleBinding(applyConfig, applyOptions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyRoleBinding", reflect.TypeOf((*MockClientInterface)(nil).ApplyRoleBinding), applyConfig, applyOptions)
+}
+
 // ApplyService mocks base method.
 func (m *MockClientInterface) ApplyService(arg0 *v13.ServiceApplyConfiguration, arg1 v12.ApplyOptions) (*v10.Service, error) {
 	m.ctrl.T.Helper()
@@ -1605,6 +1620,21 @@ func NewMockRoleBindingClient(ctrl *gomock.Controller) *MockRoleBindingClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRoleBindingClient) EXPECT() *MockRoleBindingClientMockRecorder {
 	return m.recorder
+}
+
+// ApplyRoleBinding mocks base method.
+func (m *MockRoleBindingClient) ApplyRoleBinding(applyConfig *v14.RoleBindingApplyConfiguration, applyOptions v12.ApplyOptions) (*v11.RoleBinding, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyRoleBinding", applyConfig, applyOptions)
+	ret0, _ := ret[0].(*v11.RoleBinding)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyRoleBinding indicates an expected call of ApplyRoleBinding.
+func (mr *MockRoleBindingClientMockRecorder) ApplyRoleBinding(applyConfig, applyOptions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyRoleBinding", reflect.TypeOf((*MockRoleBindingClient)(nil).ApplyRoleBinding), applyConfig, applyOptions)
 }
 
 // CreateRoleBinding mocks base method.

--- a/pkg/lib/operatorclient/rolebinding.go
+++ b/pkg/lib/operatorclient/rolebinding.go
@@ -7,8 +7,14 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	acv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 	"k8s.io/klog"
 )
+
+// ApplyRoleBinding applies the roleBinding.
+func (c *Client) ApplyRoleBinding(applyConfig *acv1.RoleBindingApplyConfiguration, applyOptions metav1.ApplyOptions) (*rbacv1.RoleBinding, error) {
+	return c.RbacV1().RoleBindings(*applyConfig.Namespace).Apply(context.TODO(), applyConfig, applyOptions)
+}
 
 // CreateRoleBinding creates the roleBinding.
 func (c *Client) CreateRoleBinding(ig *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {


### PR DESCRIPTION
Switch to SSA for RoleBindings during install (as we do now for Services and ClusterRoleBindings #3182 ) to avoid issues with race conditions and/or failures to retrieve resources due to missing labels.
