### PR TITLE
fix: set correct groupName tag for packages.operators.coreos.com

### DIFF
--- a/pkg/package-server/apis/operators/doc.go
+++ b/pkg/package-server/apis/operators/doc.go
@@ -1,5 +1,5 @@
 // +k8s:deepcopy-gen=package
 
 // Package operators is the internal version of the API.
-// +groupName=operators.coreos.com
+// +groupName=packages.operators.coreos.com
 package operators

--- a/pkg/package-server/apis/operators/v1/doc.go
+++ b/pkg/package-server/apis/operators/v1/doc.go
@@ -3,5 +3,5 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:openapi-gen=true
 
-// +groupName=operators.coreos.com
+// +groupName=packages.operators.coreos.com
 package v1

--- a/pkg/package-server/client/clientset/internalversion/clientset.go
+++ b/pkg/package-server/client/clientset/internalversion/clientset.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
-	operatorsinternalversion "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion"
+	packagesinternalversion "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -30,18 +30,18 @@ import (
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	Operators() operatorsinternalversion.OperatorsInterface
+	Packages() packagesinternalversion.PackagesInterface
 }
 
 // Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	operators *operatorsinternalversion.OperatorsClient
+	packages *packagesinternalversion.PackagesClient
 }
 
-// Operators retrieves the OperatorsClient
-func (c *Clientset) Operators() operatorsinternalversion.OperatorsInterface {
-	return c.operators
+// Packages retrieves the PackagesClient
+func (c *Clientset) Packages() packagesinternalversion.PackagesInterface {
+	return c.packages
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -88,7 +88,7 @@ func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset,
 
 	var cs Clientset
 	var err error
-	cs.operators, err = operatorsinternalversion.NewForConfigAndClient(&configShallowCopy, httpClient)
+	cs.packages, err = packagesinternalversion.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.operators = operatorsinternalversion.New(c)
+	cs.packages = packagesinternalversion.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/pkg/package-server/client/clientset/internalversion/fake/clientset_generated.go
+++ b/pkg/package-server/client/clientset/internalversion/fake/clientset_generated.go
@@ -20,8 +20,8 @@ package fake
 
 import (
 	clientset "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/internalversion"
-	operatorsinternalversion "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion"
-	fakeoperatorsinternalversion "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/fake"
+	packagesinternalversion "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion"
+	fakepackagesinternalversion "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -83,7 +83,7 @@ var (
 	_ testing.FakeClient  = &Clientset{}
 )
 
-// Operators retrieves the OperatorsClient
-func (c *Clientset) Operators() operatorsinternalversion.OperatorsInterface {
-	return &fakeoperatorsinternalversion.FakeOperators{Fake: &c.Fake}
+// Packages retrieves the PackagesClient
+func (c *Clientset) Packages() packagesinternalversion.PackagesInterface {
+	return &fakepackagesinternalversion.FakePackages{Fake: &c.Fake}
 }

--- a/pkg/package-server/client/clientset/internalversion/fake/register.go
+++ b/pkg/package-server/client/clientset/internalversion/fake/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	operatorsinternalversion "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators"
+	packagesinternalversion "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +31,7 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 var localSchemeBuilder = runtime.SchemeBuilder{
-	operatorsinternalversion.AddToScheme,
+	packagesinternalversion.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/package-server/client/clientset/internalversion/scheme/register.go
+++ b/pkg/package-server/client/clientset/internalversion/scheme/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package scheme
 
 import (
-	operators "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/install"
+	packages "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/install"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,5 +37,5 @@ func init() {
 
 // Install registers the API group and adds types to a scheme
 func Install(scheme *runtime.Scheme) {
-	operators.Install(scheme)
+	packages.Install(scheme)
 }

--- a/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/fake/fake_operators_client.go
+++ b/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/fake/fake_operators_client.go
@@ -24,17 +24,17 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-type FakeOperators struct {
+type FakePackages struct {
 	*testing.Fake
 }
 
-func (c *FakeOperators) PackageManifests(namespace string) internalversion.PackageManifestInterface {
+func (c *FakePackages) PackageManifests(namespace string) internalversion.PackageManifestInterface {
 	return &FakePackageManifests{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeOperators) RESTClient() rest.Interface {
+func (c *FakePackages) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/fake/fake_packagemanifest.go
+++ b/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/fake/fake_packagemanifest.go
@@ -31,7 +31,7 @@ import (
 
 // FakePackageManifests implements PackageManifestInterface
 type FakePackageManifests struct {
-	Fake *FakeOperators
+	Fake *FakePackages
 	ns   string
 }
 

--- a/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/operators_client.go
+++ b/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/operators_client.go
@@ -25,24 +25,24 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-type OperatorsInterface interface {
+type PackagesInterface interface {
 	RESTClient() rest.Interface
 	PackageManifestsGetter
 }
 
-// OperatorsClient is used to interact with features provided by the operators.coreos.com group.
-type OperatorsClient struct {
+// PackagesClient is used to interact with features provided by the packages.operators.coreos.com group.
+type PackagesClient struct {
 	restClient rest.Interface
 }
 
-func (c *OperatorsClient) PackageManifests(namespace string) PackageManifestInterface {
+func (c *PackagesClient) PackageManifests(namespace string) PackageManifestInterface {
 	return newPackageManifests(c, namespace)
 }
 
-// NewForConfig creates a new OperatorsClient for the given config.
+// NewForConfig creates a new PackagesClient for the given config.
 // NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
 // where httpClient was generated with rest.HTTPClientFor(c).
-func NewForConfig(c *rest.Config) (*OperatorsClient, error) {
+func NewForConfig(c *rest.Config) (*PackagesClient, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -54,9 +54,9 @@ func NewForConfig(c *rest.Config) (*OperatorsClient, error) {
 	return NewForConfigAndClient(&config, httpClient)
 }
 
-// NewForConfigAndClient creates a new OperatorsClient for the given config and http client.
+// NewForConfigAndClient creates a new PackagesClient for the given config and http client.
 // Note the http client provided takes precedence over the configured transport values.
-func NewForConfigAndClient(c *rest.Config, h *http.Client) (*OperatorsClient, error) {
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*PackagesClient, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -65,12 +65,12 @@ func NewForConfigAndClient(c *rest.Config, h *http.Client) (*OperatorsClient, er
 	if err != nil {
 		return nil, err
 	}
-	return &OperatorsClient{client}, nil
+	return &PackagesClient{client}, nil
 }
 
-// NewForConfigOrDie creates a new OperatorsClient for the given config and
+// NewForConfigOrDie creates a new PackagesClient for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *OperatorsClient {
+func NewForConfigOrDie(c *rest.Config) *PackagesClient {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -78,9 +78,9 @@ func NewForConfigOrDie(c *rest.Config) *OperatorsClient {
 	return client
 }
 
-// New creates a new OperatorsClient for the given RESTClient.
-func New(c rest.Interface) *OperatorsClient {
-	return &OperatorsClient{c}
+// New creates a new PackagesClient for the given RESTClient.
+func New(c rest.Interface) *PackagesClient {
+	return &PackagesClient{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -88,8 +88,8 @@ func setConfigDefaults(config *rest.Config) error {
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
-	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("operators.coreos.com")[0].Group {
-		gv := scheme.Scheme.PrioritizedVersionsForGroup("operators.coreos.com")[0]
+	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("packages.operators.coreos.com")[0].Group {
+		gv := scheme.Scheme.PrioritizedVersionsForGroup("packages.operators.coreos.com")[0]
 		config.GroupVersion = &gv
 	}
 	config.NegotiatedSerializer = scheme.Codecs
@@ -106,7 +106,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *OperatorsClient) RESTClient() rest.Interface {
+func (c *PackagesClient) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/packagemanifest.go
+++ b/pkg/package-server/client/clientset/internalversion/typed/operators/internalversion/packagemanifest.go
@@ -56,7 +56,7 @@ type packageManifests struct {
 }
 
 // newPackageManifests returns a PackageManifests
-func newPackageManifests(c *OperatorsClient, namespace string) *packageManifests {
+func newPackageManifests(c *PackagesClient, namespace string) *packageManifests {
 	return &packageManifests{
 		gentype.NewClientWithList[*operators.PackageManifest, *operators.PackageManifestList](
 			"packagemanifests",

--- a/pkg/package-server/client/clientset/versioned/clientset.go
+++ b/pkg/package-server/client/clientset/versioned/clientset.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
-	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned/typed/operators/v1"
+	packagesv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned/typed/operators/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -30,18 +30,18 @@ import (
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	OperatorsV1() operatorsv1.OperatorsV1Interface
+	PackagesV1() packagesv1.PackagesV1Interface
 }
 
 // Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	operatorsV1 *operatorsv1.OperatorsV1Client
+	packagesV1 *packagesv1.PackagesV1Client
 }
 
-// OperatorsV1 retrieves the OperatorsV1Client
-func (c *Clientset) OperatorsV1() operatorsv1.OperatorsV1Interface {
-	return c.operatorsV1
+// PackagesV1 retrieves the PackagesV1Client
+func (c *Clientset) PackagesV1() packagesv1.PackagesV1Interface {
+	return c.packagesV1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -88,7 +88,7 @@ func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset,
 
 	var cs Clientset
 	var err error
-	cs.operatorsV1, err = operatorsv1.NewForConfigAndClient(&configShallowCopy, httpClient)
+	cs.packagesV1, err = packagesv1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.operatorsV1 = operatorsv1.New(c)
+	cs.packagesV1 = packagesv1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/pkg/package-server/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/package-server/client/clientset/versioned/fake/clientset_generated.go
@@ -20,8 +20,8 @@ package fake
 
 import (
 	clientset "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned"
-	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned/typed/operators/v1"
-	fakeoperatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned/typed/operators/v1/fake"
+	packagesv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned/typed/operators/v1"
+	fakepackagesv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned/typed/operators/v1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -83,7 +83,7 @@ var (
 	_ testing.FakeClient  = &Clientset{}
 )
 
-// OperatorsV1 retrieves the OperatorsV1Client
-func (c *Clientset) OperatorsV1() operatorsv1.OperatorsV1Interface {
-	return &fakeoperatorsv1.FakeOperatorsV1{Fake: &c.Fake}
+// PackagesV1 retrieves the PackagesV1Client
+func (c *Clientset) PackagesV1() packagesv1.PackagesV1Interface {
+	return &fakepackagesv1.FakePackagesV1{Fake: &c.Fake}
 }

--- a/pkg/package-server/client/clientset/versioned/fake/register.go
+++ b/pkg/package-server/client/clientset/versioned/fake/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	packagesv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +31,7 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 var localSchemeBuilder = runtime.SchemeBuilder{
-	operatorsv1.AddToScheme,
+	packagesv1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/package-server/client/clientset/versioned/scheme/register.go
+++ b/pkg/package-server/client/clientset/versioned/scheme/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package scheme
 
 import (
-	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	packagesv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +31,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	operatorsv1.AddToScheme,
+	packagesv1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/package-server/client/clientset/versioned/typed/operators/v1/fake/fake_operators_client.go
+++ b/pkg/package-server/client/clientset/versioned/typed/operators/v1/fake/fake_operators_client.go
@@ -24,17 +24,17 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-type FakeOperatorsV1 struct {
+type FakePackagesV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeOperatorsV1) PackageManifests(namespace string) v1.PackageManifestInterface {
+func (c *FakePackagesV1) PackageManifests(namespace string) v1.PackageManifestInterface {
 	return &FakePackageManifests{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeOperatorsV1) RESTClient() rest.Interface {
+func (c *FakePackagesV1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/package-server/client/clientset/versioned/typed/operators/v1/fake/fake_packagemanifest.go
+++ b/pkg/package-server/client/clientset/versioned/typed/operators/v1/fake/fake_packagemanifest.go
@@ -31,7 +31,7 @@ import (
 
 // FakePackageManifests implements PackageManifestInterface
 type FakePackageManifests struct {
-	Fake *FakeOperatorsV1
+	Fake *FakePackagesV1
 	ns   string
 }
 

--- a/pkg/package-server/client/clientset/versioned/typed/operators/v1/operators_client.go
+++ b/pkg/package-server/client/clientset/versioned/typed/operators/v1/operators_client.go
@@ -26,24 +26,24 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-type OperatorsV1Interface interface {
+type PackagesV1Interface interface {
 	RESTClient() rest.Interface
 	PackageManifestsGetter
 }
 
-// OperatorsV1Client is used to interact with features provided by the operators.coreos.com group.
-type OperatorsV1Client struct {
+// PackagesV1Client is used to interact with features provided by the packages.operators.coreos.com group.
+type PackagesV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *OperatorsV1Client) PackageManifests(namespace string) PackageManifestInterface {
+func (c *PackagesV1Client) PackageManifests(namespace string) PackageManifestInterface {
 	return newPackageManifests(c, namespace)
 }
 
-// NewForConfig creates a new OperatorsV1Client for the given config.
+// NewForConfig creates a new PackagesV1Client for the given config.
 // NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
 // where httpClient was generated with rest.HTTPClientFor(c).
-func NewForConfig(c *rest.Config) (*OperatorsV1Client, error) {
+func NewForConfig(c *rest.Config) (*PackagesV1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -55,9 +55,9 @@ func NewForConfig(c *rest.Config) (*OperatorsV1Client, error) {
 	return NewForConfigAndClient(&config, httpClient)
 }
 
-// NewForConfigAndClient creates a new OperatorsV1Client for the given config and http client.
+// NewForConfigAndClient creates a new PackagesV1Client for the given config and http client.
 // Note the http client provided takes precedence over the configured transport values.
-func NewForConfigAndClient(c *rest.Config, h *http.Client) (*OperatorsV1Client, error) {
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*PackagesV1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -66,12 +66,12 @@ func NewForConfigAndClient(c *rest.Config, h *http.Client) (*OperatorsV1Client, 
 	if err != nil {
 		return nil, err
 	}
-	return &OperatorsV1Client{client}, nil
+	return &PackagesV1Client{client}, nil
 }
 
-// NewForConfigOrDie creates a new OperatorsV1Client for the given config and
+// NewForConfigOrDie creates a new PackagesV1Client for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *OperatorsV1Client {
+func NewForConfigOrDie(c *rest.Config) *PackagesV1Client {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -79,9 +79,9 @@ func NewForConfigOrDie(c *rest.Config) *OperatorsV1Client {
 	return client
 }
 
-// New creates a new OperatorsV1Client for the given RESTClient.
-func New(c rest.Interface) *OperatorsV1Client {
-	return &OperatorsV1Client{c}
+// New creates a new PackagesV1Client for the given RESTClient.
+func New(c rest.Interface) *PackagesV1Client {
+	return &PackagesV1Client{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -99,7 +99,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *OperatorsV1Client) RESTClient() rest.Interface {
+func (c *PackagesV1Client) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/pkg/package-server/client/clientset/versioned/typed/operators/v1/packagemanifest.go
+++ b/pkg/package-server/client/clientset/versioned/typed/operators/v1/packagemanifest.go
@@ -56,7 +56,7 @@ type packageManifests struct {
 }
 
 // newPackageManifests returns a PackageManifests
-func newPackageManifests(c *OperatorsV1Client, namespace string) *packageManifests {
+func newPackageManifests(c *PackagesV1Client, namespace string) *packageManifests {
 	return &packageManifests{
 		gentype.NewClientWithList[*v1.PackageManifest, *v1.PackageManifestList](
 			"packagemanifests",

--- a/pkg/package-server/client/informers/externalversions/factory.go
+++ b/pkg/package-server/client/informers/externalversions/factory.go
@@ -254,9 +254,9 @@ type SharedInformerFactory interface {
 	// client.
 	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
 
-	Operators() operators.Interface
+	Packages() operators.Interface
 }
 
-func (f *sharedInformerFactory) Operators() operators.Interface {
+func (f *sharedInformerFactory) Packages() operators.Interface {
 	return operators.New(f, f.namespace, f.tweakListOptions)
 }

--- a/pkg/package-server/client/informers/externalversions/generic.go
+++ b/pkg/package-server/client/informers/externalversions/generic.go
@@ -52,9 +52,9 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=operators.coreos.com, Version=v1
+	// Group=packages.operators.coreos.com, Version=v1
 	case v1.SchemeGroupVersion.WithResource("packagemanifests"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Operators().V1().PackageManifests().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Packages().V1().PackageManifests().Informer()}, nil
 
 	}
 

--- a/pkg/package-server/client/informers/externalversions/operators/v1/packagemanifest.go
+++ b/pkg/package-server/client/informers/externalversions/operators/v1/packagemanifest.go
@@ -62,13 +62,13 @@ func NewFilteredPackageManifestInformer(client versioned.Interface, namespace st
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OperatorsV1().PackageManifests(namespace).List(context.TODO(), options)
+				return client.PackagesV1().PackageManifests(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OperatorsV1().PackageManifests(namespace).Watch(context.TODO(), options)
+				return client.PackagesV1().PackageManifests(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&operatorsv1.PackageManifest{},

--- a/pkg/package-server/client/informers/internalversion/factory.go
+++ b/pkg/package-server/client/informers/internalversion/factory.go
@@ -254,9 +254,9 @@ type SharedInformerFactory interface {
 	// client.
 	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
 
-	Operators() operators.Interface
+	Packages() operators.Interface
 }
 
-func (f *sharedInformerFactory) Operators() operators.Interface {
+func (f *sharedInformerFactory) Packages() operators.Interface {
 	return operators.New(f, f.namespace, f.tweakListOptions)
 }

--- a/pkg/package-server/client/informers/internalversion/generic.go
+++ b/pkg/package-server/client/informers/internalversion/generic.go
@@ -52,9 +52,9 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=operators.coreos.com, Version=internalVersion
+	// Group=packages.operators.coreos.com, Version=internalVersion
 	case operators.SchemeGroupVersion.WithResource("packagemanifests"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Operators().InternalVersion().PackageManifests().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Packages().InternalVersion().PackageManifests().Informer()}, nil
 
 	}
 

--- a/pkg/package-server/client/informers/internalversion/operators/internalversion/packagemanifest.go
+++ b/pkg/package-server/client/informers/internalversion/operators/internalversion/packagemanifest.go
@@ -62,13 +62,13 @@ func NewFilteredPackageManifestInformer(client clientsetinternalversion.Interfac
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.Operators().PackageManifests(namespace).List(context.TODO(), options)
+				return client.Packages().PackageManifests(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.Operators().PackageManifests(namespace).Watch(context.TODO(), options)
+				return client.Packages().PackageManifests(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&operators.PackageManifest{},

--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -787,7 +787,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		By("package-server as a proxy for a functional catalog")
 		By("Waiting for packages from the catalog to show up in the Kubernetes API")
 		Eventually(func() error {
-			manifests, err := packageserverClient.OperatorsV1().PackageManifests("default").List(context.Background(), metav1.ListOptions{})
+			manifests, err := packageserverClient.PackagesV1().PackageManifests("default").List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				return err
 			}

--- a/test/e2e/packagemanifest_e2e_test.go
+++ b/test/e2e/packagemanifest_e2e_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 		It("lists PackageManifest and ensures it has valid PackageManifest item", func() {
 			By(`Get a PackageManifestList and ensure it has the correct items`)
 			Eventually(func() (bool, error) {
-				pmList, err := pmc.OperatorsV1().PackageManifests(generatedNamespace.GetName()).List(context.TODO(), metav1.ListOptions{})
+				pmList, err := pmc.PackagesV1().PackageManifests(generatedNamespace.GetName()).List(context.TODO(), metav1.ListOptions{})
 				return containsPackageManifest(pmList.Items, packageName), err
 			}).Should(BeTrue(), "required package name not found in the list")
 		})
@@ -191,7 +191,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 		It("gets the icon from the default channel", func() {
 			var res rest.Result
 			Eventually(func() error {
-				res = pmc.OperatorsV1().RESTClient().Get().Resource("packagemanifests").SubResource("icon").Namespace(generatedNamespace.GetName()).Name(packageName).Do(context.Background())
+				res = pmc.PackagesV1().RESTClient().Get().Resource("packagemanifests").SubResource("icon").Namespace(generatedNamespace.GetName()).Name(packageName).Do(context.Background())
 				return res.Error()
 			}).Should(Succeed(), "error getting icon")
 
@@ -315,7 +315,7 @@ func fetchPackageManifest(pmc pmversioned.Interface, namespace, name string, che
 
 	EventuallyWithOffset(1, func() (bool, error) {
 		ctx.Ctx().Logf("Polling...")
-		fetched, err = pmc.OperatorsV1().PackageManifests(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		fetched, err = pmc.PackagesV1().PackageManifests(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
**Description of the change:**

Seems like the `groupName` tag is not correct for the `packagemanifest_types` located in both `pkg/package-server/api/operators` and `pkg/package-server/api/operators/v1`.

These changes address the problem.

Both register.go files do point to the correct package name though.
- https://github.com/operator-framework/operator-lifecycle-manager/blob/75d70e60f7bc485c128d30808abafaade4da83d8/pkg/package-server/apis/operators/register.go#L9
- https://github.com/operator-framework/operator-lifecycle-manager/blob/75d70e60f7bc485c128d30808abafaade4da83d8/pkg/package-server/apis/operators/v1/register.go#L12

**Motivation for the change:**

Correct generation of an OpenAPI client.

**Architectural changes:**

n/a

**Testing remarks:**

n/a

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
