### PR TITLE
only create cachedir if requested, since otherwise opm will error out serving it

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -305,12 +305,14 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 
 			pod.Spec.Containers[0].Image = opmImg
 			pod.Spec.Containers[0].Command = []string{"/bin/opm"}
-			// set service cache dir unconditionally, since it should always have compatible permissions for generation, if not provided by grpcPodConfig
-			pod.Spec.Containers[0].Args = []string{
+			var containerArgs = []string{
 				"serve",
 				filepath.Join(catalogPath, "catalog"),
-				"--cache-dir=" + filepath.Join(catalogPath, "cache"),
 			}
+			if grpcPodConfig.ExtractContent.CacheDir != "" {
+				containerArgs = append(containerArgs, "--cache-dir="+filepath.Join(catalogPath, "cache"))
+			}
+			pod.Spec.Containers[0].Args = containerArgs
 			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, contentVolumeMount)
 		}
 	}

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -400,7 +400,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "b0yrMl85J8bFjFWNl1O2XxsX698iPAjbpNhRIT", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "b4ns9MTvaRBYOarmuFe6PLYK0r2kxj5Vo06WTU", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -444,7 +444,7 @@ func TestPodExtractContent(t *testing.T) {
 							Name:    "name",
 							Image:   "opmImage",
 							Command: []string{"/bin/opm"},
-							Args:    []string{"serve", "/extracted-catalog/catalog", "--cache-dir=/extracted-catalog/cache"},
+							Args:    []string{"serve", "/extracted-catalog/catalog"},
 							Ports:   []corev1.ContainerPort{{Name: "grpc", ContainerPort: 50051}},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -719,7 +719,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "3qxzUcTKDfq8QwZPoXteAv35FSwRho7vyYkv4d", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "cO4moUo3vz6jZlcoBcxY4BB8o8a4E7m5GXCzI", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -771,7 +771,7 @@ func TestPodExtractContent(t *testing.T) {
 							Name:    "name",
 							Image:   "opmImage",
 							Command: []string{"/bin/opm"},
-							Args:    []string{"serve", "/extracted-catalog/catalog", "--cache-dir=/extracted-catalog/cache"},
+							Args:    []string{"serve", "/extracted-catalog/catalog"},
 							Ports:   []corev1.ContainerPort{{Name: "grpc", ContainerPort: 50051}},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Make cachedir creation contingent on a requested extractContent.cacheDir configuration.  

**Motivation for the change:**
Otherwise, in-cluster opm will find an existing-but-empty cache directory in the filespace and will recognize it as a broken cache.  This is correct, since it could be that the creator _intended_ to put cache content in the destination, but forgot|failed to.

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**
approach:
1. bring up a kind olm cluster via `make run-local`
2. clone the default operatorhubio catsrc but w/ on-cluster (cacheless) unpacking
    1.  dump the catsrc yaml
    2. add extractConfig stanza (only configs)
    4. dump the catsrc contents `opm render` to local fs (in a subdir $catdir)
    5. `opm generate dockerfile -i scratch $catdir` to make a binless catsrc dockerfile
    6. edit the dockerfile & comment out the cache build/copy to the destination image
    7. build/push the image to an accessible registry (I used `quay.io/jordankeister/catalogs:cacheless`)
    8. change the modified catsrc yaml `.status.image`, .`.metadata.name`, `spec.displayName` to make this catsrc unique
    9. deploy the new catsrc via `kubectl apply -f catsrc.yaml`
3. profit!

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
