### PR TITLE
Improves quickstart docs to use latest manifests

### DIFF
--- a/doc/install/install.md
+++ b/doc/install/install.md
@@ -8,8 +8,8 @@ OLM deployment resources are templated so that they can be easily configured for
 
 Installing the CRDs first gives them a chance to register before installing the rest, which requires the CRDs exist.
 ```bash
-kubectl create -f deploy/upstream/quickstart/crds.yaml
-kubectl create -f deploy/upstream/quickstart/olm.yaml
+kubectl create -f https://github.com/operator-framework/operator-lifecycle-manager/releases/latest/download/crds.yaml
+kubectl create -f https://github.com/operator-framework/operator-lifecycle-manager/releases/latest/download/olm.yaml
 ```
 
 ## Install a Release


### PR DESCRIPTION
**Description of the change:**
Changes the quickstart documentation to use the latest manifests

**Motivation for the change:**
quickstart documentation for manual install has manifests that are 4 years old

**Architectural changes:**
Only documentation

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted

Closes #3605 #2875 
