### PR TITLE
fishing to see if testing explicitly for success will work for matrixed tests with fail-fast:false

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -117,9 +117,9 @@ jobs:
     - run: |
         echo "Matrix result: ${{ needs.e2e.result }}"
     - name: check individual matrix results
-      if: ${{ needs.e2e.result == 'failure' }}
+      if: ${{ needs.e2e.result != 'success' }}
       run: |
-        echo 'Failure: at least one e2e matrix job has failed'
+        echo 'Failure: at least one e2e matrix job has failed or been cancelled'
         exit 1
 
   # Run e2e tests in parallel jobs


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Test matrixed e2e test job for non-success, instead of explicitly for failure.

**Motivation for the change:**
We're seeing cases where PRs are merging even though the matrixed aggregate workflow 'e2e' has not completed.  Reading up on some docs, it appears that there are other potential 'failure but not "failure"' modes that can occur with `fail-fast:true` set. 

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
