### PR TITLE
fix: use gh release upload instead of softprops/action-gh-release

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -57,13 +57,12 @@ jobs:
         run: make release RELEASE_VERSION=${{ env.IMAGE_TAG }} IMAGE_REPO=quay.io/operator-framework/olm
 
       - name: Update release artifacts with rendered Kubernetes release manifests
-        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags')
-        with:
-          name: ${{ env.IMAGE_TAG }}
-          files: |
-            deploy/upstream/quickstart/crds.yaml
-            deploy/upstream/quickstart/olm.yaml
-            deploy/upstream/quickstart/install.sh
-          draft: true
-          token: ${{ github.token }}
+        run: |
+          gh release upload "${{ env.IMAGE_TAG }}" \
+            deploy/upstream/quickstart/crds.yaml \
+            deploy/upstream/quickstart/olm.yaml \
+            deploy/upstream/quickstart/install.sh \
+            --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
softprops/action-gh-release@v3 has deduplication logic that picks the wrong draft release when multiple drafts exist for the same tag (e.g. when a tag is moved). This caused crds.yaml, olm.yaml, and install.sh to be uploaded to a stale draft from a prior failed run rather than the current GoReleaser-created release, as seen in v0.43.0.

Replace it with 'gh release upload', which uploads directly to the release associated with the tag without creating any new release objects. --clobber makes reruns safe.

Assisted-by: Claude

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
