### PR TITLE
Revert "CVE-2025-27144: pin go-jose/v4@v4.0.5"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,6 @@ require (
 replace google.golang.org/grpc => google.golang.org/grpc v1.63.2
 
 replace (
-	github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.0.5 // CVE-2025-27144
 	// controller runtime
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20221021112143-4226c2167e40 // release-4.12
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c // release-4.12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1886,6 +1886,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # google.golang.org/grpc => google.golang.org/grpc v1.63.2
-# github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.0.5
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20221021112143-4226c2167e40
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c


### PR DESCRIPTION
Reverts operator-framework/operator-lifecycle-manager#3550


go-jose/v4@v4.0.5 is an indirect-indirect dependency, and does not need to be
`replace`-ed since it's absent to begin with. 