### PR TITLE
adds paginating lister for evaluating CRs' upgrade fitness versus new CRDs.

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -2232,7 +2232,7 @@ func validateExistingCRs(dynamicClient dynamic.Interface, gr schema.GroupResourc
 		}
 		gvr := schema.GroupVersionResource{Group: gr.Group, Version: version, Resource: gr.Resource}
 		pager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-			return dynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
+			return dynamicClient.Resource(gvr).List(context.TODO(), opts)
 		}))
 		validationFn := func(obj runtime.Object) error {
 			err = validation.ValidateCustomResource(field.NewPath(""), obj, validator).ToAggregate()


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
adds a paging lister for listing CRs deployed in the cluster, used for fitness testing new CRD versions during upgrade. 

**Motivation for the change:**
scaling issues in clusters where listing CRs for an operator would exceed apiserver timeouts

**Architectural changes:**
since previously we attempted to load the list of all related CRs into memory, this should also significantly help with memory usage by OLM during upgrade evaluation.

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
