### PR TITLE
Update if AlreadyExists

### DIFF
--- a/pkg/api/wrappers/deployment_install_client.go
+++ b/pkg/api/wrappers/deployment_install_client.go
@@ -58,11 +58,11 @@ func (c *InstallStrategyDeploymentClientForNamespace) GetOpLister() operatorlist
 }
 
 func (c *InstallStrategyDeploymentClientForNamespace) CreateRole(role *rbacv1.Role) (*rbacv1.Role, error) {
-	return c.opClient.KubernetesInterface().RbacV1().Roles(c.Namespace).Create(context.TODO(), role, metav1.CreateOptions{})
+	return c.opClient.CreateRole(role)
 }
 
 func (c *InstallStrategyDeploymentClientForNamespace) CreateRoleBinding(roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-	return c.opClient.KubernetesInterface().RbacV1().RoleBindings(c.Namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{})
+	return c.opClient.CreateRoleBinding(roleBinding)
 }
 
 func (c *InstallStrategyDeploymentClientForNamespace) EnsureServiceAccount(serviceAccount *corev1.ServiceAccount, owner ownerutil.Owner) (*corev1.ServiceAccount, error) {

--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -734,6 +734,9 @@ func (c *ConfigMapUnpacker) ensureRole(cmRef *corev1.ObjectReference) (role *rba
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			role, err = c.client.RbacV1().Roles(fresh.GetNamespace()).Create(context.TODO(), fresh, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(err) {
+				role, err = c.client.RbacV1().Roles(fresh.GetNamespace()).Update(context.TODO(), fresh, metav1.UpdateOptions{})
+			}
 		}
 
 		return
@@ -778,6 +781,9 @@ func (c *ConfigMapUnpacker) ensureRoleBinding(cmRef *corev1.ObjectReference) (ro
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			roleBinding, err = c.client.RbacV1().RoleBindings(fresh.GetNamespace()).Create(context.TODO(), fresh, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(err) {
+				roleBinding, err = c.client.RbacV1().RoleBindings(fresh.GetNamespace()).Update(context.TODO(), fresh, metav1.UpdateOptions{})
+			}
 		}
 
 		return

--- a/pkg/controller/operators/operatorcondition_controller.go
+++ b/pkg/controller/operators/operatorcondition_controller.go
@@ -150,7 +150,10 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRole(operatorCondit
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
-		return r.Client.Create(context.TODO(), role)
+		err = r.Client.Create(context.TODO(), role)
+		if apierrors.IsAlreadyExists(err) {
+			return r.Client.Update(context.TODO(), role)
+		}
 	}
 
 	if ownerutil.IsOwnedBy(existingRole, operatorCondition) &&
@@ -199,7 +202,10 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRoleBinding(operato
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
-		return r.Client.Create(context.TODO(), roleBinding)
+		err = r.Client.Create(context.TODO(), roleBinding)
+		if apierrors.IsAlreadyExists(err) {
+			return r.Client.Update(context.TODO(), roleBinding)
+		}
 	}
 
 	if ownerutil.IsOwnedBy(existingRoleBinding, operatorCondition) &&

--- a/pkg/lib/operatorclient/apiservice.go
+++ b/pkg/lib/operatorclient/apiservice.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
-// CreateAPIService creates the APIService.
+// CreateAPIService creates the APIService or Updates if it already exists.
 func (c *Client) CreateAPIService(ig *apiregistrationv1.APIService) (*apiregistrationv1.APIService, error) {
-	return c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Create(context.TODO(), ig, metav1.CreateOptions{})
+	createdAS, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Create(context.TODO(), ig, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return c.UpdateAPIService(ig)
+	}
+	return createdAS, err
 }
 
 // GetAPIService returns the existing APIService.

--- a/pkg/lib/operatorclient/clusterrole.go
+++ b/pkg/lib/operatorclient/clusterrole.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 )
 
-// CreateClusterRole creates the ClusterRole.
+// CreateClusterRole creates the ClusterRole or Updates if it already exists.
 func (c *Client) CreateClusterRole(r *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-	return c.RbacV1().ClusterRoles().Create(context.TODO(), r, metav1.CreateOptions{})
+	createdClusterRole, err := c.RbacV1().ClusterRoles().Create(context.TODO(), r, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return c.UpdateClusterRole(r)
+	}
+	return createdClusterRole, err
 }
 
 // GetClusterRole returns the existing ClusterRole.

--- a/pkg/lib/operatorclient/configmap.go
+++ b/pkg/lib/operatorclient/configmap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -12,7 +13,11 @@ import (
 
 // CreateConfigMap creates the ConfigMap.
 func (c *Client) CreateConfigMap(ig *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return c.CoreV1().ConfigMaps(ig.GetNamespace()).Create(context.TODO(), ig, metav1.CreateOptions{})
+	createdCM, err := c.CoreV1().ConfigMaps(ig.GetNamespace()).Create(context.TODO(), ig, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return c.UpdateConfigMap(ig)
+	}
+	return createdCM, err
 }
 
 // GetConfigMap returns the existing ConfigMap.

--- a/pkg/lib/operatorclient/deployment.go
+++ b/pkg/lib/operatorclient/deployment.go
@@ -25,10 +25,15 @@ func (c *Client) GetDeployment(namespace, name string) (*appsv1.Deployment, erro
 	return c.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-// CreateDeployment creates the Deployment object.
+// CreateDeployment creates the Deployment object or Updates if it already exists.
 func (c *Client) CreateDeployment(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 	klog.V(4).Infof("[CREATE Deployment]: %s:%s", dep.Namespace, dep.Name)
-	return c.AppsV1().Deployments(dep.Namespace).Create(context.TODO(), dep, metav1.CreateOptions{})
+	createdDep, err := c.AppsV1().Deployments(dep.Namespace).Create(context.TODO(), dep, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		updatedDep, _, err := c.UpdateDeployment(dep)
+		return updatedDep, err
+	}
+	return createdDep, err
 }
 
 // DeleteDeployment deletes the Deployment object.

--- a/pkg/lib/operatorclient/role.go
+++ b/pkg/lib/operatorclient/role.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 )
 
-// CreateRole creates the role.
+// CreateRole creates the role or Updates if it already exists.
 func (c *Client) CreateRole(r *rbacv1.Role) (*rbacv1.Role, error) {
-	return c.RbacV1().Roles(r.GetNamespace()).Create(context.TODO(), r, metav1.CreateOptions{})
+	createdRole, err := c.RbacV1().Roles(r.GetNamespace()).Create(context.TODO(), r, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return c.UpdateRole(r)
+	}
+	return createdRole, err
 }
 
 // GetRole returns the existing role.

--- a/pkg/lib/operatorclient/secret.go
+++ b/pkg/lib/operatorclient/secret.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 )
 
-// CreateSecret creates the Secret.
+// CreateSecret creates the Secret or Updates if it already exists.
 func (c *Client) CreateSecret(ig *v1.Secret) (*v1.Secret, error) {
-	return c.CoreV1().Secrets(ig.GetNamespace()).Create(context.TODO(), ig, metav1.CreateOptions{})
+	createdSecret, err := c.CoreV1().Secrets(ig.GetNamespace()).Create(context.TODO(), ig, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return c.UpdateSecret(ig)
+	}
+	return createdSecret, err
 }
 
 // GetSecret returns the existing Secret.


### PR DESCRIPTION
Adds code to the client calls for Create to run an Update if the object already exists. This allows us to bypass issues where the object was not found in cache but already exists in the cluster.