### PR TITLE
Add tests for package migration/renaming

### DIFF
--- a/pkg/controller/registry/resolver/step_resolver_test.go
+++ b/pkg/controller/registry/resolver/step_resolver_test.go
@@ -733,6 +733,30 @@ func TestResolver(t *testing.T) {
 			},
 		},
 		{
+			// Tests the migration from one package name to another with replaces.
+			// Useful when renaming a package or combining two packages into one.
+			name: "InstalledSub/UpdateAvailable/FromDifferentPackage",
+			clusterState: []runtime.Object{
+				existingSub(namespace, "a.v1", "b", "alpha", catalog),
+				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
+			},
+			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
+				catalog: {
+					bundle("a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+					bundle("b.v2", "b", "alpha", "a.v1", Provides1, nil, nil, nil),
+				},
+			},
+			out: resolverTestOut{
+				steps: [][]*v1alpha1.Step{
+					bundleSteps(bundle("b.v2", "b", "alpha", "a.v1", Provides1, nil, nil, nil), namespace, "", catalog),
+				},
+				subs: []*v1alpha1.Subscription{
+					updatedSub(namespace, "b.v2", "a.v1", "b", "alpha", catalog),
+				},
+			},
+		},
+		{
 			name: "InstalledSub/UpdateAvailable/FromBundlePath",
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),


### PR DESCRIPTION
**Description of the change:**

Tests upgrades from one package to another within the same subscription. This is useful when renaming operator package.

No new features introduced: this is currently supported by OLM, but there are no tests for this.

**Motivation for the change:**

I'm currently working on migrating from one package name to another one and want to make sure this is supported by tests. From my experience this need arises from time to time: companies rename/rebrand their products and want pack names to match.

**Architectural changes:**

None

**Testing remarks:**

Adds tests

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
