### PR TITLE
:seedling: update skopeo openshift test

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -820,7 +820,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 
 		By("Create an image based catalog source from public Quay image using a unique tag as identifier")
 		var registryURL string
-		var registryAuth string
+		var registryAuthSecretName string
 		if local {
 			By("Creating a local registry to use")
 			registryURL, err = createDockerRegistry(c, generatedNamespace.GetName())
@@ -836,7 +836,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		} else {
 			registryURL = fmt.Sprintf("%s/%s", openshiftregistryFQDN, generatedNamespace.GetName())
 			By("Using the OpenShift registry at " + registryURL)
-			registryAuth, err = openshiftRegistryAuth(c, generatedNamespace.GetName())
+			registryAuthSecretName, err = getRegistryAuthSecretName(c, generatedNamespace.GetName())
 			Expect(err).NotTo(HaveOccurred(), "error getting openshift registry authentication: %s", err)
 		}
 
@@ -853,8 +853,8 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Expect(err).NotTo(HaveOccurred(), "error copying old registry file: %s", err)
 		} else {
 			By("creating a skopoeo Pod to do the copying")
-			skopeoArgs := skopeoCopyCmd(testImage, tag, catsrcImage, "old", registryAuth)
-			err = createSkopeoPod(c, skopeoArgs, generatedNamespace.GetName())
+			skopeoArgs := skopeoCopyCmd(testImage, tag, catsrcImage, "old", registryAuthSecretName)
+			err = createSkopeoPod(c, skopeoArgs, generatedNamespace.GetName(), registryAuthSecretName)
 			Expect(err).NotTo(HaveOccurred(), "error creating skopeo pod: %s", err)
 
 			By("waiting for the skopeo pod to exit successfully")
@@ -948,8 +948,8 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 			Expect(err).NotTo(HaveOccurred(), "error copying new registry file: %s", err)
 		} else {
 			By("creating a skopoeo Pod to do the copying")
-			skopeoArgs := skopeoCopyCmd(testImage, tag, catsrcImage, "new", registryAuth)
-			err = createSkopeoPod(c, skopeoArgs, generatedNamespace.GetName())
+			skopeoArgs := skopeoCopyCmd(testImage, tag, catsrcImage, "new", registryAuthSecretName)
+			err = createSkopeoPod(c, skopeoArgs, generatedNamespace.GetName(), registryAuthSecretName)
 			Expect(err).NotTo(HaveOccurred(), "error creating skopeo pod: %s", err)
 
 			By("waiting for the skopeo pod to exit successfully")

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2597,19 +2597,24 @@ var _ = Describe("Subscription", func() {
 				err = magicCatalog.UpdateCatalog(context.Background(), provider)
 				Expect(err).To(BeNil())
 
-				By("waiting for the subscription to have v0.3.0 installed")
+				By("waiting for the subscription to switch to v0.3.0")
 				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionHasCurrentCSV("example-operator.v0.3.0"))
 				Expect(err).Should(BeNil())
 
-				By("waiting for the subscription to have v0.3.0 installed with a Package deprecated condition")
+				By("waiting for the subscription to have be at latest known")
+				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker())
+				Expect(err).Should(BeNil())
+
+				By("waiting for the subscription to have v0.3.0 installed without a bundle deprecated condition")
 				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName,
 					subscriptionHasCondition(
-						operatorsv1alpha1.SubscriptionPackageDeprecated,
-						corev1.ConditionTrue,
+						operatorsv1alpha1.SubscriptionInstallPlanPending,
+						corev1.ConditionUnknown,
 						"",
-						"olm.package/test-package: test-package has been deprecated. Please switch to another-package.",
+						"",
 					),
 				)
+				Expect(err).Should(BeNil())
 
 				By("checking for the deprecated conditions")
 				By(`Operator is deprecated at only Package and Channel levels`)


### PR DESCRIPTION
**Description of the change:**
This update does not affect OLM. This updates an e2e test that is used downstream by Red Hat. This PR updates the version of skopeo used in the test as well as the way the skopeo pod is built for it. Now, we mount the secret as a volume and convert its contents to an auth.json file that skopeo can use and also mount an emptydir as a local cache for skopeo (something the logs showed skopeo was complaining about). I've reproduced this issue and tested this fix using an Openshift cluster.

**Motivation for the change:**
The test expected Openshift to add credential annotations in a secret that contains the auth configuration for the internal registry.

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
