### PR TITLE
NO-ISSUE: Enabled readonlyRootFilesystem by default

### DIFF
--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -35,10 +35,13 @@ spec:
         secret:
           secretName: {{ .Values.olm.clientCASecret }}
       {{- end }}
+      - name: tmpfs
+        emptyDir: {}
       containers:
         - name: olm-operator
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: [ "ALL" ]
           {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
@@ -54,6 +57,8 @@ spec:
             mountPath: "/profile-collector-cert"
             readOnly: true
           {{- end }}
+          - name: tmpfs
+            mountPath: /tmp
           command:
           - /bin/olm
           args:

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -35,10 +35,13 @@ spec:
         secret:
           secretName: {{ .Values.catalog.clientCASecret }}
       {{- end }}
+      - name: tmpfs
+        emptyDir: {}
       containers:
         - name: catalog-operator
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: [ "ALL" ]
           {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
@@ -54,6 +57,8 @@ spec:
             mountPath: "/profile-collector-cert"
             readOnly: true
           {{- end }}
+          - name: tmpfs
+            mountPath: /tmp
           command:
           - /bin/catalog
           args:

--- a/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -31,6 +31,7 @@ spec:
       - name: packageserver
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop: [ "ALL" ]
         command:

--- a/pkg/controller/bundle/bundle_unpacker.go
+++ b/pkg/controller/bundle/bundle_unpacker.go
@@ -154,6 +154,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(bool(false)),
+								ReadOnlyRootFilesystem:   ptr.To(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
@@ -180,6 +181,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(bool(false)),
+								ReadOnlyRootFilesystem:   ptr.To(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
@@ -209,6 +211,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(bool(false)),
+								ReadOnlyRootFilesystem:   ptr.To(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},

--- a/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/pkg/controller/bundle/bundle_unpacker_test.go
@@ -308,6 +308,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -334,6 +335,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -363,6 +365,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -524,6 +527,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -550,6 +554,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -579,6 +584,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -780,6 +786,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -806,6 +813,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -835,6 +843,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1031,6 +1040,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1057,6 +1067,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1086,6 +1097,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1252,6 +1264,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1278,6 +1291,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1307,6 +1321,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1486,6 +1501,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1512,6 +1528,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},
@@ -1541,6 +1558,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 											},
 											SecurityContext: &corev1.SecurityContext{
 												AllowPrivilegeEscalation: ptr.To(bool(false)),
+												ReadOnlyRootFilesystem:   ptr.To(true),
 												Capabilities: &corev1.Capabilities{
 													Drop: []corev1.Capability{"ALL"},
 												},

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -371,7 +371,7 @@ func addSecurityContext(pod *corev1.Pod, runAsUser int64) {
 			pod.Spec.Containers[i].SecurityContext = &corev1.SecurityContext{}
 		}
 		pod.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
-		pod.Spec.InitContainers[i].SecurityContext.ReadOnlyRootFilesystem = ptr.To(true)
+		pod.Spec.Containers[i].SecurityContext.ReadOnlyRootFilesystem = ptr.To(true)
 		pod.Spec.Containers[i].SecurityContext.Capabilities = &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		}

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -191,7 +191,7 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
-						ReadOnlyRootFilesystem: ptr.To(false),
+						ReadOnlyRootFilesystem: ptr.To(true),
 					},
 					ImagePullPolicy:          image.InferImagePullPolicy(img),
 					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
@@ -361,6 +361,7 @@ func addSecurityContext(pod *corev1.Pod, runAsUser int64) {
 			pod.Spec.InitContainers[i].SecurityContext = &corev1.SecurityContext{}
 		}
 		pod.Spec.InitContainers[i].SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
+		pod.Spec.InitContainers[i].SecurityContext.ReadOnlyRootFilesystem = ptr.To(true)
 		pod.Spec.InitContainers[i].SecurityContext.Capabilities = &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		}
@@ -370,6 +371,7 @@ func addSecurityContext(pod *corev1.Pod, runAsUser int64) {
 			pod.Spec.Containers[i].SecurityContext = &corev1.SecurityContext{}
 		}
 		pod.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
+		pod.Spec.InitContainers[i].SecurityContext.ReadOnlyRootFilesystem = ptr.To(true)
 		pod.Spec.Containers[i].SecurityContext.Capabilities = &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		}


### PR DESCRIPTION
Description of the change:

Enforce readOnlyRootFilesystem: true for enhanced security (and provide brief justification for false exceptions)
Motivation for the change:

Reviewer Checklist

- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to /docs
- [ ] Commit messages sensible and descriptive