### PR TITLE
Fix race condition in duplicate InstallPlan prevention

### DIFF
--- a/pkg/controller/operators/catalog/operator.go
+++ b/pkg/controller/operators/catalog/operator.go
@@ -1654,12 +1654,6 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, gen
 		return nil, nil
 	}
 
-	// Check if any existing installplans are creating the same resources
-	installPlans, err := o.listInstallPlans(namespace)
-	if err != nil {
-		return nil, err
-	}
-
 	// There are multiple(2) worker threads process the namespaceQueue.
 	// Both worker can work at the same time when 2 separate updates are made for the namespace.
 	// The following sequence causes 2 installplans are created for a subscription
@@ -1679,6 +1673,14 @@ func (o *Operator) ensureInstallPlan(logger *logrus.Entry, namespace string, gen
 	// 8. worker 2 unlocks
 	o.muInstallPlan.Lock()
 	defer o.muInstallPlan.Unlock()
+
+	// Check if any existing installplans are creating the same resources
+	// This must be done AFTER acquiring the lock to ensure worker 2 sees
+	// the installplan created by worker 1
+	installPlans, err := o.listInstallPlans(namespace)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, installPlan := range installPlans {
 		if installPlan.Spec.Generation == gen {


### PR DESCRIPTION




<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Move the listInstallPlans() call to after the muInstallPlan lock is acquired in ensureInstallPlan(). Previously, the check for existing install plans happened before acquiring the lock, which meant that worker 2 could check for install plans before worker 1 had a chance to create one, even with the lock in place.

This fixes the race condition by ensuring that the sequence is:
1. Worker 1 acquires lock
2. Worker 1 checks for existing install plans
3. Worker 1 creates new install plan (if needed)
4. Worker 1 releases lock
5. Worker 2 acquires lock
6. Worker 2 checks for existing install plans (now sees worker 1's)
7. Worker 2 reuses existing install plan
8. Worker 2 releases lock

**Motivation for the change:**

Without this fix, both workers could see no existing install plans before either acquired the lock, leading to duplicate install plans being created for the same subscription.

**Architectural changes:**

None

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
