### PR TITLE
Fix TOCTOU race condition in ensureInstallPlan

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -5853,6 +5853,12 @@ func RequireObjectsInCache(t *testing.T, lister operatorlister.OperatorLister, n
 			fetched, err = lister.RbacV1().RoleBindingLister().RoleBindings(namespace).Get(o.GetName())
 		case *v1alpha1.ClusterServiceVersion:
 			fetched, err = lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(namespace).Get(o.GetName())
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return err
+				}
+				return errors.Join(err, fmt.Errorf("namespace: %v, error: %v", namespace, err))
+			}
 			// We don't care about finalizers
 			object.(*v1alpha1.ClusterServiceVersion).Finalizers = nil
 			fetched.(*v1alpha1.ClusterServiceVersion).Finalizers = nil


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fixes a race condition that causes OLM to create duplicate InstallPlans for the same subscription when multiple worker threads reconcile a namespace concurrently.

  #### Problem
  When two worker threads process the namespace queue simultaneously:
  1. Worker 1 calls `listInstallPlans()` and finds no existing InstallPlan
  2. Worker 2 calls `listInstallPlans()` and finds no existing InstallPlan
  3. Worker 1 acquires the mutex lock and creates an InstallPlan
  4. Worker 1 releases the lock
  5. Worker 2 acquires the mutex lock, checks its stale list (from step 2), and creates a duplicate InstallPlan

  This is a classic Time-of-Check-to-Time-of-Use (TOCTOU) vulnerability.


**Motivation for the change:**

**Architectural changes:**
Move the `listInstallPlans()` call **inside** the mutex-protected critical section to ensure atomic check-and-create behavior.

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**
  Added `TestEnsureInstallPlanConcurrency` which:
  - Launches 10 concurrent goroutines calling `ensureInstallPlan()`
  - Verifies only one InstallPlan is created
  - Verifies all goroutines receive the same InstallPlan reference
<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted

Assisted-by: Claude Code
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
