### PR TITLE
fix: Refactor test package names

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -1449,7 +1449,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 						CatalogSource:          catalogSourceName,
 						CatalogSourceNamespace: generatedNamespace.GetName(),
 						Channel:                "stable",
-						Package:                "packageA",
+						Package:                "test-package",
 					},
 				}
 				Expect(c.Create(context.Background(), subscription)).To(BeNil())

--- a/test/e2e/catalog_exclusion_test.go
+++ b/test/e2e/catalog_exclusion_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 				Spec: &v1alpha1.SubscriptionSpec{
 					CatalogSource:          localCatalog.GetName(),
 					CatalogSourceNamespace: localCatalog.GetNamespace(),
-					Package:                "packageA",
+					Package:                "test-package",
 					Channel:                "stable",
 					InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 				},

--- a/test/e2e/data/catalog.new.yaml
+++ b/test/e2e/data/catalog.new.yaml
@@ -1,4 +1,4 @@
-# Contains PackageB (Updated), PackageC (new)
+# Contains another-package (Updated), PackageC (new)
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/test/e2e/data/catalog.old.yaml
+++ b/test/e2e/data/catalog.old.yaml
@@ -1,4 +1,4 @@
-# Contains PackageA, PackageB
+# Contains test-package, another-package
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/test/e2e/fail_forward_e2e_test.go
+++ b/test/e2e/fail_forward_e2e_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 					CatalogSource:          catalogSourceName,
 					CatalogSourceNamespace: generatedNamespace.GetName(),
 					Channel:                "stable",
-					Package:                "packageA",
+					Package:                "test-package",
 				},
 			}
 			Expect(c.Create(context.Background(), subscription)).To(BeNil())
@@ -348,7 +348,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 					CatalogSource:          catalogSourceName,
 					CatalogSourceNamespace: generatedNamespace.GetName(),
 					Channel:                "stable",
-					Package:                "packageA",
+					Package:                "test-package",
 				},
 			}
 			Expect(c.Create(context.Background(), subscription)).To(BeNil())

--- a/test/e2e/magic_catalog_test.go
+++ b/test/e2e/magic_catalog_test.go
@@ -90,11 +90,11 @@ var _ = Describe("MagicCatalog", func() {
 					return data
 				}, ContainSubstring(`---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: busybox.v2.0.0
@@ -102,7 +102,7 @@ entries:
 ---
 schema: olm.bundle
 name: busybox.v2.0.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/busybox-bundle:2.0.0
 properties:
   - type: olm.gvk
@@ -112,7 +112,7 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0
 `)),
 			))

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -1461,16 +1461,19 @@ var _ = Describe("Subscription", func() {
 		By(`csvs for catalogsource 2`)
 		csvs2 := make([]operatorsv1alpha1.ClusterServiceVersion, 0)
 
-		packageA := registry.PackageManifest{PackageName: "PackageA"}
+		test -package := registry.PackageManifest{PackageName: "test-package"}
 		By("Package A", func() {
 			Step(1, "Default Channel: Stable", func() {
-				packageA.DefaultChannelName = stableChannel
+				test -package.
+				DefaultChannelName = stableChannel
 			})
 
 			Step(1, "Channel Stable", func() {
 				Step(2, "Operator A (Requires CRD, CRD 2)", func() {
 					csvA := newCSV("csv-a", generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensionsv1.CustomResourceDefinition{crd, crd2}, nil)
-					packageA.Channels = append(packageA.Channels, registry.PackageChannel{Name: stableChannel, CurrentCSVName: csvA.GetName()})
+					test -package.
+					Channels = append(test -package.
+					Channels, registry.PackageChannel{Name: stableChannel, CurrentCSVName: csvA.GetName()})
 					csvs1 = append(csvs1, csvA)
 				})
 			})
@@ -1478,22 +1481,24 @@ var _ = Describe("Subscription", func() {
 			Step(1, "Channel Alpha", func() {
 				Step(2, "Operator ABC (Provides: CRD, CRD 2)", func() {
 					csvABC := newCSV("csv-abc", generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensionsv1.CustomResourceDefinition{crd, crd2}, nil, nil)
-					packageA.Channels = append(packageA.Channels, registry.PackageChannel{Name: alphaChannel, CurrentCSVName: csvABC.GetName()})
+					test -package.
+					Channels = append(test -package.
+					Channels, registry.PackageChannel{Name: alphaChannel, CurrentCSVName: csvABC.GetName()})
 					csvs1 = append(csvs1, csvABC)
 				})
 			})
 		})
 
-		packageB := registry.PackageManifest{PackageName: "PackageB"}
+		another-package := registry.PackageManifest{PackageName: "another-package"}
 		By("Package B", func() {
 			Step(1, "Default Channel: Stable", func() {
-				packageB.DefaultChannelName = stableChannel
+				another-package.DefaultChannelName = stableChannel
 			})
 
 			Step(1, "Channel Stable", func() {
 				Step(2, "Operator B (Provides: CRD)", func() {
 					csvB := newCSV("csv-b", generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensionsv1.CustomResourceDefinition{crd}, nil, nil)
-					packageB.Channels = append(packageB.Channels, registry.PackageChannel{Name: stableChannel, CurrentCSVName: csvB.GetName()})
+					another-package.Channels = append(another-package.Channels, registry.PackageChannel{Name: stableChannel, CurrentCSVName: csvB.GetName()})
 					csvs1 = append(csvs1, csvB)
 				})
 			})
@@ -1501,13 +1506,13 @@ var _ = Describe("Subscription", func() {
 			Step(1, "Channel Alpha", func() {
 				Step(2, "Operator D (Provides: CRD)", func() {
 					csvD := newCSV("csv-d", generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensionsv1.CustomResourceDefinition{crd}, nil, nil)
-					packageB.Channels = append(packageB.Channels, registry.PackageChannel{Name: alphaChannel, CurrentCSVName: csvD.GetName()})
+					another-package.Channels = append(another-package.Channels, registry.PackageChannel{Name: alphaChannel, CurrentCSVName: csvD.GetName()})
 					csvs1 = append(csvs1, csvD)
 				})
 			})
 		})
 
-		packageBInCatsrc2 := registry.PackageManifest{PackageName: "PackageB"}
+		packageBInCatsrc2 := registry.PackageManifest{PackageName: "another-package"}
 		By("Package B", func() {
 			Step(1, "Default Channel: Stable", func() {
 				packageBInCatsrc2.DefaultChannelName = stableChannel
@@ -1542,7 +1547,7 @@ var _ = Describe("Subscription", func() {
 		var cleanup cleanupFunc
 		By("creating catalogsources", func() {
 			var c1, c2 cleanupFunc
-			catsrc, c1 = createInternalCatalogSource(kubeClient, crClient, genName("catsrc"), generatedNamespace.GetName(), []registry.PackageManifest{packageA, packageB}, []apiextensionsv1.CustomResourceDefinition{crd, crd2}, csvs1)
+			catsrc, c1 = createInternalCatalogSource(kubeClient, crClient, genName("catsrc"), generatedNamespace.GetName(), []registry.PackageManifest{test -package, another-package}, []apiextensionsv1.CustomResourceDefinition{crd, crd2}, csvs1)
 			catsrc2, c2 = createInternalCatalogSource(kubeClient, crClient, genName("catsrc2"), generatedNamespace.GetName(), []registry.PackageManifest{packageBInCatsrc2, packageC}, []apiextensionsv1.CustomResourceDefinition{crd, crd2}, csvs2)
 			cleanup = func() {
 				c1()
@@ -1558,11 +1563,11 @@ var _ = Describe("Subscription", func() {
 			require.NoError(GinkgoT(), err)
 		})
 
-		By(`Create a subscription for packageA in catsrc`)
+		By(`Create a subscription for test-package in catsrc`)
 		subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
 			CatalogSource:          catsrc.GetName(),
 			CatalogSourceNamespace: catsrc.GetNamespace(),
-			Package:                packageA.PackageName,
+			Package:                test -package.PackageName,
 			Channel:                stableChannel,
 			InstallPlanApproval:    operatorsv1alpha1.ApprovalAutomatic,
 		}
@@ -1668,7 +1673,7 @@ var _ = Describe("Subscription", func() {
 				var subscription *operatorsv1alpha1.Subscription
 
 				BeforeEach(func() {
-					By(`Create a subscription for packageA in catsrc`)
+					By(`Create a subscription for test-package in catsrc`)
 					subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
 						CatalogSource:          catsrcMain.GetName(),
 						CatalogSourceNamespace: catsrcMain.GetNamespace(),
@@ -1756,7 +1761,7 @@ var _ = Describe("Subscription", func() {
 				var subscription *operatorsv1alpha1.Subscription
 
 				BeforeEach(func() {
-					By(`Create a subscription for packageA in catsrc`)
+					By(`Create a subscription for test-package in catsrc`)
 					subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
 						CatalogSource:          catsrcMain.GetName(),
 						CatalogSourceNamespace: catsrcMain.GetNamespace(),
@@ -1850,7 +1855,7 @@ var _ = Describe("Subscription", func() {
 				var subscription *operatorsv1alpha1.Subscription
 
 				BeforeEach(func() {
-					By(`Create a subscription for packageA in catsrc`)
+					By(`Create a subscription for test-package in catsrc`)
 					subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
 						CatalogSource:          catsrcMain.GetName(),
 						CatalogSourceNamespace: catsrcMain.GetNamespace(),
@@ -1944,7 +1949,7 @@ var _ = Describe("Subscription", func() {
 				var subscription *operatorsv1alpha1.Subscription
 
 				BeforeEach(func() {
-					By(`Create a subscription for packageA in catsrc`)
+					By(`Create a subscription for test-package in catsrc`)
 					subscriptionSpec := &operatorsv1alpha1.SubscriptionSpec{
 						CatalogSource:          catsrcMain.GetName(),
 						CatalogSourceNamespace: catsrcMain.GetNamespace(),
@@ -2156,7 +2161,7 @@ var _ = Describe("Subscription", func() {
 
 			packages = []registry.PackageManifest{
 				{
-					PackageName: "packageA",
+					PackageName: "test-package",
 					Channels: []registry.PackageChannel{
 						{Name: "alpha", CurrentCSVName: "csvA"},
 					},
@@ -2171,7 +2176,7 @@ var _ = Describe("Subscription", func() {
 			_, err := fetchCatalogSourceOnStatus(crc, catSrcName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced())
 			require.NoError(GinkgoT(), err)
 
-			cleanup = createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subName, catSrcName, "packageA", "alpha", "", operatorsv1alpha1.ApprovalAutomatic)
+			cleanup = createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subName, catSrcName, "test-package", "alpha", "", operatorsv1alpha1.ApprovalAutomatic)
 		})
 
 		AfterEach(func() {
@@ -2193,7 +2198,7 @@ var _ = Describe("Subscription", func() {
 
 			BeforeEach(func() {
 				newPkg := registry.PackageManifest{
-					PackageName: "PackageB",
+					PackageName: "another-package",
 					Channels: []registry.PackageChannel{
 						{Name: "alpha", CurrentCSVName: "csvB"},
 					},
@@ -2422,8 +2427,8 @@ var _ = Describe("Subscription", func() {
 			Expect(magicCatalog.DeployCatalog(context.Background())).To(BeNil())
 
 			By("creating the testing subscription")
-			subName = fmt.Sprintf("%s-packagea-sub", generatedNamespace.GetName())
-			createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subName, catalogSourceName, "packageA", stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subName = fmt.Sprintf("%s-test-package-sub", generatedNamespace.GetName())
+			createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subName, catalogSourceName, "test-package", stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 
 			By("waiting until the subscription has an IP reference")
 			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionHasInstallPlanChecker())
@@ -2600,7 +2605,7 @@ var _ = Describe("Subscription", func() {
 					operatorsv1alpha1.SubscriptionPackageDeprecated,
 					corev1.ConditionTrue,
 					"",
-					"olm.package/packageA: packageA has been deprecated. Please switch to packageB."))
+					"olm.package/test-package: test-package has been deprecated. Please switch to another-package."))
 				Expect(err).Should(BeNil())
 
 				By("checking for the deprecated conditions")
@@ -2827,8 +2832,8 @@ properties:
 			Expect(magicCatalog.DeployCatalog(context.Background())).To(BeNil())
 
 			By("creating the testing subscription")
-			subName := fmt.Sprintf("%s-packagea-sub", generatedNamespace.GetName())
-			createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subName, catalogSourceName, "packageA", stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subName := fmt.Sprintf("%s-test-package-sub", generatedNamespace.GetName())
+			createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subName, catalogSourceName, "test-package", stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 
 			By("waiting until the subscription has an IP reference")
 			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionHasInstallPlanChecker())

--- a/test/e2e/testdata/bad-csv/bad-csv.yaml
+++ b/test/e2e/testdata/bad-csv/bad-csv.yaml
@@ -1,17 +1,17 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: bad-csv
 ---
 schema: olm.bundle
 name: bad-csv
-package: packageA
+package: test-package
 image: quay.io/olmtest/missing_api_version:latest
 properties:
   - type: olm.gvk
@@ -21,5 +21,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0

--- a/test/e2e/testdata/fail-forward/v0.1.0/packagemanifest.yaml
+++ b/test/e2e/testdata/fail-forward/v0.1.0/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.1.0

--- a/test/e2e/testdata/fail-forward/v0.2.0-invalid-csv/packagemanifest.yaml
+++ b/test/e2e/testdata/fail-forward/v0.2.0-invalid-csv/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.2.0&invalid

--- a/test/e2e/testdata/fail-forward/v0.2.0-invalid-deployment/packagemanifest.yaml
+++ b/test/e2e/testdata/fail-forward/v0.2.0-invalid-deployment/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.2.0

--- a/test/e2e/testdata/fail-forward/v0.2.1-invalid-csv/packagemanifest.yaml
+++ b/test/e2e/testdata/fail-forward/v0.2.1-invalid-csv/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.2.1&invalid

--- a/test/e2e/testdata/fail-forward/v0.3.0-replaces-invalid-csv/packagemanifest.yaml
+++ b/test/e2e/testdata/fail-forward/v0.3.0-replaces-invalid-csv/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.3.0

--- a/test/e2e/testdata/fail-forward/v0.3.0-replaces-invalid-deployment/packagemanifest.yaml
+++ b/test/e2e/testdata/fail-forward/v0.3.0-replaces-invalid-deployment/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.3.0

--- a/test/e2e/testdata/fail-forward/v0.3.0-skip-range/packagemanifest.yaml
+++ b/test/e2e/testdata/fail-forward/v0.3.0-skip-range/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.3.0

--- a/test/e2e/testdata/fail-forward/v0.3.0-skips/packagemanifest.yaml
+++ b/test/e2e/testdata/fail-forward/v0.3.0-skips/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.3.0

--- a/test/e2e/testdata/magiccatalog/fbc_catalog.json
+++ b/test/e2e/testdata/magiccatalog/fbc_catalog.json
@@ -1,23 +1,23 @@
 {
   "schema": "olm.package",
-  "name": "packageA",
+  "name": "test-package",
   "defaultChannel": "stable"
 }
 {
   "schema": "olm.channel",
   "name": "stable",
-  "package": "packageA",
+  "package": "test-package",
   "entries": [
     {
-      "name": "packageA.v1.0.0"
+      "name": "test-package.v1.0.0"
     }
   ]
 }
 {
   "schema": "olm.bundle",
-  "name": "packageA.v1.0.0",
-  "package": "packageA",
-  "image": "packageA:v1.0.0",
+  "name": "test-package.v1.0.0",
+  "package": "test-package",
+  "image": "test-package:v1.0.0",
   "properties": [
     {
       "type": "olm.gvk",
@@ -30,7 +30,7 @@
     {
       "type": "olm.package",
       "value": {
-        "packageName": "packageA",
+        "packageName": "test-package",
         "version": "1.0.0"
       }
     }

--- a/test/e2e/testdata/magiccatalog/fbc_initial.yaml
+++ b/test/e2e/testdata/magiccatalog/fbc_initial.yaml
@@ -1,17 +1,17 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: busybox.v1.0.0
 ---
 schema: olm.bundle
 name: busybox.v1.0.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/busybox-bundle:1.0.0
 properties:
   - type: olm.gvk
@@ -21,5 +21,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0

--- a/test/e2e/testdata/magiccatalog/fbc_updated.yaml
+++ b/test/e2e/testdata/magiccatalog/fbc_updated.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: busybox.v2.0.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: busybox.v2.0.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/busybox-bundle:2.0.0
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0

--- a/test/e2e/testdata/subscription/example-operator.v0.1.0.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.1.0.yaml
@@ -1,17 +1,17 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.1.0
 ---
 schema: olm.bundle
 name: example-operator.v0.1.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.1.0
 properties:
   - type: olm.gvk
@@ -21,5 +21,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0

--- a/test/e2e/testdata/subscription/example-operator.v0.2.0-deprecations.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.2.0-deprecations.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.2.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.2.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.2.0
 properties:
   - type: olm.gvk
@@ -22,15 +22,15 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.1
 ---
 schema: olm.deprecations
-package: packageA
+package: test-package
 entries:
   - reference:
       schema: olm.package
-    message: packageA has been deprecated. Please switch to packageB.
+    message: test-package has been deprecated. Please switch to another-package.
   - reference:
       schema: olm.channel
       name: stable

--- a/test/e2e/testdata/subscription/example-operator.v0.2.0-invalid-csv.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.2.0-invalid-csv.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.2.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.2.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.2.0-invalid-csv
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.1

--- a/test/e2e/testdata/subscription/example-operator.v0.2.0-non-existent-tag.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.2.0-non-existent-tag.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.2.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.2.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:non-existent-tag
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.1

--- a/test/e2e/testdata/subscription/example-operator.v0.2.0.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.2.0.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.2.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.2.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.2.0
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.1

--- a/test/e2e/testdata/subscription/example-operator.v0.3.0-deprecations.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.3.0-deprecations.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.3.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.3.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.3.0
 properties:
   - type: olm.gvk
@@ -22,15 +22,15 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 0.3.0
 ---
 schema: olm.deprecations
-package: packageA
+package: test-package
 entries:
   - reference:
       schema: olm.package
-    message: packageA has been deprecated. Please switch to packageB.
+    message: test-package has been deprecated. Please switch to another-package.
   - reference:
       schema: olm.channel
       name: stable

--- a/test/e2e/testdata/subscription/example-operator.v0.3.0.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.3.0.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.3.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.3.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.3.0
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 0.3.0


### PR DESCRIPTION
**Description of the change:**
In our test catalogs we have packages with names 'packageA' and 'packageB'. This seems to break e2e tests:

```
time="2024-05-16T09:18:58Z" level=fatal msg="failed to load or rebuild cache: failed to rebuild cache: build package
index: process package \"packageA\": invalid package name \"packageA\": [a lowercase RFC 1123 label must consist of
lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or
'123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]"
```

**Motivation for the change:**

**Architectural changes:**

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
