### PR TITLE
Fix release automation

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -27,16 +27,6 @@ jobs:
             echo IMAGE_TAG="snapshot" >> $GITHUB_ENV
           fi
 
-      - name: Create a draft release
-        uses: softprops/action-gh-release@v2
-        id: release
-        if: startsWith(github.ref, 'refs/tags')
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          name: ${{ env.IMAGE_TAG }}
-          draft: true
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -58,6 +48,10 @@ jobs:
           IMAGE_REPO: quay.io/operator-framework/olm
           PKG: github.com/operator-framework/operator-lifecycle-manager
 
+      # The below steps depend on a image being present in a image registry
+      # as well as existence of a release on GitHub which are not
+      # being created by goreleaser when run against anything other than a tag.
+      # So we only run the steps below for tags.
       - name: Generate quickstart release manifests
         if: startsWith(github.ref, 'refs/tags')
         run: make release RELEASE_VERSION=${{ env.IMAGE_TAG }} IMAGE_REPO=quay.io/operator-framework/olm


### PR DESCRIPTION
**Description of the change:**

We want one draft to be created by goreleaser
and we want softprops/action-gh-release GitHub action to append artifacts into the existing release.

Since goreleaser creates a draft anyway it seems like "Create a draft release" is not necessary.

**Motivation for the change:**

Currently two release drafts are being created.

**Architectural changes:**

Changing release tooling only.

**Testing remarks:**

Need to push a tag

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
