### PR TITLE
:seedling: add copy-content to goreleaser and release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,6 +74,23 @@ builds:
     ldflags:
     - -X {{ .Env.PKG }}/pkg/version.GitCommit={{ .FullCommit }}
     - -X {{ .Env.PKG }}/pkg/version.OLMVersion={{ .Tag }}
+  - id: copy-content
+    main: ./cmd/copy-content
+    binary: copy-content
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - ppc64le
+      - s390x
+    tags:
+      - json1
+    flags:
+      - -mod=vendor
+    ldflags:
+      - -X {{ .Env.PKG }}/pkg/version.GitCommit={{ .FullCommit }}
+      - -X {{ .Env.PKG }}/pkg/version.OLMVersion={{ .Tag }}
 dockers:
 - image_templates:
   - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -7,6 +7,7 @@ RUN ["/busybox/ln", "-s", "/busybox/cp", "/bin/cp"]
 COPY olm /bin/olm
 COPY catalog /bin/catalog
 COPY package-server /bin/package-server
+COPY copy-content /bin/copy-content
 COPY cpb /bin/cpb
 EXPOSE 8080
 EXPOSE 5443


### PR DESCRIPTION
**Description of the change:**
I've noticed that `copy-content` is missing from the release artifacts. This PR adds it to goreleaser and the released images

**Motivation for the change:**
copy-content is used for a particular mode of CatalogSource that uses the registry image only for its content (not using its opm server)

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
