### PR TITLE
Migrate deprecated gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,11 +34,11 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.podman.io/image/v5 v5.40.0
 	go.uber.org/mock v0.6.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.82.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
 	k8s.io/apiextensions-apiserver v0.36.2
 	k8s.io/apimachinery v0.36.2
@@ -174,7 +174,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.37.0 // indirect
@@ -193,6 +192,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/kms v0.36.2 // indirect
 	k8s.io/streaming v0.36.2 // indirect

--- a/pkg/controller/operators/catalog/operator_test.go
+++ b/pkg/controller/operators/catalog/operator_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/time/rate"
-	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -219,7 +219,8 @@ func TestTransitionInstallPlan(t *testing.T) {
 
 func TestSyncInstallPlanUnhappy(t *testing.T) {
 	namespace := "ns"
-	ipWithSteps := withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+	ipWithSteps := withSteps(
+		installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 		[]*v1alpha1.Step{
 			{
 				Resource: v1alpha1.StepResource{
@@ -421,7 +422,8 @@ func TestExecutePlan(t *testing.T) {
 		},
 		{
 			testName: "MultipleSteps",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resource: v1alpha1.StepResource{
@@ -454,7 +456,8 @@ func TestExecutePlan(t *testing.T) {
 		},
 		{
 			testName: "CreateServiceAccount",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resource: v1alpha1.StepResource{
@@ -476,7 +479,8 @@ func TestExecutePlan(t *testing.T) {
 		},
 		{
 			testName: "CreateConfigMap",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resource: v1alpha1.StepResource{
@@ -497,7 +501,8 @@ func TestExecutePlan(t *testing.T) {
 		},
 		{
 			testName: "CreateSecretFromBundle",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resource: v1alpha1.StepResource{
@@ -518,7 +523,8 @@ func TestExecutePlan(t *testing.T) {
 		},
 		{
 			testName: "DoesNotCreateSecretNotFromBundle",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resource: v1alpha1.StepResource{
@@ -539,7 +545,8 @@ func TestExecutePlan(t *testing.T) {
 		},
 		{
 			testName: "UpdateServiceAccountWithSameFields",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resource: v1alpha1.StepResource{
@@ -573,7 +580,8 @@ func TestExecutePlan(t *testing.T) {
 		},
 		{
 			testName: "UpdateServiceAccountWithDiffFields",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resource: v1alpha1.StepResource{
@@ -607,7 +615,8 @@ func TestExecutePlan(t *testing.T) {
 		},
 		{
 			testName: "DynamicResourcesAreOwnerReferencedToCSV",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resolving: "csv",
@@ -640,7 +649,8 @@ func TestExecutePlan(t *testing.T) {
 			extObjs: []runtime.Object{decodeFile(t, "./testdata/prometheusrule.crd.yaml", &apiextensionsv1beta1.CustomResourceDefinition{})},
 			want: []runtime.Object{
 				csv("csv", namespace, nil, nil),
-				modify(t, decodeFile(t, "./testdata/prometheusrule.cr.yaml", &unstructured.Unstructured{}),
+				modify(
+					t, decodeFile(t, "./testdata/prometheusrule.cr.yaml", &unstructured.Unstructured{}),
 					withNamespace(namespace),
 					withOwner(csv("csv", namespace, nil, nil)),
 					modifyMeta(func(m metav1.Object) {
@@ -809,7 +819,8 @@ func TestExecutePlanDynamicResources(t *testing.T) {
 	}{
 		{
 			testName: "UnsupportedObject",
-			in: withSteps(installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
+			in: withSteps(
+				installPlan("p", namespace, v1alpha1.InstallPlanPhaseInstalling, "csv"),
 				[]*v1alpha1.Step{
 					{
 						Resource: v1alpha1.StepResource{
@@ -2212,7 +2223,8 @@ func NewFakeOperator(ctx context.Context, namespace string, namespaces []string,
 	configMapInformer := factory.Core().V1().ConfigMaps()
 	networkPolicyInformer := factory.Networking().V1().NetworkPolicies()
 
-	sharedInformers = append(sharedInformers,
+	sharedInformers = append(
+		sharedInformers,
 		roleInformer.Informer(),
 		roleBindingInformer.Informer(),
 		serviceAccountInformer.Informer(),
@@ -2257,7 +2269,8 @@ func NewFakeOperator(ctx context.Context, namespace string, namespaces []string,
 			),
 			workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
 				Name: "resolver",
-			}),
+			},
+		),
 		resolver:              config.resolver,
 		reconciler:            config.reconciler,
 		recorder:              config.recorder,
@@ -2294,6 +2307,7 @@ func NewFakeOperator(ctx context.Context, namespace string, namespaces []string,
 
 	return op, nil
 }
+
 func installPlan(name, namespace string, phase v1alpha1.InstallPlanPhase, names ...string) *v1alpha1.InstallPlan {
 	return &v1alpha1.InstallPlan{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2415,6 +2429,7 @@ func configMap(name, namespace string) *corev1.ConfigMap {
 func grpcServerNetworkPolicy(catSrc *v1alpha1.CatalogSource, matchLabels map[string]string) *networkingv1.NetworkPolicy {
 	return reconciler.DesiredGRPCServerNetworkPolicy(catSrc, matchLabels)
 }
+
 func unpackBundlesNetworkPolicy(catSrc *v1alpha1.CatalogSource) *networkingv1.NetworkPolicy {
 	return reconciler.DesiredUnpackBundlesNetworkPolicy(catSrc)
 }

--- a/util/cpb/main.go
+++ b/util/cpb/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 	"github.com/otiai10/copy"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func main() {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Migrate deprecated `gopkg.in/yaml.v3` to `go.yaml.in/yaml/v3` from direct dependenies.
Reference: https://github.com/yaml/go-yaml

**Motivation for the change:**
The gopkg.in domain is deprecated and the yaml project has moved to go.yaml.in.
This ensures continued updates and security patches.

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [x] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [x] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [x] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
