### PR TITLE
:seedling: parameterizes the e2e target and pins opm images

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       # set e2e environment variables
       # Set ginkgo output and parallelism
-      - run: echo "GINKGO_E2E_OPTS=-output-dir ${ARTIFACT_DIR} -junit-report junit_e2e.xml -nodes ${E2E_NODES}" >> $GITHUB_ENV
+      - run: echo "GINKGO_OPTS=-output-dir ${ARTIFACT_DIR} -junit-report junit_e2e.xml -nodes ${E2E_NODES}" >> $GITHUB_ENV
 
       # Setting -kubeconfig-root tells the e2e test suite to look for kubeconfigs
       # in <kubeconfig-root>/kubeconfig-<node-number>
@@ -98,7 +98,7 @@ jobs:
         # focus on those tests and skip tests marked as FLAKE
         run: |
           E2E_TEST_NUM_CHUNKS=$(( ${{ strategy.job-total }} - 1 )) \
-          GINKGO_E2E_OPTS="${GINKGO_E2E_OPTS} -focus '$(go run ./test/e2e/split/... -chunks $E2E_TEST_NUM_CHUNKS -print-chunk $E2E_TEST_CHUNK ./test/e2e)' -skip '\[FLAKE\]'" \
+          GINKGO_OPTS="${GINKGO_OPTS} -focus '$(go run ./test/e2e/split/... -chunks $E2E_TEST_NUM_CHUNKS -print-chunk $E2E_TEST_CHUNK ./test/e2e)' -skip '\[FLAKE\]'" \
           make e2e;
 
       # run e2e tests for flakes if matrix-id is 'flakes'
@@ -106,7 +106,7 @@ jobs:
         if: ${{ matrix.parallel-id == 'flakes' }}
         # focus on tests marked as FLAKE
         run: |
-          GINKGO_E2E_OPTS="${GINKGO_E2E_OPTS} -focus '\[FLAKE\]'" make e2e
+          GINKGO_OPTS="${GINKGO_OPTS} -focus '\[FLAKE\]'" make e2e
 
       # archive test results
       - name: Archive Test Artifacts

--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,16 @@ e2e.namespace:
 	@printf "e2e-tests-$(shell date +%s)-$$RANDOM" > e2e.namespace
 
 .PHONY: e2e
-GINKGO_E2E_OPTS += -timeout 90m -v -randomize-suites -race -trace --show-node-events
-E2E_OPTS += -namespace=operators -olmNamespace=operator-lifecycle-manager -catalogNamespace=operator-lifecycle-manager -dummyImage=bitnami/nginx:latest
+E2E_TIMEOUT ?= 90m
+E2E_TEST_NS ?= operators
+E2E_INSTALL_NS ?= operator-lifecycle-manager
+E2E_CATALOG_NS ?= $(E2E_INSTALL_NS)
+GINKGO_OPTS += -v -randomize-suites -race -trace --show-node-events
 e2e:
-	$(GINKGO) $(GINKGO_E2E_OPTS) ./test/e2e -- $(E2E_OPTS)
+	$(GINKGO) -timeout $(E2E_TIMEOUT) $(GINKGO_OPTS) ./test/e2e -- -namespace=E2E_TEST_NS -olmNamespace=$(E2E_INSTALL_NS) -catalogNamespace=$(E2E_CATALOG_NS) $(E2E_OPTS)
+
+.PHONY: e2e-local
+e2e-local: e2e-build kind-create deploy e2e
 
 .PHONY: kind-clean
 kind-clean:

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,13 @@ KIND_NODE_VERSION ?= $(KUBE_MINOR).0
 KIND_CLUSTER_NAME ?= kind-olmv0
 KIND_CLUSTER_IMAGE := kindest/node:v$(KIND_NODE_VERSION)
 
+# Take operator registry tag from operator registry version in go.mod
+export OPERATOR_REGISTRY_TAG ?= $(shell go list -m github.com/operator-framework/operator-registry | cut -d" " -f2)
+
+# Pin operator registry images to the OPERATOR_REGISTRY_TAG
+export OPERATOR_REGISTRY_IMAGE ?= quay.io/operator-framework/opm:$(OPERATOR_REGISTRY_TAG)
+export CONFIGMAP_SERVER_IMAGE ?= quay.io/operator-framework/configmap-operator-registry:$(OPERATOR_REGISTRY_TAG)
+
 # Phony prerequisite for targets that rely on the go build cache to determine staleness.
 .PHONY: build test clean vendor \
 	coverage coverage-html e2e \
@@ -132,7 +139,7 @@ E2E_INSTALL_NS ?= operator-lifecycle-manager
 E2E_CATALOG_NS ?= $(E2E_INSTALL_NS)
 GINKGO_OPTS += -v -randomize-suites -race -trace --show-node-events
 e2e:
-	$(GINKGO) -timeout $(E2E_TIMEOUT) $(GINKGO_OPTS) ./test/e2e -- -namespace=E2E_TEST_NS -olmNamespace=$(E2E_INSTALL_NS) -catalogNamespace=$(E2E_CATALOG_NS) $(E2E_OPTS)
+	$(GINKGO) -timeout $(E2E_TIMEOUT) $(GINKGO_OPTS) ./test/e2e -- -namespace=$(E2E_TEST_NS) -olmNamespace=$(E2E_INSTALL_NS) -catalogNamespace=$(E2E_CATALOG_NS) $(E2E_OPTS)
 
 .PHONY: e2e-local
 e2e-local: e2e-build kind-create deploy e2e
@@ -150,12 +157,14 @@ kind-create: kind-clean
 OLM_IMAGE := quay.io/operator-framework/olm:local
 deploy:
 	$(KIND) load docker-image $(OLM_IMAGE) --name $(KIND_CLUSTER_NAME); \
-	$(HELM) install olm deploy/chart \
+	$(HELM) upgrade --install olm deploy/chart \
 		--set debug=true \
 		--set olm.image.ref=$(OLM_IMAGE) \
 		--set olm.image.pullPolicy=IfNotPresent \
 		--set catalog.image.ref=$(OLM_IMAGE) \
 		--set catalog.image.pullPolicy=IfNotPresent \
+		--set catalog.commandArgs=--configmapServerImage=$(CONFIGMAP_SERVER_IMAGE)\
+		--set catalog.opmImageArgs=--opmImage=$(OPERATOR_REGISTRY_IMAGE) \
 		--set package.image.ref=$(OLM_IMAGE) \
 		--set package.image.pullPolicy=IfNotPresent \
 		$(HELM_INSTALL_OPTS) \
@@ -164,7 +173,6 @@ deploy:
 .PHONY: e2e-build
 e2e-build: BUILD_TAGS="json1 e2e experimental_metrics"
 e2e-build: export GOOS=linux
-e2e-build: export GOARCH=amd64
 e2e-build: build_cmd=build
 e2e-build: e2e.Dockerfile bin/wait bin/cpb $(CMDS)
 	docker build -t quay.io/operator-framework/olm:local -f $< bin

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -40,6 +40,7 @@ catalog:
   setWorkloadUserID: true
   replicaCount: 1
   commandArgs: --configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
+  opmImageArgs: --opmImage=quay.io/operator-framework/opm:latest
   image:
     ref: quay.io/operator-framework/olm:master
     pullPolicy: Always

--- a/test/e2e/magic_catalog.go
+++ b/test/e2e/magic_catalog.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -257,11 +258,15 @@ func (c *MagicCatalog) makeCatalogSource() *operatorsv1alpha1.CatalogSource {
 func (c *MagicCatalog) makeCatalogSourcePod() *corev1.Pod {
 
 	const (
-		image                  = "quay.io/operator-framework/opm"
 		readinessDelay  int32  = 5
 		livenessDelay   int32  = 10
 		volumeMountName string = "fbc-catalog"
 	)
+
+	var image = "quay.io/operator-framework/opm"
+	if os.Getenv("OPERATOR_REGISTRY_TAG") != "" {
+		image = fmt.Sprintf("quay.io/operator-framework/opm:%s", os.Getenv("OPERATOR_REGISTRY_TAG"))
+	}
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**Description of the change:**
The previous refactored parametrization of the e2e target was too restrictive. This PR re-introduces parameters to configure the e2e test command.

It has also come to our attention that opm:latest images are being used in e2e tests. This PR also pins the opm images to the relevant version of operator-registry

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
