### PR TITLE
Allow overriding resolver scheme

### DIFF
--- a/pkg/controller/registry/grpc/source.go
+++ b/pkg/controller/registry/grpc/source.go
@@ -163,7 +163,12 @@ func grpcConnection(address string) (*grpc.ClientConn, error) {
 		}))
 	}
 
-	return grpc.NewClient(address, dialOptions...)
+	target := address
+	if scheme := os.Getenv("RESOLVER_SCHEME"); scheme != "" {
+		target = scheme + ":///" + address
+	}
+
+	return grpc.NewClient(target, dialOptions...)
 }
 
 func (s *SourceStore) Add(key registry.CatalogKey, address string) (*SourceConn, error) {


### PR DESCRIPTION
Fixes https://github.com/operator-framework/operator-lifecycle-manager/issues/3698

Introduce RESOLVER_SCHEME env variable which can be used to set the resolver scheme explicitly.

The default behaviour of grpc.NewClient does not work in all cases for OLM. The [GRPC fixes](https://github.com/grpc/grpc-go/pull/7881) in this area introduced a new resolver that handles proxy configuration and delegates to child resolvers for target and proxy address resolution. But it is only used when there's no custom dialer. [OLM calls](https://github.com/operator-framework/operator-lifecycle-manager/blob/615d70d67bd537273e4f561ce1ca5c7f633d13fd/pkg/controller/registry/grpc/source.go#L157) WithContextDialer when proxy is used. In that case, GRPC uses the default resolver which uses the default resolver scheme ("dns"), which resolves the address on client side.

There needs to be a way to specify the original "passthrough" resolver scheme which will delegate resolving to the proxy. When the dialer is used it is recommended to use the passthrough resolver to change the resolver behaviour:

> 
> // Note that gRPC by default performs name resolution on the target passed to
> // NewClient. To bypass name resolution and cause the target string to be
> // passed directly to the dialer here instead, use the "passthrough" resolver
> // by specifying it in the target string, e.g. "passthrough:target".

From [GRPC dialoptions docs](https://github.com/grpc/grpc-go/blob/7472d578b15f718cbe8ca0f5f5a3713093c47b03/dialoptions.go#L469).

**Testing remarks:**

Tested the solution with change in Hypershift: [link to commit](https://github.com/mgencur/hypershift/commit/4c72e577a0399ec926548ff80855026f5ff79ec7)
Details: TBD

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
