### PR TITLE
(fix) bind metrics server to localhost interface only

### DIFF
--- a/pkg/lib/server/server.go
+++ b/pkg/lib/server/server.go
@@ -78,9 +78,9 @@ func (sc *serverConfig) tlsEnabled() (bool, error) {
 
 func (sc *serverConfig) getAddress(tlsEnabled bool) string {
 	if tlsEnabled {
-		return ":8443"
+		return "127.0.0.1:8443"
 	}
-	return ":8080"
+	return "127.0.0.1:8080"
 }
 
 func (sc serverConfig) getListenAndServeFunc() (func() error, error) {


### PR DESCRIPTION
Bind metrics server endpoints to 127.0.0.1 instead of all interfaces to improve security by preventing direct external access to metrics endpoints. This change supports downstream kube-rbac-proxy integration (see https://github.com/openshift/operator-framework-olm/pull/1061 for more info) by ensuring metrics are only accessible locally within the pod.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
