### PR TITLE
:bug: Add kubeapi server access to packageserver network policy

### DIFF
--- a/deploy/chart/templates/0000_50_olm_01-networkpolicies.yaml
+++ b/deploy/chart/templates/0000_50_olm_01-networkpolicies.yaml
@@ -62,6 +62,7 @@ spec:
       - protocol: TCP
         port: {{ .Values.package.service.internalPort }}
   egress:
+    - {{ .Values.networkPolicy.kubeAPIServer | toYaml | nindent 6 | trimSuffix "\n" }}
     - {{ .Values.networkPolicy.dns | toYaml | nindent 6 | trimSuffix "\n" }}
     - ports:
       - protocol: TCP


### PR DESCRIPTION
**Description of the change:**

Package server needs kube api access [[ref](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/package-server/server/server.go#L213)]. This PR updates the network policy to reflect that. It's possible that it worked anyway because the kind CNI doesn't seem to block kube-api server access.

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
