### PR TITLE
OPRUN-4412: Integrate APIServer TLS controller into OLM operator

### DIFF
--- a/cmd/olm/main.go
+++ b/cmd/olm/main.go
@@ -23,6 +23,8 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/openshift"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/feature"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/apiserver"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/openshiftconfig"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
@@ -129,22 +131,6 @@ func main() {
 	}
 	config := mgr.GetConfig()
 
-	listenAndServe, err := server.GetListenAndServeFunc(
-		server.WithLogger(logger),
-		server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath),
-		server.WithKubeConfig(config),
-		server.WithDebug(*debug),
-	)
-	if err != nil {
-		logger.Fatalf("Error setting up health/metric/pprof service: %v", err)
-	}
-
-	go func() {
-		if err := listenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Error(err)
-		}
-	}()
-
 	// create a config that validates we're creating objects with labels
 	validatingConfig := validatingroundtripper.Wrap(config, mgr.GetScheme())
 
@@ -169,6 +155,50 @@ func main() {
 		logger.WithError(err).Fatal("error configuring metadata client")
 	}
 
+	// Setup APIServer TLS configuration for HTTPS servers
+	discovery := opClient.KubernetesInterface().Discovery()
+	openshiftConfigAPIExists, err := openshiftconfig.IsAPIAvailable(discovery)
+	if err != nil {
+		logger.WithError(err).Fatal("error checking for OpenShift config API support")
+	}
+
+	apiServerTLSQuerier := apiserver.NoopQuerier()
+	var apiServerFactory interface{ Start(<-chan struct{}) }
+	if openshiftConfigAPIExists {
+		logger.Info("OpenShift APIServer API available - setting up watch for APIServer TLS configuration")
+
+		apiServerInformer, apiServerSyncer, querier, factory, err := apiserver.NewSyncer(logger, versionedConfigClient)
+		if err != nil {
+			logger.WithError(err).Fatal("error initializing APIServer TLS syncer")
+		}
+
+		logger.Info("APIServer TLS configuration will be applied to HTTPS servers")
+		apiServerTLSQuerier = querier
+
+		// Register event handlers for APIServer resource changes
+		apiserver.RegisterEventHandlers(apiServerInformer, apiServerSyncer)
+
+		apiServerFactory = factory
+	}
+
+	// Setup metrics/health server with TLS configuration
+	listenAndServe, err := server.GetListenAndServeFunc(
+		server.WithLogger(logger),
+		server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath),
+		server.WithKubeConfig(config),
+		server.WithAPIServerTLSQuerier(apiServerTLSQuerier),
+		server.WithDebug(*debug),
+	)
+	if err != nil {
+		logger.Fatalf("Error setting up health/metric/pprof service: %v", err)
+	}
+
+	go func() {
+		if err := listenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error(err)
+		}
+	}()
+
 	// Create a new instance of the operator.
 	op, err := olm.NewOperator(
 		ctx,
@@ -181,6 +211,7 @@ func main() {
 		olm.WithRestConfig(validatingConfig),
 		olm.WithConfigClient(versionedConfigClient),
 		olm.WithProtectedCopiedCSVNamespaces(*protectedCopiedCSVNamespaces),
+		olm.WithOpenshiftConfigAPIExists(openshiftConfigAPIExists),
 	)
 	if err != nil {
 		logger.WithError(err).Fatal("error configuring operator")
@@ -189,6 +220,11 @@ func main() {
 
 	op.Run(ctx)
 	<-op.Ready()
+
+	// Start APIServer TLS informer factory if on OpenShift
+	if apiServerFactory != nil {
+		apiServerFactory.Start(ctx.Done())
+	}
 
 	// Emit CSV metric
 	if err = op.EnsureCSVMetric(); err != nil {

--- a/pkg/controller/operators/olm/config.go
+++ b/pkg/controller/operators/olm/config.go
@@ -37,6 +37,7 @@ type operatorConfig struct {
 	apiLabeler                   labeler.Labeler
 	restConfig                   *rest.Config
 	configClient                 configv1client.Interface
+	openshiftConfigAPIExists     bool
 }
 
 func (o *operatorConfig) OperatorClient() operatorclient.ClientInterface {
@@ -200,5 +201,11 @@ func WithRestConfig(restConfig *rest.Config) OperatorOption {
 func WithConfigClient(configClient configv1client.Interface) OperatorOption {
 	return func(config *operatorConfig) {
 		config.configClient = configClient
+	}
+}
+
+func WithOpenshiftConfigAPIExists(exists bool) OperatorOption {
+	return func(config *operatorConfig) {
+		config.openshiftConfigAPIExists = exists
 	}
 }

--- a/pkg/controller/operators/olm/operator.go
+++ b/pkg/controller/operators/olm/operator.go
@@ -57,7 +57,6 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/event"
 	index "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/index"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/labeler"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/openshiftconfig"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
@@ -853,18 +852,10 @@ func newOperatorWithConfig(ctx context.Context, config *operatorConfig) (*Operat
 		return nil, err
 	}
 
-	// Check if OpenShift config API is available (used by proxy and apiserver controllers)
-	discovery := config.operatorClient.KubernetesInterface().Discovery()
-	openshiftConfigAPIExists, err := openshiftconfig.IsAPIAvailable(discovery)
-	if err != nil {
-		op.logger.Errorf("error happened while probing for OpenShift config API support - %v", err)
-		return nil, err
-	}
-
 	// setup proxy env var injection policies
 	proxyQuerierInUse := proxy.NoopQuerier()
-	if openshiftConfigAPIExists {
-		op.logger.Info("OpenShift Proxy API  available - setting up watch for Proxy type")
+	if config.openshiftConfigAPIExists {
+		op.logger.Info("OpenShift Proxy API available - setting up watch for Proxy type")
 
 		proxyInformer, proxySyncer, proxyQuerier, err := proxy.NewSyncer(op.logger, config.configClient)
 		if err != nil {


### PR DESCRIPTION
Adds cluster-wide TLS configuration support to the OLM operator's HTTPS metrics/health server on OpenShift clusters.

Optimizes the discovery calls for both proxy and apiserver into a single call.

On OpenShift, the metrics server now automatically adopts cluster-wide TLS security profiles (Old, Intermediate, Modern, Custom) without restart.


Assisted-By: Claude

