### PR TITLE
:bug: Make PSA catalog e2e tests more resilient

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -1601,29 +1601,19 @@ var _ = Describe("Starting CatalogSource e2e tests", Label("CatalogSource"), fun
 			})
 		})
 	})
-	When("The namespace is labled as Pod Security Admission policy enforce:restricted", func() {
+	When("The namespace is labeled as Pod Security Admission policy enforce:restricted", func() {
 		BeforeEach(func() {
-			var err error
-			testNS := &corev1.Namespace{}
 			Eventually(func() error {
-				testNS, err = c.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), generatedNamespace.GetName(), metav1.GetOptions{})
+				testNS, err := c.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), generatedNamespace.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				return nil
-			}).Should(BeNil())
-
-			testNS.ObjectMeta.Labels = map[string]string{
-				"pod-security.kubernetes.io/enforce":         "restricted",
-				"pod-security.kubernetes.io/enforce-version": "latest",
-			}
-
-			Eventually(func() error {
-				_, err := c.KubernetesInterface().CoreV1().Namespaces().Update(context.TODO(), testNS, metav1.UpdateOptions{})
-				if err != nil {
-					return err
+				testNS.ObjectMeta.Labels = map[string]string{
+					"pod-security.kubernetes.io/enforce":         "restricted",
+					"pod-security.kubernetes.io/enforce-version": "latest",
 				}
-				return nil
+				_, err = c.KubernetesInterface().CoreV1().Namespaces().Update(context.TODO(), testNS, metav1.UpdateOptions{})
+				return err
 			}).Should(BeNil())
 		})
 		When("A CatalogSource built with opm v1.21.0 (<v1.23.2)is created with spec.GrpcPodConfig.SecurityContextConfig set to restricted", func() {
@@ -1674,27 +1664,17 @@ var _ = Describe("Starting CatalogSource e2e tests", Label("CatalogSource"), fun
 	})
 	When("The namespace is labled as Pod Security Admission policy enforce:baseline", func() {
 		BeforeEach(func() {
-			var err error
-			testNS := &corev1.Namespace{}
 			Eventually(func() error {
-				testNS, err = c.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), generatedNamespace.GetName(), metav1.GetOptions{})
+				testNS, err := c.KubernetesInterface().CoreV1().Namespaces().Get(context.TODO(), generatedNamespace.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				return nil
-			}).Should(BeNil())
-
-			testNS.ObjectMeta.Labels = map[string]string{
-				"pod-security.kubernetes.io/enforce":         "baseline",
-				"pod-security.kubernetes.io/enforce-version": "latest",
-			}
-
-			Eventually(func() error {
-				_, err := c.KubernetesInterface().CoreV1().Namespaces().Update(context.TODO(), testNS, metav1.UpdateOptions{})
-				if err != nil {
-					return err
+				testNS.ObjectMeta.Labels = map[string]string{
+					"pod-security.kubernetes.io/enforce":         "baseline",
+					"pod-security.kubernetes.io/enforce-version": "latest",
 				}
-				return nil
+				_, err = c.KubernetesInterface().CoreV1().Namespaces().Update(context.TODO(), testNS, metav1.UpdateOptions{})
+				return err
 			}).Should(BeNil())
 		})
 		When("A CatalogSource built with opm v1.21.0 (<v1.23.2)is created with spec.GrpcPodConfig.SecurityContextConfig set to legacy", func() {


### PR DESCRIPTION
**Description of the change:**

A couple of the PSA related e2e tests are flaking due to out of band changes to the namespace between the get and update calls. This PR adds both of those calls into a single Eventually call to guard against that.

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
