### PR TITLE
🐛 fix(olm): improve error logging for missing olm.managed label

### DIFF
--- a/pkg/controller/operators/labeller/filters.go
+++ b/pkg/controller/operators/labeller/filters.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	operators "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -177,7 +178,11 @@ func Validate(ctx context.Context, logger *logrus.Logger, metadataClient metadat
 				logger.WithFields(logrus.Fields{
 					"gvr":           gvr.String(),
 					"nonconforming": count,
-				}).Info("found nonconforming items")
+				}).Errorf(
+					"found nonconforming items: missing the the required label %q (metadata.labels[\"%s\"]=\"true\"). ",
+					install.OLMManagedLabelKey,
+					install.OLMManagedLabelKey,
+				)
 			}
 			okLock.Lock()
 			ok = ok && count == 0


### PR DESCRIPTION
Previously, nonconforming CRDs (missing the  label) were logged as INFO, but this caused the  to enter a CrashLoopBackOff state due to unhandled inconsistencies.

This commit raises the log level to  and enhances the message with actionable advice, clarifying that users should either delete CRDs for uninstalled solutions or label them appropriately.

The root cause of the scenario is: From an old release (ocp 4.15) the component managed by OLM should have the label olm.managed: true added to comply with the new checks.