### PR TITLE
Revert "Fix unpack job cache issue (#3204)"

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -671,9 +671,6 @@ func (c *ConfigMapUnpacker) ensureJob(cmRef *corev1.ObjectReference, bundlePath 
 	}
 	if len(jobs) == 0 {
 		job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Create(context.TODO(), fresh, metav1.CreateOptions{})
-		if apierrors.IsAlreadyExists(err) {
-			job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Update(context.TODO(), fresh, metav1.UpdateOptions{})
-		}
 		return
 	}
 
@@ -688,9 +685,6 @@ func (c *ConfigMapUnpacker) ensureJob(cmRef *corev1.ObjectReference, bundlePath 
 				if time.Now().After(cond.LastTransitionTime.Time.Add(unpackRetryInterval)) {
 					fresh.SetName(names.SimpleNameGenerator.GenerateName(fresh.GetName()))
 					job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Create(context.TODO(), fresh, metav1.CreateOptions{})
-					if apierrors.IsAlreadyExists(err) {
-						job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Update(context.TODO(), fresh, metav1.UpdateOptions{})
-					}
 				}
 			}
 


### PR DESCRIPTION
This reverts commit 47aaa6be4a951c6bd8be016f6610c5319adc6a47.

We previously thought this would:
1. Fix jobs not getting listed due to labeler changes
2. Add the labels to jobs when creating existing jobs then updating instead

Instead we've found that jobs created in 4.14 already meet the requirements to be listed by the labeller and that also updating the jobs in this manner can be detrimental because every field in the pod template is immutable and thus generates lots of errors when the update runs.

We'll need to find out why the jobs aren't getting listed and how to handle that in this case in another way. We think the root cause has something to do with the filtering we do [here](https://github.com/operator-framework/operator-lifecycle-manager/blob/32d8782ecf2b83eabd2eea8b158824c7cc9b0e4a/pkg/controller/bundle/bundle_unpacker.go#L668).