### PR TITLE
reconciler: fix inverted log message and level for UpdateNotReadyErr

### DIFF
--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -340,11 +340,11 @@ func (c *GrpcRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, cata
 		return pkgerrors.Wrapf(err, "error ensuring pod: %s", pod.GetName())
 	}
 	if err := c.ensureUpdatePod(logger, sa, defaultPodSecurityConfig, source); err != nil {
-		logger.WithError(err).Error("error ensuring registry server: could not ensure update pod")
 		if _, ok := err.(UpdateNotReadyErr); ok {
-			logger.WithError(err).Error("error ensuring registry server: ensure update pod error is not of type UpdateNotReadyErr")
+			logger.WithError(err).Debug("error ensuring registry server: update pod not yet ready")
 			return err
 		}
+		logger.WithError(err).Error("error ensuring registry server: could not ensure update pod")
 		return pkgerrors.Wrapf(err, "error ensuring updated catalog source pod: %s", pod.GetName())
 	}
 

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -337,7 +337,7 @@ func (c *GrpcRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, cata
 	}
 	if err := c.ensurePod(logger, source, sa, defaultPodSecurityConfig, overwritePod); err != nil {
 		logger.WithError(err).Error("error ensuring registry server: could not ensure registry pod")
-		return pkgerrors.Wrapf(err, "error ensuring pod: %s", pod.GetName())
+		return pkgerrors.Wrapf(err, "error ensuring pod: %s", pod.GetGenerateName())
 	}
 	if err := c.ensureUpdatePod(logger, sa, defaultPodSecurityConfig, source); err != nil {
 		if _, ok := err.(UpdateNotReadyErr); ok {
@@ -345,7 +345,7 @@ func (c *GrpcRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, cata
 			return err
 		}
 		logger.WithError(err).Error("error ensuring registry server: could not ensure update pod")
-		return pkgerrors.Wrapf(err, "error ensuring updated catalog source pod: %s", pod.GetName())
+		return pkgerrors.Wrapf(err, "error ensuring update pod for catalog source %s", source.GetName())
 	}
 
 	service, err := source.Service()

--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -341,7 +341,7 @@ func (c *GrpcRegistryReconciler) EnsureRegistryServer(logger *logrus.Entry, cata
 	}
 	if err := c.ensureUpdatePod(logger, sa, defaultPodSecurityConfig, source); err != nil {
 		if _, ok := err.(UpdateNotReadyErr); ok {
-			logger.WithError(err).Debug("error ensuring registry server: update pod not yet ready")
+			logger.WithError(err).Debug("registry server update pod not yet ready")
 			return err
 		}
 		logger.WithError(err).Error("error ensuring registry server: could not ensure update pod")

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -64,6 +64,16 @@ func grpcCatalogSourceWithAnnotations(annotations map[string]string) *v1alpha1.C
 	return catsrc
 }
 
+func grpcCatalogSourceWithPolling() *v1alpha1.CatalogSource {
+	catsrc := validGrpcCatalogSource("image", "")
+	catsrc.Spec.UpdateStrategy = &v1alpha1.UpdateStrategy{
+		RegistryPoll: &v1alpha1.RegistryPoll{
+			Interval: &metav1.Duration{Duration: 1 * time.Minute},
+		},
+	}
+	return catsrc
+}
+
 func grpcCatalogSourceWithName(name string) *v1alpha1.CatalogSource {
 	catsrc := validGrpcCatalogSource("image", "")
 	catsrc.SetName(name)
@@ -385,6 +395,28 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 					ServiceNamespace: testNamespace,
 					Port:             "50051",
 				},
+			},
+		},
+		{
+			testName: "Grpc/PollingEnabled/UpdatePodNotReady/ReturnsUpdateNotReadyErr",
+			in: in{
+				cluster: cluster{
+					k8sObjs: append(
+						objectsForCatalogSource(t, grpcCatalogSourceWithPolling()),
+						&corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "update-pod",
+								Namespace: testNamespace,
+								Labels:    map[string]string{CatalogSourceUpdateKey: "img-catalog"},
+							},
+							Status: corev1.PodStatus{Phase: corev1.PodRunning},
+						},
+					),
+				},
+				catsrc: grpcCatalogSourceWithPolling(),
+			},
+			out: out{
+				err: UpdateNotReadyErr{catalogName: "img-catalog", podName: "update-pod"},
 			},
 		},
 	}


### PR DESCRIPTION
**Description of the change:**

When `ensureUpdatePod` returns `UpdateNotReadyErr` — the expected, benign signal that a new update pod hasn't yet reported ready — `EnsureRegistryServer` logged it at `level=error` with the message `"ensure update pod error is not of type UpdateNotReadyErr"`. The `ok` branch fires precisely when the error *is* `UpdateNotReadyErr`, so the message was the exact opposite of what happened.

Also addresses review feedback from #3871:
- Use `pod.GetGenerateName()` in the ensure-pod wrap (desired pods set `GenerateName`, so `GetName()` is empty).
- Reference the catalog source name when wrapping update-pod ensure failures.
- Keep the Debug message free of the word "error" (`registry server update pod not yet ready`).

**Motivation for the change:**

This mislabeled error was observed flooding logs in production environments where catalog registry pods have long startup times. Every reconcile tick during pod startup hit this path, producing a steady stream of misleading `level=error` messages that appeared to indicate a failed type-assertion, when the actual state was a completely normal pod-not-ready wait. This made triage and support significantly harder.

**Architectural changes:**

None. Control flow is unchanged — `UpdateNotReadyErr` is still returned as-is; only the log message/severity and error-wrap identifiers are corrected.

**Testing remarks:**

Added a regression unit test `Grpc/PollingEnabled/UpdatePodNotReady/ReturnsUpdateNotReadyErr` in `grpc_test.go` that verifies `EnsureRegistryServer` returns `UpdateNotReadyErr` (unmodified, not wrapped) when polling is enabled and an update pod exists but has not yet reported ready. All existing tests continue to pass.

---

Supersedes #3871 (original author unavailable; includes outstanding review feedback).

Credit: @emmahone for the original fix and test; @tmshort for the Debug message wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when registry pods cannot be created or updated.
  * Reconciliation now preserves clear readiness errors for running but not-ready update pods.
  * Error messages include relevant catalog and pod details to make troubleshooting easier.

* **Tests**
  * Added coverage for registry polling scenarios where an update pod is running but not ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->