### PR TITLE
[WIP] experiment: refactor e2e to create one job per spec

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parallel-id: [0, 1, 2, 3]
+        parallel-id: [
+          "MagicCatalog",
+          "Operator API",
+          "Fail Forward Upgrades",
+          "User defined service account",
+          "Installing bundles with new object types",
+          "Global Catalog Exclusion",
+          "CatalogSource Grpc Pod Config",
+          "ClusterServiceVersion",
+          "Not found APIs",
+          "Disabling copied CSVs",
+          "Subscriptions create required objects from Catalogs",
+          "Operator Condition",
+          "Operator Group",
+          "Package Manifest API lists available Operators from Catalog Sources",
+          "ResourceManager",
+          "Scoped Client bound to a service account can be used to make API calls",
+          "CSVs with a Webhook",
+          "Subscription",
+          "Garbage collection for dependent resources",
+          "CRD Versions",
+          "Install Plan",
+          "Starting CatalogSource e2e tests",
+          "Metrics are generated for OLM managed resources"
+        ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +45,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - run: mkdir -p artifacts
-      - run: make e2e-local E2E_TEST_CHUNK=${{ matrix.parallel-id }} E2E_TEST_NUM_CHUNKS=${{ strategy.job-total }} E2E_NODES=2 ARTIFACT_DIR=./artifacts/ SKIP='\[FLAKE\]'
+      - run: make e2e-local E2E_NODES=1 ARTIFACT_DIR=./artifacts/ SKIP='\[FLAKE\]' TEST='${{ matrix.parallel-id }} .*'
       - name: Archive Test Artifacts # test results, failed or not, are always uploaded.
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - run: mkdir -p artifacts
-      - run: make e2e-local E2E_NODES=1 ARTIFACT_DIR=./artifacts/ SKIP='\[FLAKE\]' TEST='${{ matrix.parallel-id }} .*'
+      - run: make e2e-local E2E_NODES=4 ARTIFACT_DIR=./artifacts/ SKIP='\[FLAKE\]' TEST='${{ matrix.parallel-id }} .*'
       - name: Archive Test Artifacts # test results, failed or not, are always uploaded.
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
