### PR TITLE
OCPBUGS-78095: Restore registry-server startup probe FailureThreshold to 15

### DIFF
--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -180,7 +180,7 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 								Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 							},
 						},
-						FailureThreshold: 10,
+						FailureThreshold: 15,
 						PeriodSeconds:    10,
 						TimeoutSeconds:   5,
 					},

--- a/pkg/controller/registry/reconciler/reconciler.go
+++ b/pkg/controller/registry/reconciler/reconciler.go
@@ -180,7 +180,7 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 								Port: 50051,
 							},
 						},
-						FailureThreshold: 10,
+						FailureThreshold: 15,
 						PeriodSeconds:    10,
 						TimeoutSeconds:   5,
 					},

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -38,7 +38,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "KpDeU9UesY5GlqG7ZUg9deo8Jp7mEGdpBhGJn", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "9ypiMzzIhmehTVss6ziefzhUy1oqi5HaKuuKnC", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -71,7 +71,7 @@ func TestPodMemoryTarget(t *testing.T) {
 										Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -110,7 +110,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "1Cl0FkZ1FdtjQ91Ojcj7pM0MphZFlOuLPtz2Cu", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "8YO5HNCBmJmib560diQLiRqZvRvoaKhF1wrPQd", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -144,7 +144,7 @@ func TestPodMemoryTarget(t *testing.T) {
 										Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -209,7 +209,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "KpDeU9UesY5GlqG7ZUg9deo8Jp7mEGdpBhGJn", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "9ypiMzzIhmehTVss6ziefzhUy1oqi5HaKuuKnC", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -242,7 +242,7 @@ func TestPodExtractContent(t *testing.T) {
 										Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -285,7 +285,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "9SbEBzbV5JmBIA6zza29T4lIo0ESVJ8SN6slOY", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "1qbvCkU20Obt17Z3B6bQtBeGyIm5wbpv5bkpgg", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -363,7 +363,7 @@ func TestPodExtractContent(t *testing.T) {
 										Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -406,7 +406,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "1B9AFU7EIoI0CgRaHbyBL3EnGzwrkBq968SSps", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "2UwfmcYOWijz1pC3xapgQnKK3yRkVFhZN1clrb", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -486,7 +486,7 @@ func TestPodExtractContent(t *testing.T) {
 										Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -522,7 +522,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "8qB6OcFt60v8HdhXnPkB1cjF39t7RkFx9K0JxW", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "2iRFHadLZxZOhZIrrbv9BWV8iBMZTzoebGNVbG", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -555,7 +555,7 @@ func TestPodExtractContent(t *testing.T) {
 										Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -605,7 +605,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "3xuLPXGJ2pzekw21PFU68XUKOYc7PTuW45M521", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "5Snaq6foF8dkSrxPHZGSAHm0497jiRrAp6nUT2", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -687,7 +687,7 @@ func TestPodExtractContent(t *testing.T) {
 										Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -737,7 +737,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "7noQSgGmkI4BD1MPKe0pEFFfOE3jJtN2DUyZuD", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "czwUQnRXkqTsMLZO4QJUEAicYEM4O5ZCXagHS8", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -821,7 +821,7 @@ func TestPodExtractContent(t *testing.T) {
 										Command: []string{"grpc_health_probe", "-addr=:50051", "-rpc-timeout=5s"},
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},

--- a/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/pkg/controller/registry/reconciler/reconciler_test.go
@@ -38,7 +38,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "b5nr2RkG6B45bx5Cn63j7B5ybVGjvneXC0AGu7", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "cBESV2Miwqi3TX1KELgXItd7j206e4q6b21BnP", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -71,7 +71,7 @@ func TestPodMemoryTarget(t *testing.T) {
 										Port: 50051,
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -110,7 +110,7 @@ func TestPodMemoryTarget(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "62b6r57eNVnmLZo0glbfT9JJHn98HcJzBhZN94", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "22OBIOEoFxFjed27eJvvYzqL0TfdXsuapKoxsE", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -144,7 +144,7 @@ func TestPodMemoryTarget(t *testing.T) {
 										Port: 50051,
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -209,7 +209,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "b5nr2RkG6B45bx5Cn63j7B5ybVGjvneXC0AGu7", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "cBESV2Miwqi3TX1KELgXItd7j206e4q6b21BnP", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -242,7 +242,7 @@ func TestPodExtractContent(t *testing.T) {
 										Port: 50051,
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -285,7 +285,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "7RONLG0R9WhWbcfGQvcwjexvGmZhN0Hyl16mHH", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "30fzEky6rWPSaUHUtTN3mbl0SvE2PryXPIr090", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -363,7 +363,7 @@ func TestPodExtractContent(t *testing.T) {
 										Port: 50051,
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -406,7 +406,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "8GtO2FTxu9llB1icRoWQIinKIVmNcrtivDihGG", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "57eMKS6v8du5evWOTeBJEFYx7r5udVxvhEQpLB", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -486,7 +486,7 @@ func TestPodExtractContent(t *testing.T) {
 										Port: 50051,
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -522,7 +522,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "8MrvWgiEdqXHHX9wiYJTEe8NgdSQYTVQtOnqml", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "bfNQa9OTbkeciTpFoCgpKhNENGjVjY61PYAoYA", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -555,7 +555,7 @@ func TestPodExtractContent(t *testing.T) {
 										Port: 50051,
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -605,7 +605,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "30zwNEAtF3RcZ94bM4MzA64LwQ8ikpEyrQHTd6", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "5CPn3qG7EdDS0mOX7AazM9Tt1RBtR6bjjMmmep", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -687,7 +687,7 @@ func TestPodExtractContent(t *testing.T) {
 										Port: 50051,
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},
@@ -737,7 +737,7 @@ func TestPodExtractContent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test-",
 					Namespace:    "testns",
-					Labels:       map[string]string{"olm.pod-spec-hash": "G21gfJ9Iz3wyOmy5eBn7kFuqBv93zGJP5lFEM", "olm.managed": "true"},
+					Labels:       map[string]string{"olm.pod-spec-hash": "adSLBZw1o1geKStnSKaiQEubBnN4eqkHabCyHs", "olm.managed": "true"},
 					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
 				},
 				Spec: corev1.PodSpec{
@@ -821,7 +821,7 @@ func TestPodExtractContent(t *testing.T) {
 										Port: 50051,
 									},
 								},
-								FailureThreshold: 10,
+								FailureThreshold: 15,
 								PeriodSeconds:    10,
 								TimeoutSeconds:   5,
 							},


### PR DESCRIPTION
**Description of the change:**

Restores \`StartupProbe.FailureThreshold\` for the registry-server container from \`10\` back to \`15\`, returning the startup budget from 100s to 150s. This reverts the threshold portion of 401bfff4df20c97bef08db2dc9fc75bc1879be7a, which changed FailureThreshold from 15 to 10 while adding TimeoutSeconds.

Test fixtures updated to reflect the recomputed \`olm.pod-spec-hash\` values.

**Motivation for the change:**

The 100s budget (\`FailureThreshold: 10 × PeriodSeconds: 10\`) can be too tight when there are performance constraints or large custom CatalogSources (OCPBUGS-78095). The commit message in 401bfff states the intent was to "maintain the ~150s startup time failure as originally designed," suggesting the reduction from 15 to 10 was unintentional. This change restores \`FailureThreshold\` to \`15\` (150s budget), which provides sufficient margin for these scenarios without being excessive.

**Architectural changes:**

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the startup probe tolerance for registry pods, helping prevent premature health-check failures during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->