### PR TITLE
copy-content: delete destination dirs before copying

### DIFF
--- a/cmd/copy-content/main.go
+++ b/cmd/copy-content/main.go
@@ -31,6 +31,10 @@ func main() {
 		*catalogSource: *catalogDestination,
 		*cacheSource:   *cacheDestination,
 	} {
+		if err := os.RemoveAll(to); err != nil {
+			fmt.Printf("failed to remove %s: %s", to, err)
+			os.Exit(1)
+		}
 		if err := copy.Copy(from, to); err != nil {
 			fmt.Printf("failed to copy %s to %s: %s\n", from, to, err)
 			os.Exit(1)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the copy-content binary to always delete the destination directories to ensure they contain no extraneous content

**Motivation for the change:**
If a catalog pod using `extractContent` mode is restarted after the underlying catalog image changes (e.g. if a cluster is shutdown and the catalog is updated in the meantime), the copy-content init container re-runs and does not clear out the existing contents of the emptyDir, which causes the `opm serve` container to fail due to a mismatched digest.

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
