### PR TITLE
fix: bypass system registries.conf in image-canonical-ref tool

### DIFF
--- a/util/image-canonical-ref/main.go
+++ b/util/image-canonical-ref/main.go
@@ -36,9 +36,15 @@ func run(ctx context.Context, ref string) error {
 		return fmt.Errorf("error parsing image reference %q: %w", ref, err)
 	}
 
+	emptyDir, err := os.MkdirTemp("", "image-canonical-ref-*")
+	if err != nil {
+		return fmt.Errorf("error creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(emptyDir)
+
 	sysCtx := &types.SystemContext{
 		SystemRegistriesConfPath:    os.DevNull,
-		SystemRegistriesConfDirPath: "/nonexistent",
+		SystemRegistriesConfDirPath: emptyDir,
 	}
 	canonicalRef, err := resolveCanonicalRef(ctx, imgRef, sysCtx)
 	if err != nil {

--- a/util/image-canonical-ref/main.go
+++ b/util/image-canonical-ref/main.go
@@ -36,7 +36,9 @@ func run(ctx context.Context, ref string) error {
 		return fmt.Errorf("error parsing image reference %q: %w", ref, err)
 	}
 
-	sysCtx := &types.SystemContext{}
+	sysCtx := &types.SystemContext{
+		SystemRegistriesConfPath: "/dev/null",
+	}
 	canonicalRef, err := resolveCanonicalRef(ctx, imgRef, sysCtx)
 	if err != nil {
 		return fmt.Errorf("error resolving canonical reference: %w", err)

--- a/util/image-canonical-ref/main.go
+++ b/util/image-canonical-ref/main.go
@@ -37,7 +37,8 @@ func run(ctx context.Context, ref string) error {
 	}
 
 	sysCtx := &types.SystemContext{
-		SystemRegistriesConfPath: "/dev/null",
+		SystemRegistriesConfPath:    os.DevNull,
+		SystemRegistriesConfDirPath: "/nonexistent",
 	}
 	canonicalRef, err := resolveCanonicalRef(ctx, imgRef, sysCtx)
 	if err != nil {

--- a/util/image-canonical-ref/main.go
+++ b/util/image-canonical-ref/main.go
@@ -36,6 +36,8 @@ func run(ctx context.Context, ref string) error {
 		return fmt.Errorf("error parsing image reference %q: %w", ref, err)
 	}
 
+	// Bypass host registries.conf: go.podman.io/image/v5 v5.40.0+ hard-errors on v1-format configs,
+	// and CI runners may ship with one. This tool only needs direct registry access for digest resolution.
 	emptyDir, err := os.MkdirTemp("", "image-canonical-ref-*")
 	if err != nil {
 		return fmt.Errorf("error creating temp dir: %w", err)


### PR DESCRIPTION
## Summary
- The `go.podman.io/image/v5` bump from v5.39.2 to v5.40.0 (#3837) changed behavior: v1-format `registries.conf` files now produce a hard error instead of being silently converted to v2.
- CI runners (`ubuntu-latest`) ship with a v1 config at `/etc/containers/registries.conf`, breaking the release workflow (`package_release.sh`).
- Fix: set `SystemRegistriesConfPath` to `/dev/null` in the `image-canonical-ref` tool since it only resolves image digests from remote Docker registries and has no need for local registry aliasing configuration.

Tried to run a release job against the latest tag and got the following in the [logs](https://github.com/operator-framework/operator-lifecycle-manager/actions/runs/26449178526/job/77864824553):

```
./scripts/package_release.sh v0.43.0 deploy/upstream/manifests/v0.43.0 deploy/upstream/values.yaml
error running the tool: error resolving canonical reference: error creating image source: loading registries configuration: loading registries configuration "/etc/containers/registries.conf": registries.conf must be in v2 format but is in v1
```

## Test plan
- [ ] Verify `go build ./util/image-canonical-ref/` compiles successfully
- [ ] Verify the goreleaser release workflow passes on CI (the `package_release.sh` step no longer errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)