### PR TITLE
:bug: Address install plan upgrade with deprecated CRD flake

### DIFF
--- a/test/e2e/installplan_e2e_test.go
+++ b/test/e2e/installplan_e2e_test.go
@@ -1435,7 +1435,7 @@ var _ = Describe("Install Plan", func() {
 		// excluded: new CRD, same version, same schema - won't trigger a CRD update
 
 		tableEntries := []TableEntry{
-			Entry("[FLAKE] upgrade CRD with deprecated version", schemaPayload{
+			Entry("upgrade CRD with deprecated version", schemaPayload{
 				name:          "upgrade CRD with deprecated version",
 				expectedPhase: operatorsv1alpha1.InstallPlanPhaseComplete,
 				oldCRD: func() *apiextensionsv1.CustomResourceDefinition {
@@ -1471,7 +1471,7 @@ var _ = Describe("Install Plan", func() {
 						},
 						{
 							Name:    "v1alpha1",
-							Served:  false,
+							Served:  true,
 							Storage: false,
 							Schema: &apiextensionsv1.CustomResourceValidation{
 								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
@@ -1631,7 +1631,6 @@ var _ = Describe("Install Plan", func() {
 			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
-
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			By(`Ensure correct in-cluster resource(s)`)
@@ -1688,7 +1687,6 @@ var _ = Describe("Install Plan", func() {
 			validateCRDVersions(GinkgoT(), c, tt.oldCRD.GetName(), expectedVersions)
 			GinkgoT().Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
 		}, tableEntries)
-
 	})
 
 	Describe("update catalog for subscription", func() {


### PR DESCRIPTION
**Description of the change:**
The upgrade flow is tested by:
1. Creating a bundle which owns v1alpha1 of its CRD, which is the version served
2. Creating a subscription to the package and installing the first bundle
3. Updating the catalog by adding the next version: v1alpha2 (served), v1alpha1 (not served)
4. After the install plan installs the new CRD, the old CSV goes from Succeeded -> Failed -> Pending because v1alpha1 is no longer served
5. The new CSV expects the old CSV to be in a Replacing state, which it isn't

Trying to address this issue by adding a replacement check to the pending state on the CSV phase graph to kick it into Replacing.

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
