### PR TITLE
(bugfix): reduce frequency of update requests for copied CSVs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ export CONFIGMAP_SERVER_IMAGE ?= quay.io/operator-framework/configmap-operator-r
 
 PKG := github.com/operator-framework/operator-lifecycle-manager
 IMAGE_REPO ?= quay.io/operator-framework/olm
-IMAGE_TAG ?= "dev"
+IMAGE_TAG ?= dev
 
 # Go build settings #
 
@@ -211,7 +211,7 @@ kind-create: kind-clean #HELP Create a new kind cluster $KIND_CLUSTER_NAME (defa
 	$(KIND) export kubeconfig --name $(KIND_CLUSTER_NAME)
 
 .PHONY: deploy
-OLM_IMAGE := quay.io/operator-framework/olm:local
+OLM_IMAGE := $(IMAGE_REPO):$(IMAGE_TAG)
 deploy: $(KIND) $(HELM) #HELP Deploy OLM to kind cluster $KIND_CLUSTER_NAME (default: kind-olmv0) using $OLM_IMAGE (default: quay.io/operator-framework/olm:local)
 	$(KIND) load docker-image $(OLM_IMAGE) --name $(KIND_CLUSTER_NAME); \
 	$(HELM) upgrade --install olm deploy/chart \

--- a/pkg/controller/operators/olm/operatorgroup_test.go
+++ b/pkg/controller/operators/olm/operatorgroup_test.go
@@ -112,8 +112,8 @@ func TestCopyToNamespace(t *testing.T) {
 					UID:             "uid",
 					ResourceVersion: "42",
 					Annotations: map[string]string{
-						"$copyhash-nonstatus": "hn-2",
-						"$copyhash-status":    "hs",
+						nonStatusCopyHashAnnotation: "hn-2",
+						statusCopyHashAnnotation:    "hs",
 					},
 				},
 			},
@@ -165,8 +165,8 @@ func TestCopyToNamespace(t *testing.T) {
 					UID:             "uid",
 					ResourceVersion: "42",
 					Annotations: map[string]string{
-						"$copyhash-nonstatus": "hn",
-						"$copyhash-status":    "hs-2",
+						nonStatusCopyHashAnnotation: "hn",
+						statusCopyHashAnnotation:    "hs-2",
 					},
 				},
 			},
@@ -218,8 +218,8 @@ func TestCopyToNamespace(t *testing.T) {
 					UID:             "uid",
 					ResourceVersion: "42",
 					Annotations: map[string]string{
-						"$copyhash-nonstatus": "hn-2",
-						"$copyhash-status":    "hs-2",
+						nonStatusCopyHashAnnotation: "hn-2",
+						statusCopyHashAnnotation:    "hs-2",
 					},
 				},
 			},
@@ -278,8 +278,8 @@ func TestCopyToNamespace(t *testing.T) {
 					Namespace: "to",
 					UID:       "uid",
 					Annotations: map[string]string{
-						"$copyhash-nonstatus": "hn",
-						"$copyhash-status":    "hs",
+						nonStatusCopyHashAnnotation: "hn",
+						statusCopyHashAnnotation:    "hs",
 					},
 				},
 			},


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Reduces the frequency of update requests for copied CSVs by:
- Adding the `olm.operatorframework.io/nonStatusCopyHash` annotation to the copied CSVs, populated with a hash of all the non-status fields of the original CSV.
- Adding the `olm.operatorframework.io/statusCopyHash` annotation to the copied CSVs, populated with a hash of all the status fields of the original CSV.
- Updating the above annotations as necessary on the copied CSVs when changes are made to the original CSV

This appears to have been the desired behavior of this function, as evidenced by: https://github.com/operator-framework/operator-lifecycle-manager/blob/461018e2e232865d97830b3accad9f1e8a58c7bc/pkg/controller/operators/olm/operatorgroup.go#L829-L830

The problem with the previous implementation was that these annotations were never set on the copied CSVs.

**Motivation for the change:**
- Reduce the frequency of `UPDATE` requests made to the Kubernetes API Server for copied CSVs

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
