### PR TITLE
Hard-code version upgrade message for 4.22 upgrade paths

### DIFF
--- a/pkg/controller/operators/openshift/helpers.go
+++ b/pkg/controller/operators/openshift/helpers.go
@@ -91,12 +91,8 @@ func (s skews) String() string {
 		j--
 	}
 
-	// it is safe to ignore the error here, with the assumption
-	// that we build each skew object only after verifying that the
-	// version string is parseable safely.
-	maxOCPVersion, _ := semver.ParseTolerant(s[0].maxOpenShiftVersion)
-	nextY := nextY(maxOCPVersion).String()
-	return fmt.Sprintf("ClusterServiceVersions blocking minor version upgrades to %s or higher:\n%s", nextY, strings.Join(msg, "\n"))
+	// TODO Revisit this message after 4.23 release once release schedule is determined for future possible minor versions.
+	return fmt.Sprintf("ClusterServiceVersions blocking minor version upgrades to 4.23 or major version upgrades to 5.0:\n%s", strings.Join(msg, "\n"))
 }
 
 type skew struct {


### PR DESCRIPTION
Rather than update the logic, since we do not know whether what the upgrade paths will look like for potential minor versions past 4.23, we are simply hard-coding the upgrade message for 4.23 and will return to change it once upgrade paths are known.

OPRUN-4401

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
