### PR TITLE
fix: disable WatchListClient for envtest-based tests to fix unit test timeouts 

### DIFF
--- a/pkg/controller/operators/openshift/suite_test.go
+++ b/pkg/controller/operators/openshift/suite_test.go
@@ -2,6 +2,7 @@ package openshift
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,6 +20,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
+
+// TestMain disables WatchListClient feature for all tests in this package.
+// This is required because envtest doesn't fully support WatchList semantics in K8s 1.35.
+// See: https://github.com/kubernetes/kubernetes/issues/135895
+func TestMain(m *testing.M) {
+	// Disable WatchListClient feature gate
+	os.Setenv("KUBE_FEATURE_WatchListClient", "false")
+	os.Exit(m.Run())
+}
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/controller/operators/suite_test.go
+++ b/pkg/controller/operators/suite_test.go
@@ -3,6 +3,7 @@ package operators
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -71,6 +72,15 @@ var (
 		testobj.WithFixtureFile(&operatorsv1alpha1.InstallPlan{}, "testdata/fixtures/installplan.yaml"),
 	)
 )
+
+// TestMain disables WatchListClient feature for all tests in this package.
+// This is required because envtest doesn't fully support WatchList semantics in K8s 1.35.
+// See: https://github.com/kubernetes/kubernetes/issues/135895
+func TestMain(m *testing.M) {
+	// Disable WatchListClient feature gate
+	os.Setenv("KUBE_FEATURE_WatchListClient", "false")
+	os.Exit(m.Run())
+}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR fixes the unit test timeouts in pkg/controller/operators and pkg/controller/operators/openshift packages that occur after the K8s 1.35 upgrade.

**Motivation for the change:**
To address https://github.com/openshift/operator-framework-olm/pull/1208#issuecomment-3816763863

**Architectural changes:**

After upgrading to K8s 1.35, the WatchListClient feature gate is enabled by default. However, envtest environments don't fully support WatchList semantics, causing informer caches to hang indefinitely while waiting for sync. This results in test timeouts after 10 minutes:                                                            
  ```go                                                                                                                                                                        
  panic: test timed out after 10m0s                                                                                                                                       
      running tests:                                                                                                                                                      
          TestAPIs (10m0s)                                                                                                                                                
  FAIL    github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators    600.143s                                                                   
  ```                                                                                                                                                                                                                                        
Add TestMain function to disable the WatchListClient feature gate before tests run, forcing informers to use the traditional List+Watch behavior instead of the new WatchList semantics.   
                                                                                
<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Assisted-By: Claude-COde