### PR TITLE
Disable dynamic resource e2e tests

### DIFF
--- a/test/e2e/dynamic_resource_e2e_test.go
+++ b/test/e2e/dynamic_resource_e2e_test.go
@@ -17,7 +17,10 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
-var _ = Describe("Subscriptions create required objects from Catalogs", func() {
+// This test was disabled because both of its tests are currently being skipped
+// We need to understand why and whether this test is even needed:
+// https://github.com/operator-framework/operator-lifecycle-manager/issues/3402
+var _ = XDescribe("Subscriptions create required objects from Catalogs", func() {
 	var (
 		crc                versioned.Interface
 		generatedNamespace corev1.Namespace


### PR DESCRIPTION
**Description of the change:**

These tests have been holding back the downstream sync. Given that they are skipped, and only the before/after each are being executed, I'm disabling the whole suite until we can figure out if we need these tests, if they are (still) correct, and whether we can enable them again (#3402)

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
