### PR TITLE
Add support for ConsolePlugin resource

### DIFF
--- a/pkg/controller/operators/catalog/supportedresources.go
+++ b/pkg/controller/operators/catalog/supportedresources.go
@@ -10,6 +10,7 @@ const (
 	ConsoleQuickStartKind     = "ConsoleQuickStart"
 	ConsoleCLIDownloadKind    = "ConsoleCLIDownload"
 	ConsoleLinkKind           = "ConsoleLink"
+	ConsolePlugin             = "ConsolePlugin"
 )
 
 var supportedKinds = map[string]struct{}{
@@ -22,6 +23,7 @@ var supportedKinds = map[string]struct{}{
 	ConsoleQuickStartKind:     {},
 	ConsoleCLIDownloadKind:    {},
 	ConsoleLinkKind:           {},
+	ConsolePlugin:             {},
 }
 
 // isSupported returns true if OLM supports this type of CustomResource.


### PR DESCRIPTION
**Description of the change:**

Add support for `ConsolePlugin` resource

**Motivation for the change:**

We (netobserv) would like to deploy a `ConsolePlugin ` as part of the operator bundle to implement custom UI on top of the CRs.
https://redhat-internal.slack.com/archives/C3VS0LV41/p1743609892173279

**Architectural changes:**

None

**Testing remarks:**

TODO

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
