### PR TITLE
Fix unpack job cache issue

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -671,6 +671,9 @@ func (c *ConfigMapUnpacker) ensureJob(cmRef *corev1.ObjectReference, bundlePath 
 	}
 	if len(jobs) == 0 {
 		job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Create(context.TODO(), fresh, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Update(context.TODO(), fresh, metav1.UpdateOptions{})
+		}
 		return
 	}
 
@@ -685,6 +688,9 @@ func (c *ConfigMapUnpacker) ensureJob(cmRef *corev1.ObjectReference, bundlePath 
 				if time.Now().After(cond.LastTransitionTime.Time.Add(unpackRetryInterval)) {
 					fresh.SetName(names.SimpleNameGenerator.GenerateName(fresh.GetName()))
 					job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Create(context.TODO(), fresh, metav1.CreateOptions{})
+					if apierrors.IsAlreadyExists(err) {
+						job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Update(context.TODO(), fresh, metav1.UpdateOptions{})
+					}
 				}
 			}
 


### PR DESCRIPTION
In the same vein as https://github.com/operator-framework/operator-lifecycle-manager/pull/3202, use update if the unpack job already exists but isn't cached