### PR TITLE
🐛 Fix nil pointer dereference panic in event recorder

### DIFF
--- a/pkg/lib/event/event.go
+++ b/pkg/lib/event/event.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -22,24 +24,99 @@ func init() {
 	}
 }
 
+// safeSpamKeyFunc builds a spam key from event fields with nil checks to prevent panics.
+// This protects against nil pointer dereferences when event.InvolvedObject fields are empty.
+func safeSpamKeyFunc(event *v1.Event) string {
+	if event == nil {
+		return "unknown/unknown/unknown/unknown"
+	}
+
+	kind := event.InvolvedObject.Kind
+	namespace := event.InvolvedObject.Namespace
+	name := event.InvolvedObject.Name
+	reason := event.Reason
+
+	// Provide defaults for empty fields to avoid issues
+	if kind == "" {
+		kind = "Unknown"
+	}
+	if name == "" {
+		name = "unknown"
+	}
+
+	return fmt.Sprintf("%s/%s/%s/%s", kind, namespace, name, reason)
+}
+
+// SafeEventRecorder wraps record.EventRecorder with nil checks to prevent panics
+// when recording events for objects with nil or invalid metadata.
+type SafeEventRecorder struct {
+	recorder record.EventRecorder
+}
+
+// isValidObject checks if the object has valid metadata required for event recording.
+func isValidObject(object runtime.Object) bool {
+	if object == nil {
+		return false
+	}
+
+	// Handle ObjectReference type (used for events with FieldPath)
+	if ref, ok := object.(*v1.ObjectReference); ok {
+		return ref.Name != ""
+	}
+
+	// Check if object implements metav1.Object interface
+	accessor, ok := object.(metav1.Object)
+	if !ok {
+		return false
+	}
+
+	// Ensure the object has a valid name (required for event recording)
+	if accessor.GetName() == "" {
+		return false
+	}
+
+	return true
+}
+
+// Event records an event for the given object, with nil checks.
+func (s *SafeEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	if !isValidObject(object) {
+		klog.V(4).Infof("Skipping event recording: invalid object (nil or missing name), reason=%s, message=%s", reason, message)
+		return
+	}
+	s.recorder.Event(object, eventtype, reason, message)
+}
+
+// Eventf records a formatted event for the given object, with nil checks.
+func (s *SafeEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	if !isValidObject(object) {
+		klog.V(4).Infof("Skipping event recording: invalid object (nil or missing name), reason=%s, messageFmt=%s", reason, messageFmt)
+		return
+	}
+	s.recorder.Eventf(object, eventtype, reason, messageFmt, args...)
+}
+
+// AnnotatedEventf records a formatted event with annotations for the given object, with nil checks.
+func (s *SafeEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	if !isValidObject(object) {
+		klog.V(4).Infof("Skipping event recording: invalid object (nil or missing name), reason=%s, messageFmt=%s", reason, messageFmt)
+		return
+	}
+	s.recorder.AnnotatedEventf(object, annotations, eventtype, reason, messageFmt, args...)
+}
+
 // NewRecorder returns an EventRecorder type that can be
 // used to post Events to different object's lifecycles.
+// The returned recorder includes nil checks to prevent panics from invalid objects.
 func NewRecorder(event typedcorev1.EventInterface) (record.EventRecorder, error) {
 	eventBroadcaster := record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{
-		BurstSize: 10,
-		SpamKeyFunc: func(event *v1.Event) string {
-			return fmt.Sprintf(
-				"%s/%s/%s/%s",
-				event.InvolvedObject.Kind,
-				event.InvolvedObject.Namespace,
-				event.InvolvedObject.Name,
-				event.Reason,
-			)
-		},
+		BurstSize:   10,
+		SpamKeyFunc: safeSpamKeyFunc,
 	})
 	eventBroadcaster.StartLogging(klog.Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: event})
 	recorder := eventBroadcaster.NewRecorder(s, v1.EventSource{Component: component})
 
-	return recorder, nil
+	// Wrap the recorder with SafeEventRecorder for nil protection
+	return &SafeEventRecorder{recorder: recorder}, nil
 }

--- a/pkg/lib/event/event_test.go
+++ b/pkg/lib/event/event_test.go
@@ -1,0 +1,312 @@
+package event
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestSafeSpamKeyFunc(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    *v1.Event
+		expected string
+	}{
+		{
+			name:     "nil event",
+			event:    nil,
+			expected: "unknown/unknown/unknown/unknown",
+		},
+		{
+			name: "empty event",
+			event: &v1.Event{
+				InvolvedObject: v1.ObjectReference{},
+			},
+			expected: "Unknown//unknown/",
+		},
+		{
+			name: "valid event",
+			event: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: "default",
+					Name:      "test-pod",
+				},
+				Reason: "Created",
+			},
+			expected: "Pod/default/test-pod/Created",
+		},
+		{
+			name: "event with empty kind",
+			event: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Namespace: "default",
+					Name:      "test-pod",
+				},
+				Reason: "Created",
+			},
+			expected: "Unknown/default/test-pod/Created",
+		},
+		{
+			name: "event with empty name",
+			event: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: "default",
+				},
+				Reason: "Created",
+			},
+			expected: "Pod/default/unknown/Created",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := safeSpamKeyFunc(tt.event)
+			if result != tt.expected {
+				t.Errorf("safeSpamKeyFunc() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsValidObject(t *testing.T) {
+	tests := []struct {
+		name     string
+		object   runtime.Object
+		expected bool
+	}{
+		{
+			name:     "nil object",
+			object:   nil,
+			expected: false,
+		},
+		{
+			name: "valid pod",
+			object: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod with empty name",
+			object: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "valid namespace",
+			object: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ns",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "valid ObjectReference",
+			object: &v1.ObjectReference{
+				Kind:      "InstallPlan",
+				Namespace: "default",
+				Name:      "test-plan",
+				FieldPath: "status.plan[0]",
+			},
+			expected: true,
+		},
+		{
+			name: "ObjectReference with empty name",
+			object: &v1.ObjectReference{
+				Kind:      "InstallPlan",
+				Namespace: "default",
+				FieldPath: "status.plan[0]",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidObject(tt.object)
+			if result != tt.expected {
+				t.Errorf("isValidObject() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// mockEventRecorder is a mock implementation of record.EventRecorder for testing
+type mockEventRecorder struct {
+	events []string
+}
+
+func (m *mockEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	m.events = append(m.events, reason+":"+message)
+}
+
+func (m *mockEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	m.events = append(m.events, reason+":"+messageFmt)
+}
+
+func (m *mockEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	m.events = append(m.events, reason+":"+messageFmt)
+}
+
+// Ensure mockEventRecorder implements record.EventRecorder
+var _ record.EventRecorder = &mockEventRecorder{}
+
+func TestSafeEventRecorder_Event(t *testing.T) {
+	tests := []struct {
+		name           string
+		object         runtime.Object
+		expectRecorded bool
+	}{
+		{
+			name:           "nil object - should not record",
+			object:         nil,
+			expectRecorded: false,
+		},
+		{
+			name: "valid object - should record",
+			object: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			expectRecorded: true,
+		},
+		{
+			name: "object with empty name - should not record",
+			object: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+			},
+			expectRecorded: false,
+		},
+		{
+			name: "valid ObjectReference - should record",
+			object: &v1.ObjectReference{
+				Kind:      "InstallPlan",
+				Namespace: "default",
+				Name:      "test-plan",
+				FieldPath: "status.plan[0]",
+			},
+			expectRecorded: true,
+		},
+		{
+			name: "ObjectReference with empty name - should not record",
+			object: &v1.ObjectReference{
+				Kind:      "InstallPlan",
+				Namespace: "default",
+			},
+			expectRecorded: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockEventRecorder{}
+			safe := &SafeEventRecorder{recorder: mock}
+
+			safe.Event(tt.object, v1.EventTypeNormal, "TestReason", "Test message")
+
+			if tt.expectRecorded && len(mock.events) != 1 {
+				t.Errorf("Expected event to be recorded, but got %d events", len(mock.events))
+			}
+			if !tt.expectRecorded && len(mock.events) != 0 {
+				t.Errorf("Expected no events to be recorded, but got %d events", len(mock.events))
+			}
+		})
+	}
+}
+
+func TestSafeEventRecorder_Eventf(t *testing.T) {
+	tests := []struct {
+		name           string
+		object         runtime.Object
+		expectRecorded bool
+	}{
+		{
+			name:           "nil object - should not record",
+			object:         nil,
+			expectRecorded: false,
+		},
+		{
+			name: "valid object - should record",
+			object: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			expectRecorded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockEventRecorder{}
+			safe := &SafeEventRecorder{recorder: mock}
+
+			safe.Eventf(tt.object, v1.EventTypeNormal, "TestReason", "Test message %s", "arg")
+
+			if tt.expectRecorded && len(mock.events) != 1 {
+				t.Errorf("Expected event to be recorded, but got %d events", len(mock.events))
+			}
+			if !tt.expectRecorded && len(mock.events) != 0 {
+				t.Errorf("Expected no events to be recorded, but got %d events", len(mock.events))
+			}
+		})
+	}
+}
+
+func TestSafeEventRecorder_AnnotatedEventf(t *testing.T) {
+	tests := []struct {
+		name           string
+		object         runtime.Object
+		expectRecorded bool
+	}{
+		{
+			name:           "nil object - should not record",
+			object:         nil,
+			expectRecorded: false,
+		},
+		{
+			name: "valid object - should record",
+			object: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			expectRecorded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockEventRecorder{}
+			safe := &SafeEventRecorder{recorder: mock}
+
+			annotations := map[string]string{"key": "value"}
+			safe.AnnotatedEventf(tt.object, annotations, v1.EventTypeNormal, "TestReason", "Test message %s", "arg")
+
+			if tt.expectRecorded && len(mock.events) != 1 {
+				t.Errorf("Expected event to be recorded, but got %d events", len(mock.events))
+			}
+			if !tt.expectRecorded && len(mock.events) != 0 {
+				t.Errorf("Expected no events to be recorded, but got %d events", len(mock.events))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

  Add SafeEventRecorder wrapper that validates objects before recording
  events to prevent panics when objects have nil or empty metadata.

  - Add safeSpamKeyFunc with nil checks for event fields
  - Add SafeEventRecorder wrapper implementing record.EventRecorder
  - Add isValidObject helper to validate object metadata
  - Skip event recording for invalid objects with debug logging
  - Add comprehensive unit tests for new functionality

  This fixes a panic that occurs when recording events for objects
  that have been deleted or have incomplete metadata during rapid
  reconciliation cycles."

**Motivation for the change:**
To fix https://issues.redhat.com/browse/OCPBUGS-69688
```go
Undiagnosed panic detected in pod
{  pods/openshift-operator-lifecycle-manager_olm-operator-566b7b56b4-njjp6_olm-operator_previous.log.gz:E1217 02:12:17.881155       1 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<}
```
**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Assisted-by: Claude Code