### PR TITLE
Allow override of go-verdiff result via label

### DIFF
--- a/.github/workflows/go-verdiff.yaml
+++ b/.github/workflows/go-verdiff.yaml
@@ -10,8 +10,16 @@ jobs:
   go-verdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check golang version
-        run: hack/tools/check-go-version.sh "${{ github.event.pull_request.base.sha }}"
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check golang version
+      run: |
+        export LABELS="$(gh api repos/$OWNER/$REPO/pulls/$PR --jq '.labels.[].name')"
+        hack/tools/check-go-version.sh -b "${{ github.event.pull_request.base.sha }}"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+        PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Rather than disabling the go-verdiff CI to allow it to pass when there is a legitimate golang version change, use a label to override the test results.

The label is `(override-go-verdiff)`.

See: https://github.com/operator-framework/operator-controller/pull/1964

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
