### PR TITLE
make cache flags optional for extractContent functionality

### DIFF
--- a/cmd/copy-content/main.go
+++ b/cmd/copy-content/main.go
@@ -1,43 +1,55 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
 	"github.com/otiai10/copy"
+	"github.com/spf13/cobra"
 )
 
 func main() {
-	catalogSource := flag.String("catalog.from", "", "Path to catalog contents to copy.")
-	catalogDestination := flag.String("catalog.to", "", "Path to where catalog contents should be copied.")
-	cacheSource := flag.String("cache.from", "", "Path to cache contents to copy.")
-	cacheDestination := flag.String("cache.to", "", "Path to where cache contents should be copied.")
-	flag.Parse()
+	cmd := newCmd()
+	cmd.Execute()
+}
 
-	for flagName, value := range map[string]*string{
-		"catalog.from": catalogSource,
-		"catalog.to":   catalogDestination,
-		"cache.from":   cacheSource,
-		"cache.to":     cacheDestination,
-	} {
-		if value == nil || *value == "" {
-			fmt.Printf("--%s is required", flagName)
-			os.Exit(1)
-		}
+func newCmd() *cobra.Command {
+	var (
+		catalogFrom string
+		catalogTo   string
+		cacheFrom   string
+		cacheTo     string
+	)
+	cmd := &cobra.Command{
+		Use:   "copy-content",
+		Short: "Copy catalog and cache content",
+		Long:  `Copy catalog and cache content`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var contentMap = make(map[string]string, 2)
+			contentMap[catalogFrom] = catalogTo
+			if cmd.Flags().Changed("cache.from") {
+				contentMap[cacheFrom] = cacheTo
+			}
+
+			for from, to := range contentMap {
+				if err := os.RemoveAll(to); err != nil {
+					fmt.Printf("failed to remove %s: %s", to, err)
+					os.Exit(1)
+				}
+				if err := copy.Copy(from, to); err != nil {
+					fmt.Printf("failed to copy %s to %s: %s\n", from, to, err)
+					os.Exit(1)
+				}
+			}
+		},
 	}
 
-	for from, to := range map[string]string{
-		*catalogSource: *catalogDestination,
-		*cacheSource:   *cacheDestination,
-	} {
-		if err := os.RemoveAll(to); err != nil {
-			fmt.Printf("failed to remove %s: %s", to, err)
-			os.Exit(1)
-		}
-		if err := copy.Copy(from, to); err != nil {
-			fmt.Printf("failed to copy %s to %s: %s\n", from, to, err)
-			os.Exit(1)
-		}
-	}
+	cmd.Flags().StringVar(&catalogFrom, "catalog.from", "", "Path to catalog contents to copy")
+	cmd.Flags().StringVar(&catalogTo, "catalog.to", "", "Path to where catalog contents should be copied")
+	cmd.Flags().StringVar(&cacheFrom, "cache.from", "", "Path to cache contents to copy (required if cache.to is set)")              // optional
+	cmd.Flags().StringVar(&cacheTo, "cache.to", "", "Path to where cache contents should be copied (required if cache.from is set)") // optional
+	cmd.MarkFlagRequired("catalog.from")
+	cmd.MarkFlagRequired("catalog.to")
+	cmd.MarkFlagsRequiredTogether("cache.from", "cache.to")
+	return cmd
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
allow the cache.[to|from] flags to be missing, so long as they are BOTH missing. 

**Motivation for the change:**
https://github.com/operator-framework/api/pull/421 and https://github.com/operator-framework/operator-lifecycle-manager/pull/3556 made it possible for users to access the `grpcPodConfig.extractContent` API without a `CatalogSource` cache, but we were missing changes to the copy-content helper which migrates the catalog content/cache into a pod for serving.

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
