### PR TITLE
Mark 'operator workload continues running after catalog source is deleted' test as flaky

### DIFF
--- a/test/e2e/catalog_e2e_test.go
+++ b/test/e2e/catalog_e2e_test.go
@@ -1785,7 +1785,7 @@ var _ = Describe("Starting CatalogSource e2e tests", Label("CatalogSource"), fun
 		})
 	})
 
-	It("operator workload continues running after catalog source is deleted", func() {
+	It("[FLAKE] operator workload continues running after catalog source is deleted", func() {
 		By("Create CRD and CSV for operator")
 		packageName := genName("nginx-")
 		stableChannel := "stable"


### PR DESCRIPTION
The test has been failing pretty consistently since its introduced in #3737
