### PR TITLE
OCPBUGS-28230: fallback to logs for termination message

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -157,6 +157,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 									Drop: []corev1.Capability{"ALL"},
 								},
 							},
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						},
 					},
 					InitContainers: []corev1.Container{
@@ -182,6 +183,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 									Drop: []corev1.Capability{"ALL"},
 								},
 							},
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						},
 						{
 							Name:            "pull",
@@ -210,6 +212,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 									Drop: []corev1.Capability{"ALL"},
 								},
 							},
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						},
 					},
 					Volumes: []corev1.Volume{

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -267,6 +267,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -292,6 +293,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 										{
 											Name:            "pull",
@@ -320,6 +322,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -498,6 +501,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -523,6 +527,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 										{
 											Name:            "pull",
@@ -551,6 +556,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -769,6 +775,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -794,6 +801,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 										{
 											Name:            "pull",
@@ -822,6 +830,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -1035,6 +1044,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1060,6 +1070,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 										{
 											Name:            "pull",
@@ -1088,6 +1099,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -1270,6 +1282,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1295,6 +1308,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 										{
 											Name:            "pull",
@@ -1323,6 +1337,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									Volumes: []corev1.Volume{
@@ -1516,6 +1531,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1541,6 +1557,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 										{
 											Name:            "pull",
@@ -1569,6 +1586,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 													Drop: []corev1.Capability{"ALL"},
 												},
 											},
+											TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 										},
 									},
 									Volumes: []corev1.Volume{

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -279,11 +279,12 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 				MountPath: catalogPath,
 			}
 			pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-				Name:         "extract-utilities",
-				Image:        utilImage,
-				Command:      []string{"cp"},
-				Args:         []string{"/bin/copy-content", fmt.Sprintf("%s/copy-content", utilitiesPath)},
-				VolumeMounts: []corev1.VolumeMount{utilitiesVolumeMount},
+				Name:                     "extract-utilities",
+				Image:                    utilImage,
+				Command:                  []string{"cp"},
+				Args:                     []string{"/bin/copy-content", fmt.Sprintf("%s/copy-content", utilitiesPath)},
+				VolumeMounts:             []corev1.VolumeMount{utilitiesVolumeMount},
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			}, corev1.Container{
 				Name:            "extract-content",
 				Image:           img,
@@ -295,7 +296,8 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 					"--cache.from=" + grpcPodConfig.ExtractContent.CacheDir,
 					"--cache.to=" + fmt.Sprintf("%s/cache", catalogPath),
 				},
-				VolumeMounts: []corev1.VolumeMount{utilitiesVolumeMount, contentVolumeMount},
+				VolumeMounts:             []corev1.VolumeMount{utilitiesVolumeMount, contentVolumeMount},
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			})
 
 			pod.Spec.Containers[0].Image = opmImg

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -277,7 +277,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "2AHzz8IDqQLwPsDyu4UjUmnROr4E59PMKm9OCm", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "5MSUJs07MqD3fl9supmPaRNxD9N6tK8Bjo4OFl", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -293,11 +293,12 @@ func TestPodExtractContent(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:         "extract-utilities",
-							Image:        "utilImage",
-							Command:      []string{"cp"},
-							Args:         []string{"/bin/copy-content", "/utilities/copy-content"},
-							VolumeMounts: []corev1.VolumeMount{{Name: "utilities", MountPath: "/utilities"}},
+							Name:                     "extract-utilities",
+							Image:                    "utilImage",
+							Command:                  []string{"cp"},
+							Args:                     []string{"/bin/copy-content", "/utilities/copy-content"},
+							VolumeMounts:             []corev1.VolumeMount{{Name: "utilities", MountPath: "/utilities"}},
+							TerminationMessagePolicy: "FallbackToLogsOnError",
 						},
 						{
 							Name:            "extract-content",
@@ -314,6 +315,7 @@ func TestPodExtractContent(t *testing.T) {
 								{Name: "utilities", MountPath: "/utilities"},
 								{Name: "catalog-content", MountPath: "/extracted-catalog"},
 							},
+							TerminationMessagePolicy: "FallbackToLogsOnError",
 						},
 					},
 					Containers: []corev1.Container{


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
