### PR TITLE
:seedling: Remove go.mod commented out base-components version pin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -178,13 +178,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-// pin to v1.18.0 until k8s.io/component-base updates its prometheus dependency
-// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/3283
-//replace (
-//	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.18.0
-//	github.com/prometheus/common => github.com/prometheus/common v0.47.0
-//)
-
 // v1.64.0 breaks our e2e tests as it affects the grpc connection state transition
 // issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/3284
 replace google.golang.org/grpc => google.golang.org/grpc v1.63.2


### PR DESCRIPTION
**Description of the change:**
Closes #3283

Also done [downstream](https://github.com/openshift/operator-framework-olm/pull/848/commits/dbb5513da3444fd6a9b3aff85cf1910009c8c0a5)

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
