### PR TITLE
:seedling: patch flakes

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -4030,7 +4030,7 @@ func TestUpdates(t *testing.T) {
 					csvsToSync = syncCSVs(csvsToSync, deletedCSVs(e.shouldBe))
 					current = csvsToSync[e.whenIn.name]
 					fmt.Printf("waiting for (when) %s to be %s\n", e.whenIn.name, e.whenIn.phase)
-					time.Sleep(1 * time.Millisecond)
+					time.Sleep(1 * time.Second)
 				}
 
 				// sync the other csvs until they're in the expected status

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2597,13 +2597,19 @@ var _ = Describe("Subscription", func() {
 				err = magicCatalog.UpdateCatalog(context.Background(), provider)
 				Expect(err).To(BeNil())
 
-				By("waiting for the subscription to have v0.3.0 installed with a Package deprecated condition")
-				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionHasCondition(
-					operatorsv1alpha1.SubscriptionPackageDeprecated,
-					corev1.ConditionTrue,
-					"",
-					"olm.package/test-package: test-package has been deprecated. Please switch to another-package."))
+				By("waiting for the subscription to have v0.3.0 installed ")
+				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionHasCurrentCSV("example-operator.v0.3.0"))
 				Expect(err).Should(BeNil())
+
+				By("waiting for the subscription to have v0.3.0 installed with a Package deprecated condition")
+				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName,
+					subscriptionHasCondition(
+						operatorsv1alpha1.SubscriptionPackageDeprecated,
+						corev1.ConditionTrue,
+						"",
+						"olm.package/test-package: test-package has been deprecated. Please switch to another-package.",
+					),
+				)
 
 				By("checking for the deprecated conditions")
 				By(`Operator is deprecated at only Package and Channel levels`)

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2597,7 +2597,7 @@ var _ = Describe("Subscription", func() {
 				err = magicCatalog.UpdateCatalog(context.Background(), provider)
 				Expect(err).To(BeNil())
 
-				By("waiting for the subscription to have v0.3.0 installed ")
+				By("waiting for the subscription to have v0.3.0 installed")
 				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionHasCurrentCSV("example-operator.v0.3.0"))
 				Expect(err).Should(BeNil())
 


### PR DESCRIPTION
**Description of the change:**
 * Bumps the sleep time in the operator unit test. I think leaving it at 1ms was starving the other processes leading to flakes
 * Updates a subscription e2e test to wait until the csv has changed before waiting for condition changes (the condition check passes for the old CSV as well - so the test flakes when we pass this condition check but the csv hasn't actually turned over yet

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
