### PR TITLE
fix: call TokenRequest API when service account token secret is missing

### DIFF
--- a/pkg/lib/scoped/token_retriever.go
+++ b/pkg/lib/scoped/token_retriever.go
@@ -37,12 +37,15 @@ func (r *BearerTokenRetriever) Retrieve(reference *corev1.ObjectReference) (toke
 	}
 
 	if secret == nil {
-		err = fmt.Errorf("the service account does not have any API secret sa=%s/%s", sa.GetNamespace(), sa.GetName())
-		token, _ = requestSAToken(r.kubeclient, sa)
-		if token != "" {
-			err = nil
+		token, err = requestSAToken(r.kubeclient, sa)
+		if err != nil {
+			err = fmt.Errorf("creating service account token from TokenRequest API for sa=%s/%s; %v",
+				sa.GetNamespace(),
+				sa.GetName(),
+				err,
+			)
+			return
 		}
-		return
 	}
 
 	token = string(secret.Data[corev1.ServiceAccountTokenKey])

--- a/pkg/lib/scoped/token_retriever.go
+++ b/pkg/lib/scoped/token_retriever.go
@@ -44,8 +44,8 @@ func (r *BearerTokenRetriever) Retrieve(reference *corev1.ObjectReference) (toke
 				sa.GetName(),
 				err,
 			)
-			return
 		}
+		return
 	}
 
 	token = string(secret.Data[corev1.ServiceAccountTokenKey])


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This pull requests introduces code that will attempt to request a service account token via the TokenRequest API whenever an error is return regarding a missing service account token secret.


**Motivation for the change:**

Beyond Kubernetes 1.22, the [service account token secret](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#manual-secret-management-for-serviceaccounts) is not automatically created. Therefore, unless manually created, the service account token secret is expect to be missing.

As a result, it is necessary to update the Operator Lifecycle manager(OLM) code to account for the above change in the Kubernetes behavior.

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Closes #3376 
