### PR TITLE
:seedling: remove e2e go build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ export CONFIGMAP_SERVER_IMAGE ?= quay.io/operator-framework/configmap-operator-r
 
 PKG := github.com/operator-framework/operator-lifecycle-manager
 IMAGE_REPO ?= quay.io/operator-framework/olm
-IMAGE_TAG ?= "dev"
+IMAGE_TAG ?= "local"
 
 # Go build settings #
 
@@ -148,7 +148,7 @@ image: clean build #HELP Build image image for linux on host architecture
 .PHONY: e2e-build
 # the e2e and experimental_metrics tags are required to get e2e tests to pass
 # search the code for go:build e2e or go:build experimental_metrics to see where these tags are used
-e2e-build: export GO_BUILD_TAGS += e2e experimental_metrics #HELP Build image for e2e testing
+e2e-build: export GO_BUILD_TAGS += experimental_metrics #HELP Build image for e2e testing
 e2e-build: IMAGE_TAG = local
 e2e-build: image
 

--- a/pkg/controller/operators/catalog/supportedresourcesoveride.go
+++ b/pkg/controller/operators/catalog/supportedresourcesoveride.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 package catalog
 
 const (


### PR DESCRIPTION
**Description of the change:**
I believe the e2e build tag was a stop gap solution for a change in kind version. Removing it.

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
