### PR TITLE
Fix container image short names for OpenShift compatibility

### DIFF
--- a/pkg/controller/operators/olm/operator_test.go
+++ b/pkg/controller/operators/olm/operator_test.go
@@ -414,7 +414,7 @@ func deployment(deploymentName, namespace, serviceAccountName string, templateAn
 					Containers: []corev1.Container{
 						{
 							Name:  deploymentName + "-c1",
-							Image: "nginx:1.7.9",
+							Image: "docker.io/nginx:1.7.9",
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 80,
@@ -681,7 +681,7 @@ func installStrategy(deploymentName string, permissions []v1alpha1.StrategyDeplo
 							Containers: []corev1.Container{
 								{
 									Name:  deploymentName + "-c1",
-									Image: "nginx:1.7.9",
+									Image: "docker.io/nginx:1.7.9",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 80,

--- a/pkg/controller/operators/operatorconditiongenerator_controller_test.go
+++ b/pkg/controller/operators/operatorconditiongenerator_controller_test.go
@@ -260,7 +260,7 @@ func newNginxInstallStrategy(name string, permissions []operatorsv1alpha1.Strate
 						Spec: corev1.PodSpec{Containers: []corev1.Container{
 							{
 								Name:            genName("nginx"),
-								Image:           "bitnami/nginx:latest",
+								Image:           "docker.io/bitnami/nginx:latest",
 								Ports:           []corev1.ContainerPort{{ContainerPort: 80}},
 								ImagePullPolicy: corev1.PullIfNotPresent,
 							},

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -1259,7 +1259,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 				},
 			},
 			expectedTolerations:       nil,
@@ -1275,7 +1275,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 						NodeSelector: overriddenNodeSelectors,
 					},
@@ -1294,7 +1294,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 						PriorityClassName: &overriddenPriorityClassName,
 					},
@@ -1313,7 +1313,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 						PriorityClassName: nil,
 					},
@@ -1332,7 +1332,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 						Tolerations: overriddenTolerations,
 					},
@@ -1351,7 +1351,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 						Affinity: overriddenAffinity,
 					},
@@ -1370,7 +1370,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 						NodeSelector:      overriddenNodeSelectors,
 						PriorityClassName: &overriddenPriorityClassName,
@@ -1392,7 +1392,7 @@ func TestPodSchedulingOverrides(t *testing.T) {
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 						PriorityClassName: &overriddenPriorityClassName,
 					},

--- a/pkg/controller/registry/resolver/util_test.go
+++ b/pkg/controller/registry/resolver/util_test.go
@@ -45,7 +45,7 @@ func csv(name, replaces string, ownedCRDs, requiredCRDs, ownedAPIServices, requi
 							Containers: []corev1.Container{
 								{
 									Name:  name + "-c1",
-									Image: "nginx:1.7.9",
+									Image: "docker.io/nginx:1.7.9",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 80,

--- a/test/e2e/catsrc_pod_config_e2e_test.go
+++ b/test/e2e/catsrc_pod_config_e2e_test.go
@@ -55,7 +55,7 @@ var _ = Describe("CatalogSource Grpc Pod Config", Label("CatalogSourcePodConfig"
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
 					SourceType: v1alpha1.SourceTypeGrpc,
-					Image:      "repo/image:tag",
+					Image:      "docker.io/repo/image:tag",
 					GrpcPodConfig: &v1alpha1.GrpcPodConfig{
 						SecurityContextConfig: v1alpha1.Restricted,
 					},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,7 +46,7 @@ var (
 
 	dummyImage = flag.String(
 		"dummyImage",
-		"bitnami/nginx:latest",
+		"docker.io/bitnami/nginx:latest",
 		"dummy image to treat as an operator in tests",
 	)
 


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Replace short image names (nginx:*, bitnami/nginx:*, repo/image:*) with fully qualified names (docker.io/*) in tests to resolve failures in OpenShift clusters with container image short name enforcement enabled.


**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
