### PR TITLE
Fix release automation

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -34,9 +34,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          name: ${{ env.IMAGE_TAG }}
           draft: true
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -60,7 +59,8 @@ jobs:
           PKG: github.com/operator-framework/operator-lifecycle-manager
 
       - name: Generate quickstart release manifests
-        run: make release ver=${{ env.IMAGE_TAG }} IMAGE_REPO=quay.io/operator-framework/olm
+        if: startsWith(github.ref, 'refs/tags')
+        run: make release RELEASE_VERSION=${{ env.IMAGE_TAG }} IMAGE_REPO=quay.io/operator-framework/olm
 
       - name: Update release artifacts with rendered Kubernetes release manifests
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
**Description of the change:**

Our release automation is broken after refactoring in https://github.com/operator-framework/operator-lifecycle-manager/pull/3280: we are no longer passing a real version number from the release workflow.

Fixes #3419

**Architectural changes:**

None

**Testing remarks:**

Need to create a new tag to trigger the workflow

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
