### PR TITLE
Fix canonical image ref resolution

### DIFF
--- a/util/image-canonical-ref/main.go
+++ b/util/image-canonical-ref/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+)
+
+// This is a simple tool to resolve canonical reference of the image.
+// E.g. this resolves quay.io/operator-framework/olm:v0.28.0 to
+// quay.io/operator-framework/olm@sha256:40d0363f4aa684319cd721c2fcf3321785380fdc74de8ef821317cd25a10782a
+func main() {
+	ctx := context.Background()
+
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <image reference>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	ref := os.Args[1]
+
+	if err := run(ctx, ref); err != nil {
+		fmt.Fprintf(os.Stderr, "error running the tool: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, ref string) error {
+	imgRef, err := reference.ParseNamed(ref)
+	if err != nil {
+		return fmt.Errorf("error parsing image reference %q: %w", ref, err)
+	}
+
+	sysCtx := &types.SystemContext{}
+	canonicalRef, err := resolveCanonicalRef(ctx, imgRef, sysCtx)
+	if err != nil {
+		return fmt.Errorf("error resolving canonical reference: %w", err)
+	}
+
+	fmt.Println(canonicalRef.String())
+	return nil
+}
+
+func resolveCanonicalRef(ctx context.Context, imgRef reference.Named, sysCtx *types.SystemContext) (reference.Canonical, error) {
+	if canonicalRef, ok := imgRef.(reference.Canonical); ok {
+		return canonicalRef, nil
+	}
+
+	srcRef, err := docker.NewReference(imgRef)
+	if err != nil {
+		return nil, fmt.Errorf("error creating reference: %w", err)
+	}
+
+	imgSrc, err := srcRef.NewImageSource(ctx, sysCtx)
+	if err != nil {
+		return nil, fmt.Errorf("error creating image source: %w", err)
+	}
+	defer imgSrc.Close()
+
+	imgManifestData, _, err := imgSrc.GetManifest(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error getting manifest: %w", err)
+	}
+	imgDigest, err := manifest.Digest(imgManifestData)
+	if err != nil {
+		return nil, fmt.Errorf("error getting digest of manifest: %w", err)
+	}
+	canonicalRef, err := reference.WithDigest(reference.TrimNamed(imgRef), imgDigest)
+	if err != nil {
+		return nil, fmt.Errorf("error creating canonical reference: %w", err)
+	}
+	return canonicalRef, nil
+}


### PR DESCRIPTION
**Description of the change:**

Previously in release scripts we were using `docker inspect` which seems to sort .RepoDigests and it makes selection of the correct digest difficult because platform-specific digest can appear at a different index depending on the digests in the list.

**Motivation for the change:**

`olm.yaml` is currently being generated with platform-specific image ref. This PR fixes resolution of canonical image refs.

Related to #3419

**Architectural changes:**

N/A

**Testing remarks:**

Create a new tag to trigger release automation.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
