### PR TITLE
OCPBUGS-88737: Apply cluster TLS security profile to packageserver serving options

### DIFF
--- a/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
+++ b/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
@@ -67,6 +67,14 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - "config.openshift.io"
+          resources:
+          - apiservers
+          resourceNames:
+          - cluster
+          verbs:
+          - get
       deployments:
       - name: packageserver
         {{- include "packageserver.deployment-spec" . | nindent 8 }}

--- a/deploy/upstream/quickstart/olm.yaml
+++ b/deploy/upstream/quickstart/olm.yaml
@@ -264,6 +264,14 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - "config.openshift.io"
+          resources:
+          - apiservers
+          resourceNames:
+          - cluster
+          verbs:
+          - get
       deployments:
       - name: packageserver
         spec:

--- a/pkg/package-server/server/server.go
+++ b/pkg/package-server/server/server.go
@@ -23,13 +23,18 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+	libcrypto "github.com/openshift/library-go/pkg/crypto"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client"
 	olminformers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions"
+	olmapiserver "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/apiserver"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/openshiftconfig"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apiserver"
 	genericpackageserver "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apiserver/generic"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/provider"
+	apidiscovery "k8s.io/client-go/discovery"
 )
 
 const DefaultWakeupInterval = 12 * time.Hour
@@ -202,19 +207,13 @@ func (o *PackageServerOptions) Run(ctx context.Context) error {
 		string(genericfeatures.UnauthenticatedHTTP2DOSMitigation): true,
 	})
 
-	// Grab the config for the API server
-	config, err := o.Config(ctx)
-	if err != nil {
-		return err
-	}
-	config.GenericConfig.EnableMetrics = true
-
-	// Set up the client config
+	// Set up the client config before calling Config() so it can be used to
+	// apply the cluster TLS security profile to the serving options.
 	var clientConfig *rest.Config
+	var err error
 	if len(o.Kubeconfig) > 0 {
 		loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: o.Kubeconfig}
 		loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
-
 		clientConfig, err = loader.ClientConfig()
 	} else {
 		clientConfig, err = rest.InClusterConfig()
@@ -222,6 +221,23 @@ func (o *PackageServerOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to construct lister client config: %v", err)
 	}
+
+	// If --tls-min-version was not supplied (e.g. no PSM-injected flags yet), fall
+	// back to a direct GET of the cluster APIServer CR so the packageserver still
+	// honours the cluster TLS security profile on first boot or during upgrades.
+	if o.SecureServing.MinTLSVersion == "" {
+		if err := applyClusterTLSProfile(ctx, clientConfig, o.SecureServing); err != nil {
+			return fmt.Errorf("failed to apply cluster TLS profile to serving options: %w", err)
+		}
+	}
+
+	// Grab the config for the API server
+	var config *apiserver.Config
+	config, err = o.Config(ctx)
+	if err != nil {
+		return err
+	}
+	config.GenericConfig.EnableMetrics = true
 
 	kubeClient, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
@@ -324,5 +340,60 @@ func (op *Operator) syncOLMConfig(obj interface{}) error {
 		}
 	}
 
+	return nil
+}
+
+// applyClusterTLSProfile fetches the cluster-wide APIServer TLS security profile
+// and applies it to the SecureServingOptions. It is a no-op on non-OpenShift clusters.
+// This is the fallback path used when --tls-min-version is not provided via flags
+// (i.e. before the PSM has had a chance to inject them).
+func applyClusterTLSProfile(ctx context.Context, config *rest.Config, serving *genericoptions.SecureServingOptionsWithLoopback) error {
+	const lookupTimeout = 30 * time.Second
+	profileCtx, cancel := context.WithTimeout(ctx, lookupTimeout)
+	defer cancel()
+
+	profileConfig := rest.CopyConfig(config)
+	if profileConfig.Timeout == 0 || profileConfig.Timeout > lookupTimeout {
+		profileConfig.Timeout = lookupTimeout
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(profileConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	cfgClient, err := configv1client.NewForConfig(profileConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create config client: %w", err)
+	}
+	return applyClusterTLSProfileWithClients(profileCtx, kubeClient.Discovery(), cfgClient, serving)
+}
+
+// applyClusterTLSProfileWithClients is the testable core of applyClusterTLSProfile.
+// It applies the cluster-wide APIServer TLS security profile to the SecureServingOptions,
+// but only for fields not already set by explicit flags (--tls-min-version / --tls-cipher-suites).
+// It is a no-op on non-OpenShift clusters.
+func applyClusterTLSProfileWithClients(ctx context.Context, discovery apidiscovery.DiscoveryInterface, cfgClient configv1client.Interface, serving *genericoptions.SecureServingOptionsWithLoopback) error {
+	available, err := openshiftconfig.IsAPIAvailable(discovery)
+	if err != nil {
+		return fmt.Errorf("failed to check OpenShift config API: %w", err)
+	}
+	if !available {
+		return nil
+	}
+
+	apiServer, err := cfgClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get APIServer config: %w", err)
+	}
+
+	minVersion, cipherSuites := olmapiserver.GetSecurityProfileConfig(apiServer.Spec.TLSSecurityProfile)
+	// Only override fields not already set by explicit flags.
+	if serving.MinTLSVersion == "" {
+		serving.MinTLSVersion = libcrypto.TLSVersionToNameOrDie(minVersion)
+	}
+	if len(serving.CipherSuites) == 0 {
+		serving.CipherSuites = libcrypto.CipherSuitesToNamesOrDie(cipherSuites)
+	}
+	log.Infof("Applying cluster TLS security profile: minVersion=%s cipherSuites=%v", serving.MinTLSVersion, serving.CipherSuites)
 	return nil
 }

--- a/pkg/package-server/server/server_test.go
+++ b/pkg/package-server/server/server_test.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	apiconfigv1 "github.com/openshift/api/config/v1"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// clusterAPIServer returns a minimal APIServer singleton with the given TLS profile.
+func clusterAPIServer(profile *apiconfigv1.TLSSecurityProfile) *apiconfigv1.APIServer {
+	return &apiconfigv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       apiconfigv1.APIServerSpec{TLSSecurityProfile: profile},
+	}
+}
+
+func newServing() *genericoptions.SecureServingOptionsWithLoopback {
+	return genericoptions.NewSecureServingOptions().WithLoopback()
+}
+
+// nonOpenShiftDiscovery returns a fake discovery that advertises only core k8s
+// groups — no config.openshift.io — simulating a vanilla Kubernetes cluster.
+func nonOpenShiftDiscovery() *fakediscovery.FakeDiscovery {
+	k8sClient := k8sfake.NewSimpleClientset()
+	disc := k8sClient.Discovery().(*fakediscovery.FakeDiscovery)
+	// Set a non-empty resource list so ServerGroups doesn't return an empty
+	// list (which ServerSupportsVersion treats as "all supported").
+	disc.Resources = []*metav1.APIResourceList{
+		{GroupVersion: "v1"},
+	}
+	return disc
+}
+
+// TestApplyClusterTLSProfileWithClients_NonOpenShift verifies that the function
+// is a no-op when the OpenShift config API is not present (vanilla Kubernetes).
+func TestApplyClusterTLSProfileWithClients_NonOpenShift(t *testing.T) {
+	cfgClient := configfake.NewSimpleClientset()
+	serving := newServing()
+
+	err := applyClusterTLSProfileWithClients(context.Background(), nonOpenShiftDiscovery(), cfgClient, serving)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if serving.MinTLSVersion != "" {
+		t.Errorf("expected MinTLSVersion to be unset, got %q", serving.MinTLSVersion)
+	}
+	if len(serving.CipherSuites) != 0 {
+		t.Errorf("expected CipherSuites to be unset, got %v", serving.CipherSuites)
+	}
+}
+
+// TestApplyClusterTLSProfileWithClients_IntermediateProfile verifies that the
+// Intermediate TLS profile populates MinTLSVersion and CipherSuites.
+func TestApplyClusterTLSProfileWithClients_IntermediateProfile(t *testing.T) {
+	apiServer := clusterAPIServer(&apiconfigv1.TLSSecurityProfile{
+		Type: apiconfigv1.TLSProfileIntermediateType,
+	})
+	cfgClient := configfake.NewSimpleClientset(apiServer)
+	serving := newServing()
+
+	err := applyClusterTLSProfileWithClients(context.Background(), cfgClient.Discovery(), cfgClient, serving)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if serving.MinTLSVersion == "" {
+		t.Error("expected MinTLSVersion to be set for Intermediate profile")
+	}
+	if len(serving.CipherSuites) == 0 {
+		t.Error("expected CipherSuites to be set for Intermediate profile")
+	}
+}
+
+// TestApplyClusterTLSProfileWithClients_ModernProfile verifies that the Modern
+// profile sets MinTLSVersion to VersionTLS13.
+func TestApplyClusterTLSProfileWithClients_ModernProfile(t *testing.T) {
+	apiServer := clusterAPIServer(&apiconfigv1.TLSSecurityProfile{
+		Type: apiconfigv1.TLSProfileModernType,
+	})
+	cfgClient := configfake.NewSimpleClientset(apiServer)
+	serving := newServing()
+
+	err := applyClusterTLSProfileWithClients(context.Background(), cfgClient.Discovery(), cfgClient, serving)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if serving.MinTLSVersion != "VersionTLS13" {
+		t.Errorf("expected MinTLSVersion=VersionTLS13 for Modern profile, got %q", serving.MinTLSVersion)
+	}
+}
+
+// TestApplyClusterTLSProfileWithClients_FlagsTakePrecedence verifies that
+// explicitly set flags are not overwritten by the cluster profile.
+func TestApplyClusterTLSProfileWithClients_FlagsTakePrecedence(t *testing.T) {
+	apiServer := clusterAPIServer(&apiconfigv1.TLSSecurityProfile{
+		Type: apiconfigv1.TLSProfileModernType,
+	})
+	cfgClient := configfake.NewSimpleClientset(apiServer)
+	serving := newServing()
+	// Simulate user-supplied flags.
+	serving.MinTLSVersion = "VersionTLS12"
+	serving.CipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+
+	err := applyClusterTLSProfileWithClients(context.Background(), cfgClient.Discovery(), cfgClient, serving)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if serving.MinTLSVersion != "VersionTLS12" {
+		t.Errorf("user-supplied MinTLSVersion should not be overwritten, got %q", serving.MinTLSVersion)
+	}
+	if len(serving.CipherSuites) != 1 || serving.CipherSuites[0] != "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" {
+		t.Errorf("user-supplied CipherSuites should not be overwritten, got %v", serving.CipherSuites)
+	}
+}
+
+// TestApplyClusterTLSProfileWithClients_MissingAPIServerCR verifies that a
+// missing singleton APIServer CR propagates as an error (fail-closed).
+func TestApplyClusterTLSProfileWithClients_MissingAPIServerCR(t *testing.T) {
+	// config client advertises the API group but has no APIServer object
+	cfgClient := configfake.NewSimpleClientset()
+	serving := newServing()
+
+	err := applyClusterTLSProfileWithClients(context.Background(), cfgClient.Discovery(), cfgClient, serving)
+	if err == nil {
+		t.Fatal("expected an error when the APIServer CR is missing, got nil")
+	}
+}


### PR DESCRIPTION
Read the OpenShift APIServer CR at startup to apply the cluster-wide TLS security profile (min version and cipher suites) to the packageserver's SecureServingOptions when --tls-min-version is not already set via flags. Includes a 30s timeout on the API lookup and fails closed if the profile cannot be applied. Adds RBAC to allow reading apiservers.config.openshift.io.

This ought to complete the upstream portion of TLS profiles (not including curves). The existing catalog and olm operators also directly read the OpenShift API.
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
