### PR TITLE
:seedling: make installplan e2e test case more robust to update conflict errors

### DIFF
--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -2263,12 +2263,24 @@ var _ = Describe("Install Plan", func() {
 				Permissions:        permissions,
 				ClusterPermissions: clusterPermissions,
 			}
-			csv.Spec.InstallStrategy = operatorsv1alpha1.NamedInstallStrategy{
-				StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-				StrategySpec: modifiedDetails,
-			}
-			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.Background(), csv, metav1.UpdateOptions{})
-			require.NoError(GinkgoT(), err)
+
+			Eventually(func() error {
+				// get latest version of CSV
+				csv, err := crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), csv.GetName(), metav1.GetOptions{})
+				if err != nil {
+					return nil
+				}
+
+				// update spec
+				csv.Spec.InstallStrategy = operatorsv1alpha1.NamedInstallStrategy{
+					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+					StrategySpec: modifiedDetails,
+				}
+
+				// update csv
+				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.Background(), csv, metav1.UpdateOptions{})
+				return err
+			}).Should(Succeed())
 
 			By(`Wait for csv to update`)
 			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)


### PR DESCRIPTION
**Description of the change:**
One of the install plan e2e test cases updates a csv. This sometimes raises a conflict error, failing the test.
This PR adds an eventually around the csv update

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
