### PR TITLE
🌱 (cleanup): Update Owner Alias - remove inactive maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,15 +12,11 @@ approvers:
 # review == this code is good /lgtm
 reviewers:
   - kevinrizza
-  - benluddy
   - camilamacedo86
-  - dinhxuanvu
-  - gallettilance
   - anik120
   - ankitathomas
   - joelanford
   - perdasilva
-  - akihikokuroda
   - oceanc80
   - grokspawn
   - dtfranz


### PR DESCRIPTION
Removed maintainers from the Owner Alias who are no longer active in the project, in accordance with the [Contributor Ladder guidelines on inactive members](https://github.com/operator-framework/community/blob/master/contributor-ladder.md#inactive-members). They are invited to self-select emeritus status as outlined in the community process.
