### PR TITLE
🌱 (e2e): test: skip terminating pods in catalog image update test

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -1170,7 +1170,7 @@ var _ = Describe("Starting CatalogSource e2e tests", Label("CatalogSource"), fun
 			}
 
 			for _, pod := range podList.Items {
-				// Skip terminating pods
+				// Ignore terminating pods
 				if pod.DeletionTimestamp != nil {
 					continue
 				}
@@ -1199,8 +1199,11 @@ var _ = Describe("Starting CatalogSource e2e tests", Label("CatalogSource"), fun
 			return false
 		}
 		By("await new catalog source and ensure old one was deleted")
-		_, err = awaitPodsWithInterval(GinkgoT(), c, source.GetNamespace(), selector.String(), 30*time.Second, 10*time.Minute, podCheckFunc)
+		// the required check for ensuring there's a non-terminating pod with the new image is covered in the podCheckFunc
+		registryPods, err = awaitPodsWithInterval(GinkgoT(), c, source.GetNamespace(), selector.String(), 30*time.Second, 10*time.Minute, podCheckFunc)
 		Expect(err).ShouldNot(HaveOccurred(), "error awaiting registry pod")
+		Expect(registryPods).ShouldNot(BeNil(), "nil registry pods")
+		Expect(registryPods.Items).ToNot(BeEmpty(), "no registry pods found")
 
 		By("update catalog source with annotation (to kick resync)")
 		Eventually(func() error {


### PR DESCRIPTION
## Description

Fix flaky e2e test `[CatalogSource] image update` that fails when terminating pods are present during catalog source rollouts.

## Problem

The test was failing with:

```
unexpected number of registry pods found
Expected <[]v1.Pod | len:2> to have length 1
```


During catalog source image updates, there can be 2 pods temporarily:
- 1 old pod being deleted (with `DeletionTimestamp` set)  
- 1 new pod starting up

The test was counting terminating pods and failing instead of focusing on the actual requirement: verifying the catalog image was updated.

## Solution

Skip pods with `DeletionTimestamp != nil` when checking for the updated image.

This makes the test resilient to transient states during pod rollouts while still verifying the core requirement.

## Changes

- Add check to skip terminating pods in `podCheckFunc` (3 lines)
- Test now focuses on: "Does an active pod exist with the new image?"

## Testing

- Fixes downstream failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_operator-framework-olm/1142/pull-ci-openshift-operator-framework-olm-main-e2e-gcp-olm/1987692171796418560