### PR TITLE
🐛  Remove path requirement from go-verdiff gha

### DIFF
--- a/.github/workflows/go-verdiff.yaml
+++ b/.github/workflows/go-verdiff.yaml
@@ -1,12 +1,9 @@
 name: go-verdiff
 on:
   pull_request:
-    paths:
-      - '**.mod'
-      - '.github/workflows/go-verdiff.yaml'
-  push:
     branches:
       - master
+  push:
   workflow_dispatch:
   merge_group:
 jobs:


### PR DESCRIPTION
**Description of the change:**

Because the go-verdiff is required by branch protection, when it's not triggered (i.e. when a PR doesn't changed the listed paths), the PR will be unmergeable because GitHub will wait for a signal from the job and timeout (because it never runs).

Here we remove the path selector for the go-verdiff gha

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
