### PR TITLE
Add OpenShift service-ca support for authenticated metrics endpoints

### DIFF
--- a/deploy/chart/templates/0000_50_olm_02-olm-operator.serviceaccount.yaml
+++ b/deploy/chart/templates/0000_50_olm_02-olm-operator.serviceaccount.yaml
@@ -8,6 +8,18 @@ rules:
   verbs: ["watch", "list", "get", "create", "update", "patch", "delete", "deletecollection", "escalate", "bind"]
 - nonResourceURLs: ["*"]
   verbs: ["*"]
+- apiGroups:
+    - authentication.k8s.io
+  resources:
+    - tokenreviews
+  verbs:
+    - create
+- apiGroups:
+    - authorization.k8s.io
+  resources:
+    - subjectaccessreviews
+  verbs:
+    - create
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/deploy/chart/templates/0000_50_olm_03-services.yaml
+++ b/deploy/chart/templates/0000_50_olm_03-services.yaml
@@ -1,39 +1,43 @@
-{{ if .Values.monitoring.enabled }}
+{{- if or .Values.monitoring.enabled .Values.serviceCa.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: olm-operator-metrics
+  name: {{ .Values.olm.service.name }}
   namespace: {{ .Values.namespace }}
+  {{- if .Values.serviceCa.enabled }}
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: {{ .Values.serviceCa.olmOperator.secretName }}
+  {{- end }}
   labels:
     app: olm-operator
 spec:
   type: ClusterIP
   ports:
   - name: https-metrics
-    port: {{ .Values.olm.service.externalPort }}
+    port: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.olm.service.internalPortHttps }}{{ else }}{{ .Values.olm.service.externalPort }}{{ end }}
     protocol: TCP
-    targetPort: {{ .Values.olm.service.internalPort }}
+    targetPort: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.olm.service.internalPortHttps }}{{ else }}{{ .Values.olm.service.internalPort }}{{ end }}
   selector:
     app: olm-operator
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: catalog-operator-metrics
+  name: {{ .Values.catalog.service.name }}
   namespace: {{ .Values.namespace }}
+  {{- if .Values.serviceCa.enabled }}
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: {{ .Values.serviceCa.catalogOperator.secretName }}
+  {{- end }}
   labels:
     app: catalog-operator
 spec:
   type: ClusterIP
   ports:
   - name: https-metrics
-    port: {{ .Values.catalog.service.externalPort }}
+    port: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.catalog.service.internalPortHttps }}{{ else }}{{ .Values.catalog.service.externalPort }}{{ end }}
     protocol: TCP
-    targetPort: {{ .Values.catalog.service.internalPort }}
+    targetPort: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.catalog.service.internalPortHttps }}{{ else }}{{ .Values.catalog.service.internalPort }}{{ end }}
   selector:
     app: catalog-operator
 {{ end }}

--- a/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -30,6 +30,13 @@ spec:
       - name: profile-collector-cert
         secret:
           secretName: {{ .Values.certManager.certificate.secretName }}
+      {{- else if .Values.serviceCa.enabled }}
+      - name: srv-cert
+        secret:
+          secretName: {{ .Values.serviceCa.olmOperator.secretName }}
+      - name: profile-collector-cert
+        secret:
+          secretName: {{ .Values.serviceCa.olmOperator.secretName }}
       {{- end }}
       - name: tmpfs
         emptyDir: {}
@@ -41,7 +48,7 @@ spec:
             capabilities:
               drop: [ "ALL" ]
           volumeMounts:
-          {{- if .Values.certManager.enabled }}
+          {{- if or .Values.certManager.enabled .Values.serviceCa.enabled }}
           - name: srv-cert
             mountPath: "/srv-cert"
             readOnly: true
@@ -74,7 +81,7 @@ spec:
           - --writePackageServerStatusName
           - {{ .Values.writePackageServerStatusName }}
           {{- end }}
-         {{- if .Values.certManager.enabled }}
+         {{- if or .Values.certManager.enabled .Values.serviceCa.enabled }}
           - --tls-cert
           - /srv-cert/tls.crt
           - --tls-key
@@ -85,18 +92,18 @@ spec:
           image: {{ .Values.olm.image.ref }}
           imagePullPolicy: {{ .Values.olm.image.pullPolicy }}
           ports:
-            - containerPort: {{ if .Values.certManager.enabled }}{{ .Values.olm.service.internalPortHttps }}{{ else }}{{ .Values.olm.service.internalPort }}{{ end }}
+            - containerPort: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.olm.service.internalPortHttps }}{{ else }}{{ .Values.olm.service.internalPort }}{{ end }}
               name: metrics
           livenessProbe:
             httpGet:
               path: /healthz
-              port: {{ if .Values.certManager.enabled }}{{ .Values.olm.service.internalPortHttps }}{{ else }}{{ .Values.olm.service.internalPort }}{{ end }}
-              scheme: {{ if .Values.certManager.enabled }}HTTPS{{ else }}HTTP{{ end }}
+              port: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.olm.service.internalPortHttps }}{{ else }}{{ .Values.olm.service.internalPort }}{{ end }}
+              scheme: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}HTTPS{{ else }}HTTP{{ end }}
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ if .Values.certManager.enabled }}{{ .Values.olm.service.internalPortHttps }}{{ else }}{{ .Values.olm.service.internalPort }}{{ end }}
-              scheme: {{ if .Values.certManager.enabled }}HTTPS{{ else }}HTTP{{ end }}
+              port: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.olm.service.internalPortHttps }}{{ else }}{{ .Values.olm.service.internalPort }}{{ end }}
+              scheme: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}HTTPS{{ else }}HTTP{{ end }}
           terminationMessagePolicy: FallbackToLogsOnError
           env:
           - name: OPERATOR_NAMESPACE

--- a/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -30,6 +30,13 @@ spec:
       - name: profile-collector-cert
         secret:
           secretName: {{ .Values.certManager.certificate.secretName }}
+      {{- else if .Values.serviceCa.enabled }}
+      - name: srv-cert
+        secret:
+          secretName: {{ .Values.serviceCa.catalogOperator.secretName }}
+      - name: profile-collector-cert
+        secret:
+          secretName: {{ .Values.serviceCa.catalogOperator.secretName }}
       {{- end }}
       - name: tmpfs
         emptyDir: {}
@@ -41,7 +48,7 @@ spec:
             capabilities:
               drop: [ "ALL" ]
           volumeMounts:
-          {{- if .Values.certManager.enabled }}
+          {{- if or .Values.certManager.enabled .Values.serviceCa.enabled }}
           - name: srv-cert
             mountPath: "/srv-cert"
             readOnly: true
@@ -71,7 +78,7 @@ spec:
           - --writeStatusName
           - {{ .Values.writeStatusNameCatalog }}
           {{- end }}
-          {{- if .Values.certManager.enabled }}
+          {{- if or .Values.certManager.enabled .Values.serviceCa.enabled }}
           - --tls-cert
           - /srv-cert/tls.crt
           - --tls-key
@@ -92,18 +99,18 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:
-            - containerPort: {{ if .Values.certManager.enabled }}{{ .Values.catalog.service.internalPortHttps }}{{ else }}{{ .Values.catalog.service.internalPort }}{{ end }}
+            - containerPort: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.catalog.service.internalPortHttps }}{{ else }}{{ .Values.catalog.service.internalPort }}{{ end }}
               name: metrics
           livenessProbe:
             httpGet:
               path: /healthz
-              port: {{ if .Values.certManager.enabled }}{{ .Values.catalog.service.internalPortHttps }}{{ else }}{{ .Values.catalog.service.internalPort }}{{ end }}
-              scheme: {{ if .Values.certManager.enabled }}HTTPS{{ else }}HTTP{{ end }}
+              port: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.catalog.service.internalPortHttps }}{{ else }}{{ .Values.catalog.service.internalPort }}{{ end }}
+              scheme: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}HTTPS{{ else }}HTTP{{ end }}
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ if .Values.certManager.enabled }}{{ .Values.catalog.service.internalPortHttps }}{{ else }}{{ .Values.catalog.service.internalPort }}{{ end }}
-              scheme: {{ if .Values.certManager.enabled }}HTTPS{{ else }}HTTP{{ end }}
+              port: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}{{ .Values.catalog.service.internalPortHttps }}{{ else }}{{ .Values.catalog.service.internalPort }}{{ end }}
+              scheme: {{ if or .Values.certManager.enabled .Values.serviceCa.enabled }}HTTPS{{ else }}HTTP{{ end }}
           terminationMessagePolicy: FallbackToLogsOnError
           {{- if .Values.catalog.resources }}
           resources:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -27,6 +27,7 @@ olm:
     ref: quay.io/operator-framework/olm:master
     pullPolicy: Always
   service:
+    name: olm-operator-metrics
     internalPort: 8080
     internalPortHttps: 8443
     externalPort: metrics
@@ -46,6 +47,7 @@ catalog:
     ref: quay.io/operator-framework/olm:master
     pullPolicy: Always
   service:
+    name: catalog-operator-metrics
     internalPort: 8080
     internalPortHttps: 8443
     externalPort: metrics
@@ -88,6 +90,18 @@ certManager:
     secretName: olm-cert
     extraDnsNames: []
     extraIpAddresses: []
+
+# OpenShift service-ca configuration
+# When enabled, uses OpenShift service-ca-operator for certificate management
+# This is mutually exclusive with certManager - only one should be enabled
+serviceCa:
+  enabled: false
+  # Secret names are left empty in upstream, to be filled by downstream values.yaml
+  # Service names are taken from olm.service.name and catalog.service.name
+  olmOperator:
+    secretName: ""
+  catalogOperator:
+    secretName: ""
 
 networkPolicy:
   dns:


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Adds support for OpenShift service-ca-operator alongside existing cert-manager support for authenticated metrics endpoints. This enables the metrics authentication feature to work in both upstream Kubernetes (with cert-manager) and OpenShift (with service-ca) environments.

**Changes:**

- Add explicit RBAC permissions for `tokenreviews` and `subjectaccessreviews` required by authentication filters
- Add `serviceCa` configuration section to values.yaml with configurable secret/service names
- Update deployment templates to support both `certManager` and `serviceCa` modes conditionally
- Update service templates to conditionally add service-ca annotations when enabled
- Maintain backward compatibility with existing `certManager` and `monitoring` configurations
 
**Motivation for the change:**


<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
