### PR TITLE
fix: Make cert-manager optional for secured metrics endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ local-build: IMAGE_TAG = local
 local-build: image
 
 .PHONY: run-local
-run-local: local-build kind-create cert-manager-install deploy
+run-local: local-build kind-create deploy
 
 .PHONY: cert-manager-install
 cert-manager-install: #HELP Install cert-manager $(CERT_MANAGER_VERSION)
@@ -259,7 +259,6 @@ deploy: $(KIND) $(HELM) #HELP Deploy OLM to kind cluster $KIND_CLUSTER_NAME (def
 	$(KIND) load docker-image $(OLM_IMAGE) --name $(KIND_CLUSTER_NAME); \
 	$(HELM) upgrade --install olm deploy/chart \
 		--set debug=true \
-		--set certManager.enabled=true \
 		--set olm.image.ref=$(OLM_IMAGE) \
 		--set olm.image.pullPolicy=IfNotPresent \
 		--set catalog.image.ref=$(OLM_IMAGE) \
@@ -282,9 +281,6 @@ undeploy: $(KIND) $(HELM) #HELP Uninstall OLM from kind cluster $KIND_CLUSTER_NA
 	kubectl delete --all-namespaces --all catsrc
 	$(HELM) uninstall olm
 	kubectl delete -f deploy/chart/crds
-
-	# Uninstall cert-manager
-	$(MAKE) cert-manager-uninstall
 
 #SECTION e2e
 

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -79,7 +79,7 @@ monitoring:
   namespace: monitoring
 
 certManager:
-  enabled: true
+  enabled: false
   issuer:
     name: olm-ca-issuer
     selfSigned: true


### PR DESCRIPTION
**Problem:**

PR #3660 introduced cert-manager as a hard dependency for OLM deployments, causing installation failures when cert-manager CRDs are not present:

error getting resource "olm/olm-cert" with GVK "cert-manager.io/v1, Kind=Certificate": no matches for kind "Certificate" in version "cert-manager.io/v1"

This is a breaking change for existing users who don't have cert-manager installed.

**Solution:**

Make secured metrics endpoints an opt-in feature by setting `certManager.enabled: false` by default in Helm values. Users who want authenticated metrics must explicitly enable cert-manager.

**Changes:**

- Set `certManager.enabled: false` in `deploy/chart/values.yaml`
- Remove `cert-manager-install` dependency from `make run-local`
- Remove `--set certManager.enabled=true` override from `make deploy`
- Remove automatic cert-manager cleanup from `make undeploy`

**Behavior:**

- Default (cert-manager disabled): HTTP metrics on port 8080, no authentication
- Opt-in (`certManager.enabled: true`): HTTPS metrics on port 8443 with authentication/authorization

Fixes the breaking change introduced in #3660 while preserving the secured metrics feature for users who want it.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
