### PR TITLE
add protocols to all ports in `olm.yaml` quickstart

### DIFF
--- a/deploy/upstream/quickstart/olm.yaml
+++ b/deploy/upstream/quickstart/olm.yaml
@@ -72,6 +72,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+              protocol: TCP
             - containerPort: 8081
               name: metrics
               protocol: TCP
@@ -132,6 +133,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+              protocol: TCP
             - containerPort: 8081
               name: metrics
               protocol: TCP
@@ -295,6 +297,7 @@ spec:
                 imagePullPolicy: Always
                 ports:
                 - containerPort: 5443
+                  protocol: TCP
                 livenessProbe:
                   httpGet:
                     scheme: HTTPS


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Adds `protocol` to all of the ports defined in the `olm.yaml quickstart.

**Motivation for the change:**

I was setting up OLM with kustomization and ArgoCD, and the ArgoCD was unable to diff or sync due to the lack of `protocol` on the `apiVersion=operators.coreos.com/v1alpha1 verison=ClusterServiceVersion` resource. I figured I'd add the protocol to the two `Deployment` while I'm here anyways.

```

ComparisonError: Failed to compare desired state to live state: failed to calculate diff: error calculating structured merge diff: error building typed value from config resource: .spec.install.spec.deployments[0].spec.template.spec.containers[0].ports: element 0: associative list with keys has an element that omits key field "protocol" (and doesn't have default value). Retrying attempt #4 at 11:59AM.
```

As I understand, this is because the CRD doesn't have a default, which is probably another thing that's worth fixing. 

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

N/A

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

- I used my forked version and it worked fine with ArgoCD afterwards

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
