### PR TITLE
fix: warn-and-continue when cluster TLS profile lookup fails at startup

### DIFF
--- a/pkg/package-server/server/server.go
+++ b/pkg/package-server/server/server.go
@@ -226,8 +226,12 @@ func (o *PackageServerOptions) Run(ctx context.Context) error {
 	// back to a direct GET of the cluster APIServer CR so the packageserver still
 	// honours the cluster TLS security profile on first boot or during upgrades.
 	if o.SecureServing.MinTLSVersion == "" {
+		// Warn and continue on failure: the API server may not be reachable
+		// during initial startup (e.g. cluster bootstrap). Packageserver starts
+		// with secure TLS defaults; operators can supply --tls-min-version and
+		// --tls-cipher-suites flags to override the profile on a later restart.
 		if err := applyClusterTLSProfile(ctx, clientConfig, o.SecureServing); err != nil {
-			return fmt.Errorf("failed to apply cluster TLS profile to serving options: %w", err)
+			log.WithError(err).Warn("Failed to apply cluster TLS profile to serving options, using defaults")
 		}
 	}
 

--- a/pkg/package-server/server/server_test.go
+++ b/pkg/package-server/server/server_test.go
@@ -119,7 +119,7 @@ func TestApplyClusterTLSProfileWithClients_FlagsTakePrecedence(t *testing.T) {
 }
 
 // TestApplyClusterTLSProfileWithClients_MissingAPIServerCR verifies that a
-// missing singleton APIServer CR propagates as an error (fail-closed).
+// missing singleton APIServer CR propagates as an error.
 func TestApplyClusterTLSProfileWithClients_MissingAPIServerCR(t *testing.T) {
 	// config client advertises the API group but has no APIServer object
 	cfgClient := configfake.NewSimpleClientset()
@@ -128,5 +128,30 @@ func TestApplyClusterTLSProfileWithClients_MissingAPIServerCR(t *testing.T) {
 	err := applyClusterTLSProfileWithClients(context.Background(), cfgClient.Discovery(), cfgClient, serving)
 	if err == nil {
 		t.Fatal("expected an error when the APIServer CR is missing, got nil")
+	}
+}
+
+// TestApplyClusterTLSProfileWithClients_ErrorLeavesServingUnchanged is a
+// regression test for the warn-and-continue startup behavior introduced to
+// prevent crash-loops when the API server is not yet reachable.
+//
+// It verifies that when applyClusterTLSProfileWithClients returns an error the
+// SecureServingOptions are left in their original state, so the caller can
+// safely ignore the error and start with secure TLS defaults.
+func TestApplyClusterTLSProfileWithClients_ErrorLeavesServingUnchanged(t *testing.T) {
+	cfgClient := configfake.NewSimpleClientset() // no APIServer CR → returns error
+	serving := newServing()
+
+	err := applyClusterTLSProfileWithClients(context.Background(), cfgClient.Discovery(), cfgClient, serving)
+	if err == nil {
+		t.Fatal("expected an error to simulate API unavailability, got nil")
+	}
+
+	// Serving options must be unchanged so that starting with defaults is safe.
+	if serving.MinTLSVersion != "" {
+		t.Errorf("MinTLSVersion should be unset after error, got %q", serving.MinTLSVersion)
+	}
+	if len(serving.CipherSuites) != 0 {
+		t.Errorf("CipherSuites should be unset after error, got %v", serving.CipherSuites)
 	}
 }


### PR DESCRIPTION
In HyperShift hosted clusters the API server is not ready during initial packageserver startup, causing applyClusterTLSProfile() to timeout and return a fatal error, crash-looping the packageserver.

Change error handling to warn-and-continue so packageserver starts with secure TLS defaults. The PSM will inject the correct --tls-min-version / --tls-cipher-suites flags via the CSV once the API becomes available, triggering a clean restart with the cluster-configured profile.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
