### PR TITLE
reduce cache expiry frequency

### DIFF
--- a/pkg/controller/registry/resolver/source_registry.go
+++ b/pkg/controller/registry/resolver/source_registry.go
@@ -75,6 +75,8 @@ type RegistrySourceProvider struct {
 	invalidator  *sourceInvalidator
 }
 
+const defaultCacheLifetime time.Duration = 30 * time.Minute
+
 func SourceProviderFromRegistryClientProvider(rcp RegistryClientProvider, catsrcLister v1alpha1listers.CatalogSourceLister, logger logrus.StdLogger) *RegistrySourceProvider {
 	return &RegistrySourceProvider{
 		rcp:          rcp,
@@ -82,7 +84,7 @@ func SourceProviderFromRegistryClientProvider(rcp RegistryClientProvider, catsrc
 		catsrcLister: catsrcLister,
 		invalidator: &sourceInvalidator{
 			validChans: make(map[cache.SourceKey]chan struct{}),
-			ttl:        5 * time.Minute,
+			ttl:        defaultCacheLifetime,
 		},
 	}
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
changes the default lifetime of registry cache content from 5m to 30m.  

**Motivation for the change:**
Cache expiry requires new snapshots to be requested from catalogsources, and for combinations of short cache lifetime, # namespaces, and # subscriptions this resulted in a high rate of snapshot request.

This area in the code still suffers from (at least) two issues:
1. stampeding herd problem when multiple threads issue snapshot requests when a request is outstanding and unfulfilled; 
2. overload problem when a snapshot requests results in an error and is immediately retried

HOWEVER, this 6x reduction in frequency has been enough to make this problem disappear for all practical purposes, and can be pursued independently. 

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
