### PR TITLE
Makefile: re-add run-local target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,14 @@ image: clean build #HELP Build image image for linux on host architecture
 # the e2e and experimental_metrics tags are required to get e2e tests to pass
 # search the code for go:build e2e or go:build experimental_metrics to see where these tags are used
 e2e-build: export GO_BUILD_TAGS += e2e experimental_metrics #HELP Build image for e2e testing
-e2e-build: IMAGE_TAG = local
-e2e-build: image
+e2e-build: local-build
+
+.PHONY: local-build
+local-build: IMAGE_TAG = local
+local-build: image
+
+.PHONY: run-local
+run-local: local-build kind-create deploy
 
 .PHONY: clean
 clean: #HELP Clean up build artifacts


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Re-adds a `run-local` target to the Makefile what was lost in the refactoring we've done to align this repo with others in the Operator Framework org.

**Motivation for the change:**

To give developers and contributors a really simple on-ramp for running a cluster locally based on the code they have currently checked out.

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
