### PR TITLE
Unpack Job Creation Failure Test

### DIFF
--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -1218,14 +1218,15 @@ func TestConfigMapUnpacker(t *testing.T) {
 			},
 		},
 		{
-			description: "CatalogSourcePresent/JobFailed/BundleLookupFailed/WithJobFailReason",
+			description: "CatalogSourcePresent/JobFailed/BundleLookupFailed/WithJobFailReasonNoLabel",
 			fields: fields{
 				objs: []runtime.Object{
 					&batchv1.Job{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      pathHash,
 							Namespace: "ns-a",
-							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue, bundleUnpackRefLabel: pathHash},
+							//omit the "operatorframework.io/bundle-unpack-ref" label
+							Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",
@@ -1442,6 +1443,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 				},
 			},
 			expected: expected{
+				// If job is not found due to missing "operatorframework.io/bundle-unpack-ref" label,
+				// we will get an 'AlreadyExists' error in this test when the new job is created
+				err: nil,
 				res: &BundleUnpackResult{
 					name: pathHash,
 					BundleLookup: &operatorsv1alpha1.BundleLookup{
@@ -1474,7 +1478,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      pathHash,
 							Namespace: "ns-a",
-							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue, bundleUnpackRefLabel: pathHash},
+							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",


### PR DESCRIPTION
Extends an existing unit test to cover the scenario where an old, failed job missing the label added in later OLM versions is not found with the filtered list call, resulting in an 'AlreadyExists' error when the new job is created.

Addresses this comment:
https://github.com/operator-framework/operator-lifecycle-manager/pull/3262#issuecomment-2121996915

Test **fail** before #3262 merge [here](https://github.com/operator-framework/operator-lifecycle-manager/actions/runs/9290731611/job/25567634441?pr=3297)

Test **pass** after merge [here](https://github.com/operator-framework/operator-lifecycle-manager/actions/runs/9292499460/job/25573528070?pr=3297)