### PR TITLE
:seedling: patch subscription e2e flake

### DIFF
--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2605,10 +2605,21 @@ var _ = Describe("Subscription", func() {
 				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker())
 				Expect(err).Should(BeNil())
 
-				By("waiting for the subscription to have v0.3.0 installed without a bundle deprecated condition")
+				By("waiting for the install plan pending to go away")
 				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName,
 					subscriptionHasCondition(
 						operatorsv1alpha1.SubscriptionInstallPlanPending,
+						corev1.ConditionUnknown,
+						"",
+						"",
+					),
+				)
+				Expect(err).Should(BeNil())
+
+				By("waiting for the subscription to have v0.3.0 installed without a bundle deprecated condition")
+				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName,
+					subscriptionHasCondition(
+						operatorsv1alpha1.SubscriptionBundleDeprecated,
 						corev1.ConditionUnknown,
 						"",
 						"",
@@ -2622,8 +2633,6 @@ var _ = Describe("Subscription", func() {
 				Expect(packageCondition.Status).To(Equal(corev1.ConditionTrue))
 				channelCondition := sub.Status.GetCondition(operatorsv1alpha1.SubscriptionChannelDeprecated)
 				Expect(channelCondition.Status).To(Equal(corev1.ConditionTrue))
-				bundleCondition = sub.Status.GetCondition(operatorsv1alpha1.SubscriptionBundleDeprecated)
-				Expect(bundleCondition.Status).To(Equal(corev1.ConditionUnknown))
 
 				By("verifying that a roll-up condition is present not containing bundle deprecation condition")
 				By(`Roll-up condition should be present and contain deprecation messages from Package and Channel levels`)


### PR DESCRIPTION
**Description of the change:**
This is a flaky test because the install plan conditions change to dynamically it would find itself checking the install plan conditions too early. This PR waits for the install plan pending condition to go away (to signal that the new install plan is being/has been applied), then wait for the bundle depracated condition to go away (in case its still stuck there from the previous state). This is what the test is really all about.

**Motivation for the change:**
Flaky behaviour

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
