### PR TITLE
OCPBUGS-29729: Updates default security context behavior for catalog source pods

### DIFF
--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
 	"github.com/pkg/errors"
@@ -111,7 +110,7 @@ func (s *configMapCatalogSourceDecorator) Service() (*corev1.Service, error) {
 	return svc, nil
 }
 
-func (s *configMapCatalogSourceDecorator) getNamespaceSecurityContextConfig() (operatorsv1alpha1.SecurityConfig, error) {
+func (s *configMapCatalogSourceDecorator) getNamespaceSecurityContextConfig() (v1alpha1.SecurityConfig, error) {
 	namespace := s.GetNamespace()
 	if config, ok := s.Reconciler.namespacePSAConfigCache[namespace]; ok {
 		return config, nil
@@ -126,10 +125,10 @@ func (s *configMapCatalogSourceDecorator) getNamespaceSecurityContextConfig() (o
 	// 'pod-security.kubernetes.io/enforce' is the label used for enforcing namespace level security,
 	// and 'restricted' is the value indicating a restricted security policy.
 	if val, exists := ns.Labels["pod-security.kubernetes.io/enforce"]; exists && val == "restricted" {
-		return operatorsv1alpha1.Restricted, nil
+		return v1alpha1.Restricted, nil
 	}
 
-	return operatorsv1alpha1.Legacy, nil
+	return v1alpha1.Legacy, nil
 }
 func (s *configMapCatalogSourceDecorator) Pod(image string) (*corev1.Pod, error) {
 	securityContextConfig, err := s.getNamespaceSecurityContextConfig()
@@ -214,7 +213,7 @@ type ConfigMapRegistryReconciler struct {
 	OpClient                operatorclient.ClientInterface
 	Image                   string
 	createPodAsUser         int64
-	namespacePSAConfigCache map[string]operatorsv1alpha1.SecurityConfig
+	namespacePSAConfigCache map[string]v1alpha1.SecurityConfig
 }
 
 var _ RegistryEnsurer = &ConfigMapRegistryReconciler{}
@@ -302,7 +301,7 @@ func (c *ConfigMapRegistryReconciler) currentPodsWithCorrectResourceVersion(sour
 // EnsureRegistryServer ensures that all components of registry server are up to date.
 func (c *ConfigMapRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, catalogSource *v1alpha1.CatalogSource) error {
 	if c.namespacePSAConfigCache == nil {
-		c.namespacePSAConfigCache = make(map[string]operatorsv1alpha1.SecurityConfig)
+		c.namespacePSAConfigCache = make(map[string]v1alpha1.SecurityConfig)
 	}
 	source := configMapCatalogSourceDecorator{catalogSource, c, c.createPodAsUser}
 

--- a/pkg/controller/registry/reconciler/configmap.go
+++ b/pkg/controller/registry/reconciler/configmap.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
 	"github.com/pkg/errors"
@@ -25,7 +26,8 @@ import (
 // configMapCatalogSourceDecorator wraps CatalogSource to add additional methods
 type configMapCatalogSourceDecorator struct {
 	*v1alpha1.CatalogSource
-	runAsUser int64
+	Reconciler *ConfigMapRegistryReconciler
+	runAsUser  int64
 }
 
 const (
@@ -109,8 +111,32 @@ func (s *configMapCatalogSourceDecorator) Service() (*corev1.Service, error) {
 	return svc, nil
 }
 
+func (s *configMapCatalogSourceDecorator) getNamespaceSecurityContextConfig() (operatorsv1alpha1.SecurityConfig, error) {
+	namespace := s.GetNamespace()
+	if config, ok := s.Reconciler.namespacePSAConfigCache[namespace]; ok {
+		return config, nil
+	}
+	// Retrieve the client from the reconciler
+	client := s.Reconciler.OpClient
+
+	ns, err := client.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), s.GetNamespace(), metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error fetching namespace: %v", err)
+	}
+	// 'pod-security.kubernetes.io/enforce' is the label used for enforcing namespace level security,
+	// and 'restricted' is the value indicating a restricted security policy.
+	if val, exists := ns.Labels["pod-security.kubernetes.io/enforce"]; exists && val == "restricted" {
+		return operatorsv1alpha1.Restricted, nil
+	}
+
+	return operatorsv1alpha1.Legacy, nil
+}
 func (s *configMapCatalogSourceDecorator) Pod(image string) (*corev1.Pod, error) {
-	pod, err := Pod(s.CatalogSource, "configmap-registry-server", "", "", image, nil, s.Labels(), s.Annotations(), 5, 5, s.runAsUser)
+	securityContextConfig, err := s.getNamespaceSecurityContextConfig()
+	if err != nil {
+		return nil, err
+	}
+	pod, err := Pod(s.CatalogSource, "configmap-registry-server", "", "", image, nil, s.Labels(), s.Annotations(), 5, 5, s.runAsUser, securityContextConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -183,11 +209,12 @@ func (s *configMapCatalogSourceDecorator) RoleBinding() *rbacv1.RoleBinding {
 }
 
 type ConfigMapRegistryReconciler struct {
-	now             nowFunc
-	Lister          operatorlister.OperatorLister
-	OpClient        operatorclient.ClientInterface
-	Image           string
-	createPodAsUser int64
+	now                     nowFunc
+	Lister                  operatorlister.OperatorLister
+	OpClient                operatorclient.ClientInterface
+	Image                   string
+	createPodAsUser         int64
+	namespacePSAConfigCache map[string]operatorsv1alpha1.SecurityConfig
 }
 
 var _ RegistryEnsurer = &ConfigMapRegistryReconciler{}
@@ -274,7 +301,10 @@ func (c *ConfigMapRegistryReconciler) currentPodsWithCorrectResourceVersion(sour
 
 // EnsureRegistryServer ensures that all components of registry server are up to date.
 func (c *ConfigMapRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, catalogSource *v1alpha1.CatalogSource) error {
-	source := configMapCatalogSourceDecorator{catalogSource, c.createPodAsUser}
+	if c.namespacePSAConfigCache == nil {
+		c.namespacePSAConfigCache = make(map[string]operatorsv1alpha1.SecurityConfig)
+	}
+	source := configMapCatalogSourceDecorator{catalogSource, c, c.createPodAsUser}
 
 	image := c.Image
 	if source.Spec.SourceType == "grpc" {
@@ -449,7 +479,7 @@ func (c *ConfigMapRegistryReconciler) ensureService(source configMapCatalogSourc
 
 // CheckRegistryServer returns true if the given CatalogSource is considered healthy; false otherwise.
 func (c *ConfigMapRegistryReconciler) CheckRegistryServer(logger *logrus.Entry, catalogSource *v1alpha1.CatalogSource) (healthy bool, err error) {
-	source := configMapCatalogSourceDecorator{catalogSource, c.createPodAsUser}
+	source := configMapCatalogSourceDecorator{catalogSource, c, c.createPodAsUser}
 
 	image := c.Image
 	if source.Spec.SourceType == "grpc" {

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -3,7 +3,6 @@ package reconciler
 import (
 	"context"
 	"errors"
-
 	"fmt"
 	"slices"
 	"strings"
@@ -37,7 +36,6 @@ const (
 // grpcCatalogSourceDecorator wraps CatalogSource to add additional methods
 type grpcCatalogSourceDecorator struct {
 	*v1alpha1.CatalogSource
-	Reconciler      *GrpcRegistryReconciler
 	createPodAsUser int64
 	opmImage        string
 	utilImage       string
@@ -69,27 +67,6 @@ func (s *grpcCatalogSourceDecorator) Labels() map[string]string {
 		CatalogSourceLabelKey:      s.GetName(),
 		install.OLMManagedLabelKey: install.OLMManagedLabelValue,
 	}
-}
-
-func (s *grpcCatalogSourceDecorator) getNamespaceSecurityContextConfig() (v1alpha1.SecurityConfig, error) {
-	namespace := s.GetNamespace()
-	if config, ok := s.Reconciler.namespacePSAConfigCache[namespace]; ok {
-		return config, nil
-	}
-	// Retrieve the client from the reconciler
-	client := s.Reconciler.OpClient
-
-	ns, err := client.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), s.GetNamespace(), metav1.GetOptions{})
-	if err != nil {
-		return "", fmt.Errorf("error fetching namespace: %v", err)
-	}
-	// 'pod-security.kubernetes.io/enforce' is the label used for enforcing namespace level security,
-	// and 'restricted' is the value indicating a restricted security policy.
-	if val, exists := ns.Labels["pod-security.kubernetes.io/enforce"]; exists && val == "restricted" {
-		return v1alpha1.Restricted, nil
-	}
-
-	return v1alpha1.Legacy, nil
 }
 
 func (s *grpcCatalogSourceDecorator) Annotations() map[string]string {
@@ -157,12 +134,8 @@ func (s *grpcCatalogSourceDecorator) ServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
-func (s *grpcCatalogSourceDecorator) Pod(serviceAccount *corev1.ServiceAccount) (*corev1.Pod, error) {
-	securityContextConfig, err := s.getNamespaceSecurityContextConfig()
-	if err != nil {
-		return nil, err
-	}
-	pod, err := Pod(s.CatalogSource, "registry-server", s.opmImage, s.utilImage, s.Spec.Image, serviceAccount, s.Labels(), s.Annotations(), 5, 10, s.createPodAsUser, securityContextConfig)
+func (s *grpcCatalogSourceDecorator) Pod(serviceAccount *corev1.ServiceAccount, defaultPodSecurityConfig v1alpha1.SecurityConfig) (*corev1.Pod, error) {
+	pod, err := Pod(s.CatalogSource, "registry-server", s.opmImage, s.utilImage, s.Spec.Image, serviceAccount, s.Labels(), s.Annotations(), 5, 10, s.createPodAsUser, defaultPodSecurityConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -171,14 +144,13 @@ func (s *grpcCatalogSourceDecorator) Pod(serviceAccount *corev1.ServiceAccount) 
 }
 
 type GrpcRegistryReconciler struct {
-	now                     nowFunc
-	Lister                  operatorlister.OperatorLister
-	OpClient                operatorclient.ClientInterface
-	SSAClient               *controllerclient.ServerSideApplier
-	createPodAsUser         int64
-	opmImage                string
-	utilImage               string
-	namespacePSAConfigCache map[string]v1alpha1.SecurityConfig
+	now             nowFunc
+	Lister          operatorlister.OperatorLister
+	OpClient        operatorclient.ClientInterface
+	SSAClient       *controllerclient.ServerSideApplier
+	createPodAsUser int64
+	opmImage        string
+	utilImage       string
 }
 
 var _ RegistryReconciler = &GrpcRegistryReconciler{}
@@ -231,7 +203,7 @@ func (c *GrpcRegistryReconciler) currentUpdatePods(logger *logrus.Entry, source 
 	return pods
 }
 
-func (c *GrpcRegistryReconciler) currentPodsWithCorrectImageAndSpec(logger *logrus.Entry, source grpcCatalogSourceDecorator, serviceAccount *corev1.ServiceAccount) ([]*corev1.Pod, error) {
+func (c *GrpcRegistryReconciler) currentPodsWithCorrectImageAndSpec(logger *logrus.Entry, source grpcCatalogSourceDecorator, serviceAccount *corev1.ServiceAccount, defaultPodSecurityConfig v1alpha1.SecurityConfig) ([]*corev1.Pod, error) {
 	logger.Info("searching for current pods")
 	pods, err := c.Lister.CoreV1().PodLister().Pods(source.GetNamespace()).List(labels.SelectorFromValidatedSet(source.Labels()))
 	if err != nil {
@@ -239,7 +211,7 @@ func (c *GrpcRegistryReconciler) currentPodsWithCorrectImageAndSpec(logger *logr
 		return nil, nil
 	}
 	found := []*corev1.Pod{}
-	newPod, err := source.Pod(serviceAccount)
+	newPod, err := source.Pod(serviceAccount, defaultPodSecurityConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -278,9 +250,6 @@ func correctImages(source grpcCatalogSourceDecorator, pod *corev1.Pod) bool {
 
 // EnsureRegistryServer ensures that all components of registry server are up to date.
 func (c *GrpcRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, catalogSource *v1alpha1.CatalogSource) error {
-	if c.namespacePSAConfigCache == nil {
-		c.namespacePSAConfigCache = make(map[string]v1alpha1.SecurityConfig)
-	}
 	source := grpcCatalogSourceDecorator{CatalogSource: catalogSource, createPodAsUser: c.createPodAsUser, opmImage: c.opmImage, utilImage: c.utilImage}
 
 	// if service status is nil, we force create every object to ensure they're created the first time
@@ -304,8 +273,13 @@ func (c *GrpcRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, cata
 		return err
 	}
 
+	defaultPodSecurityConfig, err := getDefaultPodContextConfig(c.OpClient, catalogSource.GetNamespace())
+	if err != nil {
+		return err
+	}
+
 	// recreate the pod if no existing pod is serving the latest image or correct spec
-	current, err := c.currentPodsWithCorrectImageAndSpec(logger, source, sa)
+	current, err := c.currentPodsWithCorrectImageAndSpec(logger, source, sa, defaultPodSecurityConfig)
 	if err != nil {
 		return err
 	}
@@ -314,14 +288,14 @@ func (c *GrpcRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, cata
 		logger.Info("registry pods invalid, need to overwrite")
 	}
 
-	pod, err := source.Pod(sa)
+	pod, err := source.Pod(sa, defaultPodSecurityConfig)
 	if err != nil {
 		return err
 	}
-	if err := c.ensurePod(logger, source, sa, overwritePod); err != nil {
+	if err := c.ensurePod(logger, source, sa, defaultPodSecurityConfig, overwritePod); err != nil {
 		return pkgerrors.Wrapf(err, "error ensuring pod: %s", pod.GetName())
 	}
-	if err := c.ensureUpdatePod(logger, sa, source); err != nil {
+	if err := c.ensureUpdatePod(logger, sa, defaultPodSecurityConfig, source); err != nil {
 		if _, ok := err.(UpdateNotReadyErr); ok {
 			return err
 		}
@@ -371,7 +345,7 @@ func isRegistryServiceStatusValid(source *grpcCatalogSourceDecorator) (bool, err
 	return true, nil
 }
 
-func (c *GrpcRegistryReconciler) ensurePod(logger *logrus.Entry, source grpcCatalogSourceDecorator, serviceAccount *corev1.ServiceAccount, overwrite bool) error {
+func (c *GrpcRegistryReconciler) ensurePod(logger *logrus.Entry, source grpcCatalogSourceDecorator, serviceAccount *corev1.ServiceAccount, defaultPodSecurityConfig v1alpha1.SecurityConfig, overwrite bool) error {
 	// currentPods refers to the current pod instances of the catalog source
 	currentPods := c.currentPods(logger, source)
 
@@ -404,7 +378,7 @@ func (c *GrpcRegistryReconciler) ensurePod(logger *logrus.Entry, source grpcCata
 			}
 		}
 	}
-	desiredPod, err := source.Pod(serviceAccount)
+	desiredPod, err := source.Pod(serviceAccount, defaultPodSecurityConfig)
 	if err != nil {
 		return err
 	}
@@ -418,7 +392,7 @@ func (c *GrpcRegistryReconciler) ensurePod(logger *logrus.Entry, source grpcCata
 }
 
 // ensureUpdatePod checks that for the same catalog source version the same container imageID is running
-func (c *GrpcRegistryReconciler) ensureUpdatePod(logger *logrus.Entry, serviceAccount *corev1.ServiceAccount, source grpcCatalogSourceDecorator) error {
+func (c *GrpcRegistryReconciler) ensureUpdatePod(logger *logrus.Entry, serviceAccount *corev1.ServiceAccount, podSecurityConfig v1alpha1.SecurityConfig, source grpcCatalogSourceDecorator) error {
 	if !source.Poll() {
 		logger.Info("polling not enabled, no update pod will be created")
 		return nil
@@ -429,7 +403,7 @@ func (c *GrpcRegistryReconciler) ensureUpdatePod(logger *logrus.Entry, serviceAc
 
 	if source.Update() && len(currentUpdatePods) == 0 {
 		logger.Infof("catalog update required at %s", time.Now().String())
-		pod, err := c.createUpdatePod(source, serviceAccount)
+		pod, err := c.createUpdatePod(source, serviceAccount, podSecurityConfig)
 		if err != nil {
 			return pkgerrors.Wrapf(err, "creating update catalog source pod")
 		}
@@ -537,9 +511,9 @@ func ServiceHashMatch(existing, new *corev1.Service) bool {
 }
 
 // createUpdatePod is an internal method that creates a pod using the latest catalog source.
-func (c *GrpcRegistryReconciler) createUpdatePod(source grpcCatalogSourceDecorator, serviceAccount *corev1.ServiceAccount) (*corev1.Pod, error) {
+func (c *GrpcRegistryReconciler) createUpdatePod(source grpcCatalogSourceDecorator, serviceAccount *corev1.ServiceAccount, defaultPodSecurityConfig v1alpha1.SecurityConfig) (*corev1.Pod, error) {
 	// remove label from pod to ensure service does not accidentally route traffic to the pod
-	p, err := source.Pod(serviceAccount)
+	p, err := source.Pod(serviceAccount, defaultPodSecurityConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -643,13 +617,18 @@ func (c *GrpcRegistryReconciler) CheckRegistryServer(logger *logrus.Entry, catal
 		return false, nil
 	}
 
+	registryPodSecurityConfig, err := getDefaultPodContextConfig(c.OpClient, catalogSource.GetNamespace())
+	if err != nil {
+		return false, err
+	}
+
 	// Check on registry resources
 	// TODO: add gRPC health check
 	service, err := c.currentService(source)
 	if err != nil {
 		return false, err
 	}
-	current, err := c.currentPodsWithCorrectImageAndSpec(logger, source, serviceAccount)
+	current, err := c.currentPodsWithCorrectImageAndSpec(logger, source, serviceAccount, registryPodSecurityConfig)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
@@ -72,7 +71,7 @@ func (s *grpcCatalogSourceDecorator) Labels() map[string]string {
 	}
 }
 
-func (s *grpcCatalogSourceDecorator) getNamespaceSecurityContextConfig() (operatorsv1alpha1.SecurityConfig, error) {
+func (s *grpcCatalogSourceDecorator) getNamespaceSecurityContextConfig() (v1alpha1.SecurityConfig, error) {
 	namespace := s.GetNamespace()
 	if config, ok := s.Reconciler.namespacePSAConfigCache[namespace]; ok {
 		return config, nil
@@ -87,10 +86,10 @@ func (s *grpcCatalogSourceDecorator) getNamespaceSecurityContextConfig() (operat
 	// 'pod-security.kubernetes.io/enforce' is the label used for enforcing namespace level security,
 	// and 'restricted' is the value indicating a restricted security policy.
 	if val, exists := ns.Labels["pod-security.kubernetes.io/enforce"]; exists && val == "restricted" {
-		return operatorsv1alpha1.Restricted, nil
+		return v1alpha1.Restricted, nil
 	}
 
-	return operatorsv1alpha1.Legacy, nil
+	return v1alpha1.Legacy, nil
 }
 
 func (s *grpcCatalogSourceDecorator) Annotations() map[string]string {
@@ -179,7 +178,7 @@ type GrpcRegistryReconciler struct {
 	createPodAsUser         int64
 	opmImage                string
 	utilImage               string
-	namespacePSAConfigCache map[string]operatorsv1alpha1.SecurityConfig
+	namespacePSAConfigCache map[string]v1alpha1.SecurityConfig
 }
 
 var _ RegistryReconciler = &GrpcRegistryReconciler{}
@@ -280,7 +279,7 @@ func correctImages(source grpcCatalogSourceDecorator, pod *corev1.Pod) bool {
 // EnsureRegistryServer ensures that all components of registry server are up to date.
 func (c *GrpcRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, catalogSource *v1alpha1.CatalogSource) error {
 	if c.namespacePSAConfigCache == nil {
-		c.namespacePSAConfigCache = make(map[string]operatorsv1alpha1.SecurityConfig)
+		c.namespacePSAConfigCache = make(map[string]v1alpha1.SecurityConfig)
 	}
 	source := grpcCatalogSourceDecorator{CatalogSource: catalogSource, createPodAsUser: c.createPodAsUser, opmImage: c.opmImage, utilImage: c.utilImage}
 

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -85,8 +85,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		k8sObjs []runtime.Object
 	}
 	type in struct {
-		cluster cluster
-		catsrc  *v1alpha1.CatalogSource
+		cluster    cluster
+		catsrc     *v1alpha1.CatalogSource
+		reconciler RegistryReconciler
 	}
 	type out struct {
 		status  *v1alpha1.RegistryServiceStatus
@@ -101,7 +102,8 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/CreateSuccessful",
 			in: in{
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -116,7 +118,8 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/CreateSuccessful/CatalogSourceWithPeriodInNameCreatesValidServiceName",
 			in: in{
-				catsrc: grpcCatalogSourceWithName("img.catalog"),
+				catsrc:     grpcCatalogSourceWithName("img.catalog"),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -132,9 +135,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/CreateSuccessful",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}),
 				},
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -149,8 +153,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/Address/CreateSuccessful",
 			in: in{
-				cluster: cluster{},
-				catsrc:  validGrpcCatalogSource("", "catalog.svc.cluster.local:50001"),
+				cluster:    cluster{},
+				catsrc:     validGrpcCatalogSource("", "catalog.svc.cluster.local:50001"),
+				reconciler: &GrpcAddressRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -162,8 +167,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/AddressAndImage/CreateSuccessful",
 			in: in{
-				cluster: cluster{},
-				catsrc:  validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
+				cluster:    cluster{},
+				catsrc:     validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -179,9 +185,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/BadServiceWithWrongHash",
 			in: in{
 				cluster: cluster{
-					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Service{}, ServiceHashLabelKey, "wrongHash"),
+					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Service{}, ServiceHashLabelKey, "wrongHash"),
 				},
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -197,9 +204,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/BadService",
 			in: in{
 				cluster: cluster{
-					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Service{}, "badName"),
+					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Service{}, "badName"),
 				},
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -215,9 +223,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/BadPod",
 			in: in{
 				cluster: cluster{
-					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Pod{}, CatalogSourceLabelKey, ""),
+					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Pod{}, CatalogSourceLabelKey, ""),
 				},
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -233,9 +242,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/OldPod",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", "")),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", ""), &GrpcRegistryReconciler{}),
 				},
-				catsrc: validGrpcCatalogSource("new-img", ""),
+				catsrc:     validGrpcCatalogSource("new-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -260,7 +270,8 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 						},
 					},
 				},
-				catsrc: grpcCatalogSourceWithSecret(testSecrets),
+				catsrc:     grpcCatalogSourceWithSecret(testSecrets),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -305,6 +316,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 					"annotation1": "value1",
 					"annotation2": "value2",
 				}),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -320,7 +332,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/UpdateInvalidRegistryServiceStatus",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("image", "")),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("image", ""), &GrpcRegistryReconciler{}),
 				},
 				catsrc: grpcCatalogSourceWithStatus(v1alpha1.CatalogSourceStatus{
 					RegistryServiceStatus: &v1alpha1.RegistryServiceStatus{
@@ -328,6 +340,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 						Protocol:  "grpc",
 					},
 				}),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -358,7 +371,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			}
 
 			// Check for resource existence
-			decorated := grpcCatalogSourceDecorator{CatalogSource: tt.in.catsrc, createPodAsUser: runAsUser}
+			decorated := grpcCatalogSourceDecorator{CatalogSource: tt.in.catsrc, Reconciler: rec.(*GrpcRegistryReconciler), createPodAsUser: runAsUser, opmImage: ""}
 			sa := decorated.ServiceAccount()
 			pod, err := decorated.Pod(sa)
 			if err != nil {
@@ -476,8 +489,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		k8sObjs []runtime.Object
 	}
 	type in struct {
-		cluster cluster
-		catsrc  *v1alpha1.CatalogSource
+		cluster    cluster
+		catsrc     *v1alpha1.CatalogSource
+		reconciler RegistryReconciler
 	}
 	type out struct {
 		healthy bool
@@ -492,9 +506,10 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/Healthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}),
 				},
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: true,
@@ -503,7 +518,8 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/Image/NotHealthy",
 			in: in{
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: false,
@@ -513,9 +529,10 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/BadService",
 			in: in{
 				cluster: cluster{
-					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Service{}, "badName"),
+					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Service{}, "badName"),
 				},
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: false,
@@ -525,9 +542,10 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/BadServiceAccount",
 			in: in{
 				cluster: cluster{
-					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.ServiceAccount{}, "badName"),
+					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.ServiceAccount{}, "badName"),
 				},
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: false,
@@ -537,9 +555,10 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/BadPod",
 			in: in{
 				cluster: cluster{
-					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Pod{}, CatalogSourceLabelKey, ""),
+					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Pod{}, CatalogSourceLabelKey, ""),
 				},
-				catsrc: validGrpcCatalogSource("test-img", ""),
+				catsrc:     validGrpcCatalogSource("test-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: false,
@@ -549,9 +568,10 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/OldPod/NotHealthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", "")),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", ""), &GrpcRegistryReconciler{}),
 				},
-				catsrc: validGrpcCatalogSource("new-img", ""),
+				catsrc:     validGrpcCatalogSource("new-img", ""),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: false,
@@ -560,7 +580,8 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/Address/Healthy",
 			in: in{
-				catsrc: validGrpcCatalogSource("", "catalog.svc.cluster.local:50001"),
+				catsrc:     validGrpcCatalogSource("", "catalog.svc.cluster.local:50001"),
+				reconciler: &GrpcAddressRegistryReconciler{},
 			},
 			out: out{
 				healthy: true,
@@ -570,9 +591,10 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/AddressAndImage/Healthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001")),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"), &GrpcRegistryReconciler{}),
 				},
-				catsrc: validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
+				catsrc:     validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: true,
@@ -581,8 +603,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/AddressAndImage/NotHealthy",
 			in: in{
-				cluster: cluster{},
-				catsrc:  validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
+				cluster:    cluster{},
+				catsrc:     validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: false,
@@ -592,9 +615,10 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/AddressAndImage/BadService/NotHealthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "catalog.svc.cluster.local:50001")), &corev1.Service{}, "badName"),
+					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "catalog.svc.cluster.local:50001"), &GrpcRegistryReconciler{}), &corev1.Service{}, "badName"),
 				},
-				catsrc: validGrpcCatalogSource("test-img", "catalog.svc.cluster.local:50001"),
+				catsrc:     validGrpcCatalogSource("test-img", "catalog.svc.cluster.local:50001"),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: false,
@@ -604,9 +628,10 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/AddressAndImage/OldPod/NotHealthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", "catalog.svc.cluster.local:50001")),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", "catalog.svc.cluster.local:50001"), &GrpcRegistryReconciler{}),
 				},
-				catsrc: validGrpcCatalogSource("new-img", "catalog.svc.cluster.local:50001"),
+				catsrc:     validGrpcCatalogSource("new-img", "catalog.svc.cluster.local:50001"),
+				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				healthy: false,

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -2,11 +2,9 @@ package reconciler
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -26,7 +24,7 @@ func validGrpcCatalogSource(image, address string) *v1alpha1.CatalogSource {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "img-catalog",
 			Namespace: testNamespace,
-			UID:       types.UID("catalog-uid"),
+			UID:       "catalog-uid",
 			Labels:    map[string]string{"olm.catalogSource": "img-catalog"},
 		},
 		Spec: v1alpha1.CatalogSourceSpec{
@@ -85,9 +83,8 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		k8sObjs []runtime.Object
 	}
 	type in struct {
-		cluster    cluster
-		catsrc     *v1alpha1.CatalogSource
-		reconciler RegistryReconciler
+		cluster cluster
+		catsrc  *v1alpha1.CatalogSource
 	}
 	type out struct {
 		status  *v1alpha1.RegistryServiceStatus
@@ -102,8 +99,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/CreateSuccessful",
 			in: in{
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				cluster: cluster{
+					k8sObjs: baseClusterState(),
+				},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -118,8 +117,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/CreateSuccessful/CatalogSourceWithPeriodInNameCreatesValidServiceName",
 			in: in{
-				catsrc:     grpcCatalogSourceWithName("img.catalog"),
-				reconciler: &GrpcRegistryReconciler{},
+				cluster: cluster{
+					k8sObjs: baseClusterState(),
+				},
+				catsrc: grpcCatalogSourceWithName("img.catalog"),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -135,10 +136,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/CreateSuccessful",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -153,9 +153,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/Address/CreateSuccessful",
 			in: in{
-				cluster:    cluster{},
-				catsrc:     validGrpcCatalogSource("", "catalog.svc.cluster.local:50001"),
-				reconciler: &GrpcAddressRegistryReconciler{},
+				cluster: cluster{
+					k8sObjs: baseClusterState(),
+				},
+				catsrc: validGrpcCatalogSource("", "catalog.svc.cluster.local:50001"),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -167,9 +168,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/AddressAndImage/CreateSuccessful",
 			in: in{
-				cluster:    cluster{},
-				catsrc:     validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
-				reconciler: &GrpcRegistryReconciler{},
+				cluster: cluster{
+					k8sObjs: baseClusterState(),
+				},
+				catsrc: validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -185,10 +187,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/BadServiceWithWrongHash",
 			in: in{
 				cluster: cluster{
-					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Service{}, ServiceHashLabelKey, "wrongHash"),
+					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Service{}, ServiceHashLabelKey, "wrongHash"),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -204,10 +205,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/BadService",
 			in: in{
 				cluster: cluster{
-					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Service{}, "badName"),
+					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Service{}, "badName"),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -223,10 +223,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/BadPod",
 			in: in{
 				cluster: cluster{
-					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Pod{}, CatalogSourceLabelKey, ""),
+					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Pod{}, CatalogSourceLabelKey, ""),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -242,10 +241,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/OldPod",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", ""), &GrpcRegistryReconciler{}),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", "")),
 				},
-				catsrc:     validGrpcCatalogSource("new-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("new-img", ""),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -262,6 +260,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			in: in{
 				cluster: cluster{
 					k8sObjs: []runtime.Object{
+						defaultNamespace(),
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "test-secret",
@@ -270,8 +269,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 						},
 					},
 				},
-				catsrc:     grpcCatalogSourceWithSecret(testSecrets),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: grpcCatalogSourceWithSecret(testSecrets),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -312,11 +310,13 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/CreateWithAnnotations",
 			in: in{
+				cluster: cluster{
+					k8sObjs: baseClusterState(),
+				},
 				catsrc: grpcCatalogSourceWithAnnotations(map[string]string{
 					"annotation1": "value1",
 					"annotation2": "value2",
 				}),
-				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -332,7 +332,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/UpdateInvalidRegistryServiceStatus",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("image", ""), &GrpcRegistryReconciler{}),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("image", "")),
 				},
 				catsrc: grpcCatalogSourceWithStatus(v1alpha1.CatalogSourceStatus{
 					RegistryServiceStatus: &v1alpha1.RegistryServiceStatus{
@@ -340,7 +340,6 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 						Protocol:  "grpc",
 					},
 				}),
-				reconciler: &GrpcRegistryReconciler{},
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{
@@ -371,9 +370,9 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			}
 
 			// Check for resource existence
-			decorated := grpcCatalogSourceDecorator{CatalogSource: tt.in.catsrc, Reconciler: rec.(*GrpcRegistryReconciler), createPodAsUser: runAsUser, opmImage: ""}
+			decorated := grpcCatalogSourceDecorator{CatalogSource: tt.in.catsrc, createPodAsUser: runAsUser}
 			sa := decorated.ServiceAccount()
-			pod, err := decorated.Pod(sa)
+			pod, err := decorated.Pod(sa, defaultPodSecurityConfig)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -389,9 +388,6 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			case *GrpcRegistryReconciler:
 				// Should be created by a GrpcRegistryReconciler
 				require.NoError(t, podErr)
-				if diff := cmp.Diff(outPods.Items, []corev1.Pod{*pod}); diff != "" {
-					fmt.Printf("incorrect pods: %s\n", diff)
-				}
 				require.Len(t, outPods.Items, 1)
 				outPod := outPods.Items[0]
 				require.Equal(t, pod.GetGenerateName(), outPod.GetGenerateName())
@@ -463,7 +459,11 @@ func TestRegistryPodPriorityClass(t *testing.T) {
 			stopc := make(chan struct{})
 			defer close(stopc)
 
-			factory, client := fakeReconcilerFactory(t, stopc, withNow(now), withK8sObjs(tt.in.cluster.k8sObjs...), withK8sClientOptions(clientfake.WithNameGeneration(t)))
+			// a defaultNamespace resource must be present so that the reconciler can determine the
+			// security context configuration for the underlying pod
+			clusterState := append(tt.in.cluster.k8sObjs, defaultNamespace())
+
+			factory, client := fakeReconcilerFactory(t, stopc, withNow(now), withK8sObjs(clusterState...), withK8sClientOptions(clientfake.WithNameGeneration(t)))
 			rec := factory.ReconcilerForSource(tt.in.catsrc)
 
 			err := rec.EnsureRegistryServer(logrus.NewEntry(logrus.New()), tt.in.catsrc)
@@ -471,7 +471,7 @@ func TestRegistryPodPriorityClass(t *testing.T) {
 
 			// Check for resource existence
 			decorated := grpcCatalogSourceDecorator{CatalogSource: tt.in.catsrc, createPodAsUser: runAsUser}
-			pod, err := decorated.Pod(serviceAccount(tt.in.catsrc.Namespace, tt.in.catsrc.Name))
+			pod, err := decorated.Pod(serviceAccount(tt.in.catsrc.Namespace, tt.in.catsrc.Name), defaultPodSecurityConfig)
 			require.NoError(t, err)
 			listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{CatalogSourceLabelKey: tt.in.catsrc.GetName()}).String()}
 			outPods, podErr := client.KubernetesInterface().CoreV1().Pods(pod.GetNamespace()).List(context.TODO(), listOptions)
@@ -489,9 +489,8 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		k8sObjs []runtime.Object
 	}
 	type in struct {
-		cluster    cluster
-		catsrc     *v1alpha1.CatalogSource
-		reconciler RegistryReconciler
+		cluster cluster
+		catsrc  *v1alpha1.CatalogSource
 	}
 	type out struct {
 		healthy bool
@@ -506,10 +505,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/Healthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				healthy: true,
@@ -518,8 +516,7 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/Image/NotHealthy",
 			in: in{
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				healthy: false,
@@ -529,10 +526,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/BadService",
 			in: in{
 				cluster: cluster{
-					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Service{}, "badName"),
+					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Service{}, "badName"),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				healthy: false,
@@ -542,10 +538,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/BadServiceAccount",
 			in: in{
 				cluster: cluster{
-					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.ServiceAccount{}, "badName"),
+					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.ServiceAccount{}, "badName"),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				healthy: false,
@@ -555,10 +550,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/BadPod",
 			in: in{
 				cluster: cluster{
-					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", ""), &GrpcRegistryReconciler{}), &corev1.Pod{}, CatalogSourceLabelKey, ""),
+					k8sObjs: setLabel(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "")), &corev1.Pod{}, CatalogSourceLabelKey, ""),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", ""),
 			},
 			out: out{
 				healthy: false,
@@ -568,10 +562,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/Image/OldPod/NotHealthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", ""), &GrpcRegistryReconciler{}),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", "")),
 				},
-				catsrc:     validGrpcCatalogSource("new-img", ""),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("new-img", ""),
 			},
 			out: out{
 				healthy: false,
@@ -580,8 +573,7 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/Address/Healthy",
 			in: in{
-				catsrc:     validGrpcCatalogSource("", "catalog.svc.cluster.local:50001"),
-				reconciler: &GrpcAddressRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("", "catalog.svc.cluster.local:50001"),
 			},
 			out: out{
 				healthy: true,
@@ -591,10 +583,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/AddressAndImage/Healthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"), &GrpcRegistryReconciler{}),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001")),
 				},
-				catsrc:     validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
 			},
 			out: out{
 				healthy: true,
@@ -603,9 +594,7 @@ func TestGrpcRegistryChecker(t *testing.T) {
 		{
 			testName: "Grpc/NoExistingRegistry/AddressAndImage/NotHealthy",
 			in: in{
-				cluster:    cluster{},
-				catsrc:     validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("img-catalog", "catalog.svc.cluster.local:50001"),
 			},
 			out: out{
 				healthy: false,
@@ -615,10 +604,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/AddressAndImage/BadService/NotHealthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "catalog.svc.cluster.local:50001"), &GrpcRegistryReconciler{}), &corev1.Service{}, "badName"),
+					k8sObjs: modifyObjName(objectsForCatalogSource(t, validGrpcCatalogSource("test-img", "catalog.svc.cluster.local:50001")), &corev1.Service{}, "badName"),
 				},
-				catsrc:     validGrpcCatalogSource("test-img", "catalog.svc.cluster.local:50001"),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("test-img", "catalog.svc.cluster.local:50001"),
 			},
 			out: out{
 				healthy: false,
@@ -628,10 +616,9 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			testName: "Grpc/ExistingRegistry/AddressAndImage/OldPod/NotHealthy",
 			in: in{
 				cluster: cluster{
-					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", "catalog.svc.cluster.local:50001"), &GrpcRegistryReconciler{}),
+					k8sObjs: objectsForCatalogSource(t, validGrpcCatalogSource("old-img", "catalog.svc.cluster.local:50001")),
 				},
-				catsrc:     validGrpcCatalogSource("new-img", "catalog.svc.cluster.local:50001"),
-				reconciler: &GrpcRegistryReconciler{},
+				catsrc: validGrpcCatalogSource("new-img", "catalog.svc.cluster.local:50001"),
 			},
 			out: out{
 				healthy: false,

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -207,7 +207,7 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 	}
 
 	// Define default security context config
-	securityContextConfig := operatorsv1alpha1.Legacy
+	var securityContextConfig operatorsv1alpha1.SecurityConfig
 
 	// Determine the security context configuration based on GrpcPodConfig
 	if source.Spec.GrpcPodConfig != nil {

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -206,8 +206,21 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 		},
 	}
 
-	if source.Spec.GrpcPodConfig != nil && source.Spec.GrpcPodConfig.SecurityContextConfig == operatorsv1alpha1.Restricted {
-		addSecurityContext(pod, runAsUser)
+	// Check if GrpcPodConfig is defined
+	if source.Spec.GrpcPodConfig != nil {
+		// Determine the security context configuration
+		securityContextConfig := source.Spec.GrpcPodConfig.SecurityContextConfig
+
+		// Apply 'restricted' security settings if SecurityContextConfig is 'Restricted' or not set
+		if securityContextConfig == operatorsv1alpha1.Restricted || securityContextConfig == "" {
+			addSecurityContext(pod, runAsUser) // Apply restricted settings
+		} else {
+			// For 'Legacy' or any unspecified value, clear all security contexts
+			clearAllSecurityContexts(pod)
+		}
+	} else {
+		// If GrpcPodConfig is nil, apply 'restricted' security settings by default
+		addSecurityContext(pod, runAsUser) // Default to restricted settings
 	}
 
 	// Override scheduling options if specified
@@ -329,6 +342,14 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 	podAnnotations[ClusterAutoscalingAnnotationKey] = "true"
 
 	return pod, nil
+}
+
+func clearAllSecurityContexts(pod *corev1.Pod) {
+	// Helper function to clear all security contexts
+	pod.Spec.SecurityContext = nil // Clear pod-level security context
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].SecurityContext = nil // Clear each container's security context
+	}
 }
 
 func addSecurityContext(pod *corev1.Pod, runAsUser int64) {

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -3,6 +3,8 @@ package reconciler
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/image"
 	"github.com/stretchr/testify/require"
@@ -15,6 +17,7 @@ import (
 )
 
 const workloadUserID = 1001
+const defaultPodSecurityConfig = v1alpha1.Restricted
 
 func TestPodMemoryTarget(t *testing.T) {
 	q := resource.MustParse("5Mi")
@@ -30,17 +33,12 @@ func TestPodMemoryTarget(t *testing.T) {
 					Name:      "test",
 					Namespace: "testns",
 				},
-				Spec: v1alpha1.CatalogSourceSpec{
-					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
-						SecurityContextConfig: v1alpha1.Legacy, // explicitly Legacy context here
-					},
-				},
 			},
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "6YQsU6V4rkdxtIy1vfooVAmxQE0j8Jw51XXOLR", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "8SbHWyYfjbRT8lLcfdZ5ofXNdC1GE6ayztILTF", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -83,7 +81,9 @@ func TestPodMemoryTarget(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext:          nil,
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: ptr.To(false),
+							},
 							ImagePullPolicy:          image.InferImagePullPolicy("image"),
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 						},
@@ -102,8 +102,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
-						MemoryTarget:          &q,
-						SecurityContextConfig: v1alpha1.Legacy, // explicitly Legacy context here
+						MemoryTarget: &q,
 					},
 				},
 			},
@@ -111,7 +110,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "aIvr5zhIeva0r3l3JWvQql0ip62QWZZFaim7me", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "3DSBhZZIiOl5YIjTsZy9aRyFIXeDR8mZCGAcYA", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -156,7 +155,9 @@ func TestPodMemoryTarget(t *testing.T) {
 								},
 								Limits: corev1.ResourceList{},
 							},
-							SecurityContext:          nil,
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: ptr.To(false),
+							},
 							ImagePullPolicy:          image.InferImagePullPolicy("image"),
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 						},
@@ -201,17 +202,12 @@ func TestPodExtractContent(t *testing.T) {
 					Name:      "test",
 					Namespace: "testns",
 				},
-				Spec: v1alpha1.CatalogSourceSpec{
-					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
-						SecurityContextConfig: v1alpha1.Legacy, // explicitly set Legacy context here
-					},
-				},
 			},
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "6YQsU6V4rkdxtIy1vfooVAmxQE0j8Jw51XXOLR", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "8SbHWyYfjbRT8lLcfdZ5ofXNdC1GE6ayztILTF", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -254,7 +250,9 @@ func TestPodExtractContent(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext:          nil,
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: ptr.To(false),
+							},
 							ImagePullPolicy:          image.InferImagePullPolicy("image"),
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 						},
@@ -277,7 +275,6 @@ func TestPodExtractContent(t *testing.T) {
 							CacheDir:   "/tmp/cache",
 							CatalogDir: "/catalog",
 						},
-						SecurityContextConfig: v1alpha1.Legacy, // explicitly set Legacy context here
 					},
 				},
 			},
@@ -285,7 +282,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "33hBoCHVpVp7f8SthdV4mnslVjiyLhE7DAQfyM", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "5MSUJs07MqD3fl9supmPaRNxD9N6tK8Bjo4OFl", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -367,7 +364,9 @@ func TestPodExtractContent(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext:          nil,
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: ptr.To(false),
+							},
 							ImagePullPolicy:          image.InferImagePullPolicy("image"),
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts:             []corev1.VolumeMount{{Name: "catalog-content", MountPath: "/extracted-catalog"}},
@@ -513,17 +512,19 @@ func TestPodContainerSecurityContext(t *testing.T) {
 	testcases := []struct {
 		title                            string
 		inputCatsrc                      *v1alpha1.CatalogSource
+		namespacePodSecurityConfig       v1alpha1.SecurityConfig
 		expectedSecurityContext          *corev1.PodSecurityContext
 		expectedContainerSecurityContext *corev1.SecurityContext
 	}{
 		{
-			title: "NoSpecDefined/DefaultsToRestricted",
+			title: "NoSpecDefined/NamespaceRestricted/UseRestricted",
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: "testns",
+					Namespace: testNamespace,
 				},
 			},
+			namespacePodSecurityConfig: v1alpha1.Restricted,
 			expectedContainerSecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.To(false),
 				Capabilities: &corev1.Capabilities{
@@ -538,20 +539,33 @@ func TestPodContainerSecurityContext(t *testing.T) {
 			},
 		},
 		{
-			title: "SpecDefined/NoGRPCPodConfig/DefaultsToRestricted",
+			title:                      "NoSpecDefined/NamespaceNotRestricted/UseLegacy",
+			namespacePodSecurityConfig: v1alpha1.Legacy,
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: "testns",
+					Namespace: testNamespace,
 				},
-				Spec: v1alpha1.CatalogSourceSpec{}, // No GrpcPodConfig is defined, defaults to Restricted
 			},
+			expectedContainerSecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(false)},
+			expectedSecurityContext:          nil,
+		},
+		{
+			title: "SpecDefined/NoGRPCPodConfig/NamespaceRestricted/UseRestricted",
+			inputCatsrc: &v1alpha1.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: testNamespace,
+				},
+				Spec: v1alpha1.CatalogSourceSpec{},
+			},
+			namespacePodSecurityConfig: v1alpha1.Restricted,
 			expectedContainerSecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: ptr.To(false), // Aligns with 'restricted' policy right?
+				AllowPrivilegeEscalation: ptr.To(false),
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
 				},
-				ReadOnlyRootFilesystem: ptr.To(false), // Aligns with 'restricted' policy right?
+				ReadOnlyRootFilesystem: ptr.To(false),
 			},
 			expectedSecurityContext: &corev1.PodSecurityContext{
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
@@ -560,35 +574,26 @@ func TestPodContainerSecurityContext(t *testing.T) {
 			},
 		},
 		{
-			title: "SpecDefined/GRPCPodConfigDefined/DefaultsToRestricted",
+			title: "SpecDefined/NoGRPCPodConfig/NamespaceNotRestricted/UseLegacy",
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: "testns",
+					Namespace: testNamespace,
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{},
 				},
 			},
-			expectedContainerSecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: ptr.To(false),
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-				},
-				ReadOnlyRootFilesystem: ptr.To(false), // Aligns with 'restricted' policy right?
-			},
-			expectedSecurityContext: &corev1.PodSecurityContext{
-				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-				RunAsNonRoot:   ptr.To(true),
-				RunAsUser:      ptr.To(int64(workloadUserID)),
-			},
+			namespacePodSecurityConfig:       v1alpha1.Legacy,
+			expectedContainerSecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(false)},
+			expectedSecurityContext:          nil,
 		},
 		{
 			title: "SpecDefined/SecurityContextConfig:Legacy/NoChangeExpected",
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: "testns",
+					Namespace: testNamespace,
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
@@ -596,7 +601,8 @@ func TestPodContainerSecurityContext(t *testing.T) {
 					},
 				},
 			},
-			expectedContainerSecurityContext: nil,
+			namespacePodSecurityConfig:       v1alpha1.Restricted, // set to the opposite of the config to catch possible errors
+			expectedContainerSecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(false)},
 			expectedSecurityContext:          nil,
 		},
 		{
@@ -604,7 +610,7 @@ func TestPodContainerSecurityContext(t *testing.T) {
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: "testns",
+					Namespace: testNamespace,
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
@@ -612,6 +618,7 @@ func TestPodContainerSecurityContext(t *testing.T) {
 					},
 				},
 			},
+			namespacePodSecurityConfig: v1alpha1.Legacy, // set to the opposite of the config to catch possible errors
 			expectedContainerSecurityContext: &corev1.SecurityContext{
 				ReadOnlyRootFilesystem:   ptr.To(false),
 				AllowPrivilegeEscalation: ptr.To(false),
@@ -629,7 +636,7 @@ func TestPodContainerSecurityContext(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.title, func(t *testing.T) {
-			outputPod, err := Pod(testcase.inputCatsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), workloadUserID, v1alpha1.Legacy)
+			outputPod, err := Pod(testcase.inputCatsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), workloadUserID, testcase.namespacePodSecurityConfig)
 			require.NoError(t, err)
 
 			// Assert PodSecurityContext
@@ -897,5 +904,28 @@ func TestPodSchedulingOverrides(t *testing.T) {
 		require.Equal(t, testCase.expectedPriorityClassName, pod.Spec.PriorityClassName)
 		require.Equal(t, testCase.expectedTolerations, pod.Spec.Tolerations)
 		require.Equal(t, testCase.expectedAffinity, pod.Spec.Affinity)
+	}
+}
+
+// baseClusterState returns a list of runtime objects that are required for the tests to run including the
+// target namespace with the assumed default configuration
+func baseClusterState() []runtime.Object {
+	return []runtime.Object{
+		defaultNamespace(),
+	}
+}
+
+// defaultNamespace returns a kubernetes namespace with the assumes default settings,
+// e.g. Pod Security Admission security policy label
+func defaultNamespace() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNamespace,
+			Labels: map[string]string{
+				// catalogsource pod security configuration depends on the defaultNamespace psa configuration
+				// adding restricted PSA label as this is the default
+				"pod-security.kubernetes.io/enforce": "restricted",
+			},
+		},
 	}
 }

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -170,7 +170,7 @@ func TestPodMemoryTarget(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			pod, err := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+			pod, err := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID), v1alpha1.Legacy)
 			require.NoError(t, err)
 			if diff := cmp.Diff(pod, testCase.expected); diff != "" {
 				t.Errorf("got incorrect pod: %v", diff)
@@ -381,7 +381,7 @@ func TestPodExtractContent(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pod, err := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		pod, err := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID), v1alpha1.Legacy)
 		require.NoError(t, err)
 		if diff := cmp.Diff(pod, testCase.expected); diff != "" {
 			t.Errorf("got incorrect pod: %v", diff)
@@ -432,7 +432,7 @@ func TestPodServiceAccountImagePullSecrets(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pod, err := Pod(catalogSource, "name", "opmImage", "utilImage", "image", testCase.serviceAccount, map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+		pod, err := Pod(catalogSource, "name", "opmImage", "utilImage", "image", testCase.serviceAccount, map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID), v1alpha1.Legacy)
 		require.NoError(t, err)
 		if diff := cmp.Diff(testCase.serviceAccount.ImagePullSecrets, pod.Spec.ImagePullSecrets); diff != "" {
 			t.Errorf("got incorrect pod: %v", diff)
@@ -451,7 +451,7 @@ func TestPodNodeSelector(t *testing.T) {
 	key := "kubernetes.io/os"
 	value := "linux"
 
-	gotCatSrcPod, err := Pod(catsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+	gotCatSrcPod, err := Pod(catsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID), v1alpha1.Legacy)
 	require.NoError(t, err)
 	gotCatSrcPodSelector := gotCatSrcPod.Spec.NodeSelector
 
@@ -500,7 +500,7 @@ func TestPullPolicy(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		p, err := Pod(source, "catalog", "opmImage", "utilImage", tt.image, serviceAccount("", "service-account"), nil, nil, int32(0), int32(0), int64(workloadUserID))
+		p, err := Pod(source, "catalog", "opmImage", "utilImage", tt.image, serviceAccount("", "service-account"), nil, nil, int32(0), int32(0), int64(workloadUserID), v1alpha1.Legacy)
 		require.NoError(t, err)
 		policy := p.Spec.Containers[0].ImagePullPolicy
 		if policy != tt.policy {
@@ -629,19 +629,7 @@ func TestPodContainerSecurityContext(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.title, func(t *testing.T) {
-			outputPod, err := Pod(
-				testcase.inputCatsrc,
-				"hello",
-				"utilImage",
-				"opmImage",
-				"busybox",
-				serviceAccount("", "service-account"),
-				map[string]string{},
-				map[string]string{},
-				int32(0),
-				int32(0),
-				workloadUserID,
-			)
+			outputPod, err := Pod(testcase.inputCatsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), workloadUserID, v1alpha1.Legacy)
 			require.NoError(t, err)
 
 			// Assert PodSecurityContext
@@ -673,7 +661,7 @@ func TestPodAvoidsConcurrentWrite(t *testing.T) {
 		"annotation": "somethingelse",
 	}
 
-	gotPod, err := Pod(catsrc, "hello", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), labels, annotations, int32(0), int32(0), int64(workloadUserID))
+	gotPod, err := Pod(catsrc, "hello", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), labels, annotations, int32(0), int32(0), int64(workloadUserID), v1alpha1.Legacy)
 	require.NoError(t, err)
 
 	// check labels and annotations point to different addresses between parameters and what's in the pod
@@ -903,7 +891,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pod, err := Pod(testCase.catalogSource, "hello", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, testCase.annotations, int32(0), int32(0), int64(workloadUserID))
+		pod, err := Pod(testCase.catalogSource, "hello", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, testCase.annotations, int32(0), int32(0), int64(workloadUserID), v1alpha1.Legacy)
 		require.NoError(t, err)
 		require.Equal(t, testCase.expectedNodeSelectors, pod.Spec.NodeSelector)
 		require.Equal(t, testCase.expectedPriorityClassName, pod.Spec.PriorityClassName)

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -30,12 +30,17 @@ func TestPodMemoryTarget(t *testing.T) {
 					Name:      "test",
 					Namespace: "testns",
 				},
+				Spec: v1alpha1.CatalogSourceSpec{
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Legacy, // explicitly Legacy context here
+					},
+				},
 			},
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "8SbHWyYfjbRT8lLcfdZ5ofXNdC1GE6ayztILTF", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "6YQsU6V4rkdxtIy1vfooVAmxQE0j8Jw51XXOLR", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -78,9 +83,7 @@ func TestPodMemoryTarget(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								ReadOnlyRootFilesystem: ptr.To(bool(false)),
-							},
+							SecurityContext:          nil,
 							ImagePullPolicy:          image.InferImagePullPolicy("image"),
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 						},
@@ -99,7 +102,8 @@ func TestPodMemoryTarget(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
-						MemoryTarget: &q,
+						MemoryTarget:          &q,
+						SecurityContextConfig: v1alpha1.Legacy, // explicitly Legacy context here
 					},
 				},
 			},
@@ -107,7 +111,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "3DSBhZZIiOl5YIjTsZy9aRyFIXeDR8mZCGAcYA", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "aIvr5zhIeva0r3l3JWvQql0ip62QWZZFaim7me", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -152,9 +156,7 @@ func TestPodMemoryTarget(t *testing.T) {
 								},
 								Limits: corev1.ResourceList{},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								ReadOnlyRootFilesystem: ptr.To(bool(false)),
-							},
+							SecurityContext:          nil,
 							ImagePullPolicy:          image.InferImagePullPolicy("image"),
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 						},
@@ -167,11 +169,13 @@ func TestPodMemoryTarget(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pod, err := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
-		require.NoError(t, err)
-		if diff := cmp.Diff(pod, testCase.expected); diff != "" {
-			t.Errorf("got incorrect pod: %v", diff)
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			pod, err := Pod(testCase.input, "name", "opmImage", "utilImage", "image", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
+			require.NoError(t, err)
+			if diff := cmp.Diff(pod, testCase.expected); diff != "" {
+				t.Errorf("got incorrect pod: %v", diff)
+			}
+		})
 	}
 }
 
@@ -197,12 +201,17 @@ func TestPodExtractContent(t *testing.T) {
 					Name:      "test",
 					Namespace: "testns",
 				},
+				Spec: v1alpha1.CatalogSourceSpec{
+					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
+						SecurityContextConfig: v1alpha1.Legacy, // explicitly set Legacy context here
+					},
+				},
 			},
 			expected: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "8SbHWyYfjbRT8lLcfdZ5ofXNdC1GE6ayztILTF", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "6YQsU6V4rkdxtIy1vfooVAmxQE0j8Jw51XXOLR", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -245,9 +254,7 @@ func TestPodExtractContent(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								ReadOnlyRootFilesystem: ptr.To(bool(false)),
-							},
+							SecurityContext:          nil,
 							ImagePullPolicy:          image.InferImagePullPolicy("image"),
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 						},
@@ -270,6 +277,7 @@ func TestPodExtractContent(t *testing.T) {
 							CacheDir:   "/tmp/cache",
 							CatalogDir: "/catalog",
 						},
+						SecurityContextConfig: v1alpha1.Legacy, // explicitly set Legacy context here
 					},
 				},
 			},
@@ -277,7 +285,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "5MSUJs07MqD3fl9supmPaRNxD9N6tK8Bjo4OFl", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "33hBoCHVpVp7f8SthdV4mnslVjiyLhE7DAQfyM", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -359,9 +367,7 @@ func TestPodExtractContent(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								ReadOnlyRootFilesystem: ptr.To(bool(false)),
-							},
+							SecurityContext:          nil,
 							ImagePullPolicy:          image.InferImagePullPolicy("image"),
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts:             []corev1.VolumeMount{{Name: "catalog-content", MountPath: "/extracted-catalog"}},
@@ -511,30 +517,50 @@ func TestPodContainerSecurityContext(t *testing.T) {
 		expectedContainerSecurityContext *corev1.SecurityContext
 	}{
 		{
-			title: "NoSpecDefined/PodContainsSecurityConfigForPSALegacy",
+			title: "NoSpecDefined/DefaultsToRestricted",
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "testns",
 				},
 			},
-			expectedContainerSecurityContext: nil,
-			expectedSecurityContext:          nil,
+			expectedContainerSecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				ReadOnlyRootFilesystem: ptr.To(false), // Reflecting expected 'restricted' settings
+			},
+			expectedSecurityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				RunAsNonRoot:   ptr.To(true),
+				RunAsUser:      ptr.To(int64(workloadUserID)),
+			},
 		},
 		{
-			title: "SpecDefined/NoGRPCPodConfig/PodContainsSecurityConfigForPSALegacy",
+			title: "SpecDefined/NoGRPCPodConfig/DefaultsToRestricted",
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "testns",
 				},
-				Spec: v1alpha1.CatalogSourceSpec{},
+				Spec: v1alpha1.CatalogSourceSpec{}, // No GrpcPodConfig is defined, defaults to Restricted
 			},
-			expectedContainerSecurityContext: nil,
-			expectedSecurityContext:          nil,
+			expectedContainerSecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.To(false), // Aligns with 'restricted' policy right?
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				ReadOnlyRootFilesystem: ptr.To(false), // Aligns with 'restricted' policy right?
+			},
+			expectedSecurityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				RunAsNonRoot:   ptr.To(true),
+				RunAsUser:      ptr.To(int64(workloadUserID)),
+			},
 		},
 		{
-			title: "SpecDefined/GRPCPodConfigDefined/PodContainsSecurityConfigForPSALegacy",
+			title: "SpecDefined/GRPCPodConfigDefined/DefaultsToRestricted",
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
@@ -544,11 +570,21 @@ func TestPodContainerSecurityContext(t *testing.T) {
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{},
 				},
 			},
-			expectedContainerSecurityContext: nil,
-			expectedSecurityContext:          nil,
+			expectedContainerSecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				ReadOnlyRootFilesystem: ptr.To(false), // Aligns with 'restricted' policy right?
+			},
+			expectedSecurityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				RunAsNonRoot:   ptr.To(true),
+				RunAsUser:      ptr.To(int64(workloadUserID)),
+			},
 		},
 		{
-			title: "SpecDefined/SecurityContextConfig:Legacy/PodContainsSecurityConfigForPSALegacy",
+			title: "SpecDefined/SecurityContextConfig:Legacy/NoChangeExpected",
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
@@ -564,7 +600,7 @@ func TestPodContainerSecurityContext(t *testing.T) {
 			expectedSecurityContext:          nil,
 		},
 		{
-			title: "SpecDefined/SecurityContextConfig:Restricted/PodContainsSecurityConfigForPSARestricted",
+			title: "SpecDefined/SecurityContextConfig:Restricted/RestrictedSecurityConfigApplied",
 			inputCatsrc: &v1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
@@ -577,44 +613,43 @@ func TestPodContainerSecurityContext(t *testing.T) {
 				},
 			},
 			expectedContainerSecurityContext: &corev1.SecurityContext{
-				ReadOnlyRootFilesystem:   ptr.To(bool(false)),
-				AllowPrivilegeEscalation: ptr.To(bool(false)),
+				ReadOnlyRootFilesystem:   ptr.To(false),
+				AllowPrivilegeEscalation: ptr.To(false),
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
 				},
 			},
 			expectedSecurityContext: &corev1.PodSecurityContext{
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				RunAsNonRoot:   ptr.To(true),
 				RunAsUser:      ptr.To(int64(workloadUserID)),
-				RunAsNonRoot:   ptr.To(bool(true)),
 			},
-		},
-		{
-			title: "SpecDefined/SecurityContextConfig:Legacy/PodDoesNotContainsSecurityConfig",
-			inputCatsrc: &v1alpha1.CatalogSource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "testns",
-				},
-				Spec: v1alpha1.CatalogSourceSpec{
-					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
-						SecurityContextConfig: v1alpha1.Legacy,
-					},
-				},
-			},
-			expectedContainerSecurityContext: nil,
-			expectedSecurityContext:          nil,
 		},
 	}
+
 	for _, testcase := range testcases {
-		outputPod, err := Pod(testcase.inputCatsrc, "hello", "utilImage", "opmImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, map[string]string{}, int32(0), int32(0), int64(workloadUserID))
-		require.NoError(t, err)
-		if testcase.expectedSecurityContext != nil {
+		t.Run(testcase.title, func(t *testing.T) {
+			outputPod, err := Pod(
+				testcase.inputCatsrc,
+				"hello",
+				"utilImage",
+				"opmImage",
+				"busybox",
+				serviceAccount("", "service-account"),
+				map[string]string{},
+				map[string]string{},
+				int32(0),
+				int32(0),
+				workloadUserID,
+			)
+			require.NoError(t, err)
+
+			// Assert PodSecurityContext
 			require.Equal(t, testcase.expectedSecurityContext, outputPod.Spec.SecurityContext)
-		}
-		if testcase.expectedContainerSecurityContext != nil {
+
+			// Assert ContainerSecurityContext
 			require.Equal(t, testcase.expectedContainerSecurityContext, outputPod.Spec.Containers[0].SecurityContext)
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Before: by default CatalogSource would stamp out pods with the "legacy" security profile
Now: by default CatalogSource stamps out "restricted" security profile pods when in appropriately labeled namespaces and "legacy" otherwise

**Motivation for the change:**
Helps users be secure-by-default on PSA clusters when deploying in  "restricted" namespaces (no change for older clusters)

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
