### PR TITLE
 fix: buggy `nextY` logic for maxOCPVersion

### DIFF
--- a/pkg/controller/operators/openshift/helpers_test.go
+++ b/pkg/controller/operators/openshift/helpers_test.go
@@ -423,7 +423,7 @@ func TestIncompatibleOperators(t *testing.T) {
 		},
 		{
 			description: "ClusterPre",
-			version:     "1.1.0-pre", // Next Y-stream is 1.1.0, NOT 1.2.0
+			version:     "1.1.0-pre", // Next Y-stream is 1.2.0
 			in: skews{
 				{
 					name:                "almond",
@@ -432,8 +432,14 @@ func TestIncompatibleOperators(t *testing.T) {
 				},
 			},
 			expect: expect{
-				err:          false,
-				incompatible: nil,
+				err: false,
+				incompatible: skews{
+					{
+						name:                "almond",
+						namespace:           "default",
+						maxOpenShiftVersion: "1.1",
+					},
+				},
 			},
 		},
 	} {
@@ -594,6 +600,30 @@ func TestNotCopiedSelector(t *testing.T) {
 			selector, err := notCopiedSelector()
 			require.NoError(t, err)
 			require.Equal(t, tc.Matches, selector.Matches(tc.Labels))
+		})
+	}
+}
+
+func TestOCPVersionNextY(t *testing.T) {
+	for _, tc := range []struct {
+		description     string
+		inVersion       semver.Version
+		expectedVersion semver.Version
+	}{
+		{
+			description:     "Version: 4.16.0. Expected output: 4.17",
+			inVersion:       semver.MustParse("4.16.0"),
+			expectedVersion: semver.MustParse("4.17.0"),
+		},
+		{
+			description:     "Version: 4.16.0-rc1. Expected output: 4.17",
+			inVersion:       semver.MustParse("4.16.0-rc1"),
+			expectedVersion: semver.MustParse("4.17.0"),
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			outVersion := nextY(tc.inVersion)
+			require.Equal(t, outVersion, tc.expectedVersion)
 		})
 	}
 }


### PR DESCRIPTION
The handling logic of versions that are pre-releases by the
`nextY()` func (that determines the next Y release) was erroneous.
    
Eg: `nextY("4.16.0")` returns "4.17" correctly, but `nextY("4.16.0-rc1")`
returns "4.16" (the correct value is still "4.17").
    
This PR fixes the `nextY` function.
    
Also has improvement for the "not-upgradeable to next OCP" version message.
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
