### PR TITLE
fix: upgrade Go to 1.25.7 to resolve CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/operator-lifecycle-manager
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
## Summary
Upgrades Go version to 1.25.7 to fix a CRITICAL vulnerability in the Go standard library.

## CVE Fixed
CVE-2025-68121 (CRITICAL): crypto/tls session resumption vulnerability

## Vulnerability Findings

### Trivy Scan Command
```
trivy image --severity HIGH,CRITICAL quay.io/operator-framework/olm:latest
```

### Before Fix (quay.io/operator-framework/olm:latest)
```
Found: CVE-2025-68121 in stdlib v1.19
```

### After Fix
Go 1.25.7 contains patches for CVE-2025-68121.

This is a minimal patch-level version bump fix.