### PR TITLE
deploy/chart: add static NetworkPolicies for CatalogSource gRPC ingress and bundle unpack egress

### DIFF
--- a/deploy/chart/templates/0000_50_olm_01-networkpolicies.yaml
+++ b/deploy/chart/templates/0000_50_olm_01-networkpolicies.yaml
@@ -87,11 +87,17 @@ spec:
     - { }
 ---
 # Complements per-CatalogSource NPs from the controller; covers the bootstrapping window before reconciliation.
+# Effective only when catalog_namespace == namespace (the default). When they differ, no OLM-managed
+# deny-all exists in catalog_namespace, so this rule has no effect; adding one there is unsafe since
+# OLM does not exclusively own that namespace.
+# No 'from:' restriction is intentional, matching current dynamic NP behavior. If the controller ever
+# restricts ingress sources, this Helm-owned NP (which the controller cannot delete) will silently
+# override that — treat as a permanent design constraint.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: catalog-source-grpc-server
-  namespace: {{ .Values.namespace }}
+  name: olm-catalog-grpc-ingress
+  namespace: {{ .Values.catalog_namespace }}
 spec:
   podSelector:
     matchExpressions:
@@ -105,11 +111,12 @@ spec:
         port: {{ .Values.catalogGrpcPodPort }}
 ---
 # Wildcard egress; API server port omitted intentionally — it is implementation-defined and not statically knowable.
+# Carries the same split-namespace limitation as olm-catalog-grpc-ingress above.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: bundle-unpack-egress
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Values.catalog_namespace }}
 spec:
   podSelector:
     matchExpressions:

--- a/deploy/chart/templates/0000_50_olm_01-networkpolicies.yaml
+++ b/deploy/chart/templates/0000_50_olm_01-networkpolicies.yaml
@@ -85,3 +85,41 @@ spec:
     - { }
   egress:
     - { }
+---
+# Complements per-CatalogSource NPs from the controller; covers the bootstrapping window before reconciliation.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: catalog-source-grpc-server
+  namespace: {{ .Values.namespace }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: olm.catalogSource
+        operator: Exists
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+      - protocol: TCP
+        port: {{ .Values.catalogGrpcPodPort }}
+---
+# Wildcard egress; API server port omitted intentionally — it is implementation-defined and not statically knowable.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bundle-unpack-egress
+  namespace: {{ .Values.namespace }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: operatorframework.io/bundle-unpack-ref
+        operator: Exists
+      - key: olm.managed
+        operator: In
+        values:
+          - "true"
+  policyTypes:
+    - Egress
+  egress:
+    - { }


### PR DESCRIPTION
## Summary

Fixes #3676.

The Helm chart's `default-deny-all-traffic` NetworkPolicy blocked two traffic paths not covered by the existing static policies:

- **CatalogSource gRPC ingress (port 50051):** Registry pods spawned per CatalogSource could not receive inbound gRPC connections. The catalog-operator reconciler does create per-CatalogSource NetworkPolicies for this dynamically, but there is a bootstrapping gap — `default-deny-all-traffic` takes effect immediately on install/upgrade, while the per-CatalogSource policies only exist after the controller reconciles each object.
- **Bundle-unpack job egress:** Job pods created for bundle unpacking could not reach the Kubernetes API server or container registries. The API server port cannot be statically specified (it is implementation-defined), so a wildcard egress rule is used instead.

Two new NetworkPolicies are added to the chart:

| Policy | Selector | Effect |
|---|---|---|
| `olm-catalog-grpc-ingress` | pods with `olm.catalogSource` label (any value) | allow ingress on `catalogGrpcPodPort` (50051) |
| `bundle-unpack-egress` | pods with `olm.managed=true` + `operatorframework.io/bundle-unpack-ref` label | allow all egress |

The `olm-catalog-grpc-ingress` policy only lists `Ingress` in `policyTypes`, so it does not restrict egress of catalog pods (that remains under the per-CatalogSource policies from the controller). The `bundle-unpack-egress` policy only lists `Egress`, so it does not affect ingress on those pods.

## Test plan

- [ ] Deploy OLM via the Helm chart into a cluster with a default-deny NetworkPolicy enforcement (e.g., K3s / Rancher Desktop)
- [ ] Create a CatalogSource pointing to `quay.io/operatorhubio/catalog:latest`; verify `lastObservedState` reaches `READY`
- [ ] Create a Subscription; verify the InstallPlan completes without `BundleLookupFailed`
- [ ] Verify `olm-catalog-grpc-ingress` and `bundle-unpack-egress` NetworkPolicies are present in the OLM namespace after `helm install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)