### PR TITLE
reconciler: fix correctImages panic when pod has no containers

### DIFF
--- a/pkg/controller/registry/reconciler/grpc.go
+++ b/pkg/controller/registry/reconciler/grpc.go
@@ -273,6 +273,9 @@ func correctImages(source grpcCatalogSourceDecorator, pod *corev1.Pod) bool {
 			pod.Spec.InitContainers[1].Image == source.CatalogSource.Spec.Image &&
 			pod.Spec.Containers[0].Image == source.opmImage
 	}
+	if len(pod.Spec.Containers) == 0 {
+		return false
+	}
 	return pod.Spec.Containers[0].Image == source.CatalogSource.Spec.Image
 }
 

--- a/pkg/controller/registry/reconciler/grpc_test.go
+++ b/pkg/controller/registry/reconciler/grpc_test.go
@@ -816,3 +816,75 @@ func TestUpdatePodByDigest(t *testing.T) {
 		require.Equal(t, tt.result, imageChanged(logrus.NewEntry(logrus.New()), tt.updatePod, tt.servingPods), table[i].description)
 	}
 }
+
+func TestCorrectImages(t *testing.T) {
+	const catalogImage = "quay.io/test/catalog:v1"
+	const opmImage = "quay.io/test/opm:v1"
+	const utilImage = "quay.io/test/util:v1"
+
+	makeSource := func(image string, extractContent *v1alpha1.ExtractContentConfig) grpcCatalogSourceDecorator {
+		cs := validGrpcCatalogSource(image, "")
+		if extractContent != nil {
+			cs.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{ExtractContent: extractContent}
+		}
+		return grpcCatalogSourceDecorator{CatalogSource: cs, opmImage: opmImage, utilImage: utilImage}
+	}
+
+	for _, tt := range []struct {
+		name   string
+		source grpcCatalogSourceDecorator
+		pod    *corev1.Pod
+		want   bool
+	}{
+		{
+			name:   "non-ExtractContent/empty containers does not panic",
+			source: makeSource(catalogImage, nil),
+			pod:    &corev1.Pod{},
+			want:   false,
+		},
+		{
+			name:   "non-ExtractContent/matching image",
+			source: makeSource(catalogImage, nil),
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Image: catalogImage}},
+			}},
+			want: true,
+		},
+		{
+			name:   "non-ExtractContent/wrong image",
+			source: makeSource(catalogImage, nil),
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Image: "quay.io/test/catalog:v2"}},
+			}},
+			want: false,
+		},
+		{
+			name:   "ExtractContent/correct init and serving containers",
+			source: makeSource(catalogImage, &v1alpha1.ExtractContentConfig{CatalogDir: "/catalog"}),
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Image: utilImage}, {Image: catalogImage}},
+				Containers:     []corev1.Container{{Image: opmImage}},
+			}},
+			want: true,
+		},
+		{
+			name:   "ExtractContent/wrong number of init containers",
+			source: makeSource(catalogImage, &v1alpha1.ExtractContentConfig{CatalogDir: "/catalog"}),
+			pod:    &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: opmImage}}}},
+			want:   false,
+		},
+		{
+			name:   "ExtractContent/wrong serving container image",
+			source: makeSource(catalogImage, &v1alpha1.ExtractContentConfig{CatalogDir: "/catalog"}),
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Image: utilImage}, {Image: catalogImage}},
+				Containers:     []corev1.Container{{Image: "quay.io/test/opm:wrong"}},
+			}},
+			want: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, correctImages(tt.source, tt.pod))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `correctImages` accessed `pod.Spec.Containers[0]` without a length guard in the non-`ExtractContent` path, causing a panic for pods with an empty containers slice (e.g. evicted or malformed pods)
- The `ExtractContent` path already had an equivalent `len(pod.Spec.Containers) != 1` guard; this brings the fallback path in line
- Adds `TestCorrectImages` covering both paths, including the empty-containers regression case and an `ExtractContent` serving-image mismatch case

## Test plan

- [ ] `go test ./pkg/controller/registry/reconciler/... -run TestCorrectImages` — all 6 cases pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented reconciliation errors when evaluating workloads with no regular containers.
  - Improved image validation across standard and content-extraction configurations.

- **Tests**
  - Added coverage for empty-container scenarios, matching and mismatched images, container layouts, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->